### PR TITLE
feat: add --no-quarantine flag to upstream import and fix docs

### DIFF
--- a/docs/cli/command-reference.md
+++ b/docs/cli/command-reference.md
@@ -196,20 +196,20 @@ mcpproxy upstream disable <server-name>
 
 ## Configuration Import
 
-### import
+### upstream import
 
 Import MCP server configurations from other AI tools:
 
 ```bash
-mcpproxy import [flags]
+mcpproxy upstream import <path> [flags]
 ```
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--path` | Path to configuration file | - |
+| `--server, -s` | Import only a specific server by name | all |
 | `--format` | Force format (claude-desktop, claude-code, cursor, codex, gemini) | auto-detect |
-| `--servers` | Comma-separated list of server names to import | all |
-| `--preview` | Preview without importing | `false` |
+| `--dry-run` | Preview import without making changes | `false` |
+| `--no-quarantine` | Don't quarantine imported servers (use with caution) | `false` |
 
 **Supported Formats:**
 
@@ -225,19 +225,22 @@ mcpproxy import [flags]
 
 ```bash
 # Import from Claude Desktop config
-mcpproxy import --path ~/Library/Application\ Support/Claude/claude_desktop_config.json
+mcpproxy upstream import ~/Library/Application\ Support/Claude/claude_desktop_config.json
 
 # Import from Claude Code config
-mcpproxy import --path ~/.claude.json
+mcpproxy upstream import ~/.claude.json
 
 # Preview without importing
-mcpproxy import --path config.json --preview
+mcpproxy upstream import --dry-run config.json
 
 # Import with format hint (if auto-detect fails)
-mcpproxy import --path config.json --format claude-desktop
+mcpproxy upstream import --format claude-desktop config.json
 
-# Import only specific servers
-mcpproxy import --path config.json --servers "github-server,filesystem"
+# Import only a specific server
+mcpproxy upstream import --server github-server config.json
+
+# Import without quarantine (trusted configs)
+mcpproxy upstream import --no-quarantine ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 
 **Canonical Config Paths:**
@@ -251,7 +254,7 @@ mcpproxy import --path config.json --servers "github-server,filesystem"
 | Gemini CLI | `~/.gemini/settings.json` | `~/.gemini/settings.json` | `~/.gemini/settings.json` |
 
 :::note Imported servers are quarantined
-For security, all imported servers are quarantined by default. Review and approve them before enabling.
+For security, all imported servers are quarantined by default. Use `--no-quarantine` to skip quarantine for configs you trust.
 :::
 
 See [Configuration Import](/features/config-import) for Web UI and REST API documentation.

--- a/docs/features/config-import.md
+++ b/docs/features/config-import.md
@@ -62,23 +62,26 @@ For quick imports without file access:
 
 ```bash
 # Import from Claude Desktop config
-mcpproxy import --path ~/Library/Application\ Support/Claude/claude_desktop_config.json
+mcpproxy upstream import ~/Library/Application\ Support/Claude/claude_desktop_config.json
 
 # Import from Claude Code config
-mcpproxy import --path ~/.claude.json
+mcpproxy upstream import ~/.claude.json
 
 # Import with format hint (if auto-detect fails)
-mcpproxy import --path config.json --format claude-desktop
+mcpproxy upstream import --format claude-desktop config.json
 
 # Preview without importing
-mcpproxy import --path config.json --preview
+mcpproxy upstream import --dry-run config.json
+
+# Import without quarantine (trusted configs)
+mcpproxy upstream import --no-quarantine ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 
 ### Import Specific Servers
 
 ```bash
-# Import only specific servers by name
-mcpproxy import --path config.json --servers "github-server,filesystem"
+# Import only a specific server by name
+mcpproxy upstream import --server github-server config.json
 ```
 
 ## REST API

--- a/internal/configimport/import.go
+++ b/internal/configimport/import.go
@@ -113,6 +113,11 @@ func Import(content []byte, opts *ImportOptions) (*ImportResult, error) {
 		// Map to ServerConfig
 		serverConfig, skipped, warnings := MapToServerConfig(parsed, opts.Now)
 
+		// Override quarantine if SkipQuarantine is set
+		if opts.SkipQuarantine {
+			serverConfig.Quarantined = false
+		}
+
 		// Create imported server
 		imported := &ImportedServer{
 			Server:        serverConfig,

--- a/internal/configimport/types.go
+++ b/internal/configimport/types.go
@@ -155,6 +155,10 @@ type ImportOptions struct {
 	// ExistingServers is used to check for duplicates
 	ExistingServers []string
 
+	// SkipQuarantine if true, imported servers are not quarantined.
+	// By default, all imported servers are quarantined for security review.
+	SkipQuarantine bool
+
 	// Now is the timestamp to use for Created field (default: time.Now())
 	Now time.Time
 }


### PR DESCRIPTION
## Summary
- **Fix A**: Documentation incorrectly used `mcpproxy import` instead of `mcpproxy upstream import`, and had wrong flags (`--path` instead of positional arg, `--preview` instead of `--dry-run`, `--servers` instead of `--server`). Fixed in `config-import.md` and `command-reference.md`.
- **Feature A**: Added `--no-quarantine` flag to `mcpproxy upstream import` so imported servers skip quarantine. Matches existing `upstream add --no-quarantine` pattern. Opt-in flag preserves security-by-default.

## Changes
- `cmd/mcpproxy/upstream_cmd.go` — added `--no-quarantine` flag, wired to ImportOptions, added `quarantined` to JSON output, updated daemon mode to use server's quarantine state
- `internal/configimport/types.go` — added `SkipQuarantine` field to ImportOptions
- `internal/configimport/import.go` — override quarantine after mapper when flag set
- `internal/configimport/import_test.go` — 2 new tests for default and skip behaviors
- `docs/features/config-import.md` — corrected CLI syntax and flags
- `docs/cli/command-reference.md` — corrected CLI syntax, flags, and examples

## Design decisions
- **Flag name**: `--no-quarantine` — matches existing `upstream add --no-quarantine`
- **Default**: Quarantine ON (security-by-default preserved)
- **Layer**: Override applied in `Import()` after mapper sets secure default, keeping `mapper.go` untouched

## Test plan
- [x] `go test -race ./internal/configimport/...` — 53 tests pass
- [x] `go build ./cmd/mcpproxy/...` — compiles
- [x] `./mcpproxy upstream import --help` — shows new flag
- [ ] Manual: `mcpproxy upstream import --dry-run --no-quarantine <config>` — verify output shows servers not quarantined

🤖 Generated with [Claude Code](https://claude.com/claude-code)