### PR TITLE
feat: add --no-icons flag for activity list and show commands

### DIFF
--- a/cmd/mcpproxy/activity_cmd.go
+++ b/cmd/mcpproxy/activity_cmd.go
@@ -37,6 +37,7 @@ var (
 	activityLimit      int
 	activityOffset     int
 	activityIntentType string // Spec 018: Filter by operation type (read, write, destructive)
+	activityNoIcons    bool   // Disable emoji icons in output
 
 	// Show command flags
 	activityIncludeResponse bool
@@ -268,7 +269,22 @@ func formatIntentIndicator(activity map[string]interface{}) string {
 }
 
 // formatOperationIcon returns the visual indicator for an operation type
+// If activityNoIcons is true, returns text instead of emoji
 func formatOperationIcon(opType string) string {
+	if activityNoIcons {
+		// Text-only output
+		switch opType {
+		case "read":
+			return "read"
+		case "write":
+			return "write"
+		case "destructive":
+			return "destructive"
+		default:
+			return "-"
+		}
+	}
+	// Emoji output
 	switch opType {
 	case "read":
 		return "📖" // Read operation
@@ -485,6 +501,7 @@ func init() {
 	activityListCmd.Flags().IntVarP(&activityLimit, "limit", "n", 50, "Max records to return (1-100)")
 	activityListCmd.Flags().IntVar(&activityOffset, "offset", 0, "Pagination offset")
 	activityListCmd.Flags().StringVar(&activityIntentType, "intent-type", "", "Filter by intent operation type: read, write, destructive")
+	activityListCmd.Flags().BoolVar(&activityNoIcons, "no-icons", false, "Disable emoji icons in output (use text instead)")
 
 	// Watch command flags
 	activityWatchCmd.Flags().StringVarP(&activityType, "type", "t", "", "Filter by type: tool_call, policy_decision")
@@ -492,6 +509,7 @@ func init() {
 
 	// Show command flags
 	activityShowCmd.Flags().BoolVar(&activityIncludeResponse, "include-response", false, "Show full response (may be large)")
+	activityShowCmd.Flags().BoolVar(&activityNoIcons, "no-icons", false, "Disable emoji icons in output (use text instead)")
 
 	// Summary command flags
 	activitySummaryCmd.Flags().StringVarP(&activityPeriod, "period", "p", "24h", "Time period: 1h, 24h, 7d, 30d")

--- a/docs/cli/activity-commands.md
+++ b/docs/cli/activity-commands.md
@@ -59,6 +59,7 @@ mcpproxy activity list [flags]
 | `--tool` | | | Filter by tool name |
 | `--status` | | | Filter by status: `success`, `error`, `blocked` |
 | `--intent-type` | | | Filter by intent operation type: `read`, `write`, `destructive` |
+| `--no-icons` | | | Disable emoji icons in output (use text instead) |
 | `--session` | | | Filter by MCP session ID |
 | `--start-time` | | | Filter records after this time (RFC3339) |
 | `--end-time` | | | Filter records before this time (RFC3339) |


### PR DESCRIPTION
## Summary
Add `--no-icons` flag to disable emoji icons in activity output.

## Problem
Activity list uses emoji icons for intent types (📖 read, ✏️ write, ⚠️ destructive) which may not render properly in:
- Terminal environments without Unicode support
- CI/CD pipelines where text is easier to parse
- Screen readers or accessibility tools

## Solution
Add `--no-icons` flag that replaces emoji with text:
- `📖` → `read`
- `✏️` → `write`
- `⚠️` → `destructive`

## Usage
```bash
# Default (with emojis)
mcpproxy activity list

# Without emojis
mcpproxy activity list --no-icons
mcpproxy activity show <id> --no-icons
```

## Test plan
- [ ] `mcpproxy activity list --help` shows `--no-icons` flag
- [ ] `mcpproxy activity list --no-icons` shows text intent types

🤖 Generated with [Claude Code](https://claude.com/claude-code)