### PR TITLE
feat(oauth): add Runlayer mode to Go OAuth test server

### DIFF
--- a/test/integration/test_runlayer_mode.sh
+++ b/test/integration/test_runlayer_mode.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+#
+# Integration test for Go OAuth server Runlayer mode
+#
+# This test verifies that the Go OAuth test server correctly implements
+# Runlayer-style strict validation with Pydantic 422 error responses.
+#
+# Usage:
+#   ./test/integration/test_runlayer_mode.sh
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+OAUTH_SERVER_PORT=18277
+OAUTH_SERVER_PID=""
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+cleanup() {
+    echo -e "\n${YELLOW}Cleaning up...${NC}"
+
+    if [ -n "$OAUTH_SERVER_PID" ] && kill -0 "$OAUTH_SERVER_PID" 2>/dev/null; then
+        echo "Stopping OAuth server (PID: $OAUTH_SERVER_PID)"
+        kill "$OAUTH_SERVER_PID" 2>/dev/null || true
+        wait "$OAUTH_SERVER_PID" 2>/dev/null || true
+    fi
+
+    # Kill any remaining processes on our port
+    lsof -ti :$OAUTH_SERVER_PORT 2>/dev/null | xargs kill -9 2>/dev/null || true
+
+    echo -e "${GREEN}Cleanup complete${NC}"
+}
+
+trap cleanup EXIT
+
+echo -e "${YELLOW}=== Go OAuth Server Runlayer Mode Integration Test ===${NC}\n"
+
+# Start OAuth test server in Runlayer mode
+echo "Starting Go OAuth test server in Runlayer mode on port $OAUTH_SERVER_PORT..."
+cd "$ROOT_DIR"
+go run ./tests/oauthserver/cmd/server -port $OAUTH_SERVER_PORT -runlayer-mode > /dev/null 2>&1 &
+OAUTH_SERVER_PID=$!
+
+# Wait for server to be ready
+echo "Waiting for server to be ready..."
+for i in {1..30}; do
+    if curl -s "http://localhost:$OAUTH_SERVER_PORT/.well-known/oauth-authorization-server" > /dev/null 2>&1; then
+        echo -e "${GREEN}OAuth server ready${NC}"
+        break
+    fi
+    if [ $i -eq 30 ]; then
+        echo -e "${RED}ERROR: OAuth server failed to start${NC}"
+        exit 1
+    fi
+    sleep 0.5
+done
+
+# Test 1: Verify 422 Pydantic error when resource is missing
+echo -e "\n${YELLOW}Test 1: Verify Pydantic 422 error when resource is missing${NC}"
+RESPONSE=$(curl -s "http://localhost:$OAUTH_SERVER_PORT/authorize?client_id=test-client&redirect_uri=http://127.0.0.1/callback&response_type=code&state=test123&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256")
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$OAUTH_SERVER_PORT/authorize?client_id=test-client&redirect_uri=http://127.0.0.1/callback&response_type=code&state=test123&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256")
+
+# Verify HTTP status is 422
+if [ "$HTTP_CODE" != "422" ]; then
+    echo -e "${RED}FAIL: Expected HTTP 422, got $HTTP_CODE${NC}"
+    exit 1
+fi
+echo "HTTP Status: $HTTP_CODE (expected: 422) ✓"
+
+# Verify response contains Pydantic error format
+if ! echo "$RESPONSE" | grep -q '"detail"'; then
+    echo -e "${RED}FAIL: Response missing 'detail' field${NC}"
+    echo "Response: $RESPONSE"
+    exit 1
+fi
+echo "Response has 'detail' field ✓"
+
+if ! echo "$RESPONSE" | grep -q '"type":"missing"'; then
+    echo -e "${RED}FAIL: Response missing type=missing${NC}"
+    echo "Response: $RESPONSE"
+    exit 1
+fi
+echo "Response has type=missing ✓"
+
+if ! echo "$RESPONSE" | grep -q '"loc":\["query","resource"\]'; then
+    echo -e "${RED}FAIL: Response missing correct loc field${NC}"
+    echo "Response: $RESPONSE"
+    exit 1
+fi
+echo "Response has loc=[query,resource] ✓"
+
+if ! echo "$RESPONSE" | grep -q '"msg":"Field required"'; then
+    echo -e "${RED}FAIL: Response missing correct msg field${NC}"
+    echo "Response: $RESPONSE"
+    exit 1
+fi
+echo "Response has msg=Field required ✓"
+
+echo -e "${GREEN}PASS: Pydantic 422 error format is correct${NC}"
+
+# Test 2: Verify successful request when resource is provided
+echo -e "\n${YELLOW}Test 2: Verify success when resource is provided${NC}"
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$OAUTH_SERVER_PORT/authorize?client_id=test-client&redirect_uri=http://127.0.0.1/callback&response_type=code&state=test123&resource=http://example.com/mcp&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256")
+
+if [ "$HTTP_CODE" != "200" ]; then
+    echo -e "${RED}FAIL: Expected HTTP 200, got $HTTP_CODE${NC}"
+    exit 1
+fi
+echo -e "${GREEN}PASS: Request with resource parameter returns 200${NC}"
+
+# Test 3: Verify discovery endpoint works
+echo -e "\n${YELLOW}Test 3: Verify OAuth discovery endpoint${NC}"
+DISCOVERY=$(curl -s "http://localhost:$OAUTH_SERVER_PORT/.well-known/oauth-authorization-server")
+
+if ! echo "$DISCOVERY" | grep -q '"authorization_endpoint"'; then
+    echo -e "${RED}FAIL: Discovery missing authorization_endpoint${NC}"
+    exit 1
+fi
+echo -e "${GREEN}PASS: Discovery endpoint working${NC}"
+
+echo -e "\n${GREEN}=== All Runlayer mode tests passed! ===${NC}"

