### PR TITLE
fix: use consistent server count across UI components

### DIFF
--- a/frontend/src/components/NavBar.vue
+++ b/frontend/src/components/NavBar.vue
@@ -71,7 +71,7 @@
 
         <!-- Server stats -->
         <div class="flex items-center space-x-1 text-sm">
-          <span class="hidden md:inline">{{ systemStore.upstreamStats.connected_servers }}/{{ systemStore.upstreamStats.total_servers }}</span>
+          <span class="hidden md:inline">{{ serversStore.serverCount.connected }}/{{ serversStore.serverCount.total }}</span>
           <span class="text-xs opacity-60 hidden md:inline">servers</span>
         </div>
       </div>
@@ -106,6 +106,7 @@
 import { computed, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import { useSystemStore } from '@/stores/system'
+import { useServersStore } from '@/stores/servers'
 
 // Icons (we'll use SVG icons directly for simplicity)
 const DashboardIcon = 'svg'
@@ -117,6 +118,7 @@ const SettingsIcon = 'svg'
 
 const route = useRoute()
 const systemStore = useSystemStore()
+const serversStore = useServersStore()
 
 const menuItems = [
   { name: 'Dashboard', path: '/', icon: DashboardIcon },

--- a/frontend/src/components/TopHeader.vue
+++ b/frontend/src/components/TopHeader.vue
@@ -52,9 +52,9 @@
               systemStore.isRunning ? 'bg-success animate-pulse' : 'bg-error'
             ]"
           />
-          <span class="font-bold">{{ systemStore.upstreamStats.connected_servers }}</span>
+          <span class="font-bold">{{ serversStore.serverCount.connected }}</span>
           <span class="opacity-60">/</span>
-          <span>{{ systemStore.upstreamStats.total_servers }}</span>
+          <span>{{ serversStore.serverCount.total }}</span>
           <span class="text-xs opacity-60">Servers</span>
         </div>
 


### PR DESCRIPTION
## Summary

- Fixed inconsistent connected server counts between top header/NavBar and Servers page
- Top header and NavBar now use `serversStore.serverCount` as single source of truth
- This ensures the same health-based counting logic is used everywhere

## Problem

The top header showed different server counts (e.g., 8/23) than the Servers page (e.g., 14/23). This was caused by:

- **TopHeader.vue** and **NavBar.vue**: Used `systemStore.upstreamStats.connected_servers` from SSE events (raw connection count)
- **Servers.vue**: Used `serversStore.serverCount.connected` (health.level === 'healthy')

## Solution

Updated both `TopHeader.vue` and `NavBar.vue` to use `serversStore.serverCount.connected` and `serversStore.serverCount.total`, making them consistent with the Servers page.

## Test plan

- [x] Verified with curl API shows consistent counts
- [x] Verified with CLI (`mcpproxy upstream list`) 
- [x] Verified with Chrome extension that both top header and server page show matching counts

🤖 Generated with [Claude Code](https://claude.ai/code)