### PR TITLE
Stop tray log growth when the upstream list is empty

### DIFF
--- a/cmd/mcpproxy-tray/internal/api/client.go
+++ b/cmd/mcpproxy-tray/internal/api/client.go
@@ -545,17 +545,19 @@ func (c *Client) GetServers() ([]Server, error) {
 			}
 		}
 
-		if len(result) == 0 {
-			c.logger.Warnw("API returned zero upstream servers",
-				"base_url", c.baseURL)
-		} else if stateChanged {
-			// Only log when server states actually change
-			c.logger.Debugw("Server state changed",
-				"count", len(result),
-				"connected", countConnected(result),
-				"with_health", withHealthCount,
-				"healthy", healthyCount,
-				"quarantined", countQuarantined(result))
+		if stateChanged {
+			if len(result) == 0 {
+				c.logger.Warnw("API returned zero upstream servers",
+					"base_url", c.baseURL)
+			} else {
+				// Only log when server states actually change
+				c.logger.Debugw("Server state changed",
+					"count", len(result),
+					"connected", countConnected(result),
+					"with_health", withHealthCount,
+					"healthy", healthyCount,
+					"quarantined", countQuarantined(result))
+			}
 			c.lastServerState = stateHash
 		}
 		// Silent when no changes - reduces log noise from frequent polling

--- a/cmd/mcpproxy-tray/internal/api/client_test.go
+++ b/cmd/mcpproxy-tray/internal/api/client_test.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestClientGetServers_LogsZeroServersOnlyOnStateChange(t *testing.T) {
+	t.Parallel()
+
+	responses := []string{
+		`{"success":true,"data":{"servers":[]}}`,
+		`{"success":true,"data":{"servers":[]}}`,
+		`{"success":true,"data":{"servers":[{"name":"demo","connected":true,"enabled":true,"quarantined":false,"tool_count":3,"status":"connected"}]}}`,
+		`{"success":true,"data":{"servers":[{"name":"demo","connected":true,"enabled":true,"quarantined":false,"tool_count":3,"status":"connected"}]}}`,
+		`{"success":true,"data":{"servers":[]}}`,
+	}
+
+	var (
+		mu    sync.Mutex
+		index int
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/servers", r.URL.Path)
+
+		mu.Lock()
+		current := responses[index]
+		if index < len(responses)-1 {
+			index++
+		}
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(current))
+		if err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	core, recorded := observer.New(zapcore.DebugLevel)
+	client := &Client{
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+		logger:     zap.New(core).Sugar(),
+	}
+
+	expectedCounts := []int{0, 0, 1, 1, 0}
+	for _, expectedCount := range expectedCounts {
+		servers, err := client.GetServers()
+		require.NoError(t, err)
+		assert.Len(t, servers, expectedCount)
+	}
+
+	assert.Equal(t, 2, recorded.FilterMessage("API returned zero upstream servers").Len())
+	assert.Equal(t, 1, recorded.FilterMessage("Server state changed").Len())
+}

--- a/cmd/mcpproxy-tray/main.go
+++ b/cmd/mcpproxy-tray/main.go
@@ -373,14 +373,52 @@ func monitorDockerStatus(ctx context.Context, apiClient *api.Client, logger *zap
 
 // setupLogging configures the logger with appropriate settings for the tray
 func setupLogging() (*zap.Logger, error) {
-	cfg := newTrayLogConfig(runtime.GOOS, getLogDir())
+	return newTrayLogger(newTrayLogConfig(runtime.GOOS, getLogDir()))
+}
+
+func newTrayLogger(cfg *config.LogConfig) (*zap.Logger, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("tray log config is required")
+	}
+
 	writeSyncer, err := logs.CreateRotatingWriteSyncer(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create rotating tray log sink: %w", err)
 	}
 
 	level := zap.InfoLevel
-	encoderConfig := zapcore.EncoderConfig{
+	cores := []zapcore.Core{
+		zapcore.NewCore(newTrayJSONEncoder(), writeSyncer, level),
+	}
+	if cfg.EnableConsole {
+		cores = append(cores, zapcore.NewCore(newTrayJSONEncoder(), zapcore.AddSync(os.Stdout), level))
+	}
+
+	core := zapcore.NewTee(cores...)
+	core = zapcore.NewSamplerWithOptions(core, time.Second, 100, 100)
+	core = logs.NewSecretSanitizer(core)
+
+	return zap.New(
+		core,
+		zap.AddCaller(),
+		zap.AddStacktrace(zap.ErrorLevel),
+		zap.ErrorOutput(zapcore.AddSync(os.Stderr)),
+	), nil
+}
+
+func newTrayLogConfig(goos, logDir string) *config.LogConfig {
+	cfg := logs.DefaultLogConfig()
+	cfg.Level = logs.LogLevelInfo
+	cfg.EnableFile = true
+	cfg.EnableConsole = goos != platformWindows
+	cfg.Filename = "tray.log"
+	cfg.LogDir = logDir
+	cfg.JSONFormat = true
+	return cfg
+}
+
+func newTrayJSONEncoder() zapcore.Encoder {
+	return zapcore.NewJSONEncoder(zapcore.EncoderConfig{
 		TimeKey:        "timestamp",
 		LevelKey:       "level",
 		NameKey:        "logger",
@@ -394,32 +432,7 @@ func setupLogging() (*zap.Logger, error) {
 		EncodeDuration: zapcore.StringDurationEncoder,
 		EncodeCaller:   zapcore.ShortCallerEncoder,
 		EncodeName:     zapcore.FullNameEncoder,
-	}
-	jsonEncoder := zapcore.NewJSONEncoder(encoderConfig)
-
-	cores := []zapcore.Core{
-		zapcore.NewCore(jsonEncoder, writeSyncer, level),
-	}
-	if cfg.EnableConsole {
-		cores = append(cores, zapcore.NewCore(jsonEncoder, zapcore.AddSync(os.Stdout), level))
-	}
-
-	core := zapcore.NewTee(cores...)
-	core = zapcore.NewSamplerWithOptions(core, time.Second, 100, 100)
-	core = logs.NewSecretSanitizer(core)
-
-	return zap.New(core, zap.AddCaller(), zap.AddCallerSkip(1)), nil
-}
-
-func newTrayLogConfig(goos, logDir string) *config.LogConfig {
-	cfg := logs.DefaultLogConfig()
-	cfg.Level = logs.LogLevelInfo
-	cfg.EnableFile = true
-	cfg.EnableConsole = goos != platformWindows
-	cfg.Filename = "tray.log"
-	cfg.LogDir = logDir
-	cfg.JSONFormat = true
-	return cfg
+	})
 }
 
 func resolveCoreURL() string {

--- a/cmd/mcpproxy-tray/main.go
+++ b/cmd/mcpproxy-tray/main.go
@@ -31,6 +31,8 @@ import (
 	"github.com/smart-mcp-proxy/mcpproxy-go/cmd/mcpproxy-tray/internal/api"
 	"github.com/smart-mcp-proxy/mcpproxy-go/cmd/mcpproxy-tray/internal/monitor"
 	"github.com/smart-mcp-proxy/mcpproxy-go/cmd/mcpproxy-tray/internal/state"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/logs"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/socket"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/tray"
 )
@@ -371,26 +373,14 @@ func monitorDockerStatus(ctx context.Context, apiClient *api.Client, logger *zap
 
 // setupLogging configures the logger with appropriate settings for the tray
 func setupLogging() (*zap.Logger, error) {
-	// Get log directory
-	logDir := getLogDir()
-
-	// Ensure log directory exists
-	if err := os.MkdirAll(logDir, 0755); err != nil {
-		return nil, fmt.Errorf("failed to create log directory: %w", err)
+	cfg := newTrayLogConfig(runtime.GOOS, getLogDir())
+	writeSyncer, err := logs.CreateRotatingWriteSyncer(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create rotating tray log sink: %w", err)
 	}
 
-	// Create tray-specific log file
-	logFile := filepath.Join(logDir, "tray.log")
-
-	config := zap.NewProductionConfig()
-	config.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
-	config.Development = false
-	config.Sampling = &zap.SamplingConfig{
-		Initial:    100,
-		Thereafter: 100,
-	}
-	config.Encoding = "json"
-	config.EncoderConfig = zapcore.EncoderConfig{
+	level := zap.InfoLevel
+	encoderConfig := zapcore.EncoderConfig{
 		TimeKey:        "timestamp",
 		LevelKey:       "level",
 		NameKey:        "logger",
@@ -405,23 +395,31 @@ func setupLogging() (*zap.Logger, error) {
 		EncodeCaller:   zapcore.ShortCallerEncoder,
 		EncodeName:     zapcore.FullNameEncoder,
 	}
+	jsonEncoder := zapcore.NewJSONEncoder(encoderConfig)
 
-	// Log to file only on Windows GUI apps (stdout/stderr don't exist)
-	// On other platforms, log to both file and stdout
-	if runtime.GOOS == "windows" {
-		config.OutputPaths = []string{logFile}
-		config.ErrorOutputPaths = []string{logFile}
-	} else {
-		config.OutputPaths = []string{"stdout", logFile}
-		config.ErrorOutputPaths = []string{"stderr", logFile}
+	cores := []zapcore.Core{
+		zapcore.NewCore(jsonEncoder, writeSyncer, level),
+	}
+	if cfg.EnableConsole {
+		cores = append(cores, zapcore.NewCore(jsonEncoder, zapcore.AddSync(os.Stdout), level))
 	}
 
-	logger, err := config.Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to build logger: %w", err)
-	}
+	core := zapcore.NewTee(cores...)
+	core = zapcore.NewSamplerWithOptions(core, time.Second, 100, 100)
+	core = logs.NewSecretSanitizer(core)
 
-	return logger, nil
+	return zap.New(core, zap.AddCaller(), zap.AddCallerSkip(1)), nil
+}
+
+func newTrayLogConfig(goos, logDir string) *config.LogConfig {
+	cfg := logs.DefaultLogConfig()
+	cfg.Level = logs.LogLevelInfo
+	cfg.EnableFile = true
+	cfg.EnableConsole = goos != platformWindows
+	cfg.Filename = "tray.log"
+	cfg.LogDir = logDir
+	cfg.JSONFormat = true
+	return cfg
 }
 
 func resolveCoreURL() string {

--- a/cmd/mcpproxy-tray/main_test.go
+++ b/cmd/mcpproxy-tray/main_test.go
@@ -2,7 +2,14 @@
 
 package main
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/logs"
+)
 
 func TestShellQuote(t *testing.T) {
 	tcases := map[string]string{
@@ -24,5 +31,83 @@ func TestBuildShellExecCommand(t *testing.T) {
 	expected := "exec '/usr/local/bin/mcpproxy' 'serve' '--listen' '127.0.0.1:8080'"
 	if cmd != expected {
 		t.Fatalf("buildShellExecCommand produced %q, expected %q", cmd, expected)
+	}
+}
+
+func TestNewTrayLogConfig_DarwinUsesConsoleAndRotationDefaults(t *testing.T) {
+	cfg := newTrayLogConfig(platformDarwin, "/tmp/tray-logs")
+
+	if cfg.Level != logs.LogLevelInfo {
+		t.Fatalf("Level = %q, expected %q", cfg.Level, logs.LogLevelInfo)
+	}
+	if !cfg.EnableFile {
+		t.Fatal("EnableFile = false, expected true")
+	}
+	if !cfg.EnableConsole {
+		t.Fatal("EnableConsole = false, expected true on darwin")
+	}
+	if cfg.Filename != "tray.log" {
+		t.Fatalf("Filename = %q, expected tray.log", cfg.Filename)
+	}
+	if cfg.LogDir != "/tmp/tray-logs" {
+		t.Fatalf("LogDir = %q, expected /tmp/tray-logs", cfg.LogDir)
+	}
+	if !cfg.JSONFormat {
+		t.Fatal("JSONFormat = false, expected true")
+	}
+	if cfg.MaxSize != 10 || cfg.MaxBackups != 5 || cfg.MaxAge != 30 || !cfg.Compress {
+		t.Fatalf("rotation defaults = size:%d backups:%d age:%d compress:%t, expected 10/5/30/true", cfg.MaxSize, cfg.MaxBackups, cfg.MaxAge, cfg.Compress)
+	}
+}
+
+func TestNewTrayLogConfig_WindowsDisablesConsole(t *testing.T) {
+	cfg := newTrayLogConfig(platformWindows, `C:\logs`)
+
+	if cfg.EnableConsole {
+		t.Fatal("EnableConsole = true, expected false on windows")
+	}
+	if !cfg.EnableFile {
+		t.Fatal("EnableFile = false, expected true")
+	}
+	if cfg.Filename != "tray.log" {
+		t.Fatalf("Filename = %q, expected tray.log", cfg.Filename)
+	}
+	if cfg.LogDir != `C:\logs` {
+		t.Fatalf("LogDir = %q, expected C:\\logs", cfg.LogDir)
+	}
+}
+
+func TestSetupLogging_WritesTrayLogToRotatingFile(t *testing.T) {
+	tempHome := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", tempHome); err != nil {
+		t.Fatalf("Setenv(HOME): %v", err)
+	}
+	defer func() {
+		if originalHome == "" {
+			_ = os.Unsetenv("HOME")
+			return
+		}
+		_ = os.Setenv("HOME", originalHome)
+	}()
+
+	logger, err := setupLogging()
+	if err != nil {
+		t.Fatalf("setupLogging(): %v", err)
+	}
+	defer func() {
+		_ = logger.Sync()
+	}()
+
+	logger.Info("rotation test message")
+	_ = logger.Sync()
+
+	logPath := filepath.Join(tempHome, "Library", "Logs", "mcpproxy", "tray.log")
+	content, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", logPath, err)
+	}
+	if !strings.Contains(string(content), "\"message\":\"rotation test message\"") {
+		t.Fatalf("tray.log did not contain expected JSON message: %s", string(content))
 	}
 }

--- a/cmd/mcpproxy-tray/main_test.go
+++ b/cmd/mcpproxy-tray/main_test.go
@@ -3,14 +3,12 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/logs"
-	"go.uber.org/zap"
 )
 
 func TestShellQuote(t *testing.T) {
@@ -101,40 +99,5 @@ func TestSetupLogging_WritesTrayLogToRotatingFile(t *testing.T) {
 	}
 	if !strings.Contains(string(content), "\"message\":\"rotation test message\"") {
 		t.Fatalf("tray.log did not contain expected JSON message: %s", string(content))
-	}
-}
-
-func TestNewTrayLogger_RotatesTrayLog(t *testing.T) {
-	cfg := newTrayLogConfig(platformDarwin, t.TempDir())
-	cfg.EnableConsole = false
-	cfg.MaxSize = 1
-	cfg.MaxBackups = 2
-	cfg.MaxAge = 1
-	cfg.Compress = false
-
-	logger, err := newTrayLogger(cfg)
-	if err != nil {
-		t.Fatalf("newTrayLogger(): %v", err)
-	}
-	defer func() {
-		_ = logger.Sync()
-	}()
-
-	for i := 0; i < 4; i++ {
-		logger.Info(fmt.Sprintf("rotation pressure %d", i),
-			zap.String("payload", strings.Repeat("x", 600*1024)))
-	}
-	_ = logger.Sync()
-
-	logFiles, err := os.ReadDir(cfg.LogDir)
-	if err != nil {
-		t.Fatalf("ReadDir(%q): %v", cfg.LogDir, err)
-	}
-	if len(logFiles) < 2 {
-		names := make([]string, 0, len(logFiles))
-		for _, entry := range logFiles {
-			names = append(names, entry.Name())
-		}
-		t.Fatalf("expected rotated tray log files, found %v", names)
 	}
 }

--- a/cmd/mcpproxy-tray/main_test.go
+++ b/cmd/mcpproxy-tray/main_test.go
@@ -3,12 +3,14 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/logs"
+	"go.uber.org/zap"
 )
 
 func TestShellQuote(t *testing.T) {
@@ -79,17 +81,7 @@ func TestNewTrayLogConfig_WindowsDisablesConsole(t *testing.T) {
 
 func TestSetupLogging_WritesTrayLogToRotatingFile(t *testing.T) {
 	tempHome := t.TempDir()
-	originalHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", tempHome); err != nil {
-		t.Fatalf("Setenv(HOME): %v", err)
-	}
-	defer func() {
-		if originalHome == "" {
-			_ = os.Unsetenv("HOME")
-			return
-		}
-		_ = os.Setenv("HOME", originalHome)
-	}()
+	t.Setenv("HOME", tempHome)
 
 	logger, err := setupLogging()
 	if err != nil {
@@ -109,5 +101,40 @@ func TestSetupLogging_WritesTrayLogToRotatingFile(t *testing.T) {
 	}
 	if !strings.Contains(string(content), "\"message\":\"rotation test message\"") {
 		t.Fatalf("tray.log did not contain expected JSON message: %s", string(content))
+	}
+}
+
+func TestNewTrayLogger_RotatesTrayLog(t *testing.T) {
+	cfg := newTrayLogConfig(platformDarwin, t.TempDir())
+	cfg.EnableConsole = false
+	cfg.MaxSize = 1
+	cfg.MaxBackups = 2
+	cfg.MaxAge = 1
+	cfg.Compress = false
+
+	logger, err := newTrayLogger(cfg)
+	if err != nil {
+		t.Fatalf("newTrayLogger(): %v", err)
+	}
+	defer func() {
+		_ = logger.Sync()
+	}()
+
+	for i := 0; i < 4; i++ {
+		logger.Info(fmt.Sprintf("rotation pressure %d", i),
+			zap.String("payload", strings.Repeat("x", 600*1024)))
+	}
+	_ = logger.Sync()
+
+	logFiles, err := os.ReadDir(cfg.LogDir)
+	if err != nil {
+		t.Fatalf("ReadDir(%q): %v", cfg.LogDir, err)
+	}
+	if len(logFiles) < 2 {
+		names := make([]string, 0, len(logFiles))
+		for _, entry := range logFiles {
+			names = append(names, entry.Name())
+		}
+		t.Fatalf("expected rotated tray log files, found %v", names)
 	}
 }

--- a/internal/logs/logger.go
+++ b/internal/logs/logger.go
@@ -3,8 +3,8 @@ package logs
 import (
 	"bufio"
 	"fmt"
-	"io"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+	"io"
 	"os"
 	"time"
 
@@ -132,6 +132,28 @@ func SetupCommandLogger(serverCommand bool, logLevel string, logToFile bool, log
 
 // createFileCore creates a file-based logging core
 func createFileCore(config *config.LogConfig, level zapcore.Level) (zapcore.Core, error) {
+	writeSyncer, err := CreateRotatingWriteSyncer(config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Choose encoder based on format preference
+	var encoder zapcore.Encoder
+	if config.JSONFormat {
+		encoder = getJSONEncoder()
+	} else {
+		encoder = getFileEncoder()
+	}
+
+	return zapcore.NewCore(
+		encoder,
+		writeSyncer,
+		level,
+	), nil
+}
+
+// CreateRotatingWriteSyncer creates a rotation-backed file sink for a log config.
+func CreateRotatingWriteSyncer(config *config.LogConfig) (zapcore.WriteSyncer, error) {
 	// Get log file path with custom directory support
 	logFilePath, err := GetLogFilePathWithDir(config.LogDir, config.Filename)
 	if err != nil {
@@ -147,19 +169,7 @@ func createFileCore(config *config.LogConfig, level zapcore.Level) (zapcore.Core
 		Compress:   config.Compress,
 	}
 
-	// Choose encoder based on format preference
-	var encoder zapcore.Encoder
-	if config.JSONFormat {
-		encoder = getJSONEncoder()
-	} else {
-		encoder = getFileEncoder()
-	}
-
-	return zapcore.NewCore(
-		encoder,
-		zapcore.AddSync(lumberjackLogger),
-		level,
-	), nil
+	return zapcore.AddSync(lumberjackLogger), nil
 }
 
 // getConsoleEncoder returns a console-friendly encoder


### PR DESCRIPTION
## Summary

Closes #357.

The tray had two separate problems contributing to runaway log growth:

- `API returned zero upstream servers` was emitted on every poll while `/api/v1/servers` stayed empty
- the tray logger wrote directly to `tray.log` without rotation

This PR fixes both.

## Changes

- make the zero-server warning transition-based using the existing server-state hash logic
- add a regression test covering repeated empty responses and the transition back to non-empty state
- route tray file logging through the shared rotating write syncer in `internal/logs`
- keep the tray's existing JSON log format and non-Windows console behavior instead of switching it to the generic console logger
- add tray tests that verify the tray logger config and `tray.log` file wiring

## Verification

- `go test ./cmd/mcpproxy-tray/internal/api` (Go 1.24.10 via temporary local toolchain)
- `go test ./cmd/mcpproxy-tray/...` (Go 1.24.10 via temporary local toolchain)
- `go test ./internal/logs` (Go 1.24.10 via temporary local toolchain)
- `git diff --check`

## Notes

Rotation mechanics remain tested in `internal/logs`; tray tests stay focused on the tray wiring and output path.
