### PR TITLE
fix(upstream): prevent logging after context cancellation in Docker recovery retry

### DIFF
--- a/internal/upstream/manager.go
+++ b/internal/upstream/manager.go
@@ -1892,6 +1892,13 @@ func (m *Manager) handleDockerUnavailable(ctx context.Context) {
 				return
 			}
 
+			// Check if context was cancelled before logging retry
+			select {
+			case <-recoveryCtx.Done():
+				return
+			default:
+			}
+
 			// Still unavailable, save state
 			m.logger.Info("Docker recovery retry",
 				zap.Int("attempt", attempt),


### PR DESCRIPTION
## Summary

Fixed another goroutine leak where Docker recovery retry logging occurred after test completion. This is the THIRD location that needed fixing in the Docker recovery monitor.

## Root Cause

The issue occurred in `handleDockerUnavailable` when:
1. Timer fires (after 2-5 seconds wait)
2. `checkDockerAvailability` is called and returns an error
3. Test completes and context is cancelled
4. **Goroutine logs "Docker recovery retry" without checking if context was cancelled**

## Error Message

```
panic: Log in goroutine after TestUpdateListenAddressValidation has completed: 
2025-11-03T19:09:06.504Z	INFO	Docker recovery retry	
{"attempt": 1, "elapsed": "2.001453042s", "next_retry_in": "5s", 
 "error": "docker unavailable: exec: \"docker\": executable file not found in $PATH"}

goroutine 104 [running]:
mcpproxy-go/internal/upstream.(*Manager).handleDockerUnavailable(0xc000122160, {0x10348fe98, 0xc00034c050})
	/Users/runner/work/mcpproxy-go/mcpproxy-go/internal/upstream/manager.go:1896 +0x920
```

## Changes

**File: `internal/upstream/manager.go`**

Added context check before "Docker recovery retry" logging (line 1895-1900):
- Check if `recoveryCtx` was cancelled before logging
- Return immediately if shutdown is in progress
- Prevents goroutine from logging after test cleanup

## Complete Fix Summary

This PR completes the Docker recovery monitor fix by addressing ALL logging locations:

| PR | Location | Issue |
|----|----------|-------|
| **#122** | `handleDockerUnavailable` after timer | Logs without context check after sleep |
| **#123** | `startDockerRecoveryMonitor` initial check | Logs on startup without context check |
| **#124** (this PR) | `handleDockerUnavailable` retry logging | Logs after failed check without context check |

## Test Results

✅ Tests pass locally with the fix applied:
```bash
go test -v -race -run TestUpdateListenAddressValidation ./internal/runtime/...
```

## Fixes

**macOS E2E test failure:**
- End-to-End Tests (macos-latest, 1.23.10)
- https://github.com/smart-mcp-proxy/mcpproxy-go/actions/runs/19046210469

## Related PRs

- PR #122: Fixed timer-based logging (MERGED)
- PR #123: Fixed initial check logging (MERGED)
- PR #124: Fixes retry logging (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)