### PR TITLE
fix(upstream): use parent context for shutdown detection in Docker recovery

### DIFF
--- a/internal/upstream/manager.go
+++ b/internal/upstream/manager.go
@@ -1900,8 +1900,9 @@ func (m *Manager) handleDockerUnavailable(ctx context.Context) {
 			}
 
 			// Check if context was cancelled before logging retry
+			// Use parent context to catch shutdown faster
 			select {
-			case <-recoveryCtx.Done():
+			case <-ctx.Done():
 				return
 			default:
 			}


### PR DESCRIPTION
## Summary

Fixed a race condition where Docker recovery retry logging occurred after test completion despite having a context check from PR #124. The issue was using the child `recoveryCtx` instead of parent `ctx` for shutdown detection.

## Root Cause

PR #124 added a context check before logging, but it checked the wrong context:

```go
// PR #124 added this:
select {
case <-recoveryCtx.Done():  // ❌ Wrong context!
    return
default:
}
m.logger.Info("Docker recovery retry", ...)
```

The problem:
1. **`ctx`** = Parent context (cancelled when test/manager shuts down)
2. **`recoveryCtx`** = Child context created with `context.WithCancel(ctx)`
3. Child context cancellation may lag behind parent by nanoseconds
4. Race window: Check passes → Context cancelled → Log executes

On CI machines with scheduling delays, this tiny race window is hit more frequently.

## Changes

**File: `internal/upstream/manager.go`**

Use parent context for shutdown detection (line 1905):
```go
// Before (PR #124):
select {
case <-recoveryCtx.Done():  // ❌ Child context
    return
default:
}

// After (this PR):
select {
case <-ctx.Done():  // ✅ Parent context
    return
default:
}
```

## Why This Works

- Parent `ctx` is cancelled immediately when shutdown starts
- No propagation delay to child context
- Eliminates race window between check and log execution
- Test shutdown is instantly visible to the check

## Test Results

✅ Tests pass locally with the fix:
```bash
go test -v -race -run TestUpdateListenAddressValidation ./internal/runtime/...
```

## Fixes

**Main branch failure:**
- Unit Tests (macos-latest, 1.23.10)
- https://github.com/smart-mcp-proxy/mcpproxy-go/actions/runs/19047644560

**Error:**
```
panic: Log in goroutine after TestUpdateListenAddressValidation has completed: 
2025-11-03T20:02:22.176Z	INFO	Docker recovery retry	
{"attempt": 1, "elapsed": "2.002340625s", "next_retry_in": "5s"}

mcpproxy-go/internal/upstream.(*Manager).handleDockerUnavailable
	internal/upstream/manager.go:1910 +0x940
```

## Related PRs

- PR #124: Added context check (used wrong context)
- PR #126: Fixes context check to use parent context (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)