### PR TITLE
fix: persist DCR credentials for OAuth token refresh

### DIFF
--- a/internal/oauth/persistent_token_store.go
+++ b/internal/oauth/persistent_token_store.go
@@ -32,7 +32,7 @@ type PersistentTokenStore struct {
 // NewPersistentTokenStore creates a new persistent token store for a server
 func NewPersistentTokenStore(serverName, serverURL string, storage *storage.BoltDB) client.TokenStore {
 	// Create unique key combining server name and URL to handle servers with same name but different URLs
-	serverKey := generateServerKey(serverName, serverURL)
+	serverKey := GenerateServerKey(serverName, serverURL)
 
 	return &PersistentTokenStore{
 		serverKey: serverKey,
@@ -41,8 +41,9 @@ func NewPersistentTokenStore(serverName, serverURL string, storage *storage.Bolt
 	}
 }
 
-// generateServerKey creates a unique key for a server by combining name and URL
-func generateServerKey(serverName, serverURL string) string {
+// GenerateServerKey creates a unique key for a server by combining name and URL
+// Exported for use by connection.go when persisting DCR credentials
+func GenerateServerKey(serverName, serverURL string) string {
 	// Create a unique identifier by combining server name and URL
 	combined := fmt.Sprintf("%s|%s", serverName, serverURL)
 

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -71,6 +71,10 @@ type OAuthTokenRecord struct {
 	Scopes       []string  `json:"scopes,omitempty"`
 	Created      time.Time `json:"created"`
 	Updated      time.Time `json:"updated"`
+	// ClientID and ClientSecret are persisted for DCR (Dynamic Client Registration)
+	// These are required for token refresh when using DCR-obtained credentials
+	ClientID     string `json:"client_id,omitempty"`
+	ClientSecret string `json:"client_secret,omitempty"`
 }
 
 // OAuthCompletionEvent represents an OAuth completion event for cross-process notification


### PR DESCRIPTION
## Summary

- Fixes OAuth token refresh failures for servers using Dynamic Client Registration (DCR)
- Persists `client_id` and `client_secret` obtained from DCR to storage
- Loads persisted DCR credentials when creating OAuth config for token refresh
- Resolves issue where Sentry and other DCR servers would disconnect after token expiry

## Problem

When using DCR, the obtained `client_id` was not being persisted. This caused token refresh to fail:

1. DCR generates a new `client_id` for each OAuth flow
2. The `client_id` was used for the current session but not saved
3. When token refresh was needed, OAuth config had empty `client_id`
4. Token refresh failed with "no valid token available, authorization required"

## Solution

- Added `ClientID` and `ClientSecret` fields to `OAuthTokenRecord`
- Added `UpdateOAuthClientCredentials()` and `GetOAuthClientCredentials()` storage methods
- Persist DCR credentials after successful registration in `connection.go`
- Load persisted credentials in `CreateOAuthConfig()` before falling back to empty credentials
- Exported `GenerateServerKey()` for consistent server key generation across packages

## Test plan

- [x] Build succeeds
- [x] Unit tests pass (`go test ./internal/storage/... ./internal/oauth/...`)
- [x] E2E API tests pass
- [x] Sentry server connects successfully with existing valid token
- [ ] Token refresh works with persisted DCR credentials (requires waiting for token expiry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)