### PR TITLE
fix: add hostArchitectures to PKG Distribution.xml to prevent Rosetta prompt

### DIFF
--- a/scripts/create-pkg.sh
+++ b/scripts/create-pkg.sh
@@ -268,7 +268,7 @@ cat > "$TEMP_DIR/Distribution.xml" << EOF
     <title>MCP Proxy ${VERSION#v}</title>
     <organization>com.smartmcpproxy</organization>
     <domains enable_localSystem="true"/>
-    <options customize="never" require-scripts="true" rootVolumeOnly="true" />
+    <options customize="never" require-scripts="true" rootVolumeOnly="true" hostArchitectures="arm64,x86_64" />
 
     <!-- Define documents displayed at various steps -->
     <welcome file="welcome_en.rtf" mime-type="text/rtf"/>


### PR DESCRIPTION
## Summary

- Fixes macOS PKG installer incorrectly prompting to install Rosetta on Apple Silicon Macs
- Adds `hostArchitectures="arm64,x86_64"` attribute to Distribution.xml `<options>` element

## Problem

When installing `mcpproxy-*-darwin-arm64.pkg` on an ARM Mac, macOS Installer prompts:

> "To install MCP Proxy, you need to install Rosetta."

This happens even though all binaries in the package are native arm64.

## Root Cause

When using `productbuild --distribution` with a custom Distribution.xml, macOS Installer does not auto-detect architecture support. Without the `hostArchitectures` attribute, it assumes Rosetta is required for compatibility.

This is a known issue that affected:
- [fish-shell #8566](https://github.com/fish-shell/fish-shell/issues/8566)
- [PowerShell #16742](https://github.com/PowerShell/PowerShell/pull/16742)

## Solution

Add `hostArchitectures="arm64,x86_64"` to the `<options>` element in the Distribution.xml template. This explicitly tells macOS Installer that the package supports both architectures natively.

## Test plan

- [ ] Build a new PKG with this fix
- [ ] Install on Apple Silicon Mac (or Parallels ARM VM)
- [ ] Verify no Rosetta prompt appears

🤖 Generated with [Claude Code](https://claude.ai/code)