--- a/tests/oauthserver/options.go
+++ b/tests/oauthserver/options.go
@@ -68,6 +68,9 @@ type Options struct {
 	RequirePKCE              bool // Default: true
 	RequireResourceIndicator bool // RFC 8707: Require resource parameter (default: false)
 
+	// Compatibility modes
+	RunlayerMode bool // Mimic Runlayer's strict validation with Pydantic-style 422 errors
+
 	// Error injection
 	ErrorMode ErrorMode
 

--- a/tests/oauthserver/types.go
+++ b/tests/oauthserver/types.go
@@ -140,6 +140,20 @@ type OAuthError struct {
 	ErrorDescription string `json:"error_description,omitempty"`
 }
 
+// PydanticValidationError represents a Pydantic-style validation error response.
+// Used in Runlayer mode to mimic FastAPI/Pydantic 422 responses.
+type PydanticValidationError struct {
+	Detail []PydanticErrorDetail `json:"detail"`
+}
+
+// PydanticErrorDetail represents a single validation error detail.
+type PydanticErrorDetail struct {
+	Type  string   `json:"type"`            // Error type, e.g., "missing", "value_error"
+	Loc   []string `json:"loc"`             // Location path, e.g., ["query", "resource"]
+	Msg   string   `json:"msg"`             // Human-readable message
+	Input any      `json:"input,omitempty"` // The input value that caused the error
+}
+
 // RefreshTokenData stores refresh token information.
 type RefreshTokenData struct {
 	Token     string


### PR DESCRIPTION
## Summary

- Add `-runlayer-mode` flag to Go OAuth test server that mimics Runlayer's strict validation
- Returns Pydantic-style 422 errors when RFC 8707 `resource` parameter is missing
- Helps test and debug issue #271 compatibility with Runlayer servers

## Changes

**OAuth Test Server:**
- Add `PydanticValidationError` and `PydanticErrorDetail` types in `types.go`
- Add `RunlayerMode` option in `options.go`
- Add `pydanticValidationError()` method in `authorize.go`
- Add `-runlayer-mode` CLI flag (implies `-require-resource`)

**Testing:**
- Add `--runlayer-mode` flag to `scripts/run-oauth-e2e.sh`
- Add `test/integration/test_runlayer_mode.sh` integration test

**Documentation:**
- Update `docs/oauthserver_testing.md` with Runlayer mode usage
- Add comparison table for Go vs Python OAuth test servers

## Usage

```bash
# Start server in Runlayer mode
go run ./tests/oauthserver/cmd/server -port 9000 -runlayer-mode

# Test without resource - get 422 Pydantic error
curl "http://localhost:9000/authorize?client_id=test-client&..."
# Returns: {"detail":[{"type":"missing","loc":["query","resource"],"msg":"Field required"}]}
```

## Test plan

- [x] `go test ./tests/oauthserver/...` - All existing tests pass
- [x] `go vet ./tests/oauthserver/...` - No issues
- [x] `./test/integration/test_runlayer_mode.sh` - New integration test passes
- [ ] Manual testing with mcpproxy against Runlayer-style mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)