### PR TITLE
fix(build): use correct module path in ldflags for version injection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -369,7 +369,7 @@ jobs:
           CGO_LDFLAGS: "-mmacosx-version-min=12.0"
         run: |
           VERSION=${GITHUB_REF#refs/tags/}
-          LDFLAGS="-s -w -X mcpproxy-go/cmd/mcpproxy.version=${VERSION} -X main.version=${VERSION} -X mcpproxy-go/internal/httpapi.buildVersion=${VERSION}"
+          LDFLAGS="-s -w -X main.version=${VERSION} -X github.com/smart-mcp-proxy/mcpproxy-go/internal/httpapi.buildVersion=${VERSION}"
 
           # Determine clean binary name
           if [ "${{ matrix.goos }}" = "windows" ]; then

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ swagger-verify: swagger
 VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo "v0.1.0-dev")
 COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
-LDFLAGS := -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(BUILD_DATE) -X mcpproxy-go/internal/httpapi.buildVersion=$(VERSION) -s -w
+LDFLAGS := -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(BUILD_DATE) -X github.com/smart-mcp-proxy/mcpproxy-go/internal/httpapi.buildVersion=$(VERSION) -s -w
 
 # Build complete project
 build: swagger frontend-build

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,7 +10,7 @@ echo "Building mcpproxy version: $VERSION"
 echo "Commit: $COMMIT"
 echo "Date: $DATE"
 
-LDFLAGS="-X main.version=$VERSION -X main.commit=$COMMIT -X main.date=$DATE -X mcpproxy-go/internal/httpapi.buildVersion=$VERSION -s -w"
+LDFLAGS="-X main.version=$VERSION -X main.commit=$COMMIT -X main.date=$DATE -X github.com/smart-mcp-proxy/mcpproxy-go/internal/httpapi.buildVersion=$VERSION -s -w"
 
 # Build for current platform (with CGO for tray support if needed)
 echo "Building for current platform..."


### PR DESCRIPTION
## Summary
- Fix ldflags to use full module path for `buildVersion` variable injection
- Removes redundant incorrect ldflags path in release workflow

## Problem
The `buildVersion` variable in `internal/httpapi/server.go` was not being set during release builds because the ldflags used an incorrect module path:

```bash
# Incorrect (what was used)
-X mcpproxy-go/internal/httpapi.buildVersion=${VERSION}

# Correct (what's needed)
-X github.com/smart-mcp-proxy/mcpproxy-go/internal/httpapi.buildVersion=${VERSION}
```

This caused:
- `mcpproxy doctor` to show `Version: development`
- Web UI to show `development` version
- Only `mcpproxy --version` worked (because `main.version` uses the special `main` package shorthand)

## Root Cause
Go's `-X` linker flag requires the **full import path** for non-main packages. The module path in `go.mod` is `github.com/smart-mcp-proxy/mcpproxy-go`, so the correct ldflags path must include this prefix.

## Changes
1. **Makefile**: Fixed `LDFLAGS` to use full module path
2. **scripts/build.sh**: Fixed `LDFLAGS` to use full module path  
3. **.github/workflows/release.yml**: Fixed `LDFLAGS` to use full module path (also removed redundant `-X mcpproxy-go/cmd/mcpproxy.version` since `-X main.version` already works)

## Test plan
- [x] `make build` succeeds
- [x] `./mcpproxy --version` shows correct version (v0.16.7)
- [x] Server logs show correct version in startup: `Starting mcpproxy {"version": "v0.16.7", ...}`
- [x] E2E tests pass for API endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)