### PR TITLE
feat: add 410 Gone error handling for deprecated MCP endpoints

### DIFF
--- a/internal/transport/http.go
+++ b/internal/transport/http.go
@@ -88,6 +88,43 @@ func NewJSONRPCError(code int, message string, data interface{}, httpErr *HTTPEr
 	}
 }
 
+// ErrEndpointDeprecated represents a 410 Gone response indicating the endpoint has been deprecated
+type ErrEndpointDeprecated struct {
+	URL            string `json:"url"`
+	Message        string `json:"message"`
+	MigrationGuide string `json:"migration_guide,omitempty"`
+	NewEndpoint    string `json:"new_endpoint,omitempty"`
+}
+
+func (e *ErrEndpointDeprecated) Error() string {
+	if e.NewEndpoint != "" {
+		return fmt.Sprintf("endpoint deprecated (410 Gone): %s - migrate to: %s", e.Message, e.NewEndpoint)
+	}
+	if e.MigrationGuide != "" {
+		return fmt.Sprintf("endpoint deprecated (410 Gone): %s - see: %s", e.Message, e.MigrationGuide)
+	}
+	return fmt.Sprintf("endpoint deprecated (410 Gone): %s", e.Message)
+}
+
+// IsEndpointDeprecatedError checks if an error indicates a deprecated endpoint (HTTP 410)
+func IsEndpointDeprecatedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := err.(*ErrEndpointDeprecated)
+	return ok
+}
+
+// NewEndpointDeprecatedError creates a new ErrEndpointDeprecated from response details
+func NewEndpointDeprecatedError(url, message, migrationGuide, newEndpoint string) *ErrEndpointDeprecated {
+	return &ErrEndpointDeprecated{
+		URL:            url,
+		Message:        message,
+		MigrationGuide: migrationGuide,
+		NewEndpoint:    newEndpoint,
+	}
+}
+
 // HTTPTransportConfig holds configuration for HTTP transport
 type HTTPTransportConfig struct {
 	URL          string


### PR DESCRIPTION
Add detection and user-friendly error messages when an MCP server endpoint returns HTTP 410 (Gone), indicating the endpoint has been deprecated or migrated to a new URL.

Changes:
- Add ErrEndpointDeprecated error type in transport package with migration hints
- Add isDeprecatedEndpointError() detection in core/connection.go
- Add isDeprecatedEndpointError() detection in managed/client.go
- Log actionable messages with correlation_id for debugging
- Include hints about common migrations (e.g., /sse to /mcp)

This helps users understand when they need to update their server URLs instead of seeing confusing "session terminated (404)" errors.

Example detected errors:
- HTTP 410 Gone responses
- "SSE transport has been removed" (Sentry)
- "no longer supported" deprecation messages

# Pull Request

## Description
Brief description of the changes in this PR.

## Testing
- [ ] I have tested these changes locally
- [ ] I have added/updated tests that prove my fix is effective or my feature works
- [ ] All existing tests pass