### PR TITLE
feat: Improve OAuth token refresh with proactive grace period

### DIFF
--- a/internal/oauth/persistent_token_store.go
+++ b/internal/oauth/persistent_token_store.go
@@ -15,6 +15,13 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	// TokenRefreshGracePeriod defines how long before expiration we should trigger a refresh.
+	// This prevents race conditions where a token expires during an API call.
+	// Setting this to 5 minutes allows proactive token refresh before expiration.
+	TokenRefreshGracePeriod = 5 * time.Minute
+)
+
 // PersistentTokenStore implements client.TokenStore using BBolt storage
 type PersistentTokenStore struct {
 	serverKey string // Unique key combining server name and URL
@@ -56,43 +63,61 @@ func (p *PersistentTokenStore) GetToken(ctx context.Context) (*client.Token, err
 		return nil, err
 	}
 
-	p.logger.Info("🔍 Loading OAuth token from persistent storage",
+	p.logger.Debug("🔍 Loading OAuth token from persistent storage",
 		zap.String("server_key", p.serverKey))
 
 	record, err := p.storage.GetOAuthToken(p.serverKey)
 	if err != nil {
-		p.logger.Info("❌ No stored OAuth token found",
+		p.logger.Debug("❌ No stored OAuth token found",
 			zap.String("server_key", p.serverKey),
 			zap.Error(err))
 		return nil, transport.ErrNoToken
 	}
 
-	// Check if token is expired
-	if time.Now().After(record.ExpiresAt) {
-		p.logger.Info("Stored OAuth token is expired",
+	now := time.Now()
+	timeUntilExpiry := record.ExpiresAt.Sub(now)
+	isExpired := now.After(record.ExpiresAt)
+	needsRefresh := timeUntilExpiry < TokenRefreshGracePeriod
+
+	// Log token status for debugging
+	if isExpired {
+		p.logger.Warn("⚠️ OAuth token has expired and needs refresh",
+			zap.String("server_key", p.serverKey),
 			zap.Time("expires_at", record.ExpiresAt),
-			zap.Time("current_time", time.Now()))
-		// Return expired token - OAuth client will handle refresh
+			zap.Duration("expired_since", -timeUntilExpiry),
+			zap.Bool("has_refresh_token", record.RefreshToken != ""))
+	} else if needsRefresh {
+		p.logger.Info("⏰ OAuth token will expire soon, proactive refresh recommended",
+			zap.String("server_key", p.serverKey),
+			zap.Time("expires_at", record.ExpiresAt),
+			zap.Duration("time_until_expiry", timeUntilExpiry),
+			zap.Duration("grace_period", TokenRefreshGracePeriod),
+			zap.Bool("has_refresh_token", record.RefreshToken != ""))
+	} else {
+		p.logger.Debug("✅ OAuth token is valid and not expiring soon",
+			zap.String("server_key", p.serverKey),
+			zap.Time("expires_at", record.ExpiresAt),
+			zap.Duration("time_until_expiry", timeUntilExpiry),
+			zap.Bool("has_refresh_token", record.RefreshToken != ""))
 	}
 
 	// Join scopes back into space-separated string
 	scope := strings.Join(record.Scopes, " ")
 
+	// Adjust ExpiresAt to trigger proactive refresh within grace period
+	// This prevents race conditions where tokens expire during API calls
+	adjustedExpiresAt := record.ExpiresAt.Add(-TokenRefreshGracePeriod)
+
 	token := &client.Token{
 		AccessToken:  record.AccessToken,
 		RefreshToken: record.RefreshToken,
 		TokenType:    record.TokenType,
-		ExpiresAt:    record.ExpiresAt,
+		ExpiresAt:    adjustedExpiresAt, // Use grace period for proactive refresh
 		Scope:        scope,
 	}
 
-	p.logger.Info("✅ OAuth token loaded from persistent storage",
-		zap.String("server_key", p.serverKey),
-		zap.String("token_type", record.TokenType),
-		zap.Time("expires_at", record.ExpiresAt),
-		zap.Strings("scopes", record.Scopes),
-		zap.Bool("expired", time.Now().After(record.ExpiresAt)))
-
+	// Return the token - mcp-go library will check IsExpired() and handle refresh if needed
+	// By subtracting the grace period from ExpiresAt, we trigger refresh earlier
 	return token, nil
 }
 
@@ -105,9 +130,16 @@ func (p *PersistentTokenStore) SaveToken(ctx context.Context, token *client.Toke
 		return err
 	}
 
+	now := time.Now()
+	timeUntilExpiry := token.ExpiresAt.Sub(now)
+
 	p.logger.Info("💾 Saving OAuth token to persistent storage",
+		zap.String("server_key", p.serverKey),
 		zap.String("token_type", token.TokenType),
-		zap.Time("expires_at", token.ExpiresAt))
+		zap.Time("expires_at", token.ExpiresAt),
+		zap.Duration("valid_for", timeUntilExpiry),
+		zap.Bool("has_refresh_token", token.RefreshToken != ""),
+		zap.String("scope", token.Scope))
 
 	// Parse scopes from token.Scope (space-separated string)
 	var scopes []string
@@ -122,30 +154,38 @@ func (p *PersistentTokenStore) SaveToken(ctx context.Context, token *client.Toke
 		TokenType:    token.TokenType,
 		ExpiresAt:    token.ExpiresAt,
 		Scopes:       scopes,
-		Created:      time.Now(),
-		Updated:      time.Now(),
+		Created:      now,
+		Updated:      now,
 	}
 
 	err := p.storage.SaveOAuthToken(record)
 	if err != nil {
-		p.logger.Error("Failed to save OAuth token to persistent storage", zap.Error(err))
+		p.logger.Error("❌ Failed to save OAuth token to persistent storage",
+			zap.String("server_key", p.serverKey),
+			zap.Error(err))
 		return fmt.Errorf("failed to save OAuth token: %w", err)
 	}
 
-	p.logger.Info("✅ OAuth token saved to persistent storage successfully")
+	p.logger.Info("✅ OAuth token saved to persistent storage successfully",
+		zap.String("server_key", p.serverKey),
+		zap.Duration("valid_for", timeUntilExpiry))
 	return nil
 }
 
 // ClearToken removes the OAuth token from persistent storage
 func (p *PersistentTokenStore) ClearToken() error {
-	p.logger.Info("🗑️ Clearing OAuth token from persistent storage")
+	p.logger.Info("🗑️ Clearing OAuth token from persistent storage",
+		zap.String("server_key", p.serverKey))
 
 	err := p.storage.DeleteOAuthToken(p.serverKey)
 	if err != nil {
-		p.logger.Error("Failed to clear OAuth token from persistent storage", zap.Error(err))
+		p.logger.Error("❌ Failed to clear OAuth token from persistent storage",
+			zap.String("server_key", p.serverKey),
+			zap.Error(err))
 		return fmt.Errorf("failed to clear OAuth token: %w", err)
 	}
 
-	p.logger.Info("✅ OAuth token cleared from persistent storage successfully")
+	p.logger.Info("✅ OAuth token cleared from persistent storage successfully",
+		zap.String("server_key", p.serverKey))
 	return nil
 }

--- a/internal/oauth/persistent_token_store_test.go
+++ b/internal/oauth/persistent_token_store_test.go
@@ -67,8 +67,10 @@ func TestPersistentTokenStore(t *testing.T) {
 	if retrievedToken.Scope != originalToken.Scope {
 		t.Errorf("Scope mismatch: got %s, want %s", retrievedToken.Scope, originalToken.Scope)
 	}
-	if retrievedToken.ExpiresAt.Unix() != originalToken.ExpiresAt.Unix() {
-		t.Errorf("ExpiresAt mismatch: got %v, want %v", retrievedToken.ExpiresAt, originalToken.ExpiresAt)
+	// ExpiresAt should be adjusted by grace period for proactive refresh
+	expectedExpiresAt := originalToken.ExpiresAt.Add(-TokenRefreshGracePeriod)
+	if retrievedToken.ExpiresAt.Unix() != expectedExpiresAt.Unix() {
+		t.Errorf("ExpiresAt mismatch (should be adjusted by grace period): got %v, want %v", retrievedToken.ExpiresAt, expectedExpiresAt)
 	}
 
 	// Test case 4: Update token


### PR DESCRIPTION
## Summary

This PR improves the OAuth token refresh mechanism to **prevent frequent re-login requirements** by implementing proactive token refresh with a 5-minute grace period.

## Problem

Users were experiencing frequent re-login prompts with OAuth-enabled servers. Investigation revealed that while the `mcp-go` library (v0.42.0) implements automatic token refresh, it only triggers when tokens are **already expired**, leading to:

- Race conditions where tokens expire between validation and API calls
- Unnecessary re-authentication flows
- Poor user experience

## Solution

Implement **proactive token refresh** by adjusting the token expiration time with a grace period:

1. Add `TokenRefreshGracePeriod` constant (5 minutes)
2. Subtract grace period from `ExpiresAt` when returning tokens
3. This makes the mcp-go library think tokens are expired 5 minutes earlier
4. Automatic refresh triggers proactively, preventing actual expiration

## Key Changes

### Token Refresh Improvements (`internal/oauth/persistent_token_store.go`)
- ✨ Add `TokenRefreshGracePeriod = 5 * time.Minute` constant
- ✨ Adjust `ExpiresAt` by subtracting grace period in `GetToken()`
- ✨ This triggers mcp-go's automatic refresh mechanism early

### Enhanced Logging
- 📝 Add debug logging for token retrieval with expiration details
- ⚠️ Add warning logs for expired tokens with duration since expiration
- ℹ️ Add info logs for tokens expiring soon (within grace period)
- 💾 Improve `SaveToken` logging with validity duration
- 🗑️ Improve `ClearToken` logging with server key context

### Test Updates
- ✅ Update `TestPersistentTokenStore` to expect adjusted `ExpiresAt`
- 📚 Add documentation explaining grace period adjustment

## How It Works

The mcp-go library implements automatic token refresh:
```go
func (h *OAuthHandler) getValidToken(ctx context.Context) (*Token, error) {
    token, err := h.config.TokenStore.GetToken(ctx)
    
    // Check if token is expired
    if token.IsExpired() {
        // Try to refresh using refresh token
        newToken, err := h.refreshToken(ctx, token.RefreshToken)
        if err == nil {
            return newToken, nil
        }
    }
    
    return token, nil
}
```

By adjusting `ExpiresAt` in our `TokenStore.GetToken()`:
```go
adjustedExpiresAt := record.ExpiresAt.Add(-TokenRefreshGracePeriod)
```

We make the library think the token is expired 5 minutes before actual expiration, triggering proactive refresh.

## Benefits

- ✅ **Proactive Refresh**: Tokens refresh 5 minutes before expiration
- ✅ **Reduced Re-login**: Users stay authenticated longer
- ✅ **Better Debugging**: Comprehensive logging for troubleshooting
- ✅ **Race Condition Prevention**: Tokens won't expire during API calls
- ✅ **Backward Compatible**: No breaking changes to existing functionality

## Testing

- ✅ OAuth unit tests pass (`go test ./internal/oauth/... -v`)
- ✅ API E2E tests pass (`./scripts/test-api-e2e.sh`)
- ✅ No breaking changes to existing behavior
- ✅ Token refresh tested with mcp-go v0.42.0

## Technical Notes

**Token Refresh Flow**:
1. Application calls `TokenStore.GetToken()`
2. We return token with adjusted `ExpiresAt` (5 min earlier)
3. mcp-go library calls `token.IsExpired()`
4. If within grace period, library calls `refreshToken()`
5. New token saved automatically via `TokenStore.SaveToken()`
6. Application receives fresh token

**When tokens are saved**, we store the **actual** `ExpiresAt` from the OAuth server. The grace period adjustment only happens when **returning** tokens.

## Related Issues

Addresses user observation: "OAuth servers required to login too frequently"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>