### PR TITLE
Update README.md and CI workflows to support ARM64 binaries for Linux and Windows

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -16,10 +16,22 @@ jobs:
             name: mcpproxy-linux-amd64
             archive_format: tar.gz
           - os: ubuntu-latest
+            goos: linux
+            goarch: arm64
+            cgo: "0"
+            name: mcpproxy-linux-arm64
+            archive_format: tar.gz
+          - os: ubuntu-latest
             goos: windows
             goarch: amd64
             cgo: "0"
             name: mcpproxy-windows-amd64.exe
+            archive_format: zip
+          - os: ubuntu-latest
+            goos: windows
+            goarch: arm64
+            cgo: "0"
+            name: mcpproxy-windows-arm64.exe
             archive_format: zip
           - os: macos-latest
             goos: darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,22 @@ jobs:
             name: mcpproxy-linux-amd64
             archive_format: tar.gz
           - os: ubuntu-latest
+            goos: linux
+            goarch: arm64
+            cgo: "0"
+            name: mcpproxy-linux-arm64
+            archive_format: tar.gz
+          - os: ubuntu-latest
             goos: windows
             goarch: amd64
             cgo: "0"
             name: mcpproxy-windows-amd64.exe
+            archive_format: zip
+          - os: ubuntu-latest
+            goos: windows
+            goarch: arm64
+            cgo: "0"
+            name: mcpproxy-windows-arm64.exe
             archive_format: zip
           - os: macos-latest
             goos: darwin
@@ -510,7 +522,9 @@ jobs:
 
             **Latest Version (auto-updates):**
             - [Linux AMD64](https://github.com/${{ github.repository }}/releases/latest/download/mcpproxy-latest-linux-amd64.tar.gz) 
+            - [Linux ARM64](https://github.com/${{ github.repository }}/releases/latest/download/mcpproxy-latest-linux-arm64.tar.gz)
             - [Windows AMD64](https://github.com/${{ github.repository }}/releases/latest/download/mcpproxy-latest-windows-amd64.zip)
+            - [Windows ARM64](https://github.com/${{ github.repository }}/releases/latest/download/mcpproxy-latest-windows-arm64.zip)
             - [macOS AMD64](https://github.com/${{ github.repository }}/releases/latest/download/mcpproxy-latest-darwin-amd64.tar.gz)
             - [macOS ARM64](https://github.com/${{ github.repository }}/releases/latest/download/mcpproxy-latest-darwin-arm64.tar.gz)
 
@@ -520,7 +534,9 @@ jobs:
 
             **This Version (${{ github.ref_name }}):**
             - [Linux AMD64](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/mcpproxy-${{ env.CLEAN_VERSION }}-linux-amd64.tar.gz)
+            - [Linux ARM64](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/mcpproxy-${{ env.CLEAN_VERSION }}-linux-arm64.tar.gz)
             - [Windows AMD64](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/mcpproxy-${{ env.CLEAN_VERSION }}-windows-amd64.zip)
+            - [Windows ARM64](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/mcpproxy-${{ env.CLEAN_VERSION }}-windows-arm64.zip)
             - [macOS AMD64](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/mcpproxy-${{ env.CLEAN_VERSION }}-darwin-amd64.tar.gz)
             - [macOS ARM64](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/mcpproxy-${{ env.CLEAN_VERSION }}-darwin-arm64.tar.gz)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 - **Scale beyond API limits** – Federate hundreds of MCP servers while bypassing Cursor's 40-tool limit and OpenAI's 128-function cap.
 - **Save tokens & accelerate responses** – Agents load just one `retrieve_tools` function instead of hundreds of schemas. Research shows ~99 % token reduction with **43 % accuracy improvement**.
 - **Advanced security protection** – Automatic quarantine blocks Tool Poisoning Attacks until you manually approve new servers.
-- **Works offline & cross-platform** – macOS, Windows, and Linux binaries with a native system-tray UI.
+- **Works offline & cross-platform** – Native binaries for macOS (Intel & Apple Silicon), Windows (x64 & ARM64), and Linux (x64 & ARM64) with system-tray UI.
 
 ---
 
@@ -41,6 +41,11 @@ macOS (Homebrew):
 ```bash
 brew install smart-mcp-proxy/mcpproxy/mcpproxy
 ```
+
+Manual download (all platforms):
+- **Linux**: [AMD64](https://github.com/smart-mcp-proxy/mcpproxy-go/releases/latest/download/mcpproxy-latest-linux-amd64.tar.gz) | [ARM64](https://github.com/smart-mcp-proxy/mcpproxy-go/releases/latest/download/mcpproxy-latest-linux-arm64.tar.gz)
+- **Windows**: [AMD64](https://github.com/smart-mcp-proxy/mcpproxy-go/releases/latest/download/mcpproxy-latest-windows-amd64.zip) | [ARM64](https://github.com/smart-mcp-proxy/mcpproxy-go/releases/latest/download/mcpproxy-latest-windows-arm64.zip)
+- **macOS**: [Intel](https://github.com/smart-mcp-proxy/mcpproxy-go/releases/latest/download/mcpproxy-latest-darwin-amd64.tar.gz) | [Apple Silicon](https://github.com/smart-mcp-proxy/mcpproxy-go/releases/latest/download/mcpproxy-latest-darwin-arm64.tar.gz)
 
 Anywhere with Go 1.22+:
 ```bash


### PR DESCRIPTION
- Enhanced README.md to specify native binaries for macOS (Intel & Apple Silicon), Windows (x64 & ARM64), and Linux (x64 & ARM64).
- Updated GitHub Actions workflows to build and release ARM64 binaries for Linux and Windows platforms.
