### PR TITLE
fix: implement RFC 8414 compliant OAuth metadata discovery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.24.10
 
 require (
 	fyne.io/systray v1.11.0
+	github.com/BurntSushi/toml v1.6.0
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/blevesearch/bleve/v2 v2.5.2
 	github.com/dop251/goja v0.0.0-20251103141225-af2ceb9156d7
@@ -14,7 +15,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/uuid v1.6.0
 	github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf
-	github.com/mark3labs/mcp-go v0.43.1
+	github.com/mark3labs/mcp-go v0.44.0-beta.2
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/pkoukk/tiktoken-go v0.1.8
 	github.com/prometheus/client_golang v1.23.2
@@ -40,7 +41,6 @@ require (
 require (
 	al.essio.dev/pkg/shellescape v1.5.1 // indirect
 	git.sr.ht/~jackmordaunt/go-toast v1.1.2 // indirect
-	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/RoaringBitmap/roaring/v2 v2.4.5 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/mark3labs/mcp-go v0.43.1 h1:WXNVd+bRM/7mOzCM9zulSwn/s9YEdAxbmeh9LoRHEXY=
-github.com/mark3labs/mcp-go v0.43.1/go.mod h1:YnJfOL382MIWDx1kMY+2zsRHU/q78dBg9aFb8W6Thdw=
+github.com/mark3labs/mcp-go v0.44.0-beta.2 h1:gfUT0m77E4odfgiHkqV/E+MQVaQ06rbutW7Ln0JRkBA=
+github.com/mark3labs/mcp-go v0.44.0-beta.2/go.mod h1:YnJfOL382MIWDx1kMY+2zsRHU/q78dBg9aFb8W6Thdw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/internal/oauth/discovery_test.go
+++ b/internal/oauth/discovery_test.go
@@ -451,6 +451,7 @@ func TestBuildRFC8414MetadataURLs(t *testing.T) {
 			expectedURLs: []string{
 				"https://auth.smithery.ai/.well-known/oauth-authorization-server/googledrive",
 				"https://auth.smithery.ai/googledrive/.well-known/oauth-authorization-server",
+				"https://auth.smithery.ai/.well-known/oauth-authorization-server", // Base URL fallback (Cloudflare-style)
 			},
 		},
 		{
@@ -459,6 +460,7 @@ func TestBuildRFC8414MetadataURLs(t *testing.T) {
 			expectedURLs: []string{
 				"https://auth.example.com/.well-known/oauth-authorization-server/path1/path2/issuer",
 				"https://auth.example.com/path1/path2/issuer/.well-known/oauth-authorization-server",
+				"https://auth.example.com/.well-known/oauth-authorization-server", // Base URL fallback
 			},
 		},
 		{
@@ -467,6 +469,16 @@ func TestBuildRFC8414MetadataURLs(t *testing.T) {
 			expectedURLs: []string{
 				"https://auth.smithery.ai/.well-known/oauth-authorization-server/googledrive",
 				"https://auth.smithery.ai/googledrive/.well-known/oauth-authorization-server",
+				"https://auth.smithery.ai/.well-known/oauth-authorization-server", // Base URL fallback
+			},
+		},
+		{
+			name:          "Cloudflare-style URL with path",
+			authServerURL: "https://logs.mcp.cloudflare.com/mcp",
+			expectedURLs: []string{
+				"https://logs.mcp.cloudflare.com/.well-known/oauth-authorization-server/mcp",
+				"https://logs.mcp.cloudflare.com/mcp/.well-known/oauth-authorization-server",
+				"https://logs.mcp.cloudflare.com/.well-known/oauth-authorization-server", // This one works for Cloudflare
 			},
 		},
 		{
@@ -478,7 +490,7 @@ func TestBuildRFC8414MetadataURLs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			urls := buildRFC8414MetadataURLs(tt.authServerURL)
+			urls := BuildRFC8414MetadataURLs(tt.authServerURL)
 
 			if len(urls) != len(tt.expectedURLs) {
 				t.Errorf("URL count mismatch: got %d, want %d", len(urls), len(tt.expectedURLs))


### PR DESCRIPTION
## Summary

Fixes #251 - OAuth discovery fails for Smithery servers due to non-standard metadata path.

Smithery.ai servers use RFC 8414 compliant OAuth metadata paths, but mcpproxy was using a non-compliant path. Per RFC 8414 Section 3.1, when the authorization server URL contains a path, the well-known path should be inserted between host and path:

| URL Format | Standard (RFC 8414) | mcpproxy (before) |
|------------|---------------------|-------------------|
| `https://auth.smithery.ai/googledrive` | `https://auth.smithery.ai/.well-known/oauth-authorization-server/googledrive` ✅ | `https://auth.smithery.ai/googledrive/.well-known/oauth-authorization-server` ❌ |

## Changes

- **New function `buildRFC8414MetadataURLs()`**: Constructs compliant metadata URLs per RFC 8414 Section 3.1
- **New function `discoverAuthServerMetadataWithFallback()`**: Tries multiple discovery paths with fallback
- **Multi-path discovery**: Tries RFC 8414 path first, falls back to legacy path for backward compatibility
- **Better error messages**: Includes all attempted URLs in error messages for easier debugging
- **Comprehensive tests**: Unit tests for both Smithery-style and legacy server paths

## Test plan

- [x] Unit tests pass for `buildRFC8414MetadataURLs()` with various URL formats
- [x] Unit tests pass for `discoverAuthServerMetadataWithFallback()` with both path styles
- [x] All existing OAuth tests continue to pass
- [x] API E2E tests pass
- [x] Linter passes
- [ ] Manual test with Smithery server (Note: separate DCR panic issue exists - see below)

## Note on DCR panic

During testing, I discovered a separate issue where the manual `auth login` command fails with a nil pointer dereference during Dynamic Client Registration (DCR). This is a pre-existing bug unrelated to the OAuth discovery path fix. The background OAuth flow works correctly - the DCR panic only affects the CLI login command. This should be tracked as a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)