### PR TITLE
fix: make Login button consistent with other server action buttons

### DIFF
--- a/frontend/src/components/ServerCard.vue
+++ b/frontend/src/components/ServerCard.vue
@@ -91,7 +91,7 @@
           v-if="needsOAuth"
           @click="triggerOAuth"
           :disabled="loading"
-          class="btn btn-sm btn-primary"
+          class="btn btn-sm btn-outline"
         >
           <span v-if="loading" class="loading loading-spinner loading-xs"></span>
           Login


### PR DESCRIPTION
## Summary
- Change the Login button from `btn-primary` (filled style) to `btn-outline` to match the visual appearance of the Restart and Details buttons
- Fixes the UI inconsistency where the Login button appeared larger than other buttons in the server card action row

## Test plan
- [x] Built frontend with `npm run build`
- [x] Verified fix with Playwright screenshot showing consistent button sizes
- [x] Login, Restart, and Details buttons now all have the same outlined style

Fixes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)