### PR TITLE
fix: correct quarantine API docs and wire tray unquarantine menu

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,7 +214,8 @@ See [docs/configuration.md](docs/configuration.md) for complete reference.
 | `GET /api/v1/status` | Server status and statistics |
 | `GET /api/v1/servers` | List all upstream servers |
 | `POST /api/v1/servers/{name}/enable` | Enable/disable server |
-| `POST /api/v1/servers/{name}/quarantine` | Quarantine/unquarantine server |
+| `POST /api/v1/servers/{name}/quarantine` | Quarantine a server |
+| `POST /api/v1/servers/{name}/unquarantine` | Unquarantine a server |
 | `GET /api/v1/tools` | Search tools across servers |
 | `GET /api/v1/activity` | List activity records with filtering |
 | `GET /api/v1/activity/{id}` | Get activity record details |

--- a/cmd/mcpproxy-tray/internal/api/adapter.go
+++ b/cmd/mcpproxy-tray/internal/api/adapter.go
@@ -16,6 +16,8 @@ type ClientInterface interface {
 	GetServers() ([]Server, error)
 	GetInfo() (map[string]interface{}, error)
 	EnableServer(serverName string, enabled bool) error
+	QuarantineServer(serverName string) error
+	UnquarantineServer(serverName string) error
 	TriggerOAuthLogin(serverName string) error
 	StatusChannel() <-chan StatusUpdate
 }
