### PR TITLE
fix(frontend): make server name clickable in attention banner

### DIFF
--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -13,7 +13,7 @@
         <div class="text-sm space-y-1 mt-1">
           <div v-for="server in serversNeedingAttention.slice(0, 3)" :key="server.name" class="flex items-center gap-2">
             <span :class="server.health?.level === 'unhealthy' ? 'text-error' : 'text-warning'">●</span>
-            <span class="font-medium">{{ server.name }}</span>
+            <router-link :to="`/servers/${server.name}`" class="font-medium link link-hover">{{ server.name }}</router-link>
             <span class="opacity-70">{{ server.health?.summary }}</span>
             <button
               v-if="server.health?.action === 'login'"


### PR DESCRIPTION
## Summary

- Make server names clickable in the "Servers Needing Attention" banner on the dashboard
- Clicking a server name now navigates to that server's detail page
- This matches the existing behavior of server names in the Recent Tool Calls table

## Test plan

- [x] Visit the dashboard with at least one server needing attention (e.g., authentication required)
- [x] Verify the server name in the attention banner is visually styled as a link
- [x] Click the server name and confirm it navigates to `/servers/{server-name}`
