### PR TITLE
Fix: Tray startup timeout and output capture race conditions

### DIFF
--- a/cmd/mcpproxy-tray/internal/state/states.go
+++ b/cmd/mcpproxy-tray/internal/state/states.go
@@ -106,7 +106,7 @@ type Info struct {
 
 // GetInfo returns metadata for a given state
 func GetInfo(state State) Info {
-	timeout30s := 30 * time.Second
+	timeout90s := 90 * time.Second  // Must exceed health monitor's readinessTimeout (60s)
 	timeout5s := 5 * time.Second
 	timeout10s := 10 * time.Second
 
@@ -127,7 +127,7 @@ func GetInfo(state State) Info {
 			Name:        StateWaitingForCore,
 			Description: "Waiting for core to become ready",
 			UserMessage: "Core starting up...",
-			Timeout:     &timeout30s,
+			Timeout:     &timeout90s,  // Increased to 90s to allow Docker isolation startup (health timeout is 60s)
 		},
 		StateConnectingAPI: {
 			Name:        StateConnectingAPI,


### PR DESCRIPTION
## Problem

The tray application had two critical issues preventing reliable core process startup:

1. **Timeout Mismatch**: State machine's `StateWaitingForCore` timeout (30s) fired before the health monitor's readiness timeout (60s), causing premature failures during Docker isolation startup
2. **Output Capture Race**: Capture goroutines might not be ready before the process starts, causing early stderr/stdout to be lost—critical for diagnosing startup failures

## Changes

### 1. Fix State Machine Timeout Mismatch

**File**: `cmd/mcpproxy-tray/internal/state/states.go`

- Increased `StateWaitingForCore` timeout from **30s → 90s**
- Ensures state machine timeout exceeds health monitor's 60s readiness check
- Allows sufficient time for Docker container initialization during startup
- Added explanatory comment to prevent future regressions

**Before**:
```go
timeout30s := 30 * time.Second
StateWaitingForCore: {
    Timeout: &timeout30s,
}
```

**After**:
```go
timeout90s := 90 * time.Second  // Must exceed health monitor's readinessTimeout (60s)
StateWaitingForCore: {
    Timeout: &timeout90s,  // Increased to allow Docker isolation startup
}
```

### 2. Synchronize Output Capture Goroutine Startup

**File**: `cmd/mcpproxy-tray/internal/monitor/process.go`

- Added `sync.WaitGroup` in `setupOutputCapture()` to synchronize goroutine readiness
- Updated `captureOutput()` to accept WaitGroup and signal when ready to read
- Added debug logging for goroutine initialization
- **Guarantees** all stderr/stdout is captured from the very first moment of process execution

**Execution Sequence** (now guaranteed):
1. Create stdout/stderr pipes
2. Launch capture goroutines
3. **Wait for both goroutines to signal ready** ← NEW
4. Start process (goroutines are now blocking on pipe reads)

## Testing

- ✅ Linter passed (0 issues)
- ✅ All unit tests pass
- ✅ Tray state machine tests pass (25s runtime)
- ℹ️ Binary E2E tests skipped (require built binary, not affected by these changes)

## Impact

These fixes ensure:
- Tray waits sufficiently long for core to start with Docker isolation
- All early error output is captured for debugging
- Servers list populates correctly after successful connection
- Better reliability for users with slow Docker startup times

🤖 Generated with [Claude Code](https://claude.com/claude-code)