@@ -210,9 +212,7 @@ func (a *ServerAdapter) GetQuarantinedServers() ([]map[string]interface{}, error
 
 // UnquarantineServer removes a server from quarantine
 func (a *ServerAdapter) UnquarantineServer(serverName string) error {
-	// This functionality is not available in the current API
-	// Would need to be added to the API first
-	return fmt.Errorf("UnquarantineServer not yet supported via API for %s", serverName)
+	return a.client.UnquarantineServer(serverName)
 }
 
 // EnableServer enables or disables a server
@@ -222,9 +222,10 @@ func (a *ServerAdapter) EnableServer(serverName string, enabled bool) error {
 
 // QuarantineServer sets quarantine status for a server
 func (a *ServerAdapter) QuarantineServer(serverName string, quarantined bool) error {
-	// This functionality is not available in the current API
-	// Would need to be added to the API first
-	return fmt.Errorf("QuarantineServer not yet supported via API for %s (quarantined=%t)", serverName, quarantined)
+	if quarantined {
+		return a.client.QuarantineServer(serverName)
+	}
+	return a.client.UnquarantineServer(serverName)
 }
 
 // GetAllServers returns all servers

--- a/cmd/mcpproxy-tray/internal/api/client.go
+++ b/cmd/mcpproxy-tray/internal/api/client.go
@@ -677,6 +677,38 @@ func (c *Client) GetServerTools(serverName string) ([]Tool, error) {
 	return result, nil
 }
 
+// QuarantineServer places a server in quarantine
+func (c *Client) QuarantineServer(serverName string) error {
+	endpoint := fmt.Sprintf("/api/v1/servers/%s/quarantine", serverName)
+
+	resp, err := c.makeRequest("POST", endpoint, nil)
+	if err != nil {
+		return err
+	}
+
+	if !resp.Success {
+		return fmt.Errorf("API error: %s", resp.Error)
+	}
+
+	return nil
+}
+
+// UnquarantineServer removes a server from quarantine
+func (c *Client) UnquarantineServer(serverName string) error {
+	endpoint := fmt.Sprintf("/api/v1/servers/%s/unquarantine", serverName)
+
+	resp, err := c.makeRequest("POST", endpoint, nil)
+	if err != nil {
+		return err
+	}
+
+	if !resp.Success {
+		return fmt.Errorf("API error: %s", resp.Error)
+	}
+
+	return nil
+}
+
 // SearchTools searches for tools
 // GetInfo fetches server information from /api/v1/info endpoint
 func (c *Client) GetInfo() (map[string]interface{}, error) {

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -177,14 +177,11 @@ Disable a server.
 
 #### POST /api/v1/servers/{name}/quarantine
 
-Set quarantine status.
+Place a server in quarantine to prevent tool execution. No request body required.
 
-**Request Body:**
-```json
-{
-  "quarantined": true
-}
-```
+#### POST /api/v1/servers/{name}/unquarantine
+
+Remove a server from quarantine to allow tool execution. No request body required.
 
 #### POST /api/v1/servers/{name}/restart
 

--- a/docs/cli-management-commands.md
+++ b/docs/cli-management-commands.md
@@ -497,10 +497,8 @@ mcpproxy upstream list
 # 🔒 notion  http  0  Pending approval  Approve in Web UI
 
 # Approve in web UI or via API:
-curl -X POST "http://localhost:8080/api/v1/servers/notion/quarantine" \
-  -H "X-API-Key: your-key" \
-  -H "Content-Type: application/json" \
-  -d '{"quarantined": false}'
+curl -X POST "http://localhost:8080/api/v1/servers/notion/unquarantine" \
+  -H "X-API-Key: your-key"
 ```
 
 ### Bulk Operations Warning

--- a/docs/features/security-quarantine.md
+++ b/docs/features/security-quarantine.md
@@ -102,9 +102,7 @@ mcpproxy upstream list
 ```bash
 curl -X POST \
   -H "X-API-Key: your-key" \
-  -H "Content-Type: application/json" \
-  -d '{"quarantined": false}' \
-  http://127.0.0.1:8080/api/v1/servers/server-name/quarantine
+  http://127.0.0.1:8080/api/v1/servers/server-name/unquarantine
 ```
 
 **Config File:**
@@ -132,8 +130,6 @@ If you need to quarantine a previously approved server:
 ```bash
 curl -X POST \
   -H "X-API-Key: your-key" \
-  -H "Content-Type: application/json" \
-  -d '{"quarantined": true}' \
   http://127.0.0.1:8080/api/v1/servers/server-name/quarantine
 ```
 


### PR DESCRIPTION
## Summary
- **Fix B**: Documentation showed incorrect curl examples for unquarantine — used `POST /quarantine` with `{"quarantined": false}` body. Actual API uses separate `POST /quarantine` and `POST /unquarantine` endpoints with no request body. Fixed in `rest-api.md`, `security-quarantine.md`, `cli-management-commands.md`, and `CLAUDE.md`.
- **Fix C**: Tray app unquarantine menu item returned "not yet supported via API". Added `QuarantineServer()` and `UnquarantineServer()` methods to tray API client and wired the adapter to call them.

## Changes
- `docs/api/rest-api.md` — split single quarantine entry into two endpoints
- `docs/features/security-quarantine.md` — fixed curl examples
- `docs/cli-management-commands.md` — fixed curl example
- `CLAUDE.md` — split quarantine/unquarantine table entry
- `cmd/mcpproxy-tray/internal/api/client.go` — added QuarantineServer/UnquarantineServer methods
- `cmd/mcpproxy-tray/internal/api/adapter.go` — wired adapter to call actual endpoints
- `cmd/mcpproxy-tray/internal/api/adapter_test.go` — 5 new tests (27 total pass with -race)

## Correct API usage
```bash
# Quarantine (no body)
curl -X POST -H "X-API-Key: your-key" http://127.0.0.1:8080/api/v1/servers/server-name/quarantine

# Unquarantine (no body)
curl -X POST -H "X-API-Key: your-key" http://127.0.0.1:8080/api/v1/servers/server-name/unquarantine
```

## Test plan
- [x] `go test -race ./cmd/mcpproxy-tray/internal/api/...` — 27 tests pass
- [x] `go build ./cmd/mcpproxy-tray/...` — compiles
- [ ] Manual: start mcpproxy + tray, quarantine a server, use tray menu to unquarantine

🤖 Generated with [Claude Code](https://claude.com/claude-code)