### PR TITLE
Update command usage in documentation and scripts to reflect new 'serve' command for mcpproxy

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -114,7 +114,7 @@ jobs:
           ./mcpproxy --help
 
           # Test logging functionality
-          timeout 10s ./mcpproxy --log-to-file --log-level debug --listen :0 --tray=false || true
+          timeout 10s ./mcpproxy serve --log-to-file --log-level debug --listen :0 --tray=false || true
 
           # Verify log file was created in standard OS location
           if [ "$(uname)" = "Linux" ]; then
@@ -207,7 +207,7 @@ jobs:
           echo "OS Standard: ${{ matrix.log_standard }}"
 
           # Run mcpproxy briefly to create log files
-          ./mcpproxy --log-to-file --log-level info --listen :0 --tray=false &
+          ./mcpproxy serve --log-to-file --log-level info --listen :0 --tray=false &
           MCPPROXY_PID=$!
           sleep 5
           kill $MCPPROXY_PID 2>/dev/null || true

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -256,7 +256,7 @@ jobs:
 
           # Run mcpproxy briefly to create log files
           try {
-            $process = Start-Process -FilePath "./mcpproxy.exe" -ArgumentList "--log-to-file", "--log-level", "info", "--listen", ":0", "--tray=false" -NoNewWindow -PassThru
+            $process = Start-Process -FilePath "./mcpproxy.exe" -ArgumentList "serve", "--log-to-file", "--log-level", "info", "--listen", ":0", "--tray=false" -NoNewWindow -PassThru
             Start-Sleep -Seconds 5
             $process | Stop-Process -Force -ErrorAction SilentlyContinue
           } catch {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -563,9 +563,9 @@ jobs:
 
             ### Usage
 
-            - With tray: `./mcpproxy` (default)
-            - Custom port (default: 8080): `./mcpproxy --listen :8081`
-            - Headless: `./mcpproxy --tray=false`
+            - With tray: `./mcpproxy serve` (default)
+            - Custom port (default: 8080): `./mcpproxy serve --listen :8081`
+            - Headless: `./mcpproxy serve --tray=false`
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/AUTOUPDATE.md
+++ b/AUTOUPDATE.md
@@ -13,7 +13,7 @@ This document describes the auto-update functionality and release automation sys
 
 ```bash
 # Default mode - auto-update enabled
-./mcpproxy --tray=true
+./mcpproxy serve --tray=true
 ```
 
 ### 🚫 Disabled Mode
@@ -24,7 +24,7 @@ This document describes the auto-update functionality and release automation sys
 ```bash
 # Disable auto-update completely
 export MCPPROXY_DISABLE_AUTO_UPDATE=true
-./mcpproxy --tray=true
+./mcpproxy serve --tray=true
 
 # Or add to shell profile for permanent setting
 echo 'export MCPPROXY_DISABLE_AUTO_UPDATE=true' >> ~/.zshrc
@@ -39,7 +39,7 @@ echo 'export MCPPROXY_DISABLE_AUTO_UPDATE=true' >> ~/.zshrc
 ```bash
 # Notification-only mode
 export MCPPROXY_UPDATE_NOTIFY_ONLY=true
-./mcpproxy --tray=true
+./mcpproxy serve --tray=true
 ```
 
 ## Package Manager Integration

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ go install github.com/smart-mcp-proxy/mcpproxy-go/cmd/mcpproxy@latest
 ### 2. Run
 
 ```bash
-mcpproxy                # starts HTTP server on :8080 and shows tray
+mcpproxy serve          # starts HTTP server on :8080 and shows tray
 ```
 
 ### 3. Add servers
@@ -121,7 +121,7 @@ Edit `mcp_config.json` (see below). Or **ask LLM** to add servers (see [doc](htt
 ### CLI flags
 
 ```text
-mcpproxy --help
+mcpproxy serve --help
   -c, --config <file>          path to mcp_config.json
   -l, --listen <addr>          listen address (":8080")
   -d, --data-dir <dir>         custom data directory
@@ -186,7 +186,7 @@ MCPProxy provides **seamless OAuth 2.1 authentication** for MCP servers that req
 Enable debug logging to see the complete OAuth flow:
 
 ```bash
-mcpproxy --log-level=debug --tray=false
+mcpproxy serve --log-level=debug --tray=false
 ```
 
 Check logs for OAuth flow details:

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -18,16 +18,16 @@ The logging system provides:
 
 ```bash
 # Enable file logging with default settings
-mcpproxy --log-to-file
+mcpproxy serve --log-to-file
 
 # Set log level and enable file logging
-mcpproxy --log-level debug --log-to-file
+mcpproxy serve --log-level debug --log-to-file
 
 # Use custom log file location
-mcpproxy --log-file /path/to/custom/mcpproxy.log
+mcpproxy serve --log-file /path/to/custom/mcpproxy.log
 
 # Disable file logging (console only)
-mcpproxy --log-to-file=false
+mcpproxy serve --log-to-file=false
 ```
 
 ### Configuration File
@@ -137,7 +137,7 @@ The logging system automatically selects the appropriate directory based on your
 
 ```bash
 # Use a custom log file path
-mcpproxy --log-file /var/log/myapp/mcpproxy.log
+mcpproxy serve --log-file /var/log/myapp/mcpproxy.log
 
 # Use custom path with configuration
 {
@@ -204,7 +204,7 @@ Use the built-in command to find log directory:
 
 ```bash
 # The log directory path is shown in startup logs
-mcpproxy --log-level debug | grep "Log directory configured"
+mcpproxy serve --log-level debug | grep "Log directory configured"
 ```
 
 ### Common Log Patterns
@@ -253,7 +253,7 @@ Failed to connect to upstream server | {"server": "example", "error": "connectio
 
 ```bash
 # Test with custom path
-mcpproxy --log-file ./mcpproxy.log --log-level debug
+mcpproxy serve --log-file ./mcpproxy.log --log-level debug
 ```
 
 ### Log Rotation Not Working
@@ -321,7 +321,7 @@ ENV LOG_TO_FILE=true
 Description=MCP Proxy Service
 
 [Service]
-ExecStart=/usr/local/bin/mcpproxy --log-to-file --log-level info
+ExecStart=/usr/local/bin/mcpproxy serve --log-to-file --log-level info
 StandardOutput=journal
 StandardError=journal
 

--- a/docs/search_servers.md
+++ b/docs/search_servers.md
@@ -1,0 +1,586 @@
+Search Servers Feature Design for MCPProxy
+
+📌 Functional Spec & Example Input/Output
+
+Objective: Extend mcpproxy with a new search_servers capability, enabling discovery of Model Context Protocol (MCP) servers from a built-in registry-of-registries. This mirrors the functionality of Mastra’s registryServers tool – allowing users or AI agents to list available MCP servers by querying known registries ￼. The feature will support filtering by a specific registry (exact match on registry ID or name) as well as optional search terms and tags for narrowing results.
+
+User Workflow:
+	•	Specify Registry: The user (or agent) can target a particular MCP registry by providing its ID or exact name via a CLI flag or tool input (e.g. --registry mcprun). If a registry filter is given, search_servers will query only that registry. Without this filter, the command can either (a) list all known registries or (b) search all registries. For this design, we assume an explicit registry is required (similar to Mastra’s approach), to avoid heavy multi-registry queries. Attempting to search without specifying a registry will prompt the user to supply one or list available registries.
+	•	Search and Tag Filters: The user may also provide a search term to match against server names/descriptions, and/or a tag to filter results. The search is case-insensitive and matches substrings in the server’s name or description ￼. (Mastra’s implementation demonstrates filtering server entries by search term ￼.) If a tag is provided and the target registry categorizes servers by tags, the results will be filtered accordingly (though many MCP server listings may not have tags on individual servers).
+	•	Output: The output will be a structured list of servers (e.g. in JSON or table form) rich enough to directly feed into the upstream_servers add command. Specifically, each result will include all details needed to add that server as an upstream in MCPProxy. This includes at least a human-friendly name, a description, and crucially the connection endpoint or URL of the MCP server. By providing the server’s address in the search results, the user/agent can immediately invoke the add command without making another lookup call. For example, if searching the “MCP Run” registry for “weather”, the output might be:
+
+[
+  {
+    "registry": "MCP Run",
+    "id": "weather",
+    "name": "WeatherInfo",
+    "description": "Provides real-time weather data",
+    "url": "https://weather.mcp.run/mcp/", 
+    "updatedAt": "2025-05-01T12:00:00Z"
+  }
+]
+
+In this example, the result indicates a server named “WeatherInfo”, with a base MCP endpoint URL. The user or agent can then call:
+
+mcpproxy upstream_servers add --name "WeatherInfo" --url "https://weather.mcp.run/mcp/"
+
+or equivalently invoke the upstream_servers add tool with the given URL to integrate the server. The goal is that no further registry queries are needed after search_servers – the result is immediately actionable. (If multiple results are returned, the user can pick one and supply its URL to the add command.)
+
+	•	Error Handling: If the specified registry ID is not found in the embedded registry list, an error is returned (e.g. “Registry with ID ‘X’ not found”). If the registry is found but has no known servers_url (no server listing endpoint), an error is returned indicating that the registry cannot provide server data. Network or parsing errors during fetch will be surfaced as well (with clear error messages). These mirror error conditions tested in Mastra’s getServersFromRegistry (e.g. error when registry ID is invalid ￼).
+	•	Example CLI Usage:
+
+# Example 1: Search "MCP Run" registry for servers with "weather" in name or description
+mcpproxy search-servers --registry mcprun --search weather
+
+# Example 2: List all servers from the "Pulse MCP" registry tagged as "finance"
+mcpproxy search-servers --registry pulse --tag finance
+
+# Example 3: List all known registries (if no search term given and special flag used)
+mcpproxy search-servers --list-registries
+
+Example Output (for Example 1):
+
+[
+  {
+    "registry": "MCP Run",
+    "id": "weather",
+    "name": "WeatherInfo",
+    "description": "Provides real-time weather data",
+    "url": "https://weather.mcp.run/mcp/",
+    "updatedAt": "2025-05-01T12:00:00Z"
+  },
+  {
+    "registry": "MCP Run",
+    "id": "weather-forecast",
+    "name": "ForecastPro",
+    "description": "7-day weather forecast tool",
+    "url": "https://forecast.mcp.run/mcp/",
+    "updatedAt": "2025-04-20T08:30:00Z"
+  }
+]
+
+In a real scenario, the above JSON could be printed to the console or returned as an MCP tool response. The user/agent sees two matching servers from MCP Run and can choose one to add. Each entry includes url (the base endpoint to connect to the MCP server) so that no additional lookup is required beyond this search.
+
+⚙️ Architecture & Flowchart
+
+The search_servers feature will be implemented with a modular, layered design to keep it decoupled and testable. The core idea is to embed a static registry-of-registries (a list of known MCP registries and how to query them) into the proxy, and to provide logic that:
+	1.	Loads Registry Metadata: At startup, MCPProxy loads a compiled-in JSON (or Go data) structure containing all known registries and their metadata. This registry list is similar to Mastra’s registryData object ￼ ￼, but defined in Go and embedded via the embed package (see Embedded Config below).
+	2.	User Invocation: The user or AI agent invokes search_servers (via CLI command or MCP tool call). Input parameters include:
+	•	registryId or name to specify which registry to query (required for network search).
+	•	Optional search term (string) to filter server results by name/description.
+	•	Optional tag to filter server results by tag/category (if applicable).
+	3.	Registry Lookup: The search_servers handler looks up the registry entry in the loaded metadata by the given ID/name. This yields a RegistryEntry struct containing fields like the registry’s name, base URL, servers_url (endpoint for servers listing), supported protocol, and possibly a pointer to a custom parser function if needed (analogous to Mastra’s postProcessServers ￼).
+	4.	Dispatch to Fetcher: Based on the registry’s metadata, the system decides how to fetch and interpret the server list:
+	•	If the registry entry specifies a protocol type (e.g. "modelcontextprotocol/registry", or "custom/apify", etc.), a corresponding fetcher/processor will be used. Each known protocol or format is handled by a small module or function. For example:
+	•	A registry with protocol: "modelcontextprotocol/registry" uses a generic OpenAPI fetcher that calls the registry’s /v0/servers endpoint and expects a JSON response containing a list of servers.
+	•	A registry with custom format like Apify or Docker uses a specialized parser (similar to Mastra’s processApifyServers, processDockerServers, etc. ￼ ￼). These parse the specific JSON or HTML formats of those sources.
+	•	If a registry entry has a dedicated post-processing function in the metadata, we invoke it to transform the raw fetched data into our standard ServerEntry list. (This mirrors Mastra’s logic: fetch JSON from servers_url, then if postProcessServers is defined, use it ￼.)
+	•	If no special protocol or parser is specified (and the data format is assumed to already match our ServerEntry schema), a default handler will be used. The default will attempt to parse the fetched JSON in a standard way. For example, if the response JSON has a top-level "servers" array (as in the MCP Registry OpenAPI), the default handler will extract that. If the response is directly an array of server objects, it will parse it directly into []ServerEntry. This ensures that even registries without custom logic can be integrated as long as they return a reasonable JSON format (or can be extended in the future).
+	5.	Fetching Data: The appropriate fetcher then makes an HTTP GET request to the registry’s servers_url. For instance, if querying the “Pulse MCP” registry, it will GET https://api.pulsemcp.com/v0beta/servers ￼. The design uses Go’s built-in net/http (with context and timeouts) to retrieve the data. Note: All registry endpoints in the embedded list are assumed to be public and require no auth (if some do, we might extend the metadata with auth info, but out of scope for now).
+	6.	Parse & Normalize: The raw response is parsed into a list of ServerEntry objects. Each ServerEntry represents one MCP server with fields like id, name, description, and possibly updatedAt/createdAt. Crucially, we also include a field for the server’s connection URL or address (populated by the fetcher if available, or constructed if needed). The custom processors will ensure this structure is populated:
+	•	OpenAPI/Registry Example: The JSON from an OpenAPI-based registry likely includes id, name, description, etc., but may not directly provide the server’s URL. In such cases, our fetcher can perform an additional step: for each server entry, call the registry’s server detail endpoint (e.g. /v0/servers/{id}) to retrieve its base_url or connection info, if available. This extra call happens within the search_servers execution, so the user still experiences a single operation. (If the registry returns the base URL in the listing or uses the id as a URL, we can skip this step. The system is designed to accommodate either scenario.)
+	•	Custom Parsers: For sources like Apify or Docker Hub that list tools, the parser might construct an MCP endpoint URL from known patterns or metadata. For example, if Docker MCP Catalog lists image names, the parser might translate those to a hosted endpoint URL template. Each custom parser will output standardized ServerEntry objects.
+	7.	Filter Results: Once the full list of servers is obtained, the system filters them based on the user’s query parameters:
+	•	Search Term: If search was provided, filter out any servers whose name and description do not contain the term (case-insensitive) ￼.
+	•	Tag: If tag was provided, and if our ServerEntry or extended metadata includes tags or categories for servers, filter by those. (In many cases, server entries might not have tags; in such cases this filter yields either unfiltered or empty if expecting a tag that isn’t present.)
+	•	Result Count: The filtered list (or full list if no filters) is the final result. We may also include a count of servers in the output for user information.
+	8.	Output Construction: The output is formatted as a JSON array of server entries (as shown in the example above). This JSON is printed to STDOUT for CLI, and also returned as the content of the MCP tool response if search_servers is invoked via the MCP protocol. We ensure that each entry includes the url (connection endpoint) along with human-readable name/description. This satisfies the requirement that a user/agent can directly use the output to add a server without further queries.
+	9.	Integration with Upstream Add: There is no direct invocation of upstream_servers add within search_servers (we keep tools decoupled), but by design the user can seamlessly chain the two. For instance, if only one server is returned by search, the CLI might display a message like “Found 1 server. Run mcpproxy upstream_servers add --url <URL> to add it.” (The MCP tool response could likewise include an advisory.) In an AI agent scenario, the agent could parse the JSON and then call the add tool with the provided URL programmatically.
+
+Below is a high-level flowchart of the process:
+
+User/Agent -> [search_servers Tool] -> (Load embedded registry list)
+    -> Find registry by ID
+    -> Fetch servers (HTTP GET to registry.servers_url)
+    -> Parse JSON (use custom or default handler)
+    -> Filter results (search term, tag)
+    -> Return list of ServerEntry (with connection URLs)
+User/Agent -> [upstream_servers add Tool] -> Add chosen server to upstreams
+
+Each step is designed to be testable in isolation: e.g., the fetch logic can be unit-tested with mocked HTTP responses for a given registry, and filtering logic can be tested with synthetic data (as is done in Mastra ￼ ￼).
+
+📦 Module Layout in Go
+
+To implement this cleanly, we introduce a new internal package and extend a few existing components:
+	•	internal/registries (new package): Encapsulates registry metadata and search logic.
+	•	registry_data.go: Contains the embedded registry list (JSON data) and code to load/unmarshal it into Go structs at startup.
+	•	types.go: Defines data structures:
+	•	RegistryEntry – representing a registry (fields: ID, Name, Description, URL, optional ServersURL, optional Tags[], optional Count, and possibly Protocol or Type to indicate how to fetch). This maps to entries in the static list (e.g. id: “mcprun”, servers_url: “…/api/servlets”, tags: [“verified”] ￼, etc.).
+	•	ServerEntry – representing an MCP server discovered via a registry (fields: ID, Name, Description, UpdatedAt, etc., plus a URL field for the server’s endpoint). This aligns with the MCP Registry schema (ID, name, description, timestamps) ￼, extended with our url for convenience.
+	•	fetch.go (or part of search.go): Implements functions to fetch and parse servers from a registry. For example:
+	•	FetchServers(reg RegistryEntry) ([]ServerEntry, error) – core logic that dispatches to the correct handler based on reg.Protocol or known reg.ID.
+	•	Internally, this may call specific parsing functions or methods in sub-packages or closures (e.g., fetchOpenAPIRegistryServers(reg), fetchMcpRunServers(reg), etc.) similar to Mastra’s processor modules ￼ ￼ but in Go. These can live in internal/registries or a subdirectory (registries/processors) for clarity.
+	•	search.go: Implements the high-level search operation:
+	•	SearchServers(registryID string, tag string, query string) ([]ServerEntry, error) – orchestrates the steps: find registry by ID, call FetchServers, apply filtering on the result list, and return the filtered list. This function is the main entry point used by the CLI command or MCP tool handler.
+	•	Filtering subroutines can be included here (e.g., filterServers(list, tag, query)), or simply done inline since it’s straightforward (loop and match substrings/tag).
+	•	Testing: internal/registries/search_test.go etc., to unit test filtering and perhaps use stub HTTP servers to simulate registry responses. (We can inject a custom HTTP client or use Go’s http.TestServer to feed known JSON and verify parsing.)
+	•	cmd/mcpproxy (CLI integration):
+	•	If mcpproxy uses a CLI library (like Cobra), we add a new subcommand search-servers (or search_servers) in cmd/mcpproxy/main.go or a sub-file (e.g., cmd/mcpproxy/search.go). This sets up flags --registry, --search, --tag and when invoked, calls internal/registries.SearchServers with the provided flags, then prints the results.
+	•	The CLI output will pretty-print the JSON array. Alternatively, for a friendlier CLI, it could format results in a table (with columns Name, Description, URL), but JSON is straightforward and also what the MCP tool interface will use. We can start with JSON output to align with how other tools may output raw data (Mastra’s registryServers tool returns JSON as text content ￼).
+	•	Example integration in main.go: after setting up other commands, something like:
+
+proxy.RegisterTool(searchservers.Tool()) 
+// if the proxy exposes tools to MCP clients
+
+and for CLI, adding:
+
+app.Command("search-servers", "Search for MCP servers in known registries",
+    func(cmd *Command) {
+       // parse flags and call internal/registries.SearchServers
+    })
+
+(Pseudo-code, actual implementation depends on the CLI framework in use.)
+
+	•	MCP Tool Interface:
+	•	MCPProxy likely has a mechanism to expose certain functions as MCP “tools” to connected clients (so that an AI agent can call them). We will register search_servers as a new tool in the proxy’s tool registry, similar to how upstream_servers and others are registered. For example, if there’s a struct of built-in tools, we add:
+
+{
+  Name: "search_servers",
+  Description: "Discover MCP servers from known registries. Filter by registry, tag, or name.",
+  Inputs: schema defining `registryId`, `tag`, `search` (all strings),
+  Handler: function(ctx, inputs) -> executes SearchServers and returns results (as JSON text content or structured).
+}
+
+This parallels Mastra’s tool definitions ￼ ￼ but in Go. The output content will be a JSON string or object representing the servers list. By embedding the search_servers logic into the running proxy, AI agents connected to MCPProxy can invoke it just like any other tool to find new capabilities on the fly.
+
+	•	internal/upstream (upstream server management):
+	•	The existing upstream management (responsible for upstream_servers add/remove) likely resides here. We do not need to heavily modify this for search_servers, but we ensure the add path can accept the output from search. Typically, upstream_servers add might accept a URL and optional name. Our search output provides those. If needed, we could enhance add to accept a JSON blob or structured input directly, but that’s not necessary – the user/agent can pass the URL and name as separate arguments.
+	•	One potential extension: allow add to reference a registry entry directly (like --registry X --id Y), upon which the proxy could internally look up the details (similar to how search_servers does) and then add. However, this adds complexity and overlaps with search_servers, so we opt not to implement that now. Instead, the separation of concerns remains: search_servers finds and returns info; upstream_servers add simply takes the info and adds the server.
+
+This module layout ensures low coupling: the registry search logic is self-contained and interacts with the rest of the system through well-defined interfaces (function calls for CLI or tool registration). Other parts of the proxy (like indexing or OAuth) remain unaffected. We also make it easy to extend: adding a new known registry later means updating the JSON and possibly adding a parser function in internal/registries without touching unrelated code.
+
+🔐 Embedded Registries Config Layout
+
+We will embed a static configuration file (e.g. registries.json) into the Go binary using Go’s embed package (Go 1.16+). This approach ensures the registry metadata is versioned with the binary and doesn’t rely on external files at runtime ￼. It’s the recommended practice for bundling read-only data like presets or seeds in Go.
+
+File: internal/registries/registries.json (to be embedded). This JSON will contain an array of registry definitions, for example:
+
+{
+  "registries": [
+    {
+      "id": "mcprun",
+      "name": "MCP Run",
+      "description": "One platform for vertical AI across your organization.",
+      "url": "https://www.mcp.run/",
+      "servers_url": "https://www.mcp.run/api/servlets",
+      "tags": ["verified"],
+      "protocol": "custom/mcprun"
+    },
+    {
+      "id": "pulse",
+      "name": "Pulse MCP",
+      "description": "Browse and discover MCP use cases, servers, clients, and news.",
+      "url": "https://www.pulsemcp.com/",
+      "servers_url": "https://api.pulsemcp.com/v0beta/servers",
+      "tags": ["verified"],
+      "protocol": "custom/pulse"
+    },
+    {
+      "id": "smithery",
+      "name": "Smithery",
+      "description": "Extend your agent with 4,274 capabilities via MCP servers.",
+      "url": "https://smithery.ai/",
+      "servers_url": "https://registry.smithery.ai/servers",
+      "tags": ["verified"],
+      "protocol": "modelcontextprotocol/registry"
+    },
+    {
+      "id": "modelcontextprotocol-official",
+      "name": "Model Context Protocol Registry",
+      "description": "Official community-driven registry of MCP servers.",
+      "url": "http://localhost:8080", 
+      "servers_url": "http://localhost:8080/v0/servers",
+      "tags": ["official"],
+      "protocol": "modelcontextprotocol/registry"
+    }
+    // ... (other entries)
+  ]
+}
+
+This is an illustrative snippet. In practice, we will include all relevant registries (Mastra’s list contains ~17 entries ￼ ￼, which we can adapt). Each entry has:
+	•	id: a unique key (short string) for the registry.
+	•	name: human-friendly name.
+	•	description: brief info.
+	•	url: homepage or base URL.
+	•	servers_url: endpoint to fetch the list of servers (if available).
+	•	tags: categories/labels (e.g. “verified”, “open-source”, “official”).
+	•	protocol/type: (added by us) indicating how to handle this registry’s data. For example, "modelcontextprotocol/registry" for any registry conforming to the MCP Registry API (OpenAPI) ￼; "custom/..." or omitted for those requiring a custom parse.
+
+Loading the Data: In registry_data.go, we will use //go:embed to embed this JSON file as a string or bytes. On initialization, we parse the JSON into a struct like RegistryFile { Registries []RegistryEntry }. We will validate the structure (e.g., ensuring required fields like id, name, url are present) similar to Mastra’s schema validation with Zod ￼ (in Go we can simply rely on JSON parsing and maybe post-validate key fields). If parsing fails, the proxy can log a critical error and fall back to an empty list (though a compile-time known JSON should not fail).
+
+Embedding ensures the data is read-only and secure (cannot be tampered by user except via new binary). If updates are needed (e.g., new registries), releasing a new version of MCPProxy with an updated JSON is expected. This approach also avoids any startup latency or failure from fetching registry info from an external source; everything needed for discovery is baked in.
+
+Registry Entry Config Examples: We base these largely on known sources:
+	•	MCP Run: has a JSON API of servlets, requiring a custom parser (marked custom/mcprun).
+	•	Pulse MCP: has a /v0beta/servers endpoint returning a list of servers (likely needs custom parser for its specific schema, hence custom/pulse).
+	•	Smithery: likely implements the standard MCP Registry API (note the /servers endpoint and the large count ~4274 ￼). We tag it as modelcontextprotocol/registry to use the generic OpenAPI fetching logic.
+	•	Official MCP Registry: (if one is running, e.g., the open-source project on localhost:8080 as per dev) – also uses modelcontextprotocol/registry.
+	•	Others (Apify, Docker, etc.) can be included with protocol: custom/... if we plan to support them via specialized parsers (e.g., Apify’s API format).
+
+Having the protocol field explicitly in the JSON makes the dispatch logic straightforward and data-driven, rather than hard-coding based on the registry ID. It’s easy to extend: a new protocol type would correspond to writing a new handler function and marking relevant entries with that type.
+
+📥 API and CLI Extensions
+
+CLI Extension: We introduce a new top-level CLI command search-servers (or subcommand under a grouping, depending on CLI design). The usage is as described: mcpproxy search-servers --registry <id> [--search <term>] [--tag <tag>]. This command’s implementation will:
+	•	Parse flags and validate input (require --registry unless perhaps --list-registries is used).
+	•	Call internal/registries.SearchServers(reg, tag, term).
+	•	If results are returned, format them as JSON and print to console. If no results, output a friendly message, e.g., “No servers found for registry X and query Y.”
+	•	If the user requested to list registries (e.g., a --list-registries flag or using the command without a registry), we will output the embedded registries list (perhaps in summary form: ID, Name, Description, Tags), to help the user decide which to search. This uses the same embedded data (internal/registries can provide a function for listing registries, filtered or not, similar to Mastra’s registryList ￼).
+
+MCP Tool Interface: On the protocol level, MCPProxy acts as an MCP server to clients (like IDEs or AI agents). We will expose search_servers as a tool in the MCP protocol sense, so that an agent can do something like call_tool("search_servers", {"registry": "mcprun", "search": "weather"}). Under the hood, this triggers our SearchServers function, and the results are returned in the MCP response JSON. The tool schema will be defined (likely using the MCP Go library to register tools). For example:
+
+tool := mcp.Tool{
+    Name: "search_servers",
+    Description: "Search known MCP registries for servers. Filter by registry ID (exact), and optionally by tag or name.",
+    InputSchema: map[string]*mcp.Schema{
+        "registry": {Type: mcp.String, Description: "Exact registry ID or name to search in"},
+        "search":   {Type: mcp.String, Description: "Search term for server name/description (optional)"},
+        "tag":      {Type: mcp.String, Description: "Filter by server tag (optional)"},
+    },
+    OutputSchema: ... // e.g. array of ServerEntry objects (with fields id, name, description, url, etc.)
+    Handler: func(ctx context.Context, input map[string]interface{}) (interface{}, error) {
+        reg := input["registry"].(string)
+        term := input["search"].(string)
+        tag := input["tag"].(string)
+        servers, err := registries.SearchServers(reg, tag, term)
+        if err != nil { return nil, err }
+        return servers, nil  // the MCP framework will encode this as JSON in response
+    },
+}
+proxy.RegisterTool(tool)
+
+(Above is conceptual; actual integration depends on the mcp-go library’s patterns.)
+
+By doing this, any AI agent connected to MCPProxy can invoke search_servers as a tool, get the list of new servers, and then invoke upstream_servers add likewise to add one. This is extremely powerful: it enables self-service discovery of new tools by the agent. For instance, an agent could decide it needs a particular capability, use search_servers to find an appropriate MCP server providing it, then add it to the proxy, and finally use that new server’s tools – all autonomously.
+
+HTTP API (if any): MCPProxy primarily focuses on the MCP protocol and CLI, not a REST API. We won’t create a separate HTTP endpoint for searching, since the MCP tool interface covers programmatic access. (The proxy’s HTTP endpoints are usually for the unified MCP endpoint /mcp/ and OAuth callbacks, not for management operations.) The CLI and MCP tool suffice for users and agents respectively.
+
+Configuration: No new user configuration is required for this feature, since the registry list is baked in. We may add a toggle in config (e.g., to disable network access for search_servers if needed for offline mode), but by default it will be enabled. The search will respect any relevant global settings like timeouts (we might use a reasonable default timeout for the HTTP fetch, e.g. 5 seconds, to avoid hanging if a registry is down).
+
+Security Considerations: All search_servers operations are read-only and target public endpoints. Still, the proxy should guard against potential issues:
+	•	If any registry servers_url is HTTP (not HTTPS), we should consider marking it insecure or possibly disallow by default (could be overridden if needed). In the example above, mcpstore.co uses HTTP ￼; perhaps we avoid such cases or handle carefully.
+	•	The JSON parsing should be done with proper error handling to avoid panics. Malformed or unexpected data should result in a clean error message to the user.
+	•	We might implement rate-limiting or caching if a user calls search_servers very frequently, to avoid spamming registry endpoints. A simple caching strategy could be to remember results for a short period (e.g., one minute) for the same registry query, since these listings don’t change frequently. However, initially, a fresh fetch each time is acceptable.
+
+🔁 Chaining search_servers → upstream_servers add
+
+One of the primary use-cases of search_servers is to streamline adding new upstream servers to MCPProxy. The design ensures that this chaining is as smooth as possible:
+	1.	Seamless Data Handover: The output of search_servers provides all necessary info to add a server. In practice, the upstream_servers add tool typically needs a server identifier (likely a URL or address, and perhaps a name). Our ServerEntry.url fulfills the address requirement, and ServerEntry.name can serve as a default friendly name. For example, if search_servers returns an entry:
+
+{ "id": "weather", "name": "WeatherInfo", "url": "https://weather.mcp.run/mcp/" }
+
+a user could do:
+
+mcpproxy upstream_servers add --name "WeatherInfo" --url "https://weather.mcp.run/mcp/"
+
+If the CLI for add doesn’t require --name (it might derive from URL or allow omission), the user could just provide the URL. The key is that the URL is on hand from the search result.
+
+	2.	Direct Invocation in MCP context: If an AI agent is orchestrating this, it would call the search_servers tool via MCP, parse the JSON result it gets, then programmatically call upstream_servers add with the included URL. No further lookup or human input is needed. The agent doesn’t need to call any external API or have prior knowledge of the server’s address – it’s all provided by the proxy’s search. This meets the goal of “without additional calls” (beyond the two tool calls themselves).
+	3.	Internal Chaining (Future Enhancement): While not required now, the architecture allows an interesting future feature: the search_servers tool could be extended to accept a flag like --auto-add or even a query like “search and add the first result”. This would combine the search and add steps internally. We mention this as a possibility, but our current design keeps them separate for clarity and user control (especially since search can return multiple servers, and choosing which to add is a decision we leave to the user/agent).
+	4.	Example Scenario: Suppose an agent wants to translate text to Morse code but none of the current upstreams have that capability. The agent can:
+	•	Call search_servers with search="Morse", possibly across all registries or a specific one known to host community tools.
+	•	The proxy returns a server entry “MorseCoder” with URL wss://morse.api.example/mcp (maybe a WebSocket MCP server).
+	•	The agent then calls upstream_servers add with that URL (and a name). The proxy adds it and immediately indexes its tools (the proxy’s indexer will detect a new upstream and pull its tool list).
+	•	Now the agent sees a new tool “Translate to Morse” available via the unified proxy, and can invoke it as if it was always there.
+	•	Total calls by agent: 1 to search, 1 to add – no manual steps or external web queries needed.
+	5.	Upstream Indexing: When a new server is added via upstream_servers add, MCPProxy’s indexing mechanism will kick in (likely re-indexing tools from all upstreams). This means any tools on the newly added server become searchable by the proxy’s normal tool search. The design doesn’t need changes here, but it’s worth noting: after chaining search→add, there’s automatically a refresh of available tools. (The design doc for MCPProxy indicates a “full rebuild [of the index] at startup and whenever an enabled upstream is added”, so this fits perfectly.)
+	6.	Testing the Chain: We will test the end-to-end flow in a development environment:
+	•	Use a known registry (perhaps set up a test MCP Registry on localhost with a dummy server entry) to run search_servers.
+	•	Immediately run the upstream_servers add with the output URL.
+	•	Verify that the new upstream appears in upstream_servers list and that its tools are invocable.
+	•	Automate this in an integration test if possible (maybe flag it as requiring internet if using a real registry). Mastra’s integration tests provide a guide, as they actually performed live fetches from registries ￼. We can emulate a similar approach for a couple of registries to ensure our parsing and chain flow work correctly.
+
+By carefully designing the output of search_servers and leveraging MCPProxy’s existing upstream add logic, we achieve a smooth user experience: discover a server and plug it in immediately. This encourages exploration of the growing MCP ecosystem with minimal friction, directly from within MCPProxy.
+
+⸻
+
+Note: The addition of search_servers does not disrupt any existing functionality; it’s an additive feature. Users who don’t need it can ignore it, but those who do can now readily expand their toolset. This aligns with MCPProxy’s mission of “smart tool discovery and proxying for MCP servers” ￼ by making the discovery part first-class. With this design in place, MCPProxy becomes not just a proxy for known servers but a gateway to finding new ones.
+
+⸻
+
+Sources:
+	•	Mastra MCP Registry Registry – tool behaviors and data structures ￼ ￼ ￼
+	•	Model Context Protocol Registry (OpenAPI) – provides standard /v0/servers for listing MCP servers ￼
+	•	MCPProxy Design Reference – context on upstream management and indexing ￼
+
+Implementation Prompt (for use with an LLM to generate code):
+
+You are contributing to the `mcpproxy-go` project. Implement the `search_servers` feature as designed above. The goal is to add a new tool/command that allows discovery of MCP servers from a static list of registries, and to output results that can be directly used to add an upstream server.
+
+Follow these steps and file modifications:
+
+1. **Create Data Structures and Embed Registry List:**
+   - **File:** `internal/registries/types.go`  
+     Define the types for registry entries and server entries. For example:  
+     ```go
+     package registries
+     type RegistryEntry struct {
+         ID          string   `json:"id"`
+         Name        string   `json:"name"`
+         Description string   `json:"description"`
+         URL         string   `json:"url"`
+         ServersURL  string   `json:"servers_url,omitempty"`
+         Tags        []string `json:"tags,omitempty"`
+         Protocol    string   `json:"protocol,omitempty"`
+         Count       interface{} `json:"count,omitempty"` // number or string
+     }
+     type ServerEntry struct {
+         ID          string `json:"id"`
+         Name        string `json:"name"`
+         Description string `json:"description"`
+         URL         string `json:"url"`         // MCP endpoint for direct connection
+         UpdatedAt   string `json:"updatedAt,omitempty"`
+         CreatedAt   string `json:"createdAt,omitempty"`
+         // (Add other fields if needed, but these are sufficient)
+     }
+     ```
+     These structs map to the JSON structure of registries and servers.
+
+   - **File:** `internal/registries/registry_data.go`  
+     Use the Go `embed` package to include a JSON file with registry metadata. For example:  
+     ```go
+     package registries
+     import _ "embed"
+     //go:embed registries.json
+     var registryDataJSON []byte
+     var registryList []RegistryEntry
+     func init() {
+         // Unmarshal registryDataJSON into registryList ([]RegistryEntry)
+         err := json.Unmarshal(registryDataJSON, &registryStruct)
+         if err != nil {
+             log.Fatalf("Failed to load embedded registries: %v", err)
+         }
+         registryList = registryStruct.Registries
+     }
+     ```  
+     Assume `registries.json` has a top-level object with `registries: [...]`. You might need a small helper struct, e.g. `registryStruct := struct{ Registries []RegistryEntry }{}` for unmarshaling. After init, `registryList` holds all known registries.  
+     *Note:* Include necessary imports (`encoding/json`, `log`, etc.). Ensure this runs at startup so the data is ready.
+
+   - **File:** `internal/registries/registries.json`  
+     Create this JSON file containing the registry entries as designed (you can seed it with a subset for now, e.g., mcprun, pulse, smithery, etc., as examples). Ensure the JSON keys match the `RegistryEntry` struct tags. For example:
+     ```json
+     {
+       "registries": [
+         {
+           "id": "mcprun",
+           "name": "MCP Run",
+           "description": "...",
+           "url": "https://www.mcp.run/",
+           "servers_url": "https://www.mcp.run/api/servlets",
+           "tags": ["verified"],
+           "protocol": "custom/mcprun"
+         },
+         {
+           "id": "smithery",
+           "name": "Smithery",
+           "description": "...",
+           "url": "https://smithery.ai/",
+           "servers_url": "https://registry.smithery.ai/servers",
+           "tags": ["verified"],
+           "protocol": "modelcontextprotocol/registry"
+         }
+       ]
+     }
+     ```  
+     (Fill in real descriptions and additional entries as needed.)
+
+2. **Implement Fetching Logic:**
+   - **File:** `internal/registries/search.go` (new file)  
+     Implement the core logic for searching a registry and retrieving servers. Steps:
+     ```go
+     package registries
+     import (
+         "encoding/json"
+         "fmt"
+         "net/http"
+         "time"
+         "strings"
+     )
+     // SearchServers searches the given registry for servers matching optional tag and query.
+     func SearchServers(registryID string, tag string, query string) ([]ServerEntry, error) {
+         // 1. Find registry by ID (or name) in registryList
+         var reg *RegistryEntry
+         for i, r := range registryList {
+             if strings.EqualFold(r.ID, registryID) || strings.EqualFold(r.Name, registryID) {
+                 reg = &registryList[i]
+                 break
+             }
+         }
+         if reg == nil {
+             return nil, fmt.Errorf("registry '%s' not found", registryID)
+         }
+         if reg.ServersURL == "" {
+             return nil, fmt.Errorf("registry '%s' has no servers endpoint", reg.Name)
+         }
+         // 2. Fetch servers from reg.ServersURL
+         client := http.Client{ Timeout: 10 * time.Second }
+         resp, err := client.Get(reg.ServersURL)
+         if err != nil {
+             return nil, fmt.Errorf("failed to fetch servers from %s: %w", reg.ServersURL, err)
+         }
+         defer resp.Body.Close()
+         if resp.StatusCode != 200 {
+             return nil, fmt.Errorf("registry query returned %d: %s", resp.StatusCode, resp.Status)
+         }
+         // 3. Parse response JSON
+         var rawData interface{}
+         if err := json.NewDecoder(resp.Body).Decode(&rawData); err != nil {
+             return nil, fmt.Errorf("invalid JSON from registry: %w", err)
+         }
+         // 4. Process based on protocol or content
+         var servers []ServerEntry
+         switch reg.Protocol {
+         case "modelcontextprotocol/registry":
+             // Expect an object with "servers" field (list of server entries)
+             m, ok := rawData.(map[string]interface{})
+             if ok && m["servers"] != nil {
+                 // Marshal "servers" subfield to JSON and then unmarshal to []ServerEntry
+                 data, _ := json.Marshal(m["servers"])
+                 json.Unmarshal(data, &servers)
+             } else if ok && m["data"] != nil {
+                 // (If the API returns paginated data in "data" key, handle similarly)
+                 data, _ := json.Marshal(m["data"])
+                 json.Unmarshal(data, &servers)
+             } else if arr, ok := rawData.([]interface{}); ok {
+                 // If the response is directly an array
+                 data, _ := json.Marshal(arr)
+                 json.Unmarshal(data, &servers)
+             }
+             // For each server, ensure required fields and possibly set URL if provided by API (if the registry API included a field for endpoint)
+             // (If needed, a secondary fetch for details could be implemented here.)
+         case "custom/mcprun":
+             // Example: the MCP Run API returns a certain JSON structure. Implement a custom parse.
+             // e.g., perhaps resp JSON has {"servlets": [ {...}, {...} ]}. We would extract those into servers.
+             // For demonstration, assume structure similar to OpenAPI:
+             m, ok := rawData.(map[string]interface{})
+             if ok && m["servlets"] != nil {
+                 data, _ := json.Marshal(m["servlets"])
+                 json.Unmarshal(data, &servers)
+             }
+             // Then, if needed, construct the server URLs. (If MCP Run's API returns enough info, fill servers accordingly.)
+         case "custom/pulse":
+             // Parse Pulse MCP format (assuming similar to modelcontextprotocol but maybe under different fields or requiring transform).
+             m, ok := rawData.(map[string]interface{})
+             if ok && m["servers"] != nil {
+                 data, _ := json.Marshal(m["servers"])
+                 json.Unmarshal(data, &servers)
+             }
+             // Possibly Pulse returns additional metadata, but for simplicity we'll treat similarly.
+         default:
+             // Default handling: try to unmarshal rawData directly into []ServerEntry
+             data, _ := json.Marshal(rawData)
+             json.Unmarshal(data, &servers)
+         }
+         // 5. Filter by search term and tag
+         filtered := make([]ServerEntry, 0, len(servers))
+         for _, srv := range servers {
+             if query != "" {
+                 q := strings.ToLower(query)
+                 if !strings.Contains(strings.ToLower(srv.Name), q) && !strings.Contains(strings.ToLower(srv.Description), q) {
+                     continue
+                 }
+             }
+             if tag != "" {
+                 // If we had tags per server, check here. (No tags in ServerEntry by default, so this might always pass.)
+                 // This part can be expanded if server entries have a 'tags' field in some protocols.
+             }
+             // If the server entry lacks a URL (endpoint), try to infer or append if possible:
+             if srv.URL == "" {
+                 // For known protocols, we might derive the URL.
+                 // For example, if the registry provides a base URL or the server ID is a URL slug.
+                 // We could also add an optional field in RegistryEntry like BaseURLPrefix to combine with server ID.
+                 // For now, leave URL empty if unknown.
+             }
+             filtered = append(filtered, srv)
+         }
+         return filtered, nil
+     }
+     ```
+     **Important:** The above code should be refined based on actual data formats. Ensure that `ServerEntry.URL` is populated when possible:
+       - If the registry returns a direct URL field for each server, map it.
+       - If not, consider adding logic to fetch details: e.g., if `reg.Protocol == "modelcontextprotocol/registry"`, you might loop through each `ServerEntry` (with ID) and call `GET /v0/servers/{id}` on the registry. Parse the `base_url` from that and set `ServerEntry.URL`. This additional step can be added if needed to fully realize the “direct add” goal.
+     Also, handle `CreatedAt`/`UpdatedAt` if present in JSON (they will parse into the struct automatically if names match and types are string).
+
+   - **File:** `internal/registries/search_test.go`  
+     Write tests for `SearchServers`:
+     - Test that an unknown registry returns an error.
+     - Test that a known registry with no servers_url returns an error.
+     - **Optional:** simulate a registry response. For example, create a dummy HTTP server (using `httptest.NewServer`) that returns a known JSON, then temporarily override a RegistryEntry’s `ServersURL` to point to this dummy server’s URL. Then call `SearchServers` and verify the returned `ServerEntry` list matches expected data (filtered correctly).  
+     - Test the filtering logic: e.g., create a small list of `ServerEntry` in code and run the filter portion to ensure search term matching works (similar to Mastra’s test where they verify the search term is contained in results [oai_citation:36‡file-kdtztsq9jqu7kdcvvehwbr](file://file-KDtZtsQ9jqu7KDCvvEHWBr#:~:text=%2F%2F%20Search%20for%20that%20word,search%3A%20searchWord)).
+
+3. **Integrate with CLI:**
+   - **File:** `cmd/mcpproxy/main.go` (or a new command file if the project structure uses separate files for commands)  
+     Register the new CLI command. If using Cobra or similar, add something like:
+     ```go
+     var registryFlag, searchFlag, tagFlag string
+     cmd := &cobra.Command{
+         Use:   "search-servers",
+         Short: "Search MCP registries for available servers",
+         RunE: func(cmd *cobra.Command, args []string) error {
+             if registryFlag == "" {
+                 return fmt.Errorf("--registry is required (use `mcpproxy search-servers --list-registries` to see options)")
+             }
+             results, err := registries.SearchServers(registryFlag, tagFlag, searchFlag)
+             if err != nil {
+                 return err
+             }
+             // Print results as JSON
+             output, _ := json.MarshalIndent(results, "", "  ")
+             fmt.Println(string(output))
+             return nil
+         },
+     }
+     cmd.Flags().StringVarP(&registryFlag, "registry", "r", "", "Registry ID or name to search (exact match)")
+     cmd.Flags().StringVarP(&searchFlag,   "search", "s", "", "Search term for server name/description")
+     cmd.Flags().StringVarP(&tagFlag,      "tag",    "t", "", "Filter servers by tag/category")
+     // Perhaps a --list-registries flag:
+     cmd.Flags().Bool("list-registries", false, "List all known registries")
+     // (If --list-registries is set, ignore other flags and just print the registry list from internal/registries)
+     rootCmd.AddCommand(cmd)
+     ```
+     Adjust to the actual CLI framework in use. For example, if not using Cobra, handle flags parsing accordingly.
+     - Implement the `--list-registries` functionality: if that flag is true, output the `registryList` (from `registry_data.go`) in a readable format (could be JSON or a table with ID and Name). This helps users discover registry IDs.
+     - Ensure the command is hooked into the main application (added to the root command or executed in main).
+
+   - **File:** `internal/upstream/manager.go` (if needed, for any adjustments in adding logic)  
+     Likely no changes here. But confirm how `upstream_servers add` works. If it expects a raw URL, we are fine. If it requires some identification, ensure providing the URL suffices. Possibly test adding a known MCP server URL via CLI to verify the flow.
+
+4. **Register as MCP Tool:**
+   - **File:** `internal/proxy/tools.go` or wherever tools are registered for MCP (the proxy might have a method like `proxy.RegisterTool(...)`).  
+     Create a Tool definition for `search_servers`:
+     ```go
+     proxy.RegisterTool(&mcp.Tool{
+         Name: "search_servers",
+         Description: "Discover MCP servers from known registries. Use registry ID to filter.",
+         InputSchema: mcp.JSONSchema{ /* define fields "registry", "search", "tag" as strings */ },
+         OutputSchema: mcp.JSONSchema{ /* could be type array of ServerEntry schema */ },
+         Handler: func(params map[string]interface{}) (interface{}, error) {
+             reg := params["registry"].(string)
+             query := ""
+             tag := ""
+             if v, ok := params["search"]; ok { query = v.(string) }
+             if v, ok := params["tag"]; ok { tag = v.(string) }
+             return registries.SearchServers(reg, tag, query)
+         },
+     })
+     ```
+     The exact types and schema integration will depend on the `mcp-go` library. Essentially, when this tool is invoked, we parse inputs, call `SearchServers`, and return the slice of `ServerEntry` as the result. The MCP framework will handle serializing it to JSON. (Make sure the `ServerEntry` fields are all serializable; since they are basic strings, that’s fine.)
+
+5. **Update Documentation (if any):**
+   - **File:** `docs/setup.md` or `README.md`  
+     Add usage info for the new feature. For instance, under a “Managing Upstreams” section, describe how to use `mcpproxy search-servers` to find servers and then `mcpproxy upstream_servers add` to add them.
+
+6. **Test Integration Manually:**
+   - Run `mcpproxy search-servers --list-registries` to see that embedded registries load correctly.
+   - Pick a registry (like one with a known reachable endpoint) and run `mcpproxy search-servers -r <id>` with and without search terms. Confirm that results (or errors) make sense.
+   - Try the full chain: `search-servers` to find something, then `upstream_servers add` to add it, then verify the new server’s tools appear via `mcpproxy` (for example, in the UI or via `retrieve_tools` if such a command exists).
+   - If possible, test with the official MCP Registry service by running it locally or using a known instance, to ensure our `modelcontextprotocol/registry` handler works (it should list some servers).
+
+**Implementation Hints:**
+- Pay attention to error handling and messaging – it should guide the user if they misuse the command (like forgetting `--registry`).
+- Keep network operations efficient: consider reusing HTTP connections (the default Client is fine for now, since we do one request per search).
+- Make sure to not introduce global state beyond the loaded registry list; `SearchServers` should be thread-safe (our usage of a package-level slice is okay if read-only after init).
+- Use logs for debugging if needed, but avoid spamming output on normal execution (unless `-v` verbose is enabled).
+- Aim for clean, idiomatic Go code with proper naming (e.g., use `registryID` not just `id` for clarity in contexts, etc.). Add comments for any non-obvious logic like custom parsing.
+
+Once implemented, this feature will allow dynamic expansion of MCPProxy’s capabilities by tapping into the ecosystem of MCP servers. Ensure all unit tests and existing tests pass, and add new tests for this feature as described.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -34,7 +34,7 @@ go install github.com/smart-mcp-proxy/mcpproxy-go/cmd/mcpproxy@latest
 
 **From Terminal:**
 ```bash
-mcpproxy
+mcpproxy serve
 ```
 
 **macOS (DMG Install):** Use Launchpad or Spotlight search to find and launch MCPProxy.
@@ -61,7 +61,7 @@ netstat -an | findstr 8080
 
 **Change Default Port:**
 ```bash
-mcpproxy --listen :8081
+mcpproxy serve --listen :8081
 # or set in config file
 ```
 
@@ -292,9 +292,9 @@ netstat -ano | findstr :8080
 
 **Command Line:**
 ```bash
-mcpproxy --listen :8081
-mcpproxy --listen :9000
-mcpproxy --listen 127.0.0.1:8080  # Bind to specific interface
+mcpproxy serve --listen :8081
+mcpproxy serve --listen :9000
+mcpproxy serve --listen 127.0.0.1:8080  # Bind to specific interface
 ```
 
 **Configuration File:**
@@ -308,7 +308,7 @@ mcpproxy --listen 127.0.0.1:8080  # Bind to specific interface
 **Environment Variable:**
 ```bash
 export MCPP_LISTEN=":8081"
-mcpproxy
+mcpproxy serve
 ```
 
 **📝 Note:** Environment variables are prefixed with `MCPP_`. For example, `MCPP_LISTEN` controls the listen address.
@@ -319,10 +319,10 @@ Run multiple MCPProxy instances on different ports:
 
 ```bash
 # Instance 1 - Development  
-mcpproxy --config dev_config.json --listen :8080
+mcpproxy serve --config dev_config.json --listen :8080
 
 # Instance 2 - Production
-mcpproxy --config prod_config.json --listen :8081
+mcpproxy serve --config prod_config.json --listen :8081
 ```
 
 ## Troubleshooting
@@ -340,17 +340,17 @@ taskkill /PID <PID> /F          # Windows
 **2. MCPProxy Not Starting**
 ```bash
 # Check logs
-mcpproxy --log-level debug
+mcpproxy serve --log-level debug
 
 # Check configuration
-mcpproxy --config ~/.mcpproxy/mcp_config.json --log-level debug
+mcpproxy serve --config ~/.mcpproxy/mcp_config.json --log-level debug
 ```
 
 **3. Client Connection Issues**
 - Verify MCPProxy is running: Check process with `ps aux | grep mcpproxy`
 - Check firewall settings
 - Ensure correct URL in client config
-- Try different port: `mcpproxy --listen :8081`
+- Try different port: `mcpproxy serve --listen :8081`
 - Check tray icon (if enabled) for status
 
 **4. Tools Not Appearing**
@@ -370,7 +370,7 @@ ps aux | grep mcpproxy
 lsof -i :8080
 
 # View logs (with debug mode)
-mcpproxy --log-level debug
+mcpproxy serve --log-level debug
 ```
 
 **📝 Note:** MCPProxy uses the MCP protocol over HTTP, not simple REST endpoints. Use MCP clients to interact with the server, not direct curl commands.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,9 @@ type Config struct {
 
 	// Prompts settings
 	EnablePrompts bool `json:"enable_prompts" mapstructure:"enable-prompts"`
+
+	// Registries configuration for MCP server discovery
+	Registries []RegistryEntry `json:"registries,omitempty" mapstructure:"registries"`
 }
 
 // LogConfig represents logging configuration
@@ -74,6 +77,18 @@ type OAuthConfig struct {
 	RedirectURI  string   `json:"redirect_uri,omitempty" mapstructure:"redirect_uri"`
 	Scopes       []string `json:"scopes,omitempty" mapstructure:"scopes"`
 	PKCEEnabled  bool     `json:"pkce_enabled,omitempty" mapstructure:"pkce_enabled"`
+}
+
+// RegistryEntry represents a registry in the configuration
+type RegistryEntry struct {
+	ID          string      `json:"id"`
+	Name        string      `json:"name"`
+	Description string      `json:"description"`
+	URL         string      `json:"url"`
+	ServersURL  string      `json:"servers_url,omitempty"`
+	Tags        []string    `json:"tags,omitempty"`
+	Protocol    string      `json:"protocol,omitempty"`
+	Count       interface{} `json:"count,omitempty"` // number or string
 }
 
 // CursorMCPConfig represents the structure for Cursor IDE MCP configuration
@@ -192,6 +207,37 @@ func DefaultConfig() *Config {
 
 		// Prompts enabled by default
 		EnablePrompts: true,
+
+		// Default registries for MCP server discovery
+		Registries: []RegistryEntry{
+			{
+				ID:          "pulse",
+				Name:        "Pulse MCP",
+				Description: "Browse and discover MCP use-cases, servers, clients, and news",
+				URL:         "https://www.pulsemcp.com/",
+				ServersURL:  "https://api.pulsemcp.com/v0beta/servers",
+				Tags:        []string{"verified"},
+				Protocol:    "custom/pulse",
+			},
+			{
+				ID:          "docker-mcp-catalog",
+				Name:        "Docker MCP Catalog",
+				Description: "A collection of secure, high-quality MCP servers as docker images",
+				URL:         "https://hub.docker.com/catalogs/mcp",
+				ServersURL:  "https://hub.docker.com/v2/repositories/mcp/",
+				Tags:        []string{"verified"},
+				Protocol:    "custom/docker",
+			},
+			{
+				ID:          "fleur",
+				Name:        "Fleur",
+				Description: "Fleur is the app store for Claude",
+				URL:         "https://www.fleurmcp.com/",
+				ServersURL:  "https://raw.githubusercontent.com/fleuristes/app-registry/refs/heads/main/apps.json",
+				Tags:        []string{"verified"},
+				Protocol:    "custom/fleur",
+			},
+		},
 	}
 }
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -45,6 +45,9 @@ func LoadFromFile(configPath string) (*Config, error) {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
 	}
 
