### PR TITLE
fix: add JSON/YAML output support to auth status command

### DIFF
--- a/cmd/mcpproxy/auth_cmd.go
+++ b/cmd/mcpproxy/auth_cmd.go
@@ -361,15 +361,35 @@ func runAuthStatusClientMode(ctx context.Context, dataDir, serverName string, al
 		}
 	}
 
-	// Display OAuth status
-	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-	fmt.Println("🔐 OAuth Authentication Status")
-	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-	fmt.Println()
+	// Filter to only OAuth servers
+	oauthServers := filterOAuthServers(servers)
 
-	hasOAuthServers := false
+	// Get the output formatter based on global flags
+	formatter, err := GetOutputFormatter()
+	if err != nil {
+		return fmt.Errorf("failed to get output formatter: %w", err)
+	}
+
+	outputFormat := ResolveOutputFormat()
+
+	// For structured formats (json, yaml), output raw data
+	if outputFormat == "json" || outputFormat == "yaml" {
+		result, err := formatter.Format(oauthServers)
+		if err != nil {
+			return fmt.Errorf("failed to format output: %w", err)
+		}
+		fmt.Println(result)
+		return nil
+	}
+
+	// For table format, use human-readable display
+	return displayAuthStatusPretty(oauthServers)
+}
+
+// filterOAuthServers filters servers to only those with OAuth configuration
+func filterOAuthServers(servers []map[string]interface{}) []map[string]interface{} {
+	var oauthServers []map[string]interface{}
 	for _, srv := range servers {
-		name, _ := srv["name"].(string)
 		oauth, _ := srv["oauth"].(map[string]interface{})
 		authenticated, _ := srv["authenticated"].(bool)
 		lastError, _ := srv["last_error"].(string)
@@ -382,11 +402,30 @@ func runAuthStatusClientMode(ctx context.Context, dataDir, serverName string, al
 			containsIgnoreCase(lastError, "oauth") ||
 			authenticated
 
-		if !isOAuthServer {
-			continue // Skip non-OAuth servers
+		if isOAuthServer {
+			oauthServers = append(oauthServers, srv)
 		}
+	}
+	return oauthServers
+}
 
-		hasOAuthServers = true
+// displayAuthStatusPretty displays OAuth status in human-readable format
+func displayAuthStatusPretty(servers []map[string]interface{}) error {
+	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	fmt.Println("🔐 OAuth Authentication Status")
+	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	fmt.Println()
+
+	if len(servers) == 0 {
+		fmt.Println("ℹ️  No servers with OAuth configuration found.")
+		fmt.Println("   Configure OAuth in mcp_config.json to enable authentication.")
+		return nil
+	}
+
+	for _, srv := range servers {
+		name, _ := srv["name"].(string)
+		oauth, _ := srv["oauth"].(map[string]interface{})
+		lastError, _ := srv["last_error"].(string)
 
 		// Use unified health status from backend (FR-006, FR-007)
 		var healthLevel, adminState, healthSummary, healthAction string
@@ -550,11 +589,6 @@ func runAuthStatusClientMode(ctx context.Context, dataDir, serverName string, al
 		}
 
 		fmt.Println()
-	}
-
-	if !hasOAuthServers {
-		fmt.Println("ℹ️  No servers with OAuth configuration found.")
-		fmt.Println("   Configure OAuth in mcp_config.json to enable authentication.")
 	}
 
 	return nil

--- a/cmd/mcpproxy/auth_cmd_test.go
+++ b/cmd/mcpproxy/auth_cmd_test.go
@@ -181,3 +181,83 @@ func TestAuthLogin_ForceFlagWithoutAll(t *testing.T) {
 		assert.NotContains(t, err.Error(), "either --server or --all")
 	}
 }
+
+func TestFilterOAuthServers(t *testing.T) {
+	tests := []struct {
+		name     string
+		servers  []map[string]interface{}
+		expected int
+	}{
+		{
+			name: "filter servers with OAuth config",
+			servers: []map[string]interface{}{
+				{
+					"name":  "oauth-server",
+					"oauth": map[string]interface{}{"client_id": "test"},
+				},
+				{
+					"name": "non-oauth-server",
+				},
+			},
+			expected: 1,
+		},
+		{
+			name: "filter servers with authenticated status",
+			servers: []map[string]interface{}{
+				{
+					"name":          "authenticated-server",
+					"authenticated": true,
+				},
+				{
+					"name":          "non-authenticated-server",
+					"authenticated": false,
+				},
+			},
+			expected: 1,
+		},
+		{
+			name: "filter servers with OAuth errors",
+			servers: []map[string]interface{}{
+				{
+					"name":       "error-server",
+					"last_error": "OAuth authentication required",
+				},
+				{
+					"name":       "other-error-server",
+					"last_error": "Connection refused",
+				},
+			},
+			expected: 1,
+		},
+		{
+			name:     "empty server list",
+			servers:  []map[string]interface{}{},
+			expected: 0,
+		},
+		{
+			name: "all OAuth servers",
+			servers: []map[string]interface{}{
+				{
+					"name":  "oauth1",
+					"oauth": map[string]interface{}{"client_id": "test1"},
+				},
+				{
+					"name":          "oauth2",
+					"authenticated": true,
+				},
+				{
+					"name":       "oauth3",
+					"last_error": "OAuth error",
+				},
+			},
+			expected: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterOAuthServers(tt.servers)
+			assert.Equal(t, tt.expected, len(result), "filterOAuthServers should return correct number of OAuth servers")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds standard CLI output formatting support (`--json`, `--yaml`, `-o` flags) to the `mcpproxy auth status` command, making it consistent with other commands like `upstream list`, `activity list`, `tools list`, and `secrets list`.

## Changes

- Refactored `runAuthStatusClientMode()` to support output format detection via `GetOutputFormatter()` and `ResolveOutputFormat()`
- Extracted OAuth server filtering logic into `filterOAuthServers()` helper function
- Extracted pretty display logic into `displayAuthStatusPretty()` function  
- Added JSON/YAML output for structured formats
- Preserved existing human-readable output for table format (default)
- Added unit tests for `filterOAuthServers()` with 5 test cases

## Usage

```bash
# JSON output
mcpproxy auth status --json
mcpproxy auth status -o json

# YAML output
mcpproxy auth status --yaml
mcpproxy auth status -o yaml

# Table output (default - unchanged)
mcpproxy auth status
```

## Testing

- Added `TestFilterOAuthServers()` covering OAuth server detection logic
- Manually tested with running daemon (confirmed by user)
- All test cases pass

## Fixes

Closes mcpproxy-go-yv4v

🤖 Generated with [Claude Code](https://claude.com/claude-code)