### PR TITLE
fix(upstream): prevent OAuth event monitor logging after context cancellation

### DIFF
--- a/internal/upstream/manager.go
+++ b/internal/upstream/manager.go
@@ -1471,6 +1471,13 @@ func (m *Manager) startOAuthEventMonitor(ctx context.Context) {
 			m.logger.Info("OAuth event monitor stopped due to context cancellation")
 			return
 		case <-ticker.C:
+			// Check if context was cancelled before processing
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
 			if err := m.processOAuthEvents(); err != nil {
 				m.logger.Warn("Failed to process OAuth events", zap.Error(err))
 			}


### PR DESCRIPTION
## Summary

Fixed OAuth event monitor goroutine leak where logging occurred after test completion. This is a DIFFERENT monitor from the Docker recovery monitor fixed in PRs #122, #123, #124.

## Root Cause

The issue occurred in `startOAuthEventMonitor` when:
1. Ticker fires (every 5 seconds)
2. `processOAuthEvents()` is called  
3. Test completes and context is cancelled
4. **`processOAuthEvents()` logs debug message without checking if context was cancelled**

## Error Message

```
panic: Log in goroutine after TestUpdateListenAddressValidation has completed: 
2025-11-03T19:28:45.714Z	DEBUG	processOAuthEvents: checking for OAuth completion events...

goroutine 144 [running]:
mcpproxy-go/internal/upstream.(*Manager).processOAuthEvents(0xc0006b64d0)
	D:/a/mcpproxy-go/mcpproxy-go/internal/upstream/manager.go:1493 +0x9e
mcpproxy-go/internal/upstream.(*Manager).startOAuthEventMonitor(0xc0006b64d0, {0x1414d55f8, 0xc000600a50})
	D:/a/mcpproxy-go/mcpproxy-go/internal/upstream/manager.go:1474 +0x1e8
```

## Changes

**File: `internal/upstream/manager.go`**

Added context check in `startOAuthEventMonitor` after ticker fires (line 1474-1479):
- Check if context was cancelled after ticker fires
- Return immediately before calling `processOAuthEvents()`
- Prevents goroutine from logging after test cleanup

## Pattern

This follows the same fix pattern used for Docker recovery monitor:
- Check context immediately after `time.After` / ticker fires
- Return early if shutdown is in progress
- Prevents logging after test completion

## Test Results

✅ Tests pass locally with the fix applied:
```bash
go test -v -race -run TestUpdateListenAddressValidation ./internal/runtime/...
```

## Fixes

**Windows unit test failure:**
- Unit Tests (windows-latest, 1.23.10)
- https://github.com/smart-mcp-proxy/mcpproxy-go/actions/runs/19046681617/job/54396553672

## Related PRs

Docker recovery monitor fixes (different component):
- PR #122: Fixed timer-based logging (MERGED)
- PR #123: Fixed initial check logging (MERGED)
- PR #124: Fixed retry logging (READY)

OAuth monitor fix:
- PR #125: Fixes OAuth event monitor logging (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)