### PR TITLE
fix(ui): use theme-aware colors in sensitive data detection panel

### DIFF
--- a/frontend/src/views/Activity.vue
+++ b/frontend/src/views/Activity.vue
@@ -504,7 +504,7 @@
                 Sensitive Data Detected
               </h4>
               <div class="alert" :class="selectedActivity.max_severity === 'critical' ? 'alert-error' : 'alert-warning'">
-                <div class="flex flex-col gap-2 w-full">
+                <div class="flex flex-col gap-2 w-full text-inherit">
                   <div class="flex items-center gap-2">
                     <span class="font-semibold">Severity:</span>
                     <span class="badge" :class="getSeverityBadgeClass(selectedActivity.max_severity)">
@@ -517,7 +517,7 @@
                       <span
                         v-for="dtype in selectedActivity.detection_types"
                         :key="dtype"
-                        class="badge badge-sm badge-outline"
+                        class="badge badge-sm bg-base-100/20 border-current text-inherit"
                       >
                         {{ dtype }}
                       </span>
@@ -529,13 +529,13 @@
                       <div
                         v-for="(detection, idx) in (selectedActivity.metadata.sensitive_data_detection.detections || [])"
                         :key="idx"
-                        class="flex items-center gap-2 bg-base-200 rounded px-2 py-1"
+                        class="flex items-center gap-2 bg-base-100/20 rounded px-2 py-1"
                       >
                         <span class="badge badge-xs" :class="getSeverityBadgeClass(detection.severity)">
                           {{ detection.severity }}
                         </span>
-                        <span class="font-mono text-xs">{{ detection.type }}</span>
-                        <span class="text-base-content/60 text-xs">in {{ detection.location }}</span>
+                        <span class="font-mono text-xs text-inherit">{{ detection.type }}</span>
+                        <span class="text-inherit/70 text-xs">in {{ detection.location }}</span>
                         <span v-if="detection.is_likely_example" class="badge badge-xs badge-ghost">example</span>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- Fix unreadable text in sensitive data detection section on Activity drawer
- Text was using dark colors that didn't contrast with alert-error/alert-warning backgrounds in dark mode
- Updated to use DaisyUI theme-aware classes for proper contrast

## Changes
- Use `text-inherit` on container to inherit alert text color
- Use `bg-base-100/20` for semi-transparent backgrounds that work with any theme
- Use `border-current` for badge borders
- Use `text-inherit/70` for secondary text with opacity

## Test plan
- [ ] Open Activity Log in dark mode
- [ ] Click on an activity with sensitive data detections
- [ ] Verify detection type badges are readable
- [ ] Verify detection details text is readable
- [ ] Test in light mode to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)