### PR TITLE
fix(security): resolve race condition and resource leaks in flow tracker

### DIFF
--- a/internal/security/flow/tracker.go
+++ b/internal/security/flow/tracker.go
@@ -77,8 +77,8 @@ func (ft *FlowTracker) CheckFlow(sessionID string, toolName, serverName string, 
 		return nil, nil
 	}
 
-	session.mu.RLock()
-	defer session.mu.RUnlock()
+	session.mu.Lock()
+	defer session.mu.Unlock()
 
 	var edges []*FlowEdge
 	matched := make(map[string]bool) // Avoid duplicate edges for same content hash


### PR DESCRIPTION
## Summary

Fixes 3 issues found during code review of #293 (Spec 027 data flow security):

- **Race condition**: `CheckFlow()` writes to session fields under read lock — changed `RLock` to `Lock`
- **Goroutine leak**: `FlowService.Stop()` never called in `Runtime.Close()` — added shutdown call
- **Missing callback**: `SetExpiryCallback` never registered — flow session summaries now emit to activity log

## Changes

**Production fixes** (`2611a32`):
- `internal/security/flow/tracker.go`: `RLock` → `Lock` in `CheckFlow` (writes to `LastActivity`, `ToolsUsed`, `Flows` require write lock)
- `internal/runtime/runtime.go`: Added `flowService.Stop()` in `Close()` before supervisor shutdown
- `internal/runtime/runtime.go`: Registered `SetExpiryCallback` after Runtime construction to emit `EventTypeActivityFlowSummary`

**Regression tests** (`ab95259`):
- `TestFlowTracker_CheckFlow_ConcurrentRace`: 15+ goroutines exercising concurrent `CheckFlow` + `RecordOrigin`
- `TestFlowService_Stop_Idempotent`: triple-stop safety
- `TestFlowService_ExpiryCallback_EmitsSummary`: verifies callback fires with correct `FlowSummary`

## Test plan

- [x] `go test -race ./internal/security/flow/...` — all 34 tests pass
- [x] Race regression test confirms fix (would fail with `RLock`)
- [x] Code review verified: no deadlock risk, correct shutdown order, non-blocking callback

> Stacked on #293

🤖 Generated with [Claude Code](https://claude.ai/code)