### PR TITLE
fix: Set httpapi.buildVersion via ldflags for correct version display

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -202,7 +202,7 @@ jobs:
           fi
 
           echo "Building version: ${VERSION}"
-          LDFLAGS="-s -w -X mcpproxy-go/cmd/mcpproxy.version=${VERSION} -X main.version=${VERSION}"
+          LDFLAGS="-s -w -X mcpproxy-go/cmd/mcpproxy.version=${VERSION} -X main.version=${VERSION} -X mcpproxy-go/internal/httpapi.buildVersion=${VERSION}"
 
           # Determine clean binary name
           if [ "${{ matrix.goos }}" = "windows" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -368,7 +368,7 @@ jobs:
           CGO_LDFLAGS: "-mmacosx-version-min=12.0"
         run: |
           VERSION=${GITHUB_REF#refs/tags/}
-          LDFLAGS="-s -w -X mcpproxy-go/cmd/mcpproxy.version=${VERSION} -X main.version=${VERSION}"
+          LDFLAGS="-s -w -X mcpproxy-go/cmd/mcpproxy.version=${VERSION} -X main.version=${VERSION} -X mcpproxy-go/internal/httpapi.buildVersion=${VERSION}"
 
           # Determine clean binary name
           if [ "${{ matrix.goos }}" = "windows" ]; then
@@ -1137,7 +1137,7 @@ jobs:
           mkdir -p Formula
 
           # Create formula file
-          printf 'class Mcpproxy < Formula\n  desc "Smart MCP Proxy - Intelligent tool discovery and proxying for Model Context Protocol servers"\n  homepage "https://github.com/smart-mcp-proxy/mcpproxy-go"\n  url "https://github.com/smart-mcp-proxy/mcpproxy-go/archive/refs/tags/v%s.tar.gz"\n  sha256 "%s"\n  license "MIT"\n  head "https://github.com/smart-mcp-proxy/mcpproxy-go.git"\n\n  depends_on "go" => :build\n\n  def install\n    system "go", "build", "-ldflags", "-s -w -X mcpproxy-go/cmd/mcpproxy.version=v%s -X main.version=v%s", "-o", "mcpproxy", "./cmd/mcpproxy"\n    bin.install "mcpproxy"\n  end\n\n  test do\n    assert_match version.to_s, shell_output("#{bin}/mcpproxy --version")\n  end\nend\n' "${VERSION}" "${SOURCE_SHA}" "${VERSION}" "${VERSION}" > Formula/mcpproxy.rb
+          printf 'class Mcpproxy < Formula\n  desc "Smart MCP Proxy - Intelligent tool discovery and proxying for Model Context Protocol servers"\n  homepage "https://github.com/smart-mcp-proxy/mcpproxy-go"\n  url "https://github.com/smart-mcp-proxy/mcpproxy-go/archive/refs/tags/v%s.tar.gz"\n  sha256 "%s"\n  license "MIT"\n  head "https://github.com/smart-mcp-proxy/mcpproxy-go.git"\n\n  depends_on "go" => :build\n\n  def install\n    system "go", "build", "-ldflags", "-s -w -X mcpproxy-go/cmd/mcpproxy.version=v%s -X main.version=v%s -X mcpproxy-go/internal/httpapi.buildVersion=v%s", "-o", "mcpproxy", "./cmd/mcpproxy"\n    bin.install "mcpproxy"\n  end\n\n  test do\n    assert_match version.to_s, shell_output("#{bin}/mcpproxy --version")\n  end\nend\n' "${VERSION}" "${SOURCE_SHA}" "${VERSION}" "${VERSION}" "${VERSION}" > Formula/mcpproxy.rb
 
                     echo "Formula created successfully"
           cat Formula/mcpproxy.rb

--- a/Makefile
+++ b/Makefile
@@ -46,11 +46,17 @@ swagger-verify: swagger
 	fi
 	@echo "✅ OpenAPI artifacts are up to date."
 
+# Version detection for builds
+VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo "v0.1.0-dev")
+COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+LDFLAGS := -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(BUILD_DATE) -X mcpproxy-go/internal/httpapi.buildVersion=$(VERSION) -s -w
+
 # Build complete project
 build: swagger frontend-build
-	@echo "🔨 Building Go binary with embedded frontend..."
-	go build -o mcpproxy ./cmd/mcpproxy
-	go build -o mcpproxy-tray ./cmd/mcpproxy-tray
+	@echo "🔨 Building Go binary with embedded frontend (version: $(VERSION))..."
+	go build -ldflags "$(LDFLAGS)" -o mcpproxy ./cmd/mcpproxy
+	go build -ldflags "$(LDFLAGS)" -o mcpproxy-tray ./cmd/mcpproxy-tray
 	@echo "✅ Build completed! Run: ./mcpproxy serve"
 	@echo "🌐 Web UI: http://localhost:8080/ui/"
 	@echo "📚 API Docs: http://localhost:8080/swagger/"
@@ -74,8 +80,8 @@ frontend-dev:
 
 # Build backend with dev flag (for development with frontend hot reload)
 backend-dev:
-	@echo "🔨 Building backend in development mode..."
-	go build -tags dev -o mcpproxy-dev ./cmd/mcpproxy
+	@echo "🔨 Building backend in development mode (version: $(VERSION))..."
+	go build -tags dev -ldflags "$(LDFLAGS)" -o mcpproxy-dev ./cmd/mcpproxy
 	@echo "✅ Development backend ready!"
 	@echo "🚀 Run: ./mcpproxy-dev serve"
 	@echo "🌐 In dev mode, make sure frontend dev server is running on port 3000"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,7 +10,7 @@ echo "Building mcpproxy version: $VERSION"
 echo "Commit: $COMMIT"
 echo "Date: $DATE"
 
-LDFLAGS="-X main.version=$VERSION -X main.commit=$COMMIT -X main.date=$DATE -s -w"
+LDFLAGS="-X main.version=$VERSION -X main.commit=$COMMIT -X main.date=$DATE -X mcpproxy-go/internal/httpapi.buildVersion=$VERSION -s -w"
 
 # Build for current platform (with CGO for tray support if needed)
 echo "Building for current platform..."


### PR DESCRIPTION
## Summary

Fixes the issue where web UI, `mcpproxy doctor`, and version update detection show "development" instead of the actual release version after a GitHub release.

**Root cause:** The `internal/httpapi/server.go` has a separate `buildVersion` variable (defaults to "development") that was never set via ldflags during builds. Only `main.version` was being set.

**Changes:**
- Add `-X mcpproxy-go/internal/httpapi.buildVersion=$VERSION` to ldflags in all build configurations:
  - `scripts/build.sh`
  - `Makefile` (also adds version ldflags that were previously missing)
  - `.github/workflows/release.yml`
  - `.github/workflows/prerelease.yml`
  - Homebrew formula generation

## Affected Components

This fix ensures the `/api/v1/info` endpoint returns the correct version, which is used by:
- Web UI sidebar version display
- `mcpproxy doctor` command output
- Tray app "New version available" detection
- Update checker for comparing against latest GitHub release

## Test plan

- [x] Verified locally: Built with `./scripts/build.sh`, confirmed `/api/v1/info` returns correct version (v0.11.1) instead of "development"
- [ ] CI builds should now set the correct version for all release artifacts

## Before Fix
```json
{
  "version": "development",
  ...
}
```

## After Fix
```json
{
  "version": "v0.11.1",
  "update": {
    "available": false,
    "latest_version": "v0.11.1",
    ...
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)