### PR TITLE
feat(test): add rate limit testing support to OAuth test server

### DIFF
--- a/tests/oauthserver/mcp.go
+++ b/tests/oauthserver/mcp.go
@@ -55,6 +55,19 @@ func (s *OAuthTestServer) createMCPServer() *mcpserver.MCPServer {
 // oauthMiddleware wraps the MCP handler with OAuth authentication
 func (s *OAuthTestServer) oauthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check for rate limit injection BEFORE auth check
+		if s.options.ErrorMode.MCPRateLimitCount > 0 {
+			s.mu.Lock()
+			s.mcpRateLimitHits++
+			hits := s.mcpRateLimitHits
+			s.mu.Unlock()
+
+			if hits <= s.options.ErrorMode.MCPRateLimitCount {
+				s.sendMCPRateLimited(w)
+				return
+			}
+		}
+
 		// Check for Bearer token authentication
 		authHeader := r.Header.Get("Authorization")
 		if authHeader == "" || !strings.HasPrefix(authHeader, "Bearer ") {
@@ -108,4 +121,22 @@ func (s *OAuthTestServer) sendMCPUnauthorized(w http.ResponseWriter) {
 	w.Header().Set("WWW-Authenticate", wwwAuth)
 	w.WriteHeader(http.StatusUnauthorized)
 	w.Write([]byte(`{"error": "unauthorized", "error_description": "Bearer token required"}`))
+}
+
+// sendMCPRateLimited sends a 429 response for rate limit testing
+func (s *OAuthTestServer) sendMCPRateLimited(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+
+	if s.options.ErrorMode.MCPRateLimitRetryAfter > 0 && !s.options.ErrorMode.MCPRateLimitUseResetAt {
+		w.Header().Set("Retry-After", fmt.Sprintf("%d", s.options.ErrorMode.MCPRateLimitRetryAfter))
+	}
+
+	w.WriteHeader(http.StatusTooManyRequests)
+
+	if s.options.ErrorMode.MCPRateLimitUseResetAt {
+		resetAt := time.Now().Add(time.Duration(s.options.ErrorMode.MCPRateLimitRetryAfter) * time.Second).Unix()
+		w.Write([]byte(fmt.Sprintf(`{"error": "rate_limited", "reset_at": %d}`, resetAt)))
+	} else {
+		w.Write([]byte(`{"error": "rate_limited", "error_description": "Too many requests"}`))
+	}
 }

--- a/tests/oauthserver/options.go
+++ b/tests/oauthserver/options.go
@@ -42,6 +42,11 @@ type ErrorMode struct {
 	// Device code errors
 	DeviceSlowPoll bool // Return `slow_down` on device polling
 	DeviceExpired  bool // Return `expired_token` on device polling
+
+	// MCP endpoint rate limiting (for resource auto-detection testing)
+	MCPRateLimitCount      int  // Return 429 this many times before real response
+	MCPRateLimitRetryAfter int  // Retry-After header value (seconds, 0 = omit header)
+	MCPRateLimitUseResetAt bool // Use JSON body with reset_at instead of Retry-After header
 }
 
 // Options configures the OAuth test server behavior.

--- a/tests/oauthserver/types.go
+++ b/tests/oauthserver/types.go
@@ -86,6 +86,14 @@ type TokenErrorResponse struct {
 	ErrorURI         string `json:"error_uri,omitempty"`
 }
 
+// ProtectedResourceMetadata represents OAuth 2.0 Protected Resource Metadata (RFC 9728).
+type ProtectedResourceMetadata struct {
+	Resource              string   `json:"resource"`
+	AuthorizationServers  []string `json:"authorization_servers"`
+	ScopesSupported       []string `json:"scopes_supported,omitempty"`
+	BearerMethodsSupported []string `json:"bearer_methods_supported,omitempty"`
+}
+
 // DiscoveryMetadata represents OAuth 2.0 Authorization Server Metadata (RFC 8414).
 type DiscoveryMetadata struct {
 	Issuer                            string   `json:"issuer"`


### PR DESCRIPTION
## Summary
- Add rate limit injection capabilities to the OAuth test server for testing `autoDetectResource()` retry behavior with 429 responses
- Add RFC 9728 Protected Resource Metadata endpoint (`/.well-known/oauth-protected-resource`)
- Enables E2E testing of rate limit handling in OAuth resource auto-detection

## Changes
- Add `MCPRateLimitCount`, `MCPRateLimitRetryAfter`, `MCPRateLimitUseResetAt` to `ErrorMode`
- Add rate limit check to `oauthMiddleware` (before auth check)
- Add `/.well-known/oauth-protected-resource` endpoint (RFC 9728)
- Add `ProtectedResourceMetadata` type
- Add `MCPURL` and `ProtectedResourceMetadataURL` to `ServerResult`
- Add `ResetRateLimitCounter()` helper for tests
- Add tests for rate limiting and protected resource metadata

## Usage
```go
server := oauthserver.Start(t, oauthserver.Options{
    ErrorMode: oauthserver.ErrorMode{
        MCPRateLimitCount:      2,  // Return 429 twice before real response
        MCPRateLimitRetryAfter: 5,  // With Retry-After: 5
    },
})
// POST to server.MCPURL will return 429 twice, then 401
```

## Test plan
- [x] All existing OAuth test server tests pass
- [x] New `TestMCPRateLimiting` tests pass (3 sub-tests)
- [x] New `TestProtectedResourceMetadata` test passes
- [x] Verified tests fail when rate limit code is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)