+	// Initialize registries from config
+	initializeRegistries(cfg)
+
 	return cfg, nil
 }
 
@@ -131,6 +134,9 @@ func Load() (*Config, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
 	}
+
+	// Initialize registries from config
+	initializeRegistries(cfg)
 
 	return cfg, nil
 }
@@ -334,4 +340,21 @@ func createDefaultConfigFile(path string, cfg *Config) error {
 	defaultCfg.Servers = []*ServerConfig{} // Empty servers list
 
 	return SaveConfig(defaultCfg, path)
+}
+
+// initializeRegistries initializes the registries package with config data
+func initializeRegistries(cfg *Config) {
+	// This function will be implemented to avoid circular imports
+	// For now, we'll create a callback mechanism
+	if registriesInitCallback != nil {
+		registriesInitCallback(cfg)
+	}
+}
+
+// registriesInitCallback is set by main.go to avoid circular import
+var registriesInitCallback func(*Config)
+
+// SetRegistriesInitCallback sets the callback function for registries initialization
+func SetRegistriesInitCallback(callback func(*Config)) {
+	registriesInitCallback = callback
 }

--- a/internal/logs/e2e_test.go
+++ b/internal/logs/e2e_test.go
@@ -293,6 +293,7 @@ func TestE2E_MCPProxyWithLogging(t *testing.T) {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, binaryName,
+		"serve",
 		"--config", configFile,
 		"--log-level", "debug",
 		"--log-to-file",

--- a/internal/registries/integration_test.go
+++ b/internal/registries/integration_test.go
@@ -1,0 +1,187 @@
+package registries
+
+import (
+	"context"
+	"encoding/json"
+	"mcpproxy-go/internal/config"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestSearchServersIntegration tests the complete search flow with a mock HTTP server
+func TestSearchServersIntegration(t *testing.T) {
+	// Create mock server data
+	mockServers := map[string]interface{}{
+		"servers": []interface{}{
+			map[string]interface{}{
+				"id":          "weather-api",
+				"name":        "Weather API",
+				"description": "Get current weather data",
+				"url":         "https://weather.example.com/mcp",
+				"updatedAt":   "2025-01-01T12:00:00Z",
+			},
+			map[string]interface{}{
+				"id":          "news-feed",
+				"name":        "News Feed",
+				"description": "Latest news updates",
+				"url":         "https://news.example.com/mcp",
+				"updatedAt":   "2025-01-01T10:00:00Z",
+			},
+			map[string]interface{}{
+				"id":          "crypto-tracker",
+				"name":        "Crypto Tracker",
+				"description": "Track cryptocurrency prices",
+				"url":         "https://crypto.example.com/mcp",
+				"updatedAt":   "2025-01-01T08:00:00Z",
+			},
+		},
+	}
+
+	// Create mock HTTP server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(mockServers); err != nil {
+			http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	// Set up test registries using config
+	cfg := &config.Config{
+		Registries: []config.RegistryEntry{
+			{
+				ID:         "test-registry",
+				Name:       "Test Registry",
+				ServersURL: server.URL,
+				Protocol:   "modelcontextprotocol/registry",
+			},
+		},
+	}
+
+	// Store original list and restore after test
+	originalList := registryList
+	defer func() { registryList = originalList }()
+
+	// Set test registries
+	SetRegistriesFromConfig(cfg)
+
+	ctx := context.Background()
+
+	t.Run("search all servers", func(t *testing.T) {
+		servers, err := SearchServers(ctx, "test-registry", "", "")
+		if err != nil {
+			t.Fatalf("SearchServers failed: %v", err)
+		}
+
+		if len(servers) != 3 {
+			t.Errorf("expected 3 servers, got %d", len(servers))
+		}
+
+		// Verify first server
+		if servers[0].ID != "weather-api" {
+			t.Errorf("expected first server ID 'weather-api', got '%s'", servers[0].ID)
+		}
+		if servers[0].Registry != "Test Registry" {
+			t.Errorf("expected registry 'Test Registry', got '%s'", servers[0].Registry)
+		}
+		if servers[0].URL != "https://weather.example.com/mcp" {
+			t.Errorf("expected URL 'https://weather.example.com/mcp', got '%s'", servers[0].URL)
+		}
+	})
+
+	t.Run("search with filter", func(t *testing.T) {
+		servers, err := SearchServers(ctx, "test-registry", "", "weather")
+		if err != nil {
+			t.Fatalf("SearchServers failed: %v", err)
+		}
+
+		if len(servers) != 1 {
+			t.Errorf("expected 1 server matching 'weather', got %d", len(servers))
+		}
+
+		if servers[0].ID != "weather-api" {
+			t.Errorf("expected server ID 'weather-api', got '%s'", servers[0].ID)
+		}
+	})
+
+	t.Run("search no results", func(t *testing.T) {
+		servers, err := SearchServers(ctx, "test-registry", "", "nonexistent")
+		if err != nil {
+			t.Fatalf("SearchServers failed: %v", err)
+		}
+
+		if len(servers) != 0 {
+			t.Errorf("expected 0 servers, got %d", len(servers))
+		}
+	})
+
+	t.Run("unknown registry", func(t *testing.T) {
+		_, err := SearchServers(ctx, "unknown-registry", "", "")
+		if err == nil {
+			t.Error("expected error for unknown registry, got nil")
+		}
+
+		expectedMsg := "registry 'unknown-registry' not found"
+		if err.Error() != expectedMsg {
+			t.Errorf("expected error message '%s', got '%s'", expectedMsg, err.Error())
+		}
+	})
+}
+
+// TestCompleteWorkflow demonstrates the intended usage pattern
+func TestCompleteWorkflow(t *testing.T) {
+	// Set up default registries (as per user requirements: pulse, docker-mcp-catalog, fleur)
+	cfg := config.DefaultConfig()
+	SetRegistriesFromConfig(cfg)
+
+	// This test demonstrates how the search_servers feature would be used:
+	// 1. List available registries
+	// 2. Search for specific servers
+	// 3. Use the results to add upstream servers
+
+	t.Run("list registries", func(t *testing.T) {
+		registries := ListRegistries()
+		if len(registries) == 0 {
+			t.Error("expected default registries, got none")
+		}
+
+		// Verify we have the expected default registries (pulse, docker-mcp-catalog, fleur)
+		expectedIDs := []string{"pulse", "docker-mcp-catalog", "fleur"}
+		found := make(map[string]bool)
+
+		for _, reg := range registries {
+			found[reg.ID] = true
+		}
+
+		for _, expectedID := range expectedIDs {
+			if !found[expectedID] {
+				t.Errorf("expected default registry '%s' not found", expectedID)
+			}
+		}
+	})
+
+	t.Run("find registry by name", func(t *testing.T) {
+		reg := FindRegistry("Pulse MCP")
+		if reg == nil {
+			t.Error("expected to find Pulse MCP registry")
+		} else if reg.ID != "pulse" {
+			t.Errorf("expected ID 'pulse', got '%s'", reg.ID)
+		}
+	})
+
+	t.Run("validate registry data", func(t *testing.T) {
+		for _, reg := range ListRegistries() {
+			if reg.ID == "" {
+				t.Errorf("registry missing ID: %+v", reg)
+			}
+			if reg.Name == "" {
+				t.Errorf("registry missing Name: %+v", reg)
+			}
+			// ServersURL can be empty for some registries
+			if reg.Protocol == "" {
+				t.Errorf("registry missing Protocol: %+v", reg)
+			}
+		}
+	})
+}

--- a/internal/registries/registry_data.go
+++ b/internal/registries/registry_data.go
@@ -1,0 +1,80 @@
+package registries
+
+import (
+	"mcpproxy-go/internal/config"
+)
+
+var registryList []RegistryEntry
+
+// SetRegistriesFromConfig sets the registries list from configuration
+func SetRegistriesFromConfig(cfg *config.Config) {
+	if cfg != nil && cfg.Registries != nil {
+		// Convert config.RegistryEntry to registries.RegistryEntry
+		registryList = make([]RegistryEntry, len(cfg.Registries))
+		for i := range cfg.Registries {
+			r := &cfg.Registries[i]
+			registryList[i] = RegistryEntry{
+				ID:          r.ID,
+				Name:        r.Name,
+				Description: r.Description,
+				URL:         r.URL,
+				ServersURL:  r.ServersURL,
+				Tags:        r.Tags,
+				Protocol:    r.Protocol,
+				Count:       r.Count,
+			}
+		}
+	} else {
+		// Use default registries
+		registryList = []RegistryEntry{
+			{
+				ID:          "smithery",
+				Name:        "Smithery MCP Registry",
+				Description: "The official community registry for Model Context Protocol (MCP) servers.",
+				URL:         "https://smithery.ai/protocols",
+				ServersURL:  "https://smithery.ai/api/smithery-protocol-registry",
+				Tags:        []string{"official", "community"},
+				Protocol:    "modelcontextprotocol/registry",
+				Count:       -1, // Will be populated at runtime
+			},
+		}
+	}
+}
+
+// ListRegistries returns a copy of all available registries
+func ListRegistries() []RegistryEntry {
+	result := make([]RegistryEntry, len(registryList))
+	copy(result, registryList)
+	return result
+}
+
+// FindRegistry finds a registry by ID or name (case-insensitive)
+func FindRegistry(idOrName string) *RegistryEntry {
+	for i := range registryList {
+		r := &registryList[i]
+		if equalIgnoreCase(r.ID, idOrName) || equalIgnoreCase(r.Name, idOrName) {
+			return &registryList[i]
+		}
+	}
+	return nil
+}
+
+func equalIgnoreCase(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		ac := a[i]
+		bc := b[i]
+		if ac >= 'A' && ac <= 'Z' {
+			ac += 'a' - 'A'
+		}
+		if bc >= 'A' && bc <= 'Z' {
+			bc += 'a' - 'A'
+		}
+		if ac != bc {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/registries/search.go
+++ b/internal/registries/search.go
@@ -1,0 +1,613 @@
+package registries
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Constants for repeated strings
+const (
+	protocolMCPRun   = "custom/mcprun"
+	protocolMCPStore = "custom/mcpstore"
+	protocolDocker   = "custom/docker"
+	protocolFleur    = "custom/fleur"
+	dockerProtocol   = "docker"
+	noDescAvailable  = "No description available"
+)
+
+// SearchServers searches the given registry for servers matching optional tag and query
+func SearchServers(ctx context.Context, registryID, tag, query string) ([]ServerEntry, error) {
+	// Find registry by ID or name
+	reg := FindRegistry(registryID)
+	if reg == nil {
+		return nil, fmt.Errorf("registry '%s' not found", registryID)
+	}
+
+	if reg.ServersURL == "" {
+		return nil, fmt.Errorf("registry '%s' has no servers endpoint", reg.Name)
+	}
+
+	// Fetch servers from registry
+	servers, err := fetchServers(ctx, reg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch servers from %s: %w", reg.Name, err)
+	}
+
+	// Filter results
+	filtered := filterServers(servers, tag, query)
+
+	// Set registry name for all results
+	for i := range filtered {
+		filtered[i].Registry = reg.Name
+	}
+
+	return filtered, nil
+}
+
+// fetchServers fetches and parses servers from a registry based on its protocol
+func fetchServers(ctx context.Context, reg *RegistryEntry) ([]ServerEntry, error) {
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", reg.ServersURL, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch servers: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("registry query returned %d: %s", resp.StatusCode, resp.Status)
+	}
+
+	// Parse response JSON
+	var rawData interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&rawData); err != nil {
+		return nil, fmt.Errorf("invalid JSON from registry: %w", err)
+	}
+
+	// Process based on protocol
+	servers := parseServers(rawData, reg)
+	return servers, nil
+}
+
+// parseServers parses the raw JSON response based on the registry protocol
+func parseServers(rawData interface{}, reg *RegistryEntry) []ServerEntry {
+	var servers []ServerEntry
+
+	switch reg.Protocol {
+	case "modelcontextprotocol/registry":
+		servers = parseOpenAPIRegistry(rawData)
+	case protocolMCPRun:
+		servers = parseMCPRun(rawData)
+	case "custom/pulse":
+		servers = parsePulse(rawData)
+	case protocolMCPStore:
+		servers = parseMCPStore(rawData)
+	case protocolDocker:
+		servers = parseDocker(rawData)
+	case protocolFleur:
+		servers = parseFleur(rawData)
+	case "custom/apitracker":
+		servers = parseAPITracker(rawData)
+	case "custom/apify":
+		servers = parseApify(rawData)
+	default:
+		// Default handling: try to unmarshal directly into []ServerEntry
+		servers = parseDefault(rawData)
+	}
+
+	// For servers missing URLs, try to construct them if possible
+	for i := range servers {
+		if servers[i].URL == "" {
+			servers[i].URL = constructServerURL(&servers[i], reg)
+		}
+	}
+
+	return servers
+}
+
+// parseOpenAPIRegistry handles the standard MCP Registry API format
+func parseOpenAPIRegistry(rawData interface{}) []ServerEntry {
+	servers := []ServerEntry{}
+
+	switch data := rawData.(type) {
+	case map[string]interface{}:
+		// Try "servers" field first (standard)
+		if serversData := data["servers"]; serversData != nil {
+			if marshaledData, err := json.Marshal(serversData); err == nil {
+				_ = json.Unmarshal(marshaledData, &servers)
+			}
+		} else if dataField := data["data"]; dataField != nil {
+			// Try "data" field (paginated response)
+			if marshaledData, err := json.Marshal(dataField); err == nil {
+				_ = json.Unmarshal(marshaledData, &servers)
+			}
+		}
+	case []interface{}:
+		// Response is directly an array
+		if marshaledData, err := json.Marshal(data); err == nil {
+			_ = json.Unmarshal(marshaledData, &servers)
+		}
+	}
+
+	return servers
+}
+
+// parseMCPRun handles MCP Run's specific API format
+func parseMCPRun(rawData interface{}) []ServerEntry {
+	servers := []ServerEntry{}
+
+	if arr, ok := rawData.([]interface{}); ok {
+		for _, item := range arr {
+			itemMap, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if slug, ok := itemMap["slug"].(string); ok && slug != "" {
+				server := ServerEntry{
+					ID:   slug,
+					Name: slug,
+				}
+
+				// Extract description from meta if available
+				if meta, ok := itemMap["meta"].(map[string]interface{}); ok {
+					if desc, ok := meta["description"].(string); ok {
+						server.Description = desc
+					}
+				}
+
+				// For servers without descriptions, use default
+				if server.Description == "" {
+					server.Description = noDescAvailable
+				}
+
+				servers = append(servers, server)
+			}
+		}
+	}
+
+	return servers
+}
+
+// parsePulse handles Pulse registry format
+func parsePulse(rawData interface{}) []ServerEntry {
+	servers := []ServerEntry{}
+
+	data, ok := rawData.(map[string]interface{})
+	if !ok {
+		return servers
+	}
+
+	serversData, ok := data["servers"]
+	if !ok {
+		return servers
+	}
+
+	serversArray, ok := serversData.([]interface{})
+	if !ok {
+		return servers
+	}
+
+	for _, item := range serversArray {
+		itemMap, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		name, ok := itemMap["name"].(string)
+		if !ok || name == "" {
+			continue
+		}
+
+		server := ServerEntry{
+			ID:   name,
+			Name: name,
+		}
+
+		// Try to get description from multiple fields
+		if shortDesc, ok := itemMap["short_description"].(string); ok && shortDesc != "" {
+			if len(shortDesc) > 300 {
+				server.Description = shortDesc[:300]
+			} else {
+				server.Description = shortDesc
+			}
+		} else if aiDesc, ok := itemMap["EXPERIMENTAL_ai_generated_description"].(string); ok && aiDesc != "" {
+			if len(aiDesc) > 300 {
+				server.Description = aiDesc[:300]
+			} else {
+				server.Description = aiDesc
+			}
+		} else {
+			server.Description = noDescAvailable
+		}
+
+		// Extract installation command and connection URL
+		installCmd, connectURL := derivePulseServerDetails(itemMap)
+		server.InstallCmd = installCmd
+		server.ConnectURL = connectURL
+
+		servers = append(servers, server)
+	}
+
+	return servers
+}
+
+// parseMCPStore handles MCP Store's specific API format
+func parseMCPStore(rawData interface{}) []ServerEntry {
+	servers := []ServerEntry{}
+
+	if m, ok := rawData.(map[string]interface{}); ok {
+		if serversData := m["servers"]; serversData != nil {
+			if marshaledData, err := json.Marshal(serversData); err == nil {
+				_ = json.Unmarshal(marshaledData, &servers)
+			}
+		} else if packagesData := m["packages"]; packagesData != nil {
+			// MCP Store might use "packages" instead of "servers"
+			if marshaledData, err := json.Marshal(packagesData); err == nil {
+				_ = json.Unmarshal(marshaledData, &servers)
+			}
+		}
+	}
+
+	return servers
+}
+
+// parseDocker handles Docker registry format
+func parseDocker(rawData interface{}) []ServerEntry {
+	servers := []ServerEntry{}
+
+	data, ok := rawData.(map[string]interface{})
+	if !ok {
+		return servers
+	}
+
+	results, ok := data["results"].([]interface{})
+	if !ok {
+		return servers
+	}
+
+	for _, item := range results {
+		itemMap, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if name, ok := itemMap["name"].(string); ok && name != "" {
+			server := ServerEntry{
+				ID:   name,
+				Name: name,
+			}
+
+			// Try to get description from images array
+			if images, ok := itemMap["images"].([]interface{}); ok && len(images) > 0 {
+				if firstImage, ok := images[0].(map[string]interface{}); ok {
+					if description, ok := firstImage["description"].(string); ok {
+						server.Description = description
+					}
+				}
+			}
+
+			// Fallback to short_description if images description not found
+			if server.Description == "" {
+				if desc, ok := itemMap["short_description"].(string); ok {
+					server.Description = desc
+				}
+			}
+
+			if server.Description == "" {
+				server.Description = noDescAvailable
+			}
+
+			// Extract last_updated as updatedAt
+			if lastUpdated, ok := itemMap["last_updated"].(string); ok {
+				server.UpdatedAt = lastUpdated
+			}
+
+			servers = append(servers, server)
+		}
+	}
+
+	return servers
+}
+
+// parseFleur handles Fleur registry format
+func parseFleur(rawData interface{}) []ServerEntry {
+	servers := []ServerEntry{}
+
+	arr, ok := rawData.([]interface{})
+	if !ok {
+		return servers
+	}
+
+	for _, item := range arr {
+		itemMap, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		// Check if this is an MCP-enabled app
+		config, hasConfig := itemMap["config"].(map[string]interface{})
+		if !hasConfig {
+			continue
+		}
+
+		mcpKey, hasMcpKey := config["mcpKey"].(string)
+		if !hasMcpKey || mcpKey == "" {
+			continue // skip non-MCP entries
+		}
+
+		server := ServerEntry{
+			ID:   mcpKey,
+			Name: mcpKey,
+		}
+
+		// Extract description
+		if desc, ok := itemMap["description"].(string); ok {
+			server.Description = desc
+		} else if name, ok := itemMap["name"].(string); ok {
+			server.Description = name
+		} else {
+			server.Description = noDescAvailable
+		}
+
+		// Build installation command from config
+		if runtime, ok := config["runtime"].(string); ok {
+			if argsInterface, ok := config["args"].([]interface{}); ok {
+				args := make([]string, 0, len(argsInterface))
+				for _, arg := range argsInterface {
+					if argStr, ok := arg.(string); ok {
+						args = append(args, argStr)
+					}
+				}
+				server.InstallCmd = buildFleurInstallCmd(runtime, args)
+			}
+		}
+
+		servers = append(servers, server)
+	}
+
+	return servers
+}
+
+// parseAPITracker handles APITracker registry format
+func parseAPITracker(rawData interface{}) []ServerEntry {
+	servers := []ServerEntry{}
+
+	switch data := rawData.(type) {
+	case map[string]interface{}:
+		if serversData := data["servers"]; serversData != nil {
+			if marshaledData, err := json.Marshal(serversData); err == nil {
+				_ = json.Unmarshal(marshaledData, &servers)
+			}
+		} else if packagesData := data["packages"]; packagesData != nil {
+			if marshaledData, err := json.Marshal(packagesData); err == nil {
+				_ = json.Unmarshal(marshaledData, &servers)
+			}
+		} else if itemsData := data["items"]; itemsData != nil {
+			if marshaledData, err := json.Marshal(itemsData); err == nil {
+				_ = json.Unmarshal(marshaledData, &servers)
+			}
+		}
+	case []interface{}:
+		if marshaledData, err := json.Marshal(data); err == nil {
+			_ = json.Unmarshal(marshaledData, &servers)
+		}
+	}
+
+	return servers
+}
+
+// parseApify handles Apify registry format
+func parseApify(rawData interface{}) []ServerEntry {
+	servers := []ServerEntry{}
+
+	rootData, ok := rawData.(map[string]interface{})
+	if !ok {
+		return servers
+	}
+
+	// Look for data.items structure
+	dataField, ok := rootData["data"].(map[string]interface{})
+	if !ok {
+		return servers
+	}
+
+	items, ok := dataField["items"].([]interface{})
+	if !ok {
+		return servers
+	}
+
+	for _, item := range items {
+		itemMap, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if name, ok := itemMap["name"].(string); ok && name != "" {
+			server := ServerEntry{
+				ID:   name,
+				Name: name,
+			}
+
+			// Use title as Name if available
+			if title, ok := itemMap["title"].(string); ok {
+				server.Name = title
+			}
+
+			if desc, ok := itemMap["description"].(string); ok {
+				server.Description = desc
+			}
+
+			if server.Description == "" {
+				server.Description = noDescAvailable
+			}
+
+			// Extract stats for the updated date
+			if stats, ok := itemMap["stats"].(map[string]interface{}); ok {
+				if lastRunStartedAt, ok := stats["lastRunStartedAt"].(string); ok {
+					server.UpdatedAt = lastRunStartedAt
+				}
+			}
+
+			servers = append(servers, server)
+		}
+	}
+
+	return servers
+}
+
+// parseDefault handles unknown registry formats
+func parseDefault(rawData interface{}) []ServerEntry {
+	servers := []ServerEntry{}
+
+	if rawData == nil {
+		return servers
+	}
+
+	if marshaledData, err := json.Marshal(rawData); err == nil {
+		_ = json.Unmarshal(marshaledData, &servers)
+	}
+
+	return servers
+}
+
+// createServerEntry creates a basic server entry from partial data (helper function)
+func createServerEntry(data map[string]interface{}) ServerEntry {
+	server := ServerEntry{}
+
+	if id, ok := data["id"].(string); ok {
+		server.ID = id
+	}
+	if name, ok := data["name"].(string); ok {
+		server.Name = name
+	}
+	if desc, ok := data["description"].(string); ok {
+		server.Description = desc
+	}
+	if url, ok := data["url"].(string); ok {
+		server.URL = url
+	}
+
+	return server
+}
+
+// constructServerURL tries to construct a server URL if missing
+func constructServerURL(server *ServerEntry, reg *RegistryEntry) string {
+	if server.URL != "" {
+		return server.URL
+	}
+
+	// For some registries, we might be able to construct URLs from patterns
+	switch reg.Protocol {
+	case protocolMCPRun:
+		if server.ID != "" {
+			// Replace slashes with dashes to create valid subdomain URLs
+			// e.g., "G4Vi/weather-service" becomes "https://G4Vi-weather-service.mcp.run/mcp/"
+			urlSafeID := strings.ReplaceAll(server.ID, "/", "-")
+			return fmt.Sprintf("https://%s.mcp.run/mcp/", urlSafeID)
+		}
+	case protocolMCPStore:
+		if server.ID != "" {
+			return fmt.Sprintf("https://api.mcpstore.co/servers/%s/mcp", server.ID)
+		}
+	case protocolDocker:
+		if server.ID != "" {
+			return fmt.Sprintf("docker://mcp/%s", server.ID)
+		}
+	case protocolFleur:
+		if server.ID != "" {
+			return fmt.Sprintf("https://api.fleurmcp.com/apps/%s/mcp", server.ID)
+		}
+	case dockerProtocol:
+		if server.ID != "" {
+			return fmt.Sprintf("docker://%s", server.ID)
+		}
+	}
+
+	return ""
+}
+
+// filterServers filters servers by tag and query
+func filterServers(servers []ServerEntry, tag, query string) []ServerEntry {
+	if tag == "" && query == "" {
+		return servers
+	}
+
+	filtered := []ServerEntry{}
+	for i := range servers {
+		srv := &servers[i]
+
+		// Filter by query (search in name and description)
+		if query != "" {
+			q := strings.ToLower(query)
+			name := strings.ToLower(srv.Name)
+			desc := strings.ToLower(srv.Description)
+
+			if !strings.Contains(name, q) && !strings.Contains(desc, q) {
+				continue
+			}
+		}
+
+		filtered = append(filtered, *srv)
+	}
+
+	return filtered
+}
+
+// buildFleurInstallCmd constructs installation command from runtime and args (helper for tests)
+func buildFleurInstallCmd(runtime string, args []string) string {
+	switch runtime {
+	case "npx", "uvx", dockerProtocol:
+		return runtime + " " + strings.Join(args, " ")
+	case "stdio":
+		return strings.Join(args, " ")
+	default:
+		combined := append([]string{runtime}, args...)
+		return strings.Join(combined, " ")
+	}
+}
+
+// derivePulseServerDetails extracts installation command and connection URL from Pulse server data (helper for tests)
+func derivePulseServerDetails(itemMap map[string]interface{}) (installCmd, connectURL string) {
+	// Extract package registry and name for installation command
+	packageRegistry, _ := itemMap["package_registry"].(string)
+	packageName, _ := itemMap["package_name"].(string)
+
+	// Derive installation command based on registry type
+	switch packageRegistry {
+	case "npm":
+		if packageName != "" {
+			installCmd = "npx -y " + packageName
+		}
+	case "pypi", "pip":
+		if packageName != "" {
+			installCmd = "pipx run " + packageName
+		}
+	case "docker":
+		if packageName != "" {
+			installCmd = "docker run -i --rm " + packageName
+		}
+	}
+
+	// Extract remote connection URL if available
+	if remotesInterface, ok := itemMap["remotes"].([]interface{}); ok {
+		for _, remote := range remotesInterface {
+			if remoteMap, ok := remote.(map[string]interface{}); ok {
+				if urlDirect, ok := remoteMap["url_direct"].(string); ok && urlDirect != "" {
+					connectURL = urlDirect
+					break // Use first available direct URL
+				}
+			}
+		}
+	}
+
+	return installCmd, connectURL
+}

--- a/internal/registries/search_test.go
+++ b/internal/registries/search_test.go
@@ -1,0 +1,810 @@
+package registries
+
+import (
+	"context"
+	"encoding/json"
+	"mcpproxy-go/internal/config"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// setupTestRegistries sets up test registries for testing
+func setupTestRegistries() {
+	cfg := &config.Config{
+		Registries: []config.RegistryEntry{
+			{
+				ID:          "mcprun",
+				Name:        "MCP Run",
+				Description: "Test MCP Run registry",
+				URL:         "https://www.mcp.run/",
+				ServersURL:  "https://www.mcp.run/api/servlets",
+				Tags:        []string{"verified"},
+				Protocol:    "custom/mcprun",
+			},
+			{
+				ID:          "smithery",
+				Name:        "Smithery",
+				Description: "Test Smithery registry",
+				URL:         "https://smithery.ai/",
+				ServersURL:  "https://registry.smithery.ai/servers",
+				Tags:        []string{"verified"},
+				Protocol:    "modelcontextprotocol/registry",
+			},
+		},
+	}
+	SetRegistriesFromConfig(cfg)
+}
+
+func TestFindRegistry(t *testing.T) {
+	setupTestRegistries()
+
+	tests := []struct {
+		name     string
+		query    string
+		expected string
+	}{
+		{"find by ID", "mcprun", "mcprun"},
+		{"find by name", "MCP Run", "mcprun"},
+		{"case insensitive ID", "MCPRUN", "mcprun"},
+		{"case insensitive name", "mcp run", "mcprun"},
+		{"not found", "nonexistent", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := FindRegistry(tt.query)
+			if tt.expected == "" {
+				if reg != nil {
+					t.Errorf("expected nil, got %v", reg)
+				}
+			} else {
+				if reg == nil {
+					t.Errorf("expected registry with ID %s, got nil", tt.expected)
+				} else if reg.ID != tt.expected {
+					t.Errorf("expected registry ID %s, got %s", tt.expected, reg.ID)
+				}
+			}
+		})
+	}
+}
+
+func TestFilterServers(t *testing.T) {
+	servers := []ServerEntry{
+		{ID: "weather", Name: "Weather API", Description: "Get weather information"},
+		{ID: "news", Name: "News Feed", Description: "Latest news updates"},
+		{ID: "weather-pro", Name: "Weather Pro", Description: "Advanced weather forecasting"},
+		{ID: "finance", Name: "Finance Tracker", Description: "Track your financial data"},
+	}
+
+	tests := []struct {
+		name     string
+		query    string
+		tag      string
+		expected []string
+	}{
+		{"no filter", "", "", []string{"weather", "news", "weather-pro", "finance"}},
+		{"search weather", "weather", "", []string{"weather", "weather-pro"}},
+		{"search case insensitive", "WEATHER", "", []string{"weather", "weather-pro"}},
+		{"search in description", "news", "", []string{"news"}},
+		{"search finance", "finance", "", []string{"finance"}},
+		{"search pro", "pro", "", []string{"weather-pro"}},
+		{"search nonexistent", "nonexistent", "", []string{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filtered := filterServers(servers, tt.tag, tt.query)
+
+			if len(filtered) != len(tt.expected) {
+				t.Errorf("expected %d results, got %d", len(tt.expected), len(filtered))
+				return
+			}
+
+			for i, expectedID := range tt.expected {
+				if filtered[i].ID != expectedID {
+					t.Errorf("expected result %d to have ID %s, got %s", i, expectedID, filtered[i].ID)
+				}
+			}
+		})
+	}
+}
+
+func TestParseOpenAPIRegistry(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     interface{}
+		expected int
+	}{
+		{
+			"servers field",
+			map[string]interface{}{
+				"servers": []interface{}{
+					map[string]interface{}{"id": "test1", "name": "Test 1"},
+					map[string]interface{}{"id": "test2", "name": "Test 2"},
+				},
+			},
+			2,
+		},
+		{
+			"data field",
+			map[string]interface{}{
+				"data": []interface{}{
+					map[string]interface{}{"id": "test1", "name": "Test 1"},
+				},
+			},
+			1,
+		},
+		{
+			"direct array",
+			[]interface{}{
+				map[string]interface{}{"id": "test1", "name": "Test 1"},
+			},
+			1,
+		},
+		{
+			"empty",
+			map[string]interface{}{},
+			0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			servers := parseOpenAPIRegistry(tt.data)
+			if len(servers) != tt.expected {
+				t.Errorf("expected %d servers, got %d", tt.expected, len(servers))
+			}
+		})
+	}
+}
+
+func TestParseMCPRun(t *testing.T) {
+	testData := []interface{}{
+		map[string]interface{}{
+			"slug": "weather-api",
+			"meta": map[string]interface{}{
+				"description": "Weather service",
+			},
+			"created_at": "2025-01-01T00:00:00Z",
+			"updated_at": "2025-01-01T12:00:00Z",
+		},
+		map[string]interface{}{
+			"slug": "news-feed",
+		},
+	}
+
+	servers := parseMCPRun(testData)
+
+	if len(servers) != 2 {
+		t.Errorf("expected 2 servers, got %d", len(servers))
+	}
+
+	if servers[0].ID != "weather-api" {
+		t.Errorf("expected ID 'weather-api', got '%s'", servers[0].ID)
+	}
+	if servers[0].Description != "Weather service" {
+		t.Errorf("expected description 'Weather service', got '%s'", servers[0].Description)
+	}
+}
+
+func TestParsePulse(t *testing.T) {
+	testData := map[string]interface{}{
+		"servers": []interface{}{
+			map[string]interface{}{
+				"name":                                  "Taskwarrior",
+				"short_description":                     "Task management with Taskwarrior",
+				"EXPERIMENTAL_ai_generated_description": "AI generated description",
+				"package_registry":                      "npm",
+				"package_name":                          "@0xbeedao/mcp-taskwarrior",
+			},
+			map[string]interface{}{
+				"name":                                  "Ethereum RPC",
+				"EXPERIMENTAL_ai_generated_description": strings.Repeat("a", 400), // Long description
+				"package_registry":                      "docker",
+				"package_name":                          "mcp/evm-mcp-tools",
+			},
+			map[string]interface{}{
+				"name":              "Remote Service",
+				"short_description": "Service with remote connection",
+				"package_registry":  "pypi",
+				"package_name":      "some-python-package",
+				"remotes": []interface{}{
+					map[string]interface{}{
+						"url_direct": "https://api.example.com/mcp",
+					},
+				},
+			},
+		},
+	}
+
+	servers := parsePulse(testData)
+
+	if len(servers) != 3 {
+		t.Errorf("expected 3 servers, got %d", len(servers))
+	}
+
+	// Test first server - npm package
+	if servers[0].ID != "Taskwarrior" {
+		t.Errorf("expected ID 'Taskwarrior', got '%s'", servers[0].ID)
+	}
+	if servers[0].Description != "Task management with Taskwarrior" {
+		t.Errorf("expected description 'Task management with Taskwarrior', got '%s'", servers[0].Description)
+	}
+	if servers[0].InstallCmd != "npx -y @0xbeedao/mcp-taskwarrior" {
+		t.Errorf("expected InstallCmd 'npx -y @0xbeedao/mcp-taskwarrior', got '%s'", servers[0].InstallCmd)
+	}
+
+	// Test second server - docker package with truncation
+	if servers[1].ID != "Ethereum RPC" {
+		t.Errorf("expected ID 'Ethereum RPC', got '%s'", servers[1].ID)
+	}
+	if len(servers[1].Description) != 300 {
+		t.Errorf("expected description to be truncated to 300 chars, got %d", len(servers[1].Description))
+	}
+	if servers[1].InstallCmd != "docker run -i --rm mcp/evm-mcp-tools" {
+		t.Errorf("expected InstallCmd 'docker run -i --rm mcp/evm-mcp-tools', got '%s'", servers[1].InstallCmd)
+	}
+
+	// Test third server - pypi package with remote connection
+	if servers[2].ID != "Remote Service" {
+		t.Errorf("expected ID 'Remote Service', got '%s'", servers[2].ID)
+	}
+	if servers[2].InstallCmd != "pipx run some-python-package" {
+		t.Errorf("expected InstallCmd 'pipx run some-python-package', got '%s'", servers[2].InstallCmd)
+	}
+	if servers[2].ConnectURL != "https://api.example.com/mcp" {
+		t.Errorf("expected ConnectURL 'https://api.example.com/mcp', got '%s'", servers[2].ConnectURL)
+	}
+}
+
+func TestParseDocker(t *testing.T) {
+	testData := map[string]interface{}{
+		"results": []interface{}{
+			map[string]interface{}{
+				"name": "mcp-weather",
+				"images": []interface{}{
+					map[string]interface{}{
+						"description": "Weather MCP server",
+					},
+				},
+				"last_updated": "2025-01-01T12:00:00Z",
+			},
+		},
+	}
+
+	servers := parseDocker(testData)
+
+	if len(servers) != 1 {
+		t.Errorf("expected 1 server, got %d", len(servers))
+	}
+
+	if servers[0].ID != "mcp-weather" {
+		t.Errorf("expected ID 'mcp-weather', got '%s'", servers[0].ID)
+	}
+	if servers[0].Description != "Weather MCP server" {
+		t.Errorf("expected description 'Weather MCP server', got '%s'", servers[0].Description)
+	}
+}
+
+func TestParseFleur(t *testing.T) {
+	testData := []interface{}{
+		map[string]interface{}{
+			"appId":       "weather-app",
+			"name":        "Weather Application",
+			"description": "Weather forecast app",
+			"config": map[string]interface{}{
+				"mcpKey":  "github",
+				"runtime": "npx",
+				"args":    []interface{}{"-y", "@modelcontextprotocol/server-github"},
+			},
+		},
+		map[string]interface{}{
+			"appId": "news-app",
+			"name":  "News Reader",
+			"config": map[string]interface{}{
+				"mcpKey":  "news",
+				"runtime": "docker",
+				"args":    []interface{}{"news-mcp-server"},
+			},
+		},
+		map[string]interface{}{
+			"name": "non-mcp-app", // No config section, should be skipped
+		},
+		map[string]interface{}{
+			"name": "empty-mcp-app",
+			"config": map[string]interface{}{
+				"mcpKey": "", // Empty mcpKey, should be skipped
+			},
+		},
+	}
+
+	servers := parseFleur(testData)
+
+	if len(servers) != 2 {
+		t.Errorf("expected 2 servers, got %d", len(servers))
+	}
+
+	// Test first server
+	if servers[0].ID != "github" {
+		t.Errorf("expected ID 'github', got '%s'", servers[0].ID)
+	}
+	if servers[0].Name != "github" {
+		t.Errorf("expected Name 'github', got '%s'", servers[0].Name)
+	}
+	if servers[0].Description != "Weather forecast app" {
+		t.Errorf("expected Description 'Weather forecast app', got '%s'", servers[0].Description)
+	}
+	if servers[0].InstallCmd != "npx -y @modelcontextprotocol/server-github" {
+		t.Errorf("expected InstallCmd 'npx -y @modelcontextprotocol/server-github', got '%s'", servers[0].InstallCmd)
+	}
+
+	// Test second server
+	if servers[1].ID != "news" { // Should use mcpKey
+		t.Errorf("expected ID 'news', got '%s'", servers[1].ID)
+	}
+	if servers[1].InstallCmd != "docker news-mcp-server" {
+		t.Errorf("expected InstallCmd 'docker news-mcp-server', got '%s'", servers[1].InstallCmd)
+	}
+}
+
+func TestBuildFleurInstallCmd(t *testing.T) {
+	tests := []struct {
+		name     string
+		runtime  string
+		args     []string
+		expected string
+	}{
+		{
+			"npx runtime",
+			"npx",
+			[]string{"-y", "@modelcontextprotocol/server-github"},
+			"npx -y @modelcontextprotocol/server-github",
+		},
+		{
+			"docker runtime",
+			"docker",
+			[]string{"run", "-i", "mcp-server"},
+			"docker run -i mcp-server",
+		},
+		{
+			"uvx runtime",
+			"uvx",
+			[]string{"some-package"},
+			"uvx some-package",
+		},
+		{
+			"stdio runtime",
+			"stdio",
+			[]string{"python", "-m", "server"},
+			"python -m server",
+		},
+		{
+			"unknown runtime",
+			"custom-runner",
+			[]string{"arg1", "arg2"},
+			"custom-runner arg1 arg2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildFleurInstallCmd(tt.runtime, tt.args)
+			if result != tt.expected {
+				t.Errorf("expected '%s', got '%s'", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestDerivePulseServerDetails(t *testing.T) {
+	tests := []struct {
+		name            string
+		itemMap         map[string]interface{}
+		expectedCmd     string
+		expectedConnURL string
+	}{
+		{
+			"npm package",
+			map[string]interface{}{
+				"package_registry": "npm",
+				"package_name":     "@example/package",
+			},
+			"npx -y @example/package",
+			"",
+		},
+		{
+			"docker package",
+			map[string]interface{}{
+				"package_registry": "docker",
+				"package_name":     "example/image",
+			},
+			"docker run -i --rm example/image",
+			"",
+		},
+		{
+			"pypi package",
+			map[string]interface{}{
+				"package_registry": "pypi",
+				"package_name":     "example-package",
+			},
+			"pipx run example-package",
+			"",
+		},
+		{
+			"with remote connection",
+			map[string]interface{}{
+				"package_registry": "npm",
+				"package_name":     "example",
+				"remotes": []interface{}{
+					map[string]interface{}{
+						"url_direct": "https://api.example.com/mcp",
+					},
+				},
+			},
+			"npx -y example",
+			"https://api.example.com/mcp",
+		},
+		{
+			"unknown registry",
+			map[string]interface{}{
+				"package_registry": "unknown",
+				"package_name":     "example",
+			},
+			"",
+			"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, url := derivePulseServerDetails(tt.itemMap)
+			if cmd != tt.expectedCmd {
+				t.Errorf("expected cmd '%s', got '%s'", tt.expectedCmd, cmd)
+			}
+			if url != tt.expectedConnURL {
+				t.Errorf("expected url '%s', got '%s'", tt.expectedConnURL, url)
+			}
+		})
+	}
+}
+
+func TestParseAPITracker(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     interface{}
+		expected int
+	}{
+		{
+			"servers field",
+			map[string]interface{}{
+				"servers": []interface{}{
+					map[string]interface{}{"id": "api1", "name": "API 1"},
+				},
+			},
+			1,
+		},
+		{
+			"items field",
+			map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"id": "api1", "name": "API 1"},
+					map[string]interface{}{"id": "api2", "name": "API 2"},
+				},
+			},
+			2,
+		},
+		{
+			"direct array",
+			[]interface{}{
+				map[string]interface{}{"id": "api1", "name": "API 1"},
+			},
+			1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			servers := parseAPITracker(tt.data)
+			if len(servers) != tt.expected {
+				t.Errorf("expected %d servers, got %d", tt.expected, len(servers))
+			}
+		})
+	}
+}
+
+func TestParseApify(t *testing.T) {
+	testData := map[string]interface{}{
+		"data": map[string]interface{}{
+			"items": []interface{}{
+				map[string]interface{}{
+					"name":        "web-scraper",
+					"title":       "Web Scraper Tool",
+					"description": "Scrape web data",
+					"stats": map[string]interface{}{
+						"lastRunStartedAt": "2025-01-01T10:00:00Z",
+					},
+				},
+				map[string]interface{}{
+					"name":  "data-processor",
+					"title": "Data Processor",
+				},
+			},
+		},
+	}
+
+	servers := parseApify(testData)
+
+	if len(servers) != 2 {
+		t.Errorf("expected 2 servers, got %d", len(servers))
+	}
+
+	if servers[0].ID != "web-scraper" {
+		t.Errorf("expected ID 'web-scraper', got '%s'", servers[0].ID)
+	}
+	if servers[0].Name != "Web Scraper Tool" {
+		t.Errorf("expected name 'Web Scraper Tool', got '%s'", servers[0].Name)
+	}
+	if servers[0].UpdatedAt != "2025-01-01T10:00:00Z" {
+		t.Errorf("expected updatedAt '2025-01-01T10:00:00Z', got '%s'", servers[0].UpdatedAt)
+	}
+}
+
+func TestCreateServerEntry(t *testing.T) {
+	testData := map[string]interface{}{
+		"id":          "test-server",
+		"name":        "Test Server",
+		"description": "A test server",
+		"createdAt":   "2025-01-01T00:00:00Z",
+		"updated_at":  "2025-01-01T12:00:00Z",
+		"url":         "https://test.example.com",
+	}
+
+	server := createServerEntry(testData)
+
+	if server.ID != "test-server" {
+		t.Errorf("expected ID 'test-server', got '%s'", server.ID)
+	}
+	if server.Name != "Test Server" {
+		t.Errorf("expected name 'Test Server', got '%s'", server.Name)
+	}
+	if server.Description != "A test server" {
+		t.Errorf("expected description 'A test server', got '%s'", server.Description)
+	}
+	if server.URL != "https://test.example.com" {
+		t.Errorf("expected URL 'https://test.example.com', got '%s'", server.URL)
+	}
+}
+
+func TestSearchServersUnknownRegistry(t *testing.T) {
+	ctx := context.Background()
+	_, err := SearchServers(ctx, "unknown-registry", "", "")
+
+	if err == nil {
+		t.Error("expected error for unknown registry, got nil")
+	}
+
+	expectedMsg := "registry 'unknown-registry' not found"
+	if err.Error() != expectedMsg {
+		t.Errorf("expected error message '%s', got '%s'", expectedMsg, err.Error())
+	}
+}
+
+func TestSearchServersWithMockServer(t *testing.T) {
+	// Create mock server data
+	mockData := map[string]interface{}{
+		"servers": []interface{}{
+			map[string]interface{}{
+				"id":          "test-server",
+				"name":        "Test Server",
+				"description": "A test MCP server",
+				"url":         "https://test.example.com/mcp",
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(mockData); err != nil {
+			http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	// Temporarily modify the smithery registry to use our mock server
+	originalList := registryList
+	registryList = []RegistryEntry{
+		{
+			ID:         "test",
+			Name:       "Test Registry",
+			ServersURL: server.URL,
+			Protocol:   "modelcontextprotocol/registry",
+		},
+	}
+	defer func() { registryList = originalList }()
+
+	ctx := context.Background()
+	servers, err := SearchServers(ctx, "test", "", "")
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+		return
+	}
+
+	if len(servers) != 1 {
+		t.Errorf("expected 1 server, got %d", len(servers))
+		return
+	}
+
+	server1 := servers[0]
+	if server1.ID != "test-server" {
+		t.Errorf("expected server ID 'test-server', got '%s'", server1.ID)
+	}
+	if server1.Name != "Test Server" {
+		t.Errorf("expected server name 'Test Server', got '%s'", server1.Name)
+	}
+	if server1.Registry != "Test Registry" {
+		t.Errorf("expected registry 'Test Registry', got '%s'", server1.Registry)
+	}
+}
+
+func TestSearchServersWithSearch(t *testing.T) {
+	// Create mock HTTP server with multiple servers
+	mockData := map[string]interface{}{
+		"servers": []interface{}{
+			map[string]interface{}{
+				"id":          "weather-api",
+				"name":        "Weather API",
+				"description": "Get current weather data",
+			},
+			map[string]interface{}{
+				"id":          "news-feed",
+				"name":        "News Feed",
+				"description": "Latest news updates",
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(mockData); err != nil {
+			http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	// Temporarily modify registry
+	originalList := registryList
+	registryList = []RegistryEntry{
+		{
+			ID:         "test",
+			Name:       "Test Registry",
+			ServersURL: server.URL,
+			Protocol:   "modelcontextprotocol/registry",
+		},
+	}
+	defer func() { registryList = originalList }()
+
+	ctx := context.Background()
+
+	// Test search for "weather"
+	servers, err := SearchServers(ctx, "test", "", "weather")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+		return
+	}
+
+	if len(servers) != 1 {
+		t.Errorf("expected 1 server matching 'weather', got %d", len(servers))
+		return
+	}
+
+	if servers[0].ID != "weather-api" {
+		t.Errorf("expected 'weather-api', got '%s'", servers[0].ID)
+	}
+}
+
+func TestConstructServerURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		server   ServerEntry
+		registry RegistryEntry
+		expected string
+	}{
+		{
+			"already has URL",
+			ServerEntry{ID: "test", URL: "https://existing.com"},
+			RegistryEntry{Protocol: "custom/mcprun"},
+			"https://existing.com",
+		},
+		{
+			"mcprun protocol",
+			ServerEntry{ID: "weather", URL: ""},
+			RegistryEntry{Protocol: "custom/mcprun"},
+			"https://weather.mcp.run/mcp/",
+		},
+		{
+			"mcprun protocol with slash in ID",
+			ServerEntry{ID: "G4Vi/weather-service", URL: ""},
+			RegistryEntry{Protocol: "custom/mcprun"},
+			"https://G4Vi-weather-service.mcp.run/mcp/",
+		},
+		{
+			"mcprun protocol with multiple slashes in ID",
+			ServerEntry{ID: "owner/namespace/server", URL: ""},
+			RegistryEntry{Protocol: "custom/mcprun"},
+			"https://owner-namespace-server.mcp.run/mcp/",
+		},
+		{
+			"mcpstore protocol",
+			ServerEntry{ID: "news", URL: ""},
+			RegistryEntry{Protocol: "custom/mcpstore"},
+			"https://api.mcpstore.co/servers/news/mcp",
+		},
+		{
+			"docker protocol",
+			ServerEntry{ID: "scraper", URL: ""},
+			RegistryEntry{Protocol: "custom/docker"},
+			"docker://mcp/scraper",
+		},
+		{
+			"fleur protocol",
+			ServerEntry{ID: "app1", URL: ""},
+			RegistryEntry{Protocol: "custom/fleur"},
+			"https://api.fleurmcp.com/apps/app1/mcp",
+		},
+		{
+			"unknown protocol",
+			ServerEntry{ID: "test", URL: ""},
+			RegistryEntry{Protocol: "unknown"},
+			"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := constructServerURL(&tt.server, &tt.registry)
+			if result != tt.expected {
+				t.Errorf("expected '%s', got '%s'", tt.expected, result)
+			}
+		})
+	}
+}
+
+// Helper function for testing
+func TestProtocolParsersWithMissingData(t *testing.T) {
+	// Test all parsers with null/invalid data
+	tests := []struct {
+		name   string
+		parser func(interface{}) []ServerEntry
+	}{
+		{"parseMCPRun", parseMCPRun},
+		{"parsePulse", parsePulse},
+		{"parseMCPStore", parseMCPStore},
+		{"parseDocker", parseDocker},
+		{"parseFleur", parseFleur},
+		{"parseAPITracker", parseAPITracker},
+		{"parseApify", parseApify},
+		{"parseDefault", parseDefault},
+	}
+
+	invalidInputs := []interface{}{
+		nil,
+		"not an object",
+		123,
+		map[string]interface{}{},
+		[]interface{}{},
+	}
+
+	for _, tt := range tests {
+		for _, input := range invalidInputs {
+			t.Run(strings.ReplaceAll(tt.name, "parse", "parse_with_invalid_input"), func(t *testing.T) {
+				result := tt.parser(input)
+				if result == nil {
+					t.Errorf("parser %s returned nil instead of empty slice", tt.name)
+				}
+			})
+		}
+	}
+}

--- a/internal/registries/types.go
+++ b/internal/registries/types.go
@@ -1,0 +1,26 @@
+package registries
+
+// RegistryEntry represents a registry in the embedded registry list
+type RegistryEntry struct {
+	ID          string      `json:"id"`
+	Name        string      `json:"name"`
+	Description string      `json:"description"`
+	URL         string      `json:"url"`
+	ServersURL  string      `json:"servers_url,omitempty"`
+	Tags        []string    `json:"tags,omitempty"`
+	Protocol    string      `json:"protocol,omitempty"`
+	Count       interface{} `json:"count,omitempty"` // number or string
+}
+
+// ServerEntry represents an MCP server discovered via a registry
+type ServerEntry struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	URL         string `json:"url"`                  // MCP endpoint for direct connection
+	InstallCmd  string `json:"installCmd,omitempty"` // Command to install the server locally
+	ConnectURL  string `json:"connectUrl,omitempty"` // Alternative connection URL for remote servers
+	UpdatedAt   string `json:"updatedAt,omitempty"`
+	CreatedAt   string `json:"createdAt,omitempty"`
+	Registry    string `json:"registry,omitempty"` // Which registry this came from
+}

--- a/scripts/com.smartmcpproxy.mcpproxy.plist
+++ b/scripts/com.smartmcpproxy.mcpproxy.plist
@@ -8,6 +8,7 @@
     <key>ProgramArguments</key>
     <array>
         <string>/Applications/mcpproxy</string>
+        <string>serve</string>
         <string>--tray=true</string>
     </array>
     

--- a/scripts/mcpproxy.service
+++ b/scripts/mcpproxy.service
@@ -6,7 +6,7 @@ Documentation=https://github.com/smart-mcp-proxy/mcpproxy-go
 [Service]
 Type=simple
 User=%i
-ExecStart=/usr/local/bin/mcpproxy --config %h/.mcpproxy/mcp_config.json
+ExecStart=/usr/local/bin/mcpproxy serve --config %h/.mcpproxy/mcp_config.json
 Restart=always
 RestartSec=5
 StandardOutput=journal

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -22,4 +22,5 @@ if [ -n "$HOME" ] && [ -d "$HOME" ]; then
 fi
 
 echo "mcpproxy installation complete!"
-echo "Run 'mcpproxy --help' for usage information." 
+echo "Run 'mcpproxy --help' for usage information."
+echo "Run 'mcpproxy serve' to start the proxy server." 


### PR DESCRIPTION
- Changed instances of './mcpproxy' to './mcpproxy serve' in AUTOUPDATE.md, README.md, logging.md, setup.md, and various scripts.
- Updated CI workflows and service files to use the 'serve' command for starting the proxy server.
- Introduced new search_servers feature documentation and integrated it into the existing setup and usage guides.
