### PR TITLE
chore(frontend): temporarily disable Activity Log in web UI

### DIFF
--- a/frontend/src/components/SidebarNav.vue
+++ b/frontend/src/components/SidebarNav.vue
@@ -77,7 +77,8 @@ const menuItems = [
   { name: 'Secrets', path: '/secrets' },
   { name: 'Search', path: '/search' },
   { name: 'Tool Call History', path: '/tool-calls' },
-  { name: 'Activity Log', path: '/activity' },
+  // TODO: Re-enable in next release
+  // { name: 'Activity Log', path: '/activity' },
   { name: 'Repositories', path: '/repositories' },
   { name: 'Configuration', path: '/settings' },
 ]

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -141,8 +141,8 @@
     </div>
 
 
-    <!-- Activity Widget -->
-    <ActivityWidget />
+    <!-- TODO: Re-enable Activity Widget in next release -->
+    <!-- <ActivityWidget /> -->
 
     <!-- Recent Sessions -->
     <div class="card bg-base-100 shadow-md">
@@ -329,7 +329,8 @@ import { useSystemStore } from '@/stores/system'
 import api from '@/services/api'
 import CollapsibleHintsPanel from '@/components/CollapsibleHintsPanel.vue'
 import TokenPieChart from '@/components/TokenPieChart.vue'
-import ActivityWidget from '@/components/ActivityWidget.vue'
+// TODO: Re-enable in next release
+// import ActivityWidget from '@/components/ActivityWidget.vue'
 import type { Hint } from '@/components/CollapsibleHintsPanel.vue'
 
 const serversStore = useServersStore()


### PR DESCRIPTION
## Summary
- Comment out Activity Log menu item in sidebar navigation
- Comment out ActivityWidget from Dashboard
- REST API and backend functionality remain intact
- Will re-enable in next release

## Test plan
- [x] Frontend builds successfully
- [ ] Verify Activity Log menu item is hidden
- [ ] Verify Dashboard no longer shows Activity Widget

🤖 Generated with [Claude Code](https://claude.com/claude-code)