### PR TITLE
Add Azure MCP Registry Demo and Remote MCP Servers to configuration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -237,6 +237,24 @@ func DefaultConfig() *Config {
 				Tags:        []string{"verified"},
 				Protocol:    "custom/fleur",
 			},
+			{
+				ID:          "azure-mcp-demo",
+				Name:        "Azure MCP Registry Demo",
+				Description: "A reference implementation of MCP registry using Azure API Center",
+				URL:         "https://demo.registry.azure-mcp.net/",
+				ServersURL:  "https://demo.registry.azure-mcp.net/v0/servers",
+				Tags:        []string{"verified", "demo", "azure", "reference"},
+				Protocol:    "mcp/v0",
+			},
+			{
+				ID:          "remote-mcp-servers",
+				Name:        "Remote MCP Servers",
+				Description: "Community-maintained list of remote Model Context Protocol servers",
+				URL:         "https://remote-mcp-servers.com/",
+				ServersURL:  "https://remote-mcp-servers.com/api/servers",
+				Tags:        []string{"verified", "community", "remote"},
+				Protocol:    "custom/remote",
+			},
 		},
 	}
 }

--- a/internal/registries/new_parsers_test.go
+++ b/internal/registries/new_parsers_test.go
@@ -1,0 +1,173 @@
+package registries
+
+import (
+	"testing"
+)
+
+func TestParseAzureMCPDemo(t *testing.T) {
+	// Test data based on the user's example
+	sampleData := map[string]interface{}{
+		"servers": []interface{}{
+			map[string]interface{}{
+				"id":          "0d96666a-ccb9-4c1b-959a-ea5def24cf14",
+				"name":        "io.github.21st-dev/magic-mcp",
+				"description": "It's like v0 but in your Cursor/WindSurf/Cline. 21st dev Magic MCP server for working with your frontend like Magic",
+				"repository": map[string]interface{}{
+					"url":    "https://github.com/21st-dev/magic-mcp",
+					"source": "github",
+					"id":     "935450522",
+				},
+				"version_detail": map[string]interface{}{
+					"version":      "0.0.1-seed",
+					"release_date": "2025-05-15T04:52:52Z",
+					"is_latest":    true,
+				},
+			},
+			map[string]interface{}{
+				"id":          "eb5b0c73-1ed5-4180-b0ce-2cb8a36ee3f5",
+				"name":        "io.github.tinyfish-io/agentql-mcp",
+				"description": "Model Context Protocol server that integrates AgentQL's data extraction capabilities.",
+				"repository": map[string]interface{}{
+					"url":    "https://github.com/tinyfish-io/agentql-mcp",
+					"source": "github",
+					"id":     "906462272",
+				},
+				"version_detail": map[string]interface{}{
+					"version":      "0.0.1-seed",
+					"release_date": "2025-05-15T04:53:00Z",
+					"is_latest":    true,
+				},
+			},
+		},
+	}
+
+	servers := parseAzureMCPDemo(sampleData)
+
+	// Verify we parsed 2 servers
+	if len(servers) != 2 {
+		t.Errorf("Expected 2 servers, got %d", len(servers))
+	}
+
+	// Test first server
+	if len(servers) > 0 {
+		server := servers[0]
+		if server.ID != "0d96666a-ccb9-4c1b-959a-ea5def24cf14" {
+			t.Errorf("Expected ID '0d96666a-ccb9-4c1b-959a-ea5def24cf14', got '%s'", server.ID)
+		}
+		if server.Name != "io.github.21st-dev/magic-mcp" {
+			t.Errorf("Expected name 'io.github.21st-dev/magic-mcp', got '%s'", server.Name)
+		}
+		if server.URL != "https://github.com/21st-dev/magic-mcp" {
+			t.Errorf("Expected URL 'https://github.com/21st-dev/magic-mcp', got '%s'", server.URL)
+		}
+		if server.UpdatedAt != "2025-05-15T04:52:52Z" {
+			t.Errorf("Expected UpdatedAt '2025-05-15T04:52:52Z', got '%s'", server.UpdatedAt)
+		}
+		// Check that version is added to description
+		expectedDesc := "It's like v0 but in your Cursor/WindSurf/Cline. 21st dev Magic MCP server for working with your frontend like Magic (v0.0.1-seed)"
+		if server.Description != expectedDesc {
+			t.Errorf("Expected description to include version, got '%s'", server.Description)
+		}
+	}
+}
+
+func TestParseRemoteMCPServers(t *testing.T) {
+	// Test data based on the user's example
+	sampleData := map[string]interface{}{
+		"servers": []interface{}{
+			map[string]interface{}{
+				"id":   "github",
+				"name": "GitHub MCP Server",
+				"url":  "https://api.githubcopilot.com/mcp/",
+				"auth": "oauth",
+			},
+			map[string]interface{}{
+				"id":   "deepwiki",
+				"name": "DeepWiki MCP Server",
+				"url":  "https://mcp.deepwiki.com/mcp",
+				"auth": "open",
+			},
+			map[string]interface{}{
+				"id":   "custom-auth",
+				"name": "Custom Auth Server",
+				"url":  "https://api.custom.com/mcp/",
+				"auth": "api-key",
+			},
+		},
+	}
+
+	servers := parseRemoteMCPServers(sampleData)
+
+	// Verify we parsed 3 servers
+	if len(servers) != 3 {
+		t.Errorf("Expected 3 servers, got %d", len(servers))
+	}
+
+	// Test OAuth server
+	if len(servers) > 0 {
+		server := servers[0]
+		if server.ID != "github" {
+			t.Errorf("Expected ID 'github', got '%s'", server.ID)
+		}
+		if server.Name != "GitHub MCP Server" {
+			t.Errorf("Expected name 'GitHub MCP Server', got '%s'", server.Name)
+		}
+		if server.URL != "https://api.githubcopilot.com/mcp/" {
+			t.Errorf("Expected URL 'https://api.githubcopilot.com/mcp/', got '%s'", server.URL)
+		}
+		expectedDesc := "GitHub MCP Server (OAuth authentication required)"
+		if server.Description != expectedDesc {
+			t.Errorf("Expected description '%s', got '%s'", expectedDesc, server.Description)
+		}
+	}
+
+	// Test Open access server
+	if len(servers) > 1 {
+		server := servers[1]
+		expectedDesc := "DeepWiki MCP Server (Open access)"
+		if server.Description != expectedDesc {
+			t.Errorf("Expected description '%s', got '%s'", expectedDesc, server.Description)
+		}
+	}
+
+	// Test Custom auth server
+	if len(servers) > 2 {
+		server := servers[2]
+		expectedDesc := "Custom Auth Server (Authentication: api-key)"
+		if server.Description != expectedDesc {
+			t.Errorf("Expected description '%s', got '%s'", expectedDesc, server.Description)
+		}
+	}
+}
+
+func TestParseAzureMCPDemo_EmptyData(t *testing.T) {
+	// Test with empty data
+	emptyData := map[string]interface{}{}
+	servers := parseAzureMCPDemo(emptyData)
+	if len(servers) != 0 {
+		t.Errorf("Expected 0 servers for empty data, got %d", len(servers))
+	}
+
+	// Test with invalid data
+	invalidData := "not a map"
+	servers = parseAzureMCPDemo(invalidData)
+	if len(servers) != 0 {
+		t.Errorf("Expected 0 servers for invalid data, got %d", len(servers))
+	}
+}
+
+func TestParseRemoteMCPServers_EmptyData(t *testing.T) {
+	// Test with empty data
+	emptyData := map[string]interface{}{}
+	servers := parseRemoteMCPServers(emptyData)
+	if len(servers) != 0 {
+		t.Errorf("Expected 0 servers for empty data, got %d", len(servers))
+	}
+
+	// Test with invalid data
+	invalidData := "not a map"
+	servers = parseRemoteMCPServers(invalidData)
+	if len(servers) != 0 {
+		t.Errorf("Expected 0 servers for invalid data, got %d", len(servers))
+	}
+}


### PR DESCRIPTION
- Introduced new registry entries for Azure MCP Registry Demo and Remote MCP Servers in config.go.
- Added parsing tests for Azure MCP Demo and Remote MCP Servers in new_parsers_test.go.
- Updated search.go to handle new protocols for Azure MCP and Remote MCP servers.
