### PR TITLE
Fix: Make tray error states persistent for better UX clarity

### DIFF
--- a/cmd/mcpproxy-tray/internal/state/machine_error_test.go
+++ b/cmd/mcpproxy-tray/internal/state/machine_error_test.go
@@ -90,8 +90,8 @@ func TestErrorEventHandling(t *testing.T) {
 	}
 }
 
-// TestConfigErrorAutoTransition tests that config errors automatically transition to failed state
-func TestConfigErrorAutoTransition(t *testing.T) {
+// TestConfigErrorPersistence tests that config errors persist without auto-transitioning
+func TestConfigErrorPersistence(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	defer logger.Sync()
 
@@ -113,42 +113,48 @@ func TestConfigErrorAutoTransition(t *testing.T) {
 	// Trigger state entry handler
 	m.handleStateEntry(StateCoreErrorConfig)
 
-	// Wait for auto-transition (should happen within 3 seconds + some margin)
+	// Verify that the state persists without transitioning
 	timeout := time.After(5 * time.Second)
-	transitionFound := false
-
-	for !transitionFound {
-		select {
-		case transition := <-transitionsCh:
-			if transition.From == StateCoreErrorConfig && transition.To == StateFailed {
-				transitionFound = true
-				t.Logf("Config error auto-transitioned to failed state after timeout")
-			}
-		case <-timeout:
-			t.Fatal("Config error did not auto-transition to failed state within expected time")
-		case <-ctx.Done():
-			t.Fatal("Context cancelled before auto-transition")
+	select {
+	case transition := <-transitionsCh:
+		// If we get any transition, it should NOT be to failed state
+		if transition.From == StateCoreErrorConfig && transition.To == StateFailed {
+			t.Fatal("Config error should not auto-transition to failed state")
 		}
+		t.Logf("Got transition from %v to %v (not to failed - good)", transition.From, transition.To)
+	case <-timeout:
+		// Timeout is expected - config error should persist
+		t.Log("Config error persisted without auto-transition (expected behavior)")
+	case <-ctx.Done():
+		t.Fatal("Context cancelled before test completed")
 	}
 
-	// Verify final state
+	// Verify final state is still StateCoreErrorConfig
 	finalState := m.GetCurrentState()
-	if finalState != StateFailed {
-		t.Errorf("Expected final state %v, got %v", StateFailed, finalState)
+	if finalState != StateCoreErrorConfig {
+		t.Errorf("Expected state to remain %v, got %v", StateCoreErrorConfig, finalState)
+	}
+
+	// Verify that shutdown event is the only valid transition
+	newState := m.determineNewState(StateCoreErrorConfig, EventShutdown)
+	if newState != StateShuttingDown {
+		t.Errorf("Config error should transition to shutdown on EventShutdown, got %v", newState)
+	}
+
+	// Verify that other events don't cause transitions
+	newState = m.determineNewState(StateCoreErrorConfig, EventRetry)
+	if newState != StateCoreErrorConfig {
+		t.Errorf("Config error should persist on EventRetry, got %v", newState)
 	}
 }
 
-// TestStateInfoTimeout verifies that config error state has a timeout configured
-func TestStateInfoTimeout(t *testing.T) {
+// TestStateInfoNoTimeout verifies that config error state has NO timeout configured
+func TestStateInfoNoTimeout(t *testing.T) {
 	info := GetInfo(StateCoreErrorConfig)
 
-	if info.Timeout == nil {
-		t.Error("Config error state should have a timeout configured")
-	}
-
-	expectedTimeout := 3 * time.Second
-	if *info.Timeout != expectedTimeout {
-		t.Errorf("Expected timeout %v, got %v", expectedTimeout, *info.Timeout)
+	// Config errors should NOT have a timeout - they should persist
+	if info.Timeout != nil {
+		t.Error("Config error state should NOT have a timeout configured - errors should persist")
 	}
 
 	if info.CanRetry {
@@ -157,5 +163,107 @@ func TestStateInfoTimeout(t *testing.T) {
 
 	if !info.IsError {
 		t.Error("Config error state should be marked as an error")
+	}
+}
+
+// TestAllErrorStatesPersist verifies that all error states persist without auto-retry
+func TestAllErrorStatesPersist(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	defer logger.Sync()
+
+	errorStates := []State{
+		StateCoreErrorPortConflict,
+		StateCoreErrorDBLocked,
+		StateCoreErrorConfig,
+		StateCoreErrorGeneral,
+	}
+
+	for _, errorState := range errorStates {
+		t.Run(string(errorState), func(t *testing.T) {
+			m := NewMachine(logger.Sugar())
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			// Start the machine
+			m.Start()
+
+			// Subscribe to transitions
+			transitionsCh := m.Subscribe()
+
+			// Set initial state to error state
+			m.mu.Lock()
+			m.currentState = errorState
+			m.mu.Unlock()
+
+			// Trigger state entry handler
+			m.handleStateEntry(errorState)
+
+			// Verify that the state persists without transitioning
+			timeout := time.After(5 * time.Second)
+			select {
+			case transition := <-transitionsCh:
+				// We should NOT get any auto-transitions
+				t.Errorf("Error state %v should not auto-transition, got transition to %v", errorState, transition.To)
+			case <-timeout:
+				// Timeout is expected - error should persist
+				t.Logf("Error state %v persisted without auto-transition (expected)", errorState)
+			case <-ctx.Done():
+				t.Fatal("Context cancelled before test completed")
+			}
+
+			// Verify final state is still the error state
+			finalState := m.GetCurrentState()
+			if finalState != errorState {
+				t.Errorf("Expected state to remain %v, got %v", errorState, finalState)
+			}
+
+			// Verify that shutdown is the only valid transition
+			newState := m.determineNewState(errorState, EventShutdown)
+			if newState != StateShuttingDown {
+				t.Errorf("Error state %v should transition to shutdown on EventShutdown, got %v", errorState, newState)
+			}
+
+			// Verify that retry events don't cause transitions
+			newState = m.determineNewState(errorState, EventRetry)
+			if newState != errorState {
+				t.Errorf("Error state %v should persist on EventRetry, got %v", errorState, newState)
+			}
+		})
+	}
+}
+
+// TestErrorStateInfoConfiguration verifies all error states are configured correctly
+func TestErrorStateInfoConfiguration(t *testing.T) {
+	errorStates := []State{
+		StateCoreErrorPortConflict,
+		StateCoreErrorDBLocked,
+		StateCoreErrorConfig,
+		StateCoreErrorGeneral,
+	}
+
+	for _, errorState := range errorStates {
+		t.Run(string(errorState), func(t *testing.T) {
+			info := GetInfo(errorState)
+
+			// All error states should NOT have timeouts
+			if info.Timeout != nil {
+				t.Errorf("Error state %v should NOT have a timeout - errors should persist", errorState)
+			}
+
+			// All error states should NOT be retryable
+			if info.CanRetry {
+				t.Errorf("Error state %v should not be retryable", errorState)
+			}
+
+			// All should be marked as errors
+			if !info.IsError {
+				t.Errorf("Error state %v should be marked as an error", errorState)
+			}
+
+			// All should have helpful user messages
+			if info.UserMessage == "" || info.UserMessage == string(errorState) {
+				t.Errorf("Error state %v should have a helpful user message, got: %q", errorState, info.UserMessage)
+			}
+		})
 	}
 }

--- a/internal/tray/tray.go
+++ b/internal/tray/tray.go
@@ -256,19 +256,19 @@ func (a *App) applyConnectionStateToUI(state ConnectionState) {
 	case ConnectionStateAuthError:
 		statusText = "Status: Authentication error"
 		tooltip = "Core is running but API key authentication failed"
-	// ADD: Detailed error state messages
+	// ADD: Detailed error state messages with actionable instructions
 	case ConnectionStateErrorPortConflict:
 		statusText = "Status: Port conflict"
-		tooltip = "Port already in use - another instance may be running"
+		tooltip = "Port 8080 already in use. Kill other mcpproxy instance or change port in config."
 	case ConnectionStateErrorDBLocked:
 		statusText = "Status: Database locked"
-		tooltip = "Database locked - another mcpproxy instance running?"
+		tooltip = "Database locked by another mcpproxy instance. Kill other instance with: pkill mcpproxy"
 	case ConnectionStateErrorConfig:
 		statusText = "Status: Configuration error"
-		tooltip = "Configuration error - check ~/.mcpproxy/mcp_config.json"
+		tooltip = "Invalid configuration file. Fix ~/.mcpproxy/mcp_config.json and restart."
 	case ConnectionStateErrorGeneral:
 		statusText = "Status: Core startup failed"
-		tooltip = "Core failed to start - check logs for details"
+		tooltip = "Core failed to start. Check ~/Library/Logs/mcpproxy/main.log for details."
 	case ConnectionStateFailed:
 		statusText = "Status: Failed"
 		tooltip = "Core failed to start after multiple attempts"


### PR DESCRIPTION
## Summary
Makes all tray error states (port conflict, DB locked, config error, general error) **persist indefinitely** instead of auto-retrying and transitioning to a generic "Failed" state. This keeps error context visible so users always know what went wrong.

## Problem
Previously, error states would auto-retry and eventually show "Failed", losing the specific error information:
- Port conflict → Retry 2x → "Failed" ❌
- DB locked → Retry 3x → "Failed" ❌
- Config error → Auto-transition → "Failed" ❌

Users saw "Failed" but didn't know if it was a port conflict, DB lock, config error, etc.

## Solution
Error states now **persist permanently** until the user fixes the issue:
- ✅ Port conflict stays visible until user kills other instance or changes port
- ✅ DB locked stays visible until user kills other instance
- ✅ Config error stays visible until user fixes config file
- ✅ General error stays visible until user investigates logs

Error states only transition to `StateShuttingDown` when user shuts down.

## Changes

### State Machine ([machine.go](cmd/mcpproxy-tray/internal/state/machine.go))
- Removed auto-retry logic from all error states
- Removed auto-transition to `StateFailed` 
- Error states now only respond to `EventShutdown`

### State Configuration ([states.go](cmd/mcpproxy-tray/internal/state/states.go))
- Set `CanRetry: false` for all error states
- Removed timeouts from all error states
- Enhanced user messages with actionable guidance:
  - Port: "Port already in use - kill other instance or change port"
  - DB: "Database locked - kill other mcpproxy instance"
  - Config: "Configuration error - check config file"
  - General: "Core startup failed - check logs"
- Removed `StateFailed` as valid transition from error states

### UI Tooltips ([tray.go](internal/tray/tray.go))
- More detailed tooltips with specific troubleshooting steps:
  - Port: "Port 8080 already in use. Kill other mcpproxy instance or change port in config."
  - DB: "Database locked by another mcpproxy instance. Kill other instance with: pkill mcpproxy"
  - Config: "Invalid configuration file. Fix ~/.mcpproxy/mcp_config.json and restart."
  - General: "Core failed to start. Check ~/Library/Logs/mcpproxy/main.log for details."

### Tests ([machine_error_test.go](cmd/mcpproxy-tray/internal/state/machine_error_test.go))
- Added `TestAllErrorStatesPersist` - verifies all 4 error states persist without auto-transitioning
- Added `TestErrorStateInfoConfiguration` - validates error state configuration
- Updated `TestConfigErrorPersistence` to match new behavior
- **All tests pass** ✅

## Benefits
1. ✅ **Clear error identification** - Users always see the actual error
2. ✅ **Actionable instructions** - Tooltips explain how to fix
3. ✅ **Consistent behavior** - All errors behave the same way
4. ✅ **Simpler state machine** - Fewer transitions, less complexity
5. ✅ **Better UX** - No lost context, clear problem diagnosis

## Testing
```bash
# All state machine tests pass
go test ./cmd/mcpproxy-tray/internal/state -v
# PASS: TestAllErrorStatesPersist (20.01s - all 4 error states)
# PASS: TestErrorStateInfoConfiguration
# PASS: TestConfigErrorPersistence

# Binary rebuilt successfully
GOOS=darwin CGO_ENABLED=1 go build -o mcpproxy-tray ./cmd/mcpproxy-tray
```

Tested manually with:
- Config errors (corrupted mcp_config.json)
- Port conflicts (multiple instances)
- DB locks (concurrent launches)

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| Port conflict | "Port conflict" → retry → "Failed" | "Port conflict" (stays visible) ✅ |
| DB locked | "DB locked" → retry → "Failed" | "DB locked" (stays visible) ✅ |
| Config error | "Config error" → timeout → "Failed" | "Config error" (stays visible) ✅ |
| General error | "Core startup failed" → retry → "Failed" | "Core startup failed" (stays visible) ✅ |

## Related Issues
Fixes issue where tray status shows generic "Failed" instead of specific error, making troubleshooting difficult for users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)