### PR TITLE
Add diagnostics and OAuth UX safeguards

### DIFF
--- a/internal/oauth/discovery.go
+++ b/internal/oauth/discovery.go
@@ -204,6 +204,19 @@ func DiscoverScopesFromAuthorizationServer(baseURL string, timeout time.Duration
 		zap.Strings("response_types_supported", metadata.ResponseTypesSupported),
 		zap.Strings("grant_types_supported", metadata.GrantTypesSupported))
 
+	logger.Debug("Authorization Server Metadata fetched",
+		zap.String("issuer", metadata.Issuer),
+		zap.String("authorization_endpoint", metadata.AuthorizationEndpoint),
+		zap.String("token_endpoint", metadata.TokenEndpoint),
+		zap.String("registration_endpoint", metadata.RegistrationEndpoint),
+		zap.Strings("scopes_supported", metadata.ScopesSupported))
+
+	if metadata.RegistrationEndpoint == "" {
+		logger.Warn("Authorization server metadata missing registration_endpoint; clients that require DCR may keep the Login button disabled",
+			zap.String("issuer", metadata.Issuer),
+			zap.String("hint", "Provide oauth.client_id in config or use a proxy that emulates /register"))
+	}
+
 	if len(metadata.ScopesSupported) == 0 {
 		logger.Debug("Authorization Server Metadata returned empty scopes_supported",
 			zap.String("metadata_url", metadataURL))


### PR DESCRIPTION
Related OAuth 2.1 login issue
#131
Log why PRM/AS discovery fails (missing metadata, empty scopes, missing /register) so the UI can explain stalled login buttons.
Improve Linux browser launch attempts by always trying xdg-open (with a warning when no GUI is detected) instead of bailing.
Print/log the full OAuth authorization URL so users can click or copy it whenever auto-launching fails.

# Pull Request

## Description
Brief description of the changes in this PR.

## Testing
- [ ] I have tested these changes locally
- [ ] I have added/updated tests that prove my fix is effective or my feature works
- [ ] All existing tests pass