### PR TITLE
fix: improve HTTP server UI - show Login instead of Restart, use Reconnect in Actions

### DIFF
--- a/frontend/src/views/ServerDetail.vue
+++ b/frontend/src/views/ServerDetail.vue
@@ -77,7 +77,7 @@
               <li v-if="server.enabled">
                 <button @click="restartServer" :disabled="actionLoading">
                   <span v-if="actionLoading" class="loading loading-spinner loading-xs"></span>
-                  Restart
+                  {{ isHttpProtocol ? 'Reconnect' : 'Restart' }}
                 </button>
               </li>
               <li v-if="needsOAuth">
@@ -460,9 +460,13 @@ const logsError = ref<string | null>(null)
 const logTail = ref(100)
 
 // Computed
+const isHttpProtocol = computed(() => {
+  return server.value?.protocol === 'http' || server.value?.protocol === 'streamable-http'
+})
+
 const needsOAuth = computed(() => {
   return server.value &&
-         (server.value.protocol === 'http' || server.value.protocol === 'streamable-http') &&
+         isHttpProtocol.value &&
          !server.value.connected &&
          server.value.enabled &&
          server.value.last_error?.includes('authorization')


### PR DESCRIPTION
## Summary
- Hide Restart button for HTTP servers on server cards (HTTP servers don't have a process to restart)
- Show "Reconnect" instead of "Restart" in Actions menu on server detail page for HTTP servers
- Fix Login button not appearing for HTTP servers added via Web UI with `oauth: null` config

## Changes

### ServerCard.vue
- Added `isHttpProtocol` computed property
- Restart button now only shows for stdio servers (`v-if="!isHttpProtocol"`)
- HTTP servers show Login button for OAuth authentication instead

### ServerDetail.vue  
- Added `isHttpProtocol` computed property
- Actions menu shows "Reconnect" for HTTP servers, "Restart" for stdio servers

## UX Rationale
- **HTTP servers**: "Restart" doesn't make sense since there's no local process to restart. Users should use "Reconnect" or "Login" (for OAuth) instead
- **stdio servers**: "Restart" makes sense since it kills and restarts the local command process

## Test plan
- [ ] Add HTTP server via Web UI, verify Login button appears (not Restart)
- [ ] Open HTTP server detail page, verify Actions menu shows "Reconnect"
- [ ] Add stdio server, verify Restart button appears on card
- [ ] Open stdio server detail page, verify Actions menu shows "Restart"

🤖 Generated with [Claude Code](https://claude.com/claude-code)