### PR TITLE
chore: add pre-commit hooks with prek

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,33 @@
+# Pre-commit hooks for MCPProxy
+# Install: brew install prek && prek install && prek install --hook-type pre-push
+# Run manually: prek run --all-files
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-merge-conflict
+
+  - repo: local
+    hooks:
+      - id: gofmt
+        name: gofmt
+        entry: gofmt -w
+        language: system
+        types: [go]
+
+      - id: swagger-verify
+        name: Verify OpenAPI spec is up to date
+        entry: make swagger-verify
+        language: system
+        stages: [pre-push]
+        pass_filenames: false
+
+      - id: go-build
+        name: go build
+        entry: go build -o /dev/null ./cmd/mcpproxy
+        language: system
+        stages: [pre-push]
+        pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,13 @@ dev-setup:
 	cd e2e/playwright && npm install
 	@echo "📦 Installing Playwright browsers..."
 	cd e2e/playwright && npx playwright install chromium
+	@echo "📦 Installing pre-commit hooks..."
+	@if command -v prek >/dev/null 2>&1; then \
+		prek install && prek install --hook-type pre-push; \
+		echo "✅ Git hooks installed (prek)"; \
+	else \
+		echo "⚠️  prek not found. Install with: brew install prek"; \
+	fi
 	@echo "✅ Development setup completed"
 
 # Run OAuth E2E tests with Playwright

--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ Add to your `mcp_config.json`:
   "docker_isolation": {
     "enabled": true,
     "memory_limit": "512m",
-    "cpu_limit": "1.0", 
+    "cpu_limit": "1.0",
     "timeout": "60s",
     "network_mode": "bridge",
     "default_images": {
@@ -450,7 +450,7 @@ Add to your `mcp_config.json`:
       // Docker isolation applied automatically
     },
     {
-      "name": "custom-isolation-server", 
+      "name": "custom-isolation-server",
       "command": "python",
       "args": ["-m", "my_server"],
       "isolation": {
@@ -698,7 +698,7 @@ Solve project context issues by specifying working directories for stdio MCP ser
 
 **Benefits**:
 - **Project isolation**: File-based servers operate in correct directory context
-- **Multiple projects**: Same MCP server type for different projects  
+- **Multiple projects**: Same MCP server type for different projects
 - **Context separation**: Work and personal project isolation
 
 **Tool-based Management**:
@@ -810,6 +810,40 @@ curl -k https://localhost:8080/api/v1/status
 * Website: <https://mcpproxy.app>
 * Releases: <https://github.com/smart-mcp-proxy/mcpproxy-go/releases>
 
-## Contributing 🤝
+## Contributing
 
-We welcome issues, feature ideas, and PRs! Fork the repo, create a feature branch, and open a pull request. See `CONTRIBUTING.md` (coming soon) for guidelines. 
+We welcome issues, feature ideas, and PRs!
+
+### Development Setup
+
+```bash
+make dev-setup                # Install swag, frontend deps, Playwright
+brew install prek             # Install pre-commit hook runner (or: uv tool install prek)
+prek install                  # Install pre-commit hooks
+prek install --hook-type pre-push  # Install pre-push hooks
+```
+
+### Pre-commit Hooks
+
+We use [prek](https://github.com/j178/prek) to catch issues before they reach CI:
+
+| Hook | Stage | What it does |
+|------|-------|-------------|
+| `gofmt` | pre-commit | Auto-formats staged Go files |
+| `trailing-whitespace` | pre-commit | Removes trailing whitespace |
+| `end-of-file-fixer` | pre-commit | Ensures files end with newline |
+| `check-merge-conflict` | pre-commit | Detects merge conflict markers |
+| `swagger-verify` | pre-push | Fails if OpenAPI spec is out of date |
+| `go-build` | pre-push | Verifies the project compiles |
+
+Run hooks manually: `prek run --all-files`
+
+### Build & Test
+
+```bash
+make build          # Build frontend + backend
+make swagger        # Regenerate OpenAPI spec
+make test           # Unit tests
+make test-e2e       # E2E tests
+make lint           # Run linters
+```


### PR DESCRIPTION
## Summary
- Add `.pre-commit-config.yaml` with [prek](https://github.com/j178/prek) (fast Rust-based pre-commit runner)
- **Pre-commit (<1s):** gofmt auto-fix, trailing whitespace, EOF fixer, merge conflict check
- **Pre-push (<5s):** OpenAPI spec verification, go build check
- Update `make dev-setup` to install hooks automatically
- Update README Contributing section with setup instructions

Prevents CI failures like stale OpenAPI artifacts reaching CI before being caught locally.

## Setup
```bash
brew install prek
prek install && prek install --hook-type pre-push
```

## Test plan
- [x] `prek run --all-files` passes on staged files
- [x] `prek run --hook-stage pre-push` passes (swagger-verify + go build)
- [x] Hooks fire on `git commit` and `git push`
- [x] `go build` and `make swagger-verify` pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)