### PR TITLE
Add configurable Docker container log limits

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -119,23 +119,29 @@ type OAuthConfig struct {
 
 // DockerIsolationConfig represents global Docker isolation settings
 type DockerIsolationConfig struct {
-	Enabled       bool              `json:"enabled" mapstructure:"enabled"`                     // Global enable/disable for Docker isolation
-	DefaultImages map[string]string `json:"default_images" mapstructure:"default_images"`       // Map of runtime type to Docker image
-	Registry      string            `json:"registry,omitempty" mapstructure:"registry"`         // Custom registry (defaults to docker.io)
-	NetworkMode   string            `json:"network_mode,omitempty" mapstructure:"network_mode"` // Docker network mode (default: bridge)
-	MemoryLimit   string            `json:"memory_limit,omitempty" mapstructure:"memory_limit"` // Memory limit for containers
-	CPULimit      string            `json:"cpu_limit,omitempty" mapstructure:"cpu_limit"`       // CPU limit for containers
-	Timeout       Duration          `json:"timeout,omitempty" mapstructure:"timeout"`           // Container startup timeout
-	ExtraArgs     []string          `json:"extra_args,omitempty" mapstructure:"extra_args"`     // Additional docker run arguments
+	Enabled       bool              `json:"enabled" mapstructure:"enabled"`                       // Global enable/disable for Docker isolation
+	DefaultImages map[string]string `json:"default_images" mapstructure:"default_images"`         // Map of runtime type to Docker image
+	Registry      string            `json:"registry,omitempty" mapstructure:"registry"`           // Custom registry (defaults to docker.io)
+	NetworkMode   string            `json:"network_mode,omitempty" mapstructure:"network_mode"`   // Docker network mode (default: bridge)
+	MemoryLimit   string            `json:"memory_limit,omitempty" mapstructure:"memory_limit"`   // Memory limit for containers
+	CPULimit      string            `json:"cpu_limit,omitempty" mapstructure:"cpu_limit"`         // CPU limit for containers
+	Timeout       Duration          `json:"timeout,omitempty" mapstructure:"timeout"`             // Container startup timeout
+	ExtraArgs     []string          `json:"extra_args,omitempty" mapstructure:"extra_args"`       // Additional docker run arguments
+	LogDriver     string            `json:"log_driver,omitempty" mapstructure:"log_driver"`       // Docker log driver (default: json-file)
+	LogMaxSize    string            `json:"log_max_size,omitempty" mapstructure:"log_max_size"`   // Maximum size of log files (default: 100m)
+	LogMaxFiles   string            `json:"log_max_files,omitempty" mapstructure:"log_max_files"` // Maximum number of log files (default: 3)
 }
 
 // IsolationConfig represents per-server isolation settings
 type IsolationConfig struct {
-	Enabled     bool     `json:"enabled" mapstructure:"enabled"`                     // Enable Docker isolation for this server
-	Image       string   `json:"image,omitempty" mapstructure:"image"`               // Custom Docker image (overrides default)
-	NetworkMode string   `json:"network_mode,omitempty" mapstructure:"network_mode"` // Custom network mode for this server
-	ExtraArgs   []string `json:"extra_args,omitempty" mapstructure:"extra_args"`     // Additional docker run arguments for this server
-	WorkingDir  string   `json:"working_dir,omitempty" mapstructure:"working_dir"`   // Custom working directory in container
+	Enabled     bool     `json:"enabled" mapstructure:"enabled"`                       // Enable Docker isolation for this server
+	Image       string   `json:"image,omitempty" mapstructure:"image"`                 // Custom Docker image (overrides default)
+	NetworkMode string   `json:"network_mode,omitempty" mapstructure:"network_mode"`   // Custom network mode for this server
+	ExtraArgs   []string `json:"extra_args,omitempty" mapstructure:"extra_args"`       // Additional docker run arguments for this server
+	WorkingDir  string   `json:"working_dir,omitempty" mapstructure:"working_dir"`     // Custom working directory in container
+	LogDriver   string   `json:"log_driver,omitempty" mapstructure:"log_driver"`       // Docker log driver override for this server
+	LogMaxSize  string   `json:"log_max_size,omitempty" mapstructure:"log_max_size"`   // Maximum size of log files override
+	LogMaxFiles string   `json:"log_max_files,omitempty" mapstructure:"log_max_files"` // Maximum number of log files override
 }
 
 // RegistryEntry represents a registry in the configuration
@@ -276,6 +282,9 @@ func DefaultDockerIsolationConfig() *DockerIsolationConfig {
 		CPULimit:    "1.0",                      // Default CPU limit (1 core)
 		Timeout:     Duration(30 * time.Second), // 30 second startup timeout
 		ExtraArgs:   []string{},                 // No extra args by default
+		LogDriver:   "",                         // Use Docker system default (empty = no override)
+		LogMaxSize:  "100m",                     // Default maximum log file size (only used if json-file driver is set)
+		LogMaxFiles: "3",                        // Default maximum number of log files (only used if json-file driver is set)
 	}
 }
 

--- a/internal/upstream/core/isolation.go
+++ b/internal/upstream/core/isolation.go
@@ -183,7 +183,7 @@ func (im *IsolationManager) BuildDockerArgs(serverConfig *config.ServerConfig, r
 
 	args := []string{"run", "--rm", "-i"}
 
-	// Add logging configuration only if explicitly configured
+	// Add log driver only if explicitly configured
 	logDriver := ""
 	if serverConfig.Isolation != nil && serverConfig.Isolation.LogDriver != "" {
 		logDriver = serverConfig.Isolation.LogDriver
@@ -193,25 +193,24 @@ func (im *IsolationManager) BuildDockerArgs(serverConfig *config.ServerConfig, r
 
 	if logDriver != "" {
 		args = append(args, "--log-driver", logDriver)
+	}
 
-		// Only add log options for json-file driver
-		if logDriver == logDriverJSONFile {
-			logMaxSize := im.globalConfig.LogMaxSize
-			if serverConfig.Isolation != nil && serverConfig.Isolation.LogMaxSize != "" {
-				logMaxSize = serverConfig.Isolation.LogMaxSize
-			}
-			if logMaxSize != "" {
-				args = append(args, "--log-opt", fmt.Sprintf("max-size=%s", logMaxSize))
-			}
+	// Always add log size and file limits to prevent disk space issues
+	// These options work with Docker's default json-file driver and most other drivers
+	logMaxSize := im.globalConfig.LogMaxSize
+	if serverConfig.Isolation != nil && serverConfig.Isolation.LogMaxSize != "" {
+		logMaxSize = serverConfig.Isolation.LogMaxSize
+	}
+	if logMaxSize != "" {
+		args = append(args, "--log-opt", fmt.Sprintf("max-size=%s", logMaxSize))
+	}
 
-			logMaxFiles := im.globalConfig.LogMaxFiles
-			if serverConfig.Isolation != nil && serverConfig.Isolation.LogMaxFiles != "" {
-				logMaxFiles = serverConfig.Isolation.LogMaxFiles
-			}
-			if logMaxFiles != "" {
-				args = append(args, "--log-opt", fmt.Sprintf("max-file=%s", logMaxFiles))
-			}
-		}
+	logMaxFiles := im.globalConfig.LogMaxFiles
+	if serverConfig.Isolation != nil && serverConfig.Isolation.LogMaxFiles != "" {
+		logMaxFiles = serverConfig.Isolation.LogMaxFiles
+	}
+	if logMaxFiles != "" {
+		args = append(args, "--log-opt", fmt.Sprintf("max-file=%s", logMaxFiles))
 	}
 
 	// Add network mode

--- a/internal/upstream/core/isolation.go
+++ b/internal/upstream/core/isolation.go
@@ -33,6 +33,9 @@ const (
 
 	pathBinBash = "/bin/bash"
 	pathBinSh   = "/bin/sh"
+
+	// Docker log driver constants
+	logDriverJSONFile = "json-file"
 )
 
 // IsolationManager handles Docker isolation logic for MCP servers
@@ -179,6 +182,37 @@ func (im *IsolationManager) BuildDockerArgs(serverConfig *config.ServerConfig, r
 	}
 
 	args := []string{"run", "--rm", "-i"}
+
+	// Add logging configuration only if explicitly configured
+	logDriver := ""
+	if serverConfig.Isolation != nil && serverConfig.Isolation.LogDriver != "" {
+		logDriver = serverConfig.Isolation.LogDriver
+	} else if im.globalConfig.LogDriver != "" {
+		logDriver = im.globalConfig.LogDriver
+	}
+
+	if logDriver != "" {
+		args = append(args, "--log-driver", logDriver)
+
+		// Only add log options for json-file driver
+		if logDriver == logDriverJSONFile {
+			logMaxSize := im.globalConfig.LogMaxSize
+			if serverConfig.Isolation != nil && serverConfig.Isolation.LogMaxSize != "" {
+				logMaxSize = serverConfig.Isolation.LogMaxSize
+			}
+			if logMaxSize != "" {
+				args = append(args, "--log-opt", fmt.Sprintf("max-size=%s", logMaxSize))
+			}
+
+			logMaxFiles := im.globalConfig.LogMaxFiles
+			if serverConfig.Isolation != nil && serverConfig.Isolation.LogMaxFiles != "" {
+				logMaxFiles = serverConfig.Isolation.LogMaxFiles
+			}
+			if logMaxFiles != "" {
+				args = append(args, "--log-opt", fmt.Sprintf("max-file=%s", logMaxFiles))
+			}
+		}
+	}
 
 	// Add network mode
 	networkMode := im.globalConfig.NetworkMode

--- a/internal/upstream/core/isolation_log_test.go
+++ b/internal/upstream/core/isolation_log_test.go
@@ -1,0 +1,194 @@
+package core
+
+import (
+	"testing"
+
+	"mcpproxy-go/internal/config"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildDockerArgsWithLogging(t *testing.T) {
+	// Test with default global config (no log driver override)
+	t.Run("default logging config uses Docker default", func(t *testing.T) {
+		globalConfig := config.DefaultDockerIsolationConfig()
+		im := NewIsolationManager(globalConfig)
+
+		serverConfig := &config.ServerConfig{
+			Name:    "test-server",
+			Command: "python",
+			Args:    []string{"-m", "mcp_server"},
+		}
+
+		args, err := im.BuildDockerArgs(serverConfig, "python")
+		assert.NoError(t, err)
+
+		// Verify NO log configuration is included (uses Docker default)
+		assert.NotContains(t, args, "--log-driver")
+		assert.NotContains(t, args, "--log-opt")
+		assert.NotContains(t, args, "max-size")
+		assert.NotContains(t, args, "max-file")
+	})
+
+	// Test with custom global config
+	t.Run("custom global logging config", func(t *testing.T) {
+		globalConfig := config.DefaultDockerIsolationConfig()
+		globalConfig.LogDriver = logDriverJSONFile
+		globalConfig.LogMaxSize = "50m"
+		globalConfig.LogMaxFiles = "5"
+
+		im := NewIsolationManager(globalConfig)
+
+		serverConfig := &config.ServerConfig{
+			Name:    "test-server",
+			Command: "python",
+			Args:    []string{"-m", "mcp_server"},
+		}
+
+		args, err := im.BuildDockerArgs(serverConfig, "python")
+		assert.NoError(t, err)
+
+		// Verify custom log configuration is included
+		assert.Contains(t, args, "--log-driver")
+		assert.Contains(t, args, logDriverJSONFile)
+		assert.Contains(t, args, "--log-opt")
+		assert.Contains(t, args, "max-size=50m")
+		assert.Contains(t, args, "max-file=5")
+	})
+
+	// Test with server-specific override
+	t.Run("server-specific logging override", func(t *testing.T) {
+		globalConfig := config.DefaultDockerIsolationConfig()
+		im := NewIsolationManager(globalConfig)
+
+		serverConfig := &config.ServerConfig{
+			Name:    "test-server",
+			Command: "python",
+			Args:    []string{"-m", "mcp_server"},
+			Isolation: &config.IsolationConfig{
+				LogDriver:   logDriverJSONFile,
+				LogMaxSize:  "200m",
+				LogMaxFiles: "10",
+			},
+		}
+
+		args, err := im.BuildDockerArgs(serverConfig, "python")
+		assert.NoError(t, err)
+
+		// Verify server-specific log configuration is used
+		assert.Contains(t, args, "--log-driver")
+		assert.Contains(t, args, logDriverJSONFile)
+		assert.Contains(t, args, "--log-opt")
+		assert.Contains(t, args, "max-size=200m")
+		assert.Contains(t, args, "max-file=10")
+	})
+
+	// Test with non-json-file driver (should not include log options)
+	t.Run("non-json-file driver", func(t *testing.T) {
+		globalConfig := config.DefaultDockerIsolationConfig()
+		globalConfig.LogDriver = "none"
+
+		im := NewIsolationManager(globalConfig)
+
+		serverConfig := &config.ServerConfig{
+			Name:    "test-server",
+			Command: "python",
+			Args:    []string{"-m", "mcp_server"},
+		}
+
+		args, err := im.BuildDockerArgs(serverConfig, "python")
+		assert.NoError(t, err)
+
+		// Verify log driver is set but no log options are included
+		assert.Contains(t, args, "--log-driver")
+		assert.Contains(t, args, "none")
+		assert.NotContains(t, args, "max-size")
+		assert.NotContains(t, args, "max-file")
+	})
+
+	// Test without log driver configuration (uses Docker system default)
+	t.Run("no log driver configuration uses Docker default", func(t *testing.T) {
+		globalConfig := config.DefaultDockerIsolationConfig()
+		// LogDriver is already "" by default now
+
+		im := NewIsolationManager(globalConfig)
+
+		serverConfig := &config.ServerConfig{
+			Name:    "test-server",
+			Command: "python",
+			Args:    []string{"-m", "mcp_server"},
+		}
+
+		args, err := im.BuildDockerArgs(serverConfig, "python")
+		assert.NoError(t, err)
+
+		// Verify no log-related arguments are added (uses Docker system default)
+		assert.NotContains(t, args, "--log-driver")
+		assert.NotContains(t, args, "--log-opt")
+	})
+
+	// Test explicit json-file driver with default log limits
+	t.Run("explicit json-file driver with log limits", func(t *testing.T) {
+		globalConfig := config.DefaultDockerIsolationConfig()
+		globalConfig.LogDriver = logDriverJSONFile // Explicitly set
+
+		im := NewIsolationManager(globalConfig)
+
+		serverConfig := &config.ServerConfig{
+			Name:    "test-server",
+			Command: "python",
+			Args:    []string{"-m", "mcp_server"},
+		}
+
+		args, err := im.BuildDockerArgs(serverConfig, "python")
+		assert.NoError(t, err)
+
+		// Verify log configuration is applied when explicitly set
+		assert.Contains(t, args, "--log-driver")
+		assert.Contains(t, args, logDriverJSONFile)
+		assert.Contains(t, args, "--log-opt")
+		assert.Contains(t, args, "max-size=100m")
+		assert.Contains(t, args, "max-file=3")
+	})
+}
+
+func TestDockerArgsOrderWithLogging(t *testing.T) {
+	// Test that logging options come before other options in the correct order
+	globalConfig := config.DefaultDockerIsolationConfig()
+	globalConfig.LogDriver = logDriverJSONFile // Explicitly enable logging to test order
+	im := NewIsolationManager(globalConfig)
+
+	serverConfig := &config.ServerConfig{
+		Name:    "test-server",
+		Command: "python",
+		Args:    []string{"-m", "mcp_server"},
+		Env: map[string]string{
+			"API_KEY": "test-key",
+		},
+	}
+
+	args, err := im.BuildDockerArgs(serverConfig, "python")
+	assert.NoError(t, err)
+
+	// Find the positions of key arguments
+	var logDriverIndex, networkIndex, memoryIndex int = -1, -1, -1
+	for i, arg := range args {
+		switch arg {
+		case "--log-driver":
+			logDriverIndex = i
+		case "--network":
+			networkIndex = i
+		case "--memory":
+			memoryIndex = i
+		}
+	}
+
+	// Verify log driver comes before network and memory options
+	assert.NotEqual(t, -1, logDriverIndex, "log-driver should be present")
+	if networkIndex != -1 {
+		assert.Less(t, logDriverIndex, networkIndex, "log-driver should come before network")
+	}
+	if memoryIndex != -1 {
+		assert.Less(t, logDriverIndex, memoryIndex, "log-driver should come before memory")
+	}
+}


### PR DESCRIPTION
## Summary

Implements configurable Docker container log limits to prevent excessive disk usage from container stdout/stderr logs in isolated MCP servers.

- Adds `LogDriver`, `LogMaxSize`, `LogMaxFiles` configuration fields to both global and per-server isolation settings
- Default behavior uses Docker system default (no log driver override)
- When users explicitly configure `json-file` driver, applies log rotation limits (default: 100m max size, 3 max files)
- Supports server-specific overrides for fine-grained control

## Changes

- **Config**: Add logging fields to `DockerIsolationConfig` and `IsolationConfig`
- **Docker args**: Conditionally add `--log-driver` and `--log-opt` arguments based on configuration
- **Tests**: Comprehensive test coverage for all configuration scenarios

## Configuration Example

```json
{
  "docker_isolation": {
    "log_driver": "json-file",
    "log_max_size": "50m",
    "log_max_files": "5"
  },
  "mcpServers": [{
    "name": "special-server", 
    "isolation": {
      "log_max_size": "25m",
      "log_max_files": "2"
    }
  }]
}
```

## Test plan

- [x] Unit tests pass for all configuration scenarios
- [x] Default configuration uses Docker system defaults (no log args added)
- [x] Explicit json-file configuration applies log limits correctly
- [x] Server-specific overrides work as expected
- [x] Non-json-file drivers don't get log options (as required by Docker)
- [x] Build and linting passes