### PR TITLE
fix(upstream): use parent context in Docker recovery timer checks

### DIFF
--- a/internal/upstream/manager.go
+++ b/internal/upstream/manager.go
@@ -1838,12 +1838,12 @@ func (m *Manager) handleDockerUnavailable(ctx context.Context) {
 		currentInterval := getDockerRetryInterval(attempt)
 
 		select {
-		case <-recoveryCtx.Done():
+		case <-ctx.Done():
 			return
 		case <-time.After(currentInterval):
 			// Check if context was cancelled while waiting
 			select {
-			case <-recoveryCtx.Done():
+			case <-ctx.Done():
 				return
 			default:
 			}


### PR DESCRIPTION
## Summary
Complete the fix from PR #126 by using parent context consistently throughout `handleDockerUnavailable`. This eliminates the race condition where child context cancellation lags parent by nanoseconds.

## Root Cause
PR #126 fixed line 1905 to use parent `ctx` instead of child `recoveryCtx`, but lines 1841 and 1846 still used `recoveryCtx`. This created a race condition:

1. Test completes, parent `ctx` gets cancelled
2. Timer fires at line 1843 (after 2 seconds)
3. Code checks `recoveryCtx.Done()` at line 1846
4. Child context cancellation may lag parent by nanoseconds
5. Code falls through to default case, proceeds with logging
6. Test framework panics: "Log in goroutine after test has completed"

## Changes
- **Line 1841**: `recoveryCtx.Done()` → `ctx.Done()` in main select statement
- **Line 1846**: `recoveryCtx.Done()` → `ctx.Done()` after timer fires

## Test Results
Ran `TestUpdateListenAddressValidation` 3 times locally - all passed without panic.

## Impact
Fixes persistent test failures on macOS in workflow runs:
- https://github.com/smart-mcp-proxy/mcpproxy-go/actions/runs/19059434868

Generated with [Claude Code](https://claude.com/claude-code)