### PR TITLE
fix(upstream): prevent goroutine logging in Docker recovery monitor on Windows

### DIFF
--- a/internal/upstream/manager.go
+++ b/internal/upstream/manager.go
@@ -1713,6 +1713,13 @@ func (m *Manager) startDockerRecoveryMonitor(ctx context.Context) {
 
 	// Initial check
 	if err := m.checkDockerAvailability(ctx); err != nil {
+		// Check if context was cancelled before logging
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
 		m.logger.Warn("Docker unavailable on startup, starting recovery", zap.Error(err))
 		go m.handleDockerUnavailable(ctx)
 		return
@@ -1729,6 +1736,13 @@ func (m *Manager) startDockerRecoveryMonitor(ctx context.Context) {
 			return
 		case <-ticker.C:
 			if err := m.checkDockerAvailability(ctx); err != nil {
+				// Check if context was cancelled before logging
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+
 				m.logger.Warn("Docker became unavailable, starting recovery", zap.Error(err))
 				go m.handleDockerUnavailable(ctx)
 				return // Exit monitor, handleDockerUnavailable will restart it


### PR DESCRIPTION
## Summary

Fixed Windows test failures by adding context checks before logging in `startDockerRecoveryMonitor`. This prevents goroutines from logging after test completion, completing the fix started in PR #122.

## Root Cause

On Windows (where Docker is typically not available in CI), the issue occurred when:
1. Tests create a Runtime with upstream manager
2. Docker recovery monitor starts and checks availability
3. Docker is unavailable, so it prepares to log a warning
4. Test completes and calls `Close()`, canceling the context
5. **Goroutine logs warning synchronously without checking if context was cancelled**

This is different from the macOS/Linux issue fixed in PR #122, where the logging happened after a timer delay.

## Changes

**File: `internal/upstream/manager.go`**

1. **Added context check in initial Docker availability check** (line 1716-1721)
   - Check if context was cancelled before logging warning
   - Return immediately if shutdown is in progress

2. **Added context check in periodic monitoring** (line 1739-1744)
   - Check if context was cancelled before logging
   - Prevents logging during test cleanup

## Test Results

✅ Tests pass locally with the fix applied

## Fixes

**Windows test failure:**
- Unit Tests (windows-latest, 1.23.10)
- https://github.com/smart-mcp-proxy/mcpproxy-go/actions/runs/19045548056/job/54392774796

**Error:**
```
panic: Log in goroutine after TestUpdateListenAddressValidation has completed: 
2025-11-03T18:43:44.521Z	WARN	Docker unavailable on startup, starting recovery	
{"error": "docker unavailable: exit status 1"}

goroutine 160 [running]:
mcpproxy-go/internal/upstream.(*Manager).startDockerRecoveryMonitor(0xc000212630, {0x1414d55d8, 0xc000368dc0})
	D:/a/mcpproxy-go/mcpproxy-go/internal/upstream/manager.go:1716 +0x656
```

## Related PRs

Complements PR #122 which fixed the same issue on macOS/Linux platforms for timer-based logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)