### PR TITLE
fix(test): increase socket E2E server startup timeout

### DIFF
--- a/internal/server/socket_e2e_test.go
+++ b/internal/server/socket_e2e_test.go
@@ -88,7 +88,7 @@ func TestE2E_TrayToCore_UnixSocket(t *testing.T) {
 	// Wait for server to be ready
 	require.Eventually(t, func() bool {
 		return srv.IsReady()
-	}, 5*time.Second, 100*time.Millisecond, "Server should become ready")
+	}, 15*time.Second, 100*time.Millisecond, "Server should become ready")
 
 	// Wait for TCP address to be resolved (may take a moment with race detector)
 	var tcpAddr string
@@ -271,7 +271,7 @@ func TestE2E_DualListener_Concurrent(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return srv.IsReady()
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	tcpAddr := srv.GetListenAddress()
 	socketPath := filepath.Join(tmpDir, "mcpproxy.sock")
@@ -399,7 +399,7 @@ func TestE2E_SocketPermissions(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return srv.IsReady()
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	socketPath := filepath.Join(tmpDir, "mcpproxy.sock")
 


### PR DESCRIPTION
## Summary
Fixes flaky `TestE2E_SocketPermissions` on macOS CI runners.

The server startup timeout was 5 seconds, but macOS runners sometimes need more time. Other E2E tests already use 15 seconds. This aligns all socket E2E tests to the same 15-second timeout.

## Test plan
- [x] Only test timeouts changed (5s → 15s), no logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)