### PR TITLE
Fix stale error messages after successful OAuth authentication

### DIFF
--- a/internal/upstream/types/types.go
+++ b/internal/upstream/types/types.go
@@ -138,6 +138,8 @@ func (sm *StateManager) TransitionTo(newState ConnectionState) {
 	if newState == StateReady {
 		sm.lastError = nil
 		sm.retryCount = 0
+		sm.isOAuthError = false
+		sm.oauthRetryCount = 0
 	}
 
 	info := ConnectionInfo{


### PR DESCRIPTION
## Summary

Fixes a bug where OAuth-authenticated servers continue to show stale error messages in the UI even after successful authentication and connection.

## Problem

When a user successfully completed OAuth login for a server:
- Backend status changed to "connected" ✅
- BUT UI still showed error message: "Server Error: failed to connect: all authentication strategies failed, last error: OAuth authorization required - deferred for background processing" ❌
- Tool count always showed 0 ❌

## Root Cause

In `internal/upstream/types/types.go`, the `StateManager.TransitionTo()` method was only partially clearing error state when transitioning to `StateReady`:

```go
if newState == StateReady {
    sm.lastError = nil         // Cleared ✅
    sm.retryCount = 0          // Cleared ✅
    sm.isOAuthError = ???      // NOT cleared ❌
    sm.oauthRetryCount = ???   // NOT cleared ❌
}
```

The incomplete cleanup left OAuth-specific flags set, which could cause:
1. Stale error messages displayed in the UI
2. Incorrect retry logic treating successful connections as still in error state
3. Tool indexing issues if dependent on clean connection state

## Solution

Clear **all** error-related state flags when transitioning to `StateReady`:

```go
if newState == StateReady {
    sm.lastError = nil
    sm.retryCount = 0
    sm.isOAuthError = false      // NEW: Clear OAuth error flag
    sm.oauthRetryCount = 0       // NEW: Reset OAuth retry counter
}
```

## Testing

✅ All E2E tests pass (`./scripts/test-api-e2e.sh`)
✅ Build succeeds without errors
✅ Manual testing shows error messages clear after OAuth success

## Files Changed

- `internal/upstream/types/types.go` - Added 2 lines to clear OAuth error flags

## Related Issues

Fixes issue where UI shows stale OAuth error messages even after successful authentication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)