### PR TITLE
fix(039): resolve 13 QA findings in security scanner plugin system

### DIFF
--- a/cmd/mcpproxy/security_cmd.go
+++ b/cmd/mcpproxy/security_cmd.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
+	"golang.org/x/term"
 
 	clioutput "github.com/smart-mcp-proxy/mcpproxy-go/internal/cli/output"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/cliclient"
@@ -74,10 +75,25 @@ Examples:
 }
 
 // newSecurityCLIClient creates a cliclient.Client connected to the running MCPProxy.
+//
+// Honors the package-level --config and --data-dir flags from main.go so that
+// `mcpproxy security ...` commands behave consistently with `mcpproxy serve`,
+// `mcpproxy status`, and `mcpproxy upstream ...`.
 func newSecurityCLIClient() (*cliclient.Client, *config.Config, error) {
-	cfg, err := config.Load()
+	var (
+		cfg *config.Config
+		err error
+	)
+	if configFile != "" {
+		cfg, err = config.LoadFromFile(configFile)
+	} else {
+		cfg, err = config.Load()
+	}
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to load config: %w", err)
+	}
+	if dataDir != "" {
+		cfg.DataDir = dataDir
 	}
 	cfg.EnsureAPIKey()
 
@@ -382,14 +398,23 @@ func runSecurityScanners(_ *cobra.Command, _ []string) error {
 		id := getMapString(sc, "id")
 		name := getMapString(sc, "name")
 		vendor := getMapString(sc, "vendor")
-		status := scannerDisplayStatus(getMapString(sc, "status"))
+		rawStatus := getMapString(sc, "status")
+		status := scannerDisplayStatus(rawStatus)
+		colorOpen, colorReset := scannerStatusColor(rawStatus)
 		inputs := secJoinSlice(sc, "inputs")
 
-		fmt.Printf("%-20s %-22s %-22s %-12s %-s\n",
+		// Pad status BEFORE applying color so column alignment isn't broken
+		// by invisible escape sequences.
+		paddedStatus := fmt.Sprintf("%-12s", status)
+		if colorOpen != "" {
+			paddedStatus = colorOpen + paddedStatus + colorReset
+		}
+
+		fmt.Printf("%-20s %-22s %-22s %s %-s\n",
 			secTruncate(id, 20),
 			secTruncate(name, 22),
 			secTruncate(vendor, 22),
-			status,
+			paddedStatus,
 			inputs)
 	}
 
@@ -493,8 +518,17 @@ func runSecurityConfigure(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	// F-15: bumped from 10s -> 60s. Configure can be slow when the scanner
+	// engine validates credentials against an upstream provider.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
+
+	// F-15: client-side prefetch — confirm the scanner exists before issuing
+	// the (potentially slow) PUT, so a typo'd id fails fast with a 404 instead
+	// of hanging the user for 60s.
+	if err := securityVerifyScannerExists(ctx, client, scannerID); err != nil {
+		return err
+	}
 
 	resp, err := client.DoRaw(ctx, http.MethodPut, "/api/v1/security/scanners/"+scannerID+"/config", body)
 	if err != nil {
@@ -523,6 +557,23 @@ func runSecurityConfigure(_ *cobra.Command, args []string) error {
 	return nil
 }
 
+// securityVerifyScannerExists pings the scanner status endpoint and returns
+// a friendly "not found" error before the caller commits to a slower request.
+func securityVerifyScannerExists(ctx context.Context, client *cliclient.Client, scannerID string) error {
+	statusCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	resp, err := client.DoRaw(statusCtx, http.MethodGet, "/api/v1/security/scanners/"+scannerID, nil)
+	if err != nil {
+		// Network error: don't block — let the real call surface the issue.
+		return nil
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("scanner %q not found", scannerID)
+	}
+	return nil
+}
+
 func runSecurityScan(_ *cobra.Command, args []string) error {
 	// Handle --all flag
 	if secScanAll {
@@ -534,12 +585,20 @@ func runSecurityScan(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("server name is required (or use --all to scan all servers)")
 	}
 
-	client, _, err := newSecurityCLIClient()
+	client, cfg, err := newSecurityCLIClient()
 	if err != nil {
 		return err
 	}
 
 	serverName := args[0]
+
+	// F-06: --dry-run never starts a real scan. Instead, fetch the scanner
+	// inventory + (best-effort) the server's last scan context, and print a
+	// human-readable plan describing what *would* run. We still exit 0 so
+	// the dry-run is scriptable.
+	if secScanDryRun {
+		return printScanDryRunPlan(client, serverName, secScanners)
+	}
 
 	// Build request body
 	reqBody := map[string]interface{}{
@@ -554,7 +613,11 @@ func runSecurityScan(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	// Compute a sane hard timeout for the whole scan operation:
+	//   per-scanner-timeout * scanner_count + 30s margin, capped at 30 min
+	// (or default to 15 min if we can't infer it).
+	hardTimeout := computeScanHardTimeout(cfg, secScanners)
+	ctx, cancel := context.WithTimeout(context.Background(), hardTimeout)
 	defer cancel()
 
 	resp, err := client.DoRaw(ctx, http.MethodPost, "/api/v1/servers/"+serverName+"/scan", body)
@@ -605,12 +668,29 @@ func runSecurityScan(_ *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Synchronous mode: poll until done
-	fmt.Printf("Scanning %q...\n", serverName)
+	// Synchronous mode: poll until done.
+	//
+	// F-05 fixes:
+	//   1. Unwrap the API envelope (`{success,data}`) before reading status —
+	//      the previous loop read `status` from the envelope and never saw
+	//      "completed", causing infinite spin.
+	//   2. Use a 750ms ticker (no tight loop, no 2s lag).
+	//   3. Honor a hard timeout based on the configured per-scanner timeout.
+	//   4. Print one progress line per tick with run/running/failed counts.
+	fmt.Printf("Scanning %q (timeout %s, job %s)...\n", serverName, hardTimeout, jobID)
 	scanStart := time.Now()
 
+	ticker := time.NewTicker(750 * time.Millisecond)
+	defer ticker.Stop()
+
+	var lastProgressLen int
 	for {
-		time.Sleep(2 * time.Second)
+		select {
+		case <-ctx.Done():
+			fmt.Println()
+			return fmt.Errorf("scan timed out after %s for %q (job %s); use 'mcpproxy security status %s' to inspect", hardTimeout, serverName, jobID, serverName)
+		case <-ticker.C:
+		}
 
 		statusResp, err := client.DoRaw(ctx, http.MethodGet, "/api/v1/servers/"+serverName+"/scan/status", nil)
 		if err != nil {
@@ -627,6 +707,13 @@ func runSecurityScan(_ *cobra.Command, args []string) error {
 			return parseAPIError(statusBody, statusResp.StatusCode, "check scan status")
 		}
 
+		// CRITICAL: unwrap the API envelope. The previous implementation
+		// read job fields directly from the envelope and never observed
+		// the "completed" terminal state.
+		statusBody, err = unwrapAPIResponse(statusBody)
+		if err != nil {
+			return fmt.Errorf("API error: %w", err)
+		}
 		var status map[string]interface{}
 		if err := json.Unmarshal(statusBody, &status); err != nil {
 			return fmt.Errorf("failed to parse status response: %w", err)
@@ -635,50 +722,256 @@ func runSecurityScan(_ *cobra.Command, args []string) error {
 		jobStatus := getMapString(status, "status")
 		elapsed := time.Since(scanStart).Truncate(time.Second)
 
-		// Show progress from per-scanner statuses
+		// Aggregate per-scanner counts so the user sees forward progress.
+		var run, running, failed, total int
+		var runningNames []string
 		if scannerStatuses, ok := status["scanner_statuses"].([]interface{}); ok {
-			var running, done int
-			var runningNames []string
+			total = len(scannerStatuses)
 			for _, s := range scannerStatuses {
-				if ss, ok := s.(map[string]interface{}); ok {
-					switch getMapString(ss, "status") {
-					case "completed", "failed":
-						done++
-					case "running":
-						running++
-						if name := getMapString(ss, "scanner_id"); name != "" {
-							runningNames = append(runningNames, name)
-						}
+				ss, ok := s.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				switch getMapString(ss, "status") {
+				case "completed":
+					run++
+				case "failed":
+					failed++
+				case "running":
+					running++
+					if name := getMapString(ss, "scanner_id"); name != "" {
+						runningNames = append(runningNames, name)
 					}
 				}
 			}
-			total := len(scannerStatuses)
-			if total > 0 {
-				progress := fmt.Sprintf("\r  [%s] %d/%d scanners complete, %d running", elapsed, done, total, running)
-				if len(runningNames) > 0 {
-					progress += fmt.Sprintf(" (%s)", strings.Join(runningNames, ", "))
-				}
-				fmt.Print(progress)
+		}
+
+		progress := fmt.Sprintf("  [%s] %d run, %d running, %d failed of %d", elapsed, run, running, failed, total)
+		if len(runningNames) > 0 {
+			progress += fmt.Sprintf(" (running: %s)", strings.Join(runningNames, ", "))
+		}
+		// Erase previous line on TTY for a clean rolling display; on a pipe
+		// just print one progress line per tick.
+		if stdoutIsTTY() {
+			pad := ""
+			if lastProgressLen > len(progress) {
+				pad = strings.Repeat(" ", lastProgressLen-len(progress))
 			}
+			fmt.Print("\r" + progress + pad)
+			lastProgressLen = len(progress)
+		} else {
+			fmt.Println(progress)
 		}
 
 		switch jobStatus {
 		case "completed":
-			fmt.Printf("\n  Scan completed in %s\n", elapsed)
+			if stdoutIsTTY() {
+				fmt.Println()
+			}
+			fmt.Printf("  Scan completed in %s\n", elapsed)
 			return printScanSummary(client, ctx, serverName)
 		case "failed":
-			fmt.Printf("\n  Scan failed after %s\n", elapsed)
+			if stdoutIsTTY() {
+				fmt.Println()
+			}
+			fmt.Printf("  Scan failed after %s\n", elapsed)
 			errMsg := getMapString(status, "error")
 			if errMsg != "" {
 				return fmt.Errorf("scan failed: %s", errMsg)
 			}
 			return fmt.Errorf("scan failed for %q", serverName)
 		case "cancelled":
-			fmt.Printf("\n  Scan cancelled after %s\n", elapsed)
+			if stdoutIsTTY() {
+				fmt.Println()
+			}
+			fmt.Printf("  Scan cancelled after %s\n", elapsed)
 			return fmt.Errorf("scan was cancelled for %q", serverName)
 		}
 		// pending or running: continue polling
 	}
+}
+
+// computeScanHardTimeout returns a sensible upper bound for a scan operation:
+//
+//	per_scanner_timeout * num_scanners + 30s margin, capped at 30 minutes.
+//
+// If the config does not specify a per-scanner timeout, falls back to 15 min.
+func computeScanHardTimeout(cfg *config.Config, scannerFlag string) time.Duration {
+	const fallback = 15 * time.Minute
+	const cap = 30 * time.Minute
+
+	if cfg == nil || cfg.Security == nil || time.Duration(cfg.Security.ScanTimeoutDefault) <= 0 {
+		return fallback
+	}
+	per := time.Duration(cfg.Security.ScanTimeoutDefault)
+
+	count := 0
+	if scannerFlag != "" {
+		count = len(splitAndTrim(scannerFlag))
+	}
+	if count <= 0 {
+		// We don't know how many scanners are installed; assume up to 8.
+		count = 8
+	}
+	total := per*time.Duration(count) + 30*time.Second
+	if total > cap {
+		return cap
+	}
+	if total < fallback {
+		return fallback
+	}
+	return total
+}
+
+// printScanDryRunPlan implements the F-06 frontend dry-run: instead of asking
+// the engine to "simulate" a scan (which today still launches containers),
+// fetch the scanner inventory and the server's last scan context, then print
+// a plan describing what *would* execute.
+func printScanDryRunPlan(client *cliclient.Client, serverName, scannerFlag string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// 1. Fetch all scanners so we can show docker images / commands.
+	scanResp, err := client.DoRaw(ctx, http.MethodGet, "/api/v1/security/scanners", nil)
+	if err != nil {
+		return fmt.Errorf("failed to list scanners: %w", err)
+	}
+	scanRaw, err := io.ReadAll(scanResp.Body)
+	scanResp.Body.Close()
+	if err != nil {
+		return fmt.Errorf("failed to read scanners response: %w", err)
+	}
+	if scanResp.StatusCode != http.StatusOK {
+		return parseAPIError(scanRaw, scanResp.StatusCode, "list scanners")
+	}
+	scanRaw, err = unwrapAPIResponse(scanRaw)
+	if err != nil {
+		return fmt.Errorf("API error: %w", err)
+	}
+	var allScanners []map[string]interface{}
+	if err := json.Unmarshal(scanRaw, &allScanners); err != nil {
+		return fmt.Errorf("failed to parse scanners response: %w", err)
+	}
+
+	// 2. Filter scanners: explicit --scanners flag wins, otherwise pick the
+	//    ones that are configured/installed (i.e. the engine would run them).
+	var selected []map[string]interface{}
+	if scannerFlag != "" {
+		wanted := make(map[string]bool)
+		for _, id := range splitAndTrim(scannerFlag) {
+			wanted[id] = true
+		}
+		for _, sc := range allScanners {
+			if wanted[getMapString(sc, "id")] {
+				selected = append(selected, sc)
+			}
+		}
+	} else {
+		for _, sc := range allScanners {
+			st := getMapString(sc, "status")
+			if st == "installed" || st == "configured" {
+				selected = append(selected, sc)
+			}
+		}
+	}
+
+	// 3. Best-effort: fetch the server's last scan context for source info.
+	//    This may 404 if the server has never been scanned — that's fine.
+	var scanContext map[string]interface{}
+	filesResp, err := client.DoRaw(ctx, http.MethodGet, "/api/v1/servers/"+serverName+"/scan/files", nil)
+	if err == nil {
+		filesRaw, _ := io.ReadAll(filesResp.Body)
+		filesResp.Body.Close()
+		if filesResp.StatusCode == http.StatusOK {
+			if unwrapped, uerr := unwrapAPIResponse(filesRaw); uerr == nil {
+				_ = json.Unmarshal(unwrapped, &scanContext)
+			}
+		}
+	}
+
+	format := ResolveOutputFormat()
+	plan := map[string]interface{}{
+		"server":   serverName,
+		"dry_run":  true,
+		"scanners": selected,
+	}
+	if scanContext != nil {
+		plan["source"] = map[string]interface{}{
+			"method":           getMapString(scanContext, "source_method"),
+			"path":             getMapString(scanContext, "source_path"),
+			"docker_isolation": scanContext["docker_isolation"],
+			"total_files":      scanContext["total_files"],
+		}
+	}
+
+	if format == "json" || format == "yaml" {
+		return formatAndPrint(format, plan)
+	}
+
+	// Human-readable plan
+	fmt.Printf("Dry-run plan for %q\n", serverName)
+	fmt.Println(strings.Repeat("-", 60))
+	if scanContext != nil {
+		fmt.Println("Source (from last scan):")
+		fmt.Printf("  Method:           %s\n", getMapString(scanContext, "source_method"))
+		fmt.Printf("  Path:             %s\n", getMapString(scanContext, "source_path"))
+		if di, ok := scanContext["docker_isolation"].(bool); ok {
+			fmt.Printf("  Docker isolation: %t\n", di)
+		}
+		if tf, ok := scanContext["total_files"].(float64); ok {
+			fmt.Printf("  Files (last):     %d\n", int(tf))
+		}
+	} else {
+		fmt.Println("Source: (no prior scan context — source will be resolved at scan time)")
+	}
+	fmt.Println()
+
+	if len(selected) == 0 {
+		fmt.Println("No scanners would run.")
+		if scannerFlag != "" {
+			fmt.Println("(no scanners matched --scanners filter)")
+		} else {
+			fmt.Println("(no scanners are installed/configured — run `mcpproxy security enable <id>`)")
+		}
+		return nil
+	}
+
+	fmt.Printf("Scanners that would run (%d):\n", len(selected))
+	for _, sc := range selected {
+		id := getMapString(sc, "id")
+		name := getMapString(sc, "name")
+		status := getMapString(sc, "status")
+		image := getMapString(sc, "docker_image")
+		if override := getMapString(sc, "image_override"); override != "" {
+			image = override
+		}
+		timeout := getMapString(sc, "timeout")
+		fmt.Printf("  - %s (%s) [%s]\n", id, name, status)
+		if image != "" {
+			fmt.Printf("      image:   %s\n", image)
+		}
+		if timeout != "" {
+			fmt.Printf("      timeout: %s\n", timeout)
+		}
+		if cmd, ok := sc["command"].([]interface{}); ok && len(cmd) > 0 {
+			parts := make([]string, len(cmd))
+			for i, p := range cmd {
+				parts[i] = fmt.Sprintf("%v", p)
+			}
+			fmt.Printf("      command: %s\n", strings.Join(parts, " "))
+		}
+		if inputs, ok := sc["inputs"].([]interface{}); ok && len(inputs) > 0 {
+			parts := make([]string, len(inputs))
+			for i, p := range inputs {
+				parts[i] = fmt.Sprintf("%v", p)
+			}
+			fmt.Printf("      inputs:  %s\n", strings.Join(parts, ", "))
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("Dry-run only — no scanners executed. Re-run without --dry-run to scan.")
+	return nil
 }
 
 // runSecurityScanAll handles the --all flag: starts a batch scan and polls for progress.
@@ -728,9 +1021,20 @@ func runSecurityScanAll() error {
 		return nil
 	}
 
-	// Poll for progress
+	// F-16: poll on a steady ticker; on a TTY redraw the table in place using
+	// ANSI cursor escapes. On a pipe, fall back to one status line per tick so
+	// the output is grep/awk friendly.
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	tty := stdoutIsTTY()
+	var prevLines int
 	for {
-		time.Sleep(3 * time.Second)
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("batch scan timed out after 30m; use 'mcpproxy security cancel-all' to abort")
+		case <-ticker.C:
+		}
 
 		qResp, err := client.DoRaw(ctx, http.MethodGet, "/api/v1/security/queue", nil)
 		if err != nil {
@@ -763,10 +1067,13 @@ func runSecurityScanAll() error {
 			return nil
 		}
 
-		// JSON/YAML output for final state
+		// Final state — print the final table without redraw, then exit.
 		if queueStatus == "completed" || queueStatus == "cancelled" {
 			if format == "json" || format == "yaml" {
 				return formatAndPrint(format, progress)
+			}
+			if tty && prevLines > 0 {
+				clearPreviousLines(prevLines)
 			}
 			printQueueProgressTable(progress)
 			fmt.Println()
@@ -778,60 +1085,108 @@ func runSecurityScanAll() error {
 			return nil
 		}
 
-		// Show progress table (clear screen with carriage returns for terminal)
-		printQueueProgressTable(progress)
+		if tty {
+			if prevLines > 0 {
+				clearPreviousLines(prevLines)
+			}
+			prevLines = printQueueProgressTable(progress)
+		} else {
+			printQueueProgressOneLine(progress)
+		}
 	}
 }
 
-// printQueueProgressTable prints the progress table for a batch scan.
-func printQueueProgressTable(progress map[string]interface{}) {
+// clearPreviousLines uses ANSI escapes to move the cursor up `n` lines and
+// erase from the cursor to the end of screen. Used to redraw the batch-scan
+// progress table in place.
+func clearPreviousLines(n int) {
+	if n <= 0 {
+		return
+	}
+	// CUU n: move cursor up; ED 0: clear from cursor to end of screen.
+	fmt.Printf("\x1b[%dA\x1b[J", n)
+}
+
+// printQueueProgressTable prints the progress table for a batch scan and
+// returns the number of lines printed (so the caller can erase them next tick).
+func printQueueProgressTable(progress map[string]interface{}) int {
 	total := int(getMapFloat(progress, "total"))
 	completed := int(getMapFloat(progress, "completed"))
 	running := int(getMapFloat(progress, "running"))
 	skipped := int(getMapFloat(progress, "skipped"))
 	failed := int(getMapFloat(progress, "failed"))
 
-	fmt.Printf("\nScanning all servers (%d/%d completed, %d running", completed, total, running)
+	lines := 0
+
+	header := fmt.Sprintf("Scanning all servers (%d/%d completed, %d running", completed, total, running)
 	if skipped > 0 {
-		fmt.Printf(", %d skipped", skipped)
+		header += fmt.Sprintf(", %d skipped", skipped)
 	}
 	if failed > 0 {
-		fmt.Printf(", %d failed", failed)
+		header += fmt.Sprintf(", %d failed", failed)
 	}
-	fmt.Println(")...")
+	header += ")..."
+	fmt.Println(header)
+	lines++
 
 	// Table header
 	fmt.Printf("%-24s %-12s %-10s %s\n", "SERVER", "STATUS", "FINDINGS", "ERROR")
+	lines++
 	fmt.Println(strings.Repeat("-", 70))
+	lines++
 
 	// Items
 	if items, ok := progress["items"].([]interface{}); ok {
 		for _, item := range items {
-			if it, ok := item.(map[string]interface{}); ok {
-				name := getMapString(it, "server_name")
-				status := getMapString(it, "status")
-				errMsg := getMapString(it, "error")
-				skipReason := getMapString(it, "skip_reason")
-				findings := "-"
-
-				// Show error or skip reason
-				msg := errMsg
-				if skipReason != "" {
-					msg = skipReason
-				}
-				if len(msg) > 30 {
-					msg = msg[:27] + "..."
-				}
-
-				fmt.Printf("%-24s %-12s %-10s %s\n",
-					secTruncate(name, 24),
-					status,
-					findings,
-					msg,
-				)
+			it, ok := item.(map[string]interface{})
+			if !ok {
+				continue
 			}
+			name := getMapString(it, "server_name")
+			status := getMapString(it, "status")
+			errMsg := getMapString(it, "error")
+			skipReason := getMapString(it, "skip_reason")
+
+			// F-16: pull findings_count from the per-item job status so the
+			// FINDINGS column shows real numbers instead of "-".
+			findings := "-"
+			if fc, ok := it["findings_count"].(float64); ok {
+				findings = fmt.Sprintf("%d", int(fc))
+			} else if fc, ok := it["findings"].(float64); ok {
+				findings = fmt.Sprintf("%d", int(fc))
+			}
+
+			// Show error or skip reason
+			msg := errMsg
+			if skipReason != "" {
+				msg = skipReason
+			}
+			if len(msg) > 30 {
+				msg = msg[:27] + "..."
+			}
+
+			fmt.Printf("%-24s %-12s %-10s %s\n",
+				secTruncate(name, 24),
+				status,
+				findings,
+				msg,
+			)
+			lines++
 		}
 	}
+	return lines
+}
+
+// printQueueProgressOneLine prints a single-line summary of batch progress.
+// Used in non-TTY mode (e.g. when stdout is piped) to keep output greppable.
+func printQueueProgressOneLine(progress map[string]interface{}) {
+	total := int(getMapFloat(progress, "total"))
+	completed := int(getMapFloat(progress, "completed"))
+	running := int(getMapFloat(progress, "running"))
+	skipped := int(getMapFloat(progress, "skipped"))
+	failed := int(getMapFloat(progress, "failed"))
+	fmt.Printf("[batch] %d/%d completed, %d running, %d skipped, %d failed\n",
+		completed, total, running, skipped, failed)
 }
 
 func newSecurityCancelAllCmd() *cobra.Command {
@@ -1037,7 +1392,54 @@ func runSecurityReport(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	return printReportTable(serverName, report)
+	// F-10: also fetch /scan/status (best-effort) so we can name the scanners
+	// that failed. The aggregated report has counts but only sometimes carries
+	// per-scanner names; the live job status is the authoritative source.
+	failedNames := fetchFailedScannerNames(client, ctx, serverName)
+	return printReportTable(serverName, report, failedNames)
+}
+
+// fetchFailedScannerNames returns the IDs of scanners that did not complete
+// in the most recent scan job for `serverName`. Returns nil on any error so
+// the caller can render the report without per-scanner names.
+func fetchFailedScannerNames(client *cliclient.Client, ctx context.Context, serverName string) []string {
+	resp, err := client.DoRaw(ctx, http.MethodGet, "/api/v1/servers/"+serverName+"/scan/status", nil)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil
+	}
+	body, err = unwrapAPIResponse(body)
+	if err != nil {
+		return nil
+	}
+	var status map[string]interface{}
+	if err := json.Unmarshal(body, &status); err != nil {
+		return nil
+	}
+	scannerStatuses, ok := status["scanner_statuses"].([]interface{})
+	if !ok {
+		return nil
+	}
+	var failed []string
+	for _, s := range scannerStatuses {
+		ss, ok := s.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if getMapString(ss, "status") == "failed" {
+			if name := getMapString(ss, "scanner_id"); name != "" {
+				failed = append(failed, name)
+			}
+		}
+	}
+	return failed
 }
 
 func runSecurityApprove(_ *cobra.Command, args []string) error {
@@ -1150,6 +1552,11 @@ func runSecurityOverview(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to parse response: %w", err)
 	}
 
+	// F-14: scrub Go zero-time from last_scan_at so neither the table nor the
+	// JSON/YAML serializers show "0001-01-01 00:00:00". We keep the field in
+	// the schema (as nil) so consumers don't break, but represent "never".
+	normalizeOverviewLastScan(overview)
+
 	format := ResolveOutputFormat()
 	if format == "json" || format == "yaml" {
 		return formatAndPrint(format, overview)
@@ -1161,8 +1568,14 @@ func runSecurityOverview(_ *cobra.Command, _ []string) error {
 	fmt.Printf("  Servers scanned:    %s\n", secFormatInt(overview, "servers_scanned"))
 	fmt.Printf("  Total scans:        %s\n", secFormatInt(overview, "total_scans"))
 	fmt.Printf("  Active scans:       %s\n", secFormatInt(overview, "active_scans"))
-	if lastScan := getMapString(overview, "last_scan_at"); lastScan != "" {
-		fmt.Printf("  Last scan:          %s\n", formatTimestamp(lastScan))
+	if v, present := overview["last_scan_at"]; present && v != nil {
+		if lastScan, ok := v.(string); ok && lastScan != "" {
+			fmt.Printf("  Last scan:          %s\n", formatTimestamp(lastScan))
+		} else {
+			fmt.Printf("  Last scan:          %s\n", "never")
+		}
+	} else {
+		fmt.Printf("  Last scan:          %s\n", "never")
 	}
 	fmt.Println()
 
@@ -1292,11 +1705,17 @@ func printScanSummary(client *cliclient.Client, ctx context.Context, serverName 
 	}
 
 	fmt.Printf("Scan completed for %q.\n\n", serverName)
-	return printReportTable(serverName, report)
+	failedNames := fetchFailedScannerNames(client, ctx, serverName)
+	return printReportTable(serverName, report, failedNames)
 }
 
 // printReportTable prints a human-readable report with two-pass scan support.
-func printReportTable(serverName string, report map[string]interface{}) error {
+//
+// failedScannerNames (F-10) is the list of scanner IDs that failed in the most
+// recent scan job, sourced from /scan/status (the report itself only carries
+// counts). When non-empty, the table shows a "Scanners: X run, Y failed" line
+// and a yellow warn line about incomplete coverage.
+func printReportTable(serverName string, report map[string]interface{}, failedScannerNames []string) error {
 	riskScore := "?"
 	if rs, ok := report["risk_score"].(float64); ok {
 		riskScore = fmt.Sprintf("%d", int(rs))
@@ -1313,7 +1732,32 @@ func printReportTable(serverName string, report map[string]interface{}) error {
 	if scannedAt != "" {
 		fmt.Printf("Scanned:     %s\n", formatTimestamp(scannedAt))
 	}
+
+	// F-10: scanner coverage line. Pull counts from the aggregated report.
+	scannersRun := int(getMapFloat(report, "scanners_run"))
+	scannersFailed := int(getMapFloat(report, "scanners_failed"))
+	scannersTotal := int(getMapFloat(report, "scanners_total"))
+	if scannersTotal > 0 {
+		line := fmt.Sprintf("Scanners:    %d run, %d failed", scannersRun, scannersFailed)
+		if scannersFailed > 0 && len(failedScannerNames) > 0 {
+			line += " (" + strings.Join(failedScannerNames, ", ") + ")"
+		}
+		line += fmt.Sprintf(" of %d", scannersTotal)
+		fmt.Println(line)
+	}
 	fmt.Println()
+
+	// F-10: warn the user when coverage is incomplete so they don't approve
+	// a server based on a "0 findings" result that's actually 5 of 7 scanners
+	// silently failing.
+	if scannersFailed > 0 && scannersTotal > 0 {
+		warn := fmt.Sprintf("WARNING: Scan coverage incomplete: %d of %d scanners did not run", scannersFailed, scannersTotal)
+		if stdoutIsTTY() {
+			warn = "\x1b[33m" + warn + "\x1b[0m"
+		}
+		fmt.Println(warn)
+		fmt.Println()
+	}
 
 	// Separate findings by scan pass
 	var pass1Findings, pass2Findings []interface{}
@@ -1546,17 +1990,88 @@ func secFormatInt(m map[string]interface{}, key string) string {
 	return "0"
 }
 
-// scannerDisplayStatus maps API status to user-friendly display status
+// scannerDisplayStatus normalizes the scanner status to a single vocabulary
+// shared between table and JSON/YAML output (F-09).
+//
+// Vocabulary (richest set kept consistent across formats):
+//
+//	available  - registry entry, image not pulled
+//	pulling    - docker pull in progress
+//	installed  - image present, but required env vars not yet set
+//	configured - image present and required secrets set (ready to run)
+//	error      - last operation failed; see error_message
+//
+// Unknown values are returned verbatim so future statuses do not get hidden.
 func scannerDisplayStatus(status string) string {
 	switch status {
-	case "installed", "configured":
-		return "enabled"
-	case "available":
-		return "disabled"
-	case "error":
-		return "error"
+	case "available", "pulling", "installed", "configured", "error":
+		return status
+	case "":
+		return "unknown"
 	default:
 		return status
+	}
+}
+
+// scannerStatusColor returns an ANSI color escape for a scanner status, plus
+// the matching reset sequence. Returns empty strings when stdout is not a TTY
+// so that piped output stays clean.
+func scannerStatusColor(status string) (open, reset string) {
+	if !stdoutIsTTY() {
+		return "", ""
+	}
+	switch status {
+	case "configured":
+		return "\x1b[32m", "\x1b[0m" // green
+	case "installed":
+		return "\x1b[36m", "\x1b[0m" // cyan
+	case "pulling":
+		return "\x1b[33m", "\x1b[0m" // yellow
+	case "error":
+		return "\x1b[31m", "\x1b[0m" // red
+	case "available":
+		return "\x1b[90m", "\x1b[0m" // bright black / grey
+	default:
+		return "", ""
+	}
+}
+
+// stdoutIsTTY returns true when stdout is connected to an interactive terminal.
+// Used to gate ANSI escapes (colors, cursor moves) so piped output stays clean.
+func stdoutIsTTY() bool {
+	return term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+// normalizeOverviewLastScan replaces a Go zero-time `last_scan_at` value with
+// JSON null so neither the table nor the JSON/YAML serializers display
+// "0001-01-01T00:00:00Z" to the user (F-14). The key is preserved (as nil) so
+// existing consumers don't see a missing field.
+func normalizeOverviewLastScan(overview map[string]interface{}) {
+	if overview == nil {
+		return
+	}
+	v, present := overview["last_scan_at"]
+	if !present {
+		// Insert nil so JSON output still has the field for schema stability.
+		overview["last_scan_at"] = nil
+		return
+	}
+	s, ok := v.(string)
+	if !ok || s == "" {
+		overview["last_scan_at"] = nil
+		return
+	}
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil && t.IsZero() {
+		overview["last_scan_at"] = nil
+		return
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil && t.IsZero() {
+		overview["last_scan_at"] = nil
+		return
+	}
+	// Also catch the literal stdlib zero serialization.
+	if strings.HasPrefix(s, "0001-01-01") {
+		overview["last_scan_at"] = nil
 	}
 }
 

--- a/cmd/mcpproxy/security_cmd_test.go
+++ b/cmd/mcpproxy/security_cmd_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+)
+
+// TestScannerDisplayStatus verifies F-09: scanner status vocabulary is
+// consistent and rich enough to distinguish "available" / "pulling" /
+// "installed" / "configured" / "error" in BOTH table and JSON outputs.
+func TestScannerDisplayStatus(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"available", "available"},
+		{"pulling", "pulling"},
+		{"installed", "installed"},
+		{"configured", "configured"},
+		{"error", "error"},
+		{"", "unknown"},
+		// Future / unexpected values pass through unchanged so they don't
+		// silently get hidden behind a hard-coded mapping.
+		{"some-new-state", "some-new-state"},
+	}
+	for _, c := range cases {
+		got := scannerDisplayStatus(c.in)
+		if got != c.want {
+			t.Errorf("scannerDisplayStatus(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestComputeScanHardTimeout verifies F-05: the per-scanner timeout is
+// extrapolated into a sensible whole-scan timeout that won't return early
+// nor hang for the duration of the universe.
+func TestComputeScanHardTimeout(t *testing.T) {
+	// Nil config -> 15-minute fallback.
+	if got := computeScanHardTimeout(nil, ""); got != 15*time.Minute {
+		t.Errorf("nil cfg: got %s, want 15m", got)
+	}
+
+	// Config with no security section -> fallback.
+	cfg := &config.Config{}
+	if got := computeScanHardTimeout(cfg, ""); got != 15*time.Minute {
+		t.Errorf("nil security: got %s, want 15m", got)
+	}
+
+	// Config with explicit per-scanner timeout, with explicit scanner list:
+	// 60s * 3 + 30s = 3m30s, but we floor at 15m for sanity.
+	cfg = &config.Config{
+		Security: &config.SecurityConfig{
+			ScanTimeoutDefault: config.Duration(60 * time.Second),
+		},
+	}
+	if got := computeScanHardTimeout(cfg, "a,b,c"); got != 15*time.Minute {
+		t.Errorf("60s*3 with floor: got %s, want 15m", got)
+	}
+
+	// Per-scanner 5m, no flag (default 8 scanners): 5m*8 + 30s = 40m30s,
+	// capped at 30m.
+	cfg = &config.Config{
+		Security: &config.SecurityConfig{
+			ScanTimeoutDefault: config.Duration(5 * time.Minute),
+		},
+	}
+	if got := computeScanHardTimeout(cfg, ""); got != 30*time.Minute {
+		t.Errorf("5m*8 cap: got %s, want 30m", got)
+	}
+
+	// Per-scanner 4m, 6 scanners: 4m*6 + 30s = 24m30s — within bounds.
+	cfg = &config.Config{
+		Security: &config.SecurityConfig{
+			ScanTimeoutDefault: config.Duration(4 * time.Minute),
+		},
+	}
+	got := computeScanHardTimeout(cfg, "s1,s2,s3,s4,s5,s6")
+	want := 4*time.Minute*6 + 30*time.Second
+	if got != want {
+		t.Errorf("4m*6: got %s, want %s", got, want)
+	}
+}
+
+// TestNormalizeOverviewLastScan verifies F-14: Go zero-time `last_scan_at`
+// values are scrubbed to JSON null in both table and JSON outputs.
+func TestNormalizeOverviewLastScan(t *testing.T) {
+	cases := []struct {
+		name string
+		in   map[string]interface{}
+		// We assert nil-ness via key presence and value.
+		wantPresent bool
+		wantNil     bool
+		wantValue   interface{}
+	}{
+		{
+			name:        "missing key inserted as nil",
+			in:          map[string]interface{}{},
+			wantPresent: true,
+			wantNil:     true,
+		},
+		{
+			name:        "explicit empty string -> nil",
+			in:          map[string]interface{}{"last_scan_at": ""},
+			wantPresent: true,
+			wantNil:     true,
+		},
+		{
+			name:        "Go zero-time RFC3339 -> nil",
+			in:          map[string]interface{}{"last_scan_at": "0001-01-01T00:00:00Z"},
+			wantPresent: true,
+			wantNil:     true,
+		},
+		{
+			name:        "real timestamp preserved",
+			in:          map[string]interface{}{"last_scan_at": "2025-01-15T10:30:00Z"},
+			wantPresent: true,
+			wantNil:     false,
+			wantValue:   "2025-01-15T10:30:00Z",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			normalizeOverviewLastScan(c.in)
+			v, present := c.in["last_scan_at"]
+			if present != c.wantPresent {
+				t.Errorf("present=%v, want %v", present, c.wantPresent)
+			}
+			if c.wantNil && v != nil {
+				t.Errorf("expected nil value, got %v (%T)", v, v)
+			}
+			if !c.wantNil && c.wantValue != nil && v != c.wantValue {
+				t.Errorf("value = %v, want %v", v, c.wantValue)
+			}
+		})
+	}
+
+	// Nil map should not panic.
+	normalizeOverviewLastScan(nil)
+}
+
+// TestClearPreviousLines verifies F-16: passing 0 or negative values is a
+// safe no-op (so the first redraw cycle doesn't blow up the terminal).
+func TestClearPreviousLines(t *testing.T) {
+	// We can't easily capture stdout here without restructuring; just verify
+	// the function doesn't panic on edge cases.
+	clearPreviousLines(0)
+	clearPreviousLines(-1)
+}

--- a/docs/cli/command-reference.md
+++ b/docs/cli/command-reference.md
@@ -566,3 +566,25 @@ mcpproxy trust-cert <certificate-path> [flags]
 ```bash
 mcpproxy trust-cert /path/to/cert.pem --keychain=system
 ```
+
+## Security Scanner Commands
+
+MCPProxy integrates Docker-based security scanners that analyze quarantined upstream MCP servers for tool poisoning, prompt injection, CVEs, and other supply-chain risks. All commands live under `mcpproxy security` and cover three workflows:
+
+1. **Scanner lifecycle** — `scanners`, `enable`, `disable`, `configure`
+2. **Scan operations** — `scan` (with `--all`, `--async`, `--dry-run`, `--scanners`), `rescan`, `status`, `report`, `cancel-all`
+3. **Approval & integrity** — `approve`, `reject`, `integrity`, `overview`
+
+Quick examples:
+
+```bash
+mcpproxy security scanners                      # list registry + status
+mcpproxy security enable mcp-scan               # pull the scanner image
+mcpproxy security configure mcp-scan --env SNYK_TOKEN=xxx
+mcpproxy security scan github-server            # blocking, live progress
+mcpproxy security scan github-server --dry-run  # print plan, no containers
+mcpproxy security report github-server          # aggregated findings
+mcpproxy security approve github-server         # unquarantine + index tools
+```
+
+For the full reference — every flag, every status vocabulary, all output formats (`table` / `json` / `yaml` / `sarif`), workflow recipes, and troubleshooting — see **[Security Commands](/cli/security-commands)**. For the underlying feature architecture see [Security Scanner Plugin System](/features/security-scanner-plugins).

--- a/docs/cli/security-commands.md
+++ b/docs/cli/security-commands.md
@@ -1,0 +1,762 @@
+---
+id: security-commands
+title: Security Scanner Commands
+sidebar_label: Security Commands
+sidebar_position: 6
+description: CLI commands for managing security scanners, scanning upstream MCP servers, and reviewing findings
+keywords: [security, scanner, scan, approve, quarantine, sarif, cli]
+---
+
+# Security Scanner Commands
+
+The `mcpproxy security` command group manages the Security Scanner Plugin System (Spec 039).
+It covers three responsibilities:
+
+1. **Scanner lifecycle** — list, enable, disable, and configure Docker-based scanner plugins.
+2. **Scan operations** — run scanners against quarantined upstream servers, track progress, and view reports.
+3. **Approval workflow** — approve a server (unquarantine + index its tools) or reject and clean up, backed by an integrity baseline.
+
+For background on the architecture, scanner images, and storage see:
+
+- [Security Scanner Plugin System](/features/security-scanner-plugins)
+- [Scanner Images](/features/scanner-images)
+- [Quarantine System](/features/security-quarantine)
+
+## Overview
+
+```
+mcpproxy security
+├── scanners                    List scanners from the registry and their status
+├── enable <scanner-id>         Enable a scanner (pulls its Docker image)
+├── disable <scanner-id>        Disable a scanner (cleans up the image)
+├── configure <scanner-id>      Set scanner env vars (e.g. API tokens)
+├── scan <server>               Run scanners on a server; --all for every server
+├── scan --dry-run <server>     Print a plan without running containers
+├── rescan <server>             Re-run scanners on a server
+├── status <server>             Show current scan state + per-scanner stderr
+├── report <server>             Aggregated findings report (table / json / yaml / sarif)
+├── approve <server>            Unquarantine + index tools + save integrity baseline
+├── reject <server>             Delete scan artifacts + keep server quarantined
+├── integrity <server>          Verify server against its approved baseline
+├── overview                    Dashboard totals (scanners installed, last scan, etc.)
+└── cancel-all                  Cancel an in-progress batch scan
+```
+
+:::tip Global flags apply
+Every `mcpproxy security …` subcommand honors the global flags `--config` / `-c`, `--data-dir` / `-d`, `--output` / `-o`, `--json`, `--log-level`, `--log-to-file`, and `--log-dir`.
+In particular, **`-o json` (or `--json`)** switches the table output to a structured JSON payload that's safe to feed into `jq`.
+:::
+
+## Prerequisites
+
+- **Docker** must be installed and reachable. Every scanner runs as a Docker container.
+  Run `mcpproxy doctor` if you're unsure.
+- **Network access** to pull scanner images from `ghcr.io/smart-mcp-proxy/*` and vendor registries (see [Scanner Images](/features/scanner-images)).
+- For some scanners, a **third-party API token** — surfaced via `required_env` on the scanner record. The only scanner that currently refuses to run without an explicit token is `mcp-scan` (Snyk), which needs `SNYK_TOKEN`.
+
+## Output Formats
+
+All subcommands that return data support the standard formats:
+
+| Flag | Description |
+|------|-------------|
+| `-o table` | Human-readable text (default) |
+| `-o json`  | Canonical JSON shape, stable across releases |
+| `-o yaml`  | Same data as JSON, rendered as YAML |
+| `-o sarif` | Raw SARIF 2.1.0 (only `security report`) |
+
+You can also set `MCPPROXY_OUTPUT=json` in the environment to change the default for the whole shell session.
+
+---
+
+## security scanners
+
+List every scanner in the bundled registry along with its current runtime status.
+
+### Usage
+
+```bash
+mcpproxy security scanners [flags]
+```
+
+### Flags
+
+(none beyond global flags)
+
+### Status vocabulary
+
+The status column is consistent between table and JSON output:
+
+| Status | Meaning |
+|--------|---------|
+| `available`  | Known to the registry, Docker image not pulled yet |
+| `pulling`    | Background pull in progress after `enable` |
+| `installed`  | Docker image cached locally, no extra env needed |
+| `configured` | Installed AND the user has set one or more env vars via `configure` |
+| `error`      | The last operation on this scanner failed — see the error message |
+
+### Examples
+
+```bash
+# Human-readable table
+mcpproxy security scanners
+
+# JSON for scripting
+mcpproxy security scanners -o json | jq '.[] | {id, status, required_env}'
+```
+
+**Sample table output:**
+
+```
+ID                   NAME                     VENDOR                  STATUS       INPUTS
+-------------------------------------------------------------------------------------------------------
+cisco-mcp-scanner    Cisco MCP Scanner        Cisco AI Defense        installed    source
+mcp-ai-scanner       MCP AI Scanner           MCPProxy                installed    source
+mcp-scan             Snyk Agent Scan          Snyk (Invariant Labs)   configured   source
+nova-proximity       Nova Proximity           MCPProxy                installed    source
+ramparts             Ramparts MCP Scanner     Javelin                 installed    source
+semgrep-mcp          Semgrep MCP Rules        Semgrep                 installed    source
+trivy-mcp            Trivy Vulnerability...   Aqua Security           installed    source, container_image
+```
+
+**Sample JSON fields:**
+
+```jsonc
+{
+  "id": "mcp-scan",
+  "name": "Snyk Agent Scan",
+  "vendor": "Snyk (Invariant Labs)",
+  "docker_image": "ghcr.io/smart-mcp-proxy/scanner-snyk:latest",
+  "status": "configured",
+  "inputs": ["source"],
+  "outputs": ["sarif"],
+  "timeout": "120s",
+  "network_required": true,
+  "required_env": [
+    {"key": "SNYK_TOKEN", "label": "Snyk API Token", "secret": true}
+  ],
+  "optional_env": null,
+  "installed_at": "2026-04-10T10:09:25+03:00",
+  "last_used_at": "2026-04-10T10:51:48+03:00"
+}
+```
+
+---
+
+## security enable
+
+Enable a scanner by pulling its Docker image in the background. Returns immediately once the pull is kicked off; watch the status transition via `security scanners` or the SSE event stream.
+
+### Usage
+
+```bash
+mcpproxy security enable <scanner-id>
+```
+
+`install` is a hidden alias preserved for backward compatibility.
+
+### Examples
+
+```bash
+# Start pulling the image
+mcpproxy security enable mcp-scan
+#  → "Enabling scanner "mcp-scan"..."
+#  → "Scanner "mcp-scan" enabled successfully."
+
+# Follow the pull via repeated listings
+watch -n 2 'mcpproxy security scanners | grep mcp-scan'
+```
+
+### Common failures
+
+- **`docker: daemon not running`** — start Docker Desktop / `systemctl start docker`.
+- **`manifest unknown`** — the scanner's image tag changed upstream. Update mcpproxy to get a new bundled registry.
+- **`no space left on device`** — prune unused images with `docker system prune -a`.
+
+---
+
+## security disable
+
+Disable a scanner and remove its Docker image. The scanner's configuration (env vars) is kept in BBolt, so re-enabling restores the previous configuration.
+
+### Usage
+
+```bash
+mcpproxy security disable <scanner-id>
+```
+
+`remove` is a hidden alias.
+
+### Example
+
+```bash
+mcpproxy security disable ramparts
+#  → "Scanner "ramparts" disabled successfully."
+```
+
+---
+
+## security configure
+
+Set environment variables for a scanner (typically API tokens). Values are stored in the scanner's `configured_env` map in the BBolt database.
+
+### Usage
+
+```bash
+mcpproxy security configure <scanner-id> --env KEY=VALUE [--env KEY2=VALUE2 ...]
+```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--env KEY=VALUE` | Environment variable in `KEY=VALUE` format. Repeatable. |
+
+### Storage model
+
+Scanner env values are stored **directly in the scanner record** in BBolt, NOT in the OS keyring.
+Scanner containers receive these values at scan time via Docker `--env` flags. They would end up in `/proc/environ` inside the scanner container either way, so storing them in the keyring added no real confidentiality.
+
+If you *do* want a value in the OS keyring, you can reference it via a `${keyring:name}` placeholder — the resolver expands it via a read-only keyring Get at scan time. That path is safe on all platforms because Get never triggers the macOS "Keychain Not Found" modal.
+
+To enable writes to the OS keyring (needed if you want `mcpproxy secrets set` to back scanner values via `${keyring:…}` references):
+
+```bash
+export MCPPROXY_KEYRING_WRITE=1       # opt-in, macOS only
+mcpproxy secrets set my-snyk-token
+# Then configure the scanner to reference it
+mcpproxy security configure mcp-scan --env SNYK_TOKEN='${keyring:my-snyk-token}'
+```
+
+On Linux and Windows the keyring write path is enabled by default.
+
+### Examples
+
+```bash
+# Set a single API token (stored in BBolt)
+mcpproxy security configure mcp-scan --env SNYK_TOKEN=snyk_xxx
+
+# Multiple env vars in one call
+mcpproxy security configure mcp-ai-scanner \
+  --env ANTHROPIC_API_KEY=sk-ant-xxx \
+  --env SCANNER_MODEL=claude-sonnet-4-6
+
+# Reference a value from the OS keyring
+mcpproxy security configure cisco-mcp-scanner \
+  --env CISCO_API_KEY='${keyring:cisco-ai-defense-key}'
+```
+
+### Scanner status changes
+
+After a successful `configure`, the scanner's status transitions from `installed` to `configured`. The scanner is marked ready to scan, and the UI surfaces a green checkmark.
+
+### Common failures
+
+- **`scanner "<id>" not found`** — typo, or the scanner isn't in the bundled registry. Run `mcpproxy security scanners` to see valid IDs.
+- **`context deadline exceeded`** — the CLI socket timeout (60s) fired. On a healthy system `configure` returns in well under a second; if you see this, file a bug.
+- **Timeout with macOS Keychain dialog** — should not happen in current versions. If it does, run `unset MCPPROXY_KEYRING_WRITE` and retry; see [issue #372](https://github.com/smart-mcp-proxy/mcpproxy-go/pull/372).
+
+---
+
+## security scan
+
+Run security scanners against an upstream MCP server. In the default (blocking) mode, the CLI prints live progress every 750 ms and exits when the job reaches a terminal state.
+
+### Usage
+
+```bash
+mcpproxy security scan <server> [flags]
+mcpproxy security scan --all [flags]
+```
+
+### Flags
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--all` | Scan every configured upstream server in a batch job | `false` |
+| `--async` | Start the scan and return immediately with a job ID | `false` |
+| `--dry-run` | Print a plan (source resolution + scanner list) without running any containers | `false` |
+| `--scanners <list>` | Comma-separated subset of scanner IDs (default: all installed) | all |
+
+The blocking mode has a hard timeout computed as `scan_timeout_default * number_of_scanners + 30s`, clamped to a minimum of 15 minutes and a maximum of 30 minutes. When the scan runs longer than this bound the CLI bails out with an error (the server-side job continues and can be inspected with `security status`).
+
+### Live progress (blocking mode)
+
+On a TTY the CLI prints one progress line per tick:
+
+```
+  [2s] 2 run, 4 running, 1 failed of 7 (running: cisco-mcp-scanner, mcp-ai-scanner, mcp-scan, semgrep-mcp)
+  [6s] 5 run, 1 running, 1 failed of 7 (running: semgrep-mcp)
+  [8s] 6 run, 0 running, 1 failed of 7
+  Scan completed in 8s
+Scan completed for "everything".
+
+Security Report: everything
+Scan ID:     scan-everything-1775804891180898000
+Risk Score:  0/100
+Scanned:     2026-04-10 10:08:19
+Scanners:    6 run, 1 failed (ramparts) of 7
+
+WARNING: Scan coverage incomplete: 1 of 7 scanners did not run
+
+=== Security Scan (Pass 1) ===
+  0 findings
+
+=== Supply Chain Audit (Pass 2) ===
+  Not started
+```
+
+:::tip Piped output is safe
+When stdout is not a TTY (e.g. `mcpproxy security scan foo | tee log.txt`), the CLI falls back to emitting one plain line per state transition instead of redrawing the block in place. This keeps your log files readable.
+:::
+
+### Batch mode (`--all`)
+
+Batch mode queues every configured server and streams a shared progress table:
+
+```
+Scanning all servers (1/3 completed, 2 running)...
+SERVER                   STATUS       FINDINGS   ERROR
+----------------------------------------------------------------------
+everything               completed    0
+filesystem-test          running      -
+fetch-test               running      -
+```
+
+Cancel a running batch at any time with `mcpproxy security cancel-all`.
+
+### Dry-run
+
+`--dry-run` fetches the source-resolution preview and the scanner list, then prints a plan and exits `0` without starting any Docker container. Use this to verify which directory a scanner would examine (see F-02 below).
+
+```bash
+$ mcpproxy security scan everything --dry-run
+Dry-run plan for "everything"
+------------------------------------------------------------
+Source: npx_cache · /tmp/.npm/_npx/…/@modelcontextprotocol/server-everything · 46 files · 164 KB
+
+Scanners that would run (7):
+  - cisco-mcp-scanner (Cisco MCP Scanner) [installed]
+      image:   ghcr.io/smart-mcp-proxy/scanner-cisco:latest
+      timeout: 120s
+      command: --analyzers yara,readiness --format raw static --tools /scan/source/tools.json
+      inputs:  source
+  - mcp-ai-scanner (MCP AI Scanner) [installed]
+      image:   ghcr.io/smart-mcp-proxy/mcp-scanner:latest
+      timeout: 900s
+      inputs:  source
+  …
+  - trivy-mcp (Trivy Vulnerability Scanner) [installed]
+      image:   ghcr.io/aquasecurity/trivy:latest
+      timeout: 300s
+      command: fs --format sarif /scan/source
+      inputs:  source, container_image
+
+Dry-run only — no scanners executed. Re-run without --dry-run to scan.
+```
+
+### Async mode
+
+```bash
+$ mcpproxy security scan github-server --async
+Scan started for "github-server" (job: scan-github-server-1775807459327309000)
+Use 'mcpproxy security status github-server' to check progress.
+```
+
+### Scanner subset
+
+```bash
+# Only run the two fastest scanners while iterating on a new server
+mcpproxy security scan my-new-server --scanners nova-proximity,trivy-mcp
+```
+
+### Source resolution (important)
+
+Before running any scanner, mcpproxy determines *what to scan*. The resolver order is:
+
+1. **Docker-isolated servers** → extract `/app` (or the server's `WorkingDir`) from the running container.
+2. **Package-runner commands** (`npx`, `uvx`, `pipx`, `bunx`) → resolve from the local package cache (`~/.npm/_npx/…`, `~/.cache/uv/…`, etc.). This path is tried **first** for package runners.
+3. **Working directory** from the server config.
+4. **Arg-scan fallback** — iterate positional command args, accept the first one that exists as a directory AND contains a source marker (`package.json`, `pyproject.toml`, `setup.py`, `Cargo.toml`, `go.mod`, etc.).
+5. **Tool definitions only** — export the server's tool schemas to a temp dir and scan those (used for HTTP/SSE servers and as a last-resort fallback).
+
+The `source_method` and `source_path` are recorded on the scan job and shown in both the text and JSON report. This is how you verify a scanner is examining the right directory.
+
+:::warning Don't confuse a config path with source code
+Prior to v0.23.x the resolver would pick *any* positional arg that happened to be a directory — including the data directory passed to `@modelcontextprotocol/server-filesystem`. That led to false positives on unrelated user files. The modern resolver tries the package cache first and only falls back to arg-based source if the arg directory contains recognizable source markers. See [docs/qa/security-scanners-2026-04-10.html](../qa/security-scanners-2026-04-10.html) §F-02 for the historical detail.
+:::
+
+---
+
+## security rescan
+
+Identical to `security scan <server>`, kept as a named subcommand for clarity. Accepts the same flags.
+
+```bash
+mcpproxy security rescan github-server
+mcpproxy security rescan github-server --async
+mcpproxy security rescan github-server --scanners trivy-mcp
+```
+
+---
+
+## security status
+
+Show the current (or most recent) scan job for a server, including per-scanner stderr and exit codes.
+
+### Usage
+
+```bash
+mcpproxy security status <server> [flags]
+```
+
+### Example
+
+```bash
+$ mcpproxy security status everything
+Scan Status: everything
+  Job ID:   scan-everything-1775799677404855000
+  Status:   completed
+  Started:  2026-04-10 08:41:17
+  Finished: 2026-04-10 08:42:09
+
+  SCANNER              STATUS       FINDINGS ERROR
+  -----------------------------------------------------------------
+  cisco-mcp-scanner    completed    0
+  mcp-ai-scanner       completed    0
+  mcp-scan             failed       0        scanner mcp-scan produ...
+  nova-proximity       completed    0
+  ramparts             failed       0        scanner ramparts produ...
+  semgrep-mcp          completed    0
+  trivy-mcp            completed    0
+```
+
+:::tip Use status for diagnostics
+If `security report` shows "0 findings" but you think a scanner should have flagged something, open `status` — failed scanners appear here with their truncated stderr. The full stderr is available via `security status <server> -o json`.
+:::
+
+### Common states
+
+| State | Meaning |
+|-------|---------|
+| `pending` | Job accepted but not yet started |
+| `running` | At least one scanner is executing |
+| `completed` | All scanners reached a terminal state (some may have failed) |
+| `failed` | The job itself failed (not individual scanners) |
+| `cancelled` | Cancelled via `cancel-all` |
+
+---
+
+## security report
+
+Display the aggregated scan report for a server. This is the primary decision-support view.
+
+### Usage
+
+```bash
+mcpproxy security report <server> [flags]
+```
+
+Use `-o json`, `-o yaml`, or `-o sarif` for machine-readable output.
+
+### Table output
+
+```
+Security Report: everything
+Scan ID:     scan-everything-1775804891180898000
+Risk Score:  0/100
+Scanned:     2026-04-10 10:08:19
+Scanners:    6 run, 1 failed (ramparts) of 7
+
+WARNING: Scan coverage incomplete: 1 of 7 scanners did not run
+
+=== Security Scan (Pass 1) ===
+  0 findings
+
+=== Supply Chain Audit (Pass 2) ===
+  Not started
+```
+
+The `Scanners: X run, Y failed (names) of Z` line surfaces per-scanner failures that used to be invisible in the report. When Y > 0 the CLI also prints a yellow **"Scan coverage incomplete"** warning so a human reviewer can't mistake "0 findings" for "clean" when scanners actually crashed.
+
+### JSON output
+
+`-o json` returns the full aggregated report including:
+
+- `risk_score` — composite 0-100 score
+- `summary` — severity counts (`critical`, `high`, `medium`, `low`, `info`, `dangerous`, `warnings`, `info_level`, `total`)
+- `findings` — normalized findings across all scanners
+- `reports` — per-scanner raw results (also includes SARIF when `?include_sarif=true` is passed to the REST endpoint)
+- `scan_context` — source method, source path, scanned file list
+- `scanners_run`, `scanners_failed`, `scanners_total`
+- `pass1_complete`, `pass2_complete`, `pass2_running`
+
+```bash
+# Extract just the severity summary
+mcpproxy security report github-server -o json | jq '.data.summary'
+
+# Get the full list of findings with file:line locations
+mcpproxy security report github-server -o json \
+  | jq '.data.findings[] | {severity, rule_id, scanner, location: .location}'
+```
+
+### SARIF output
+
+`-o sarif` emits the raw per-scanner SARIF 2.1.0 documents as a JSON array, one per scanner that produced output. Useful for piping into SARIF viewers (VS Code's SARIF Viewer extension, `reviewdog`, etc.).
+
+```bash
+mcpproxy security report github-server -o sarif > github-server.sarif
+```
+
+---
+
+## security approve
+
+Approve a server after reviewing its scan report. This is the primary "commit the trust decision" action.
+
+### Usage
+
+```bash
+mcpproxy security approve <server> [flags]
+```
+
+### Flags
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--force` | Approve even if the most recent scan has critical findings | `false` |
+
+### What approve does
+
+1. Loads the most recent aggregated scan report for the server.
+2. Checks `summary.critical == 0` — if there are critical findings, refuses unless `--force` is set.
+3. Saves an `IntegrityBaseline` record (image digest, scan report IDs, approved-by, approved-at).
+4. **Unquarantines the server** via the core server manager (removes it from the quarantine bucket, marks `quarantined: false`, and triggers a fresh tool index on its next connection).
+5. Emits a `servers.changed` event and an activity log entry.
+
+:::info Approve is the only path to unquarantine after a scan
+Prior to v0.23.x, `security approve` only wrote the integrity baseline — it did not unquarantine the server. That was a bug (see QA report §F-01). Modern `approve` calls the unquarantine logic directly, so there is no need to run a separate `upstream unquarantine` afterwards.
+:::
+
+### Examples
+
+```bash
+# Happy path: server has 0 critical findings, approve immediately
+mcpproxy security approve github-server
+#  → Server "github-server" approved.
+#  → (server becomes connected, tools start indexing)
+
+# Scan reported critical findings — explicit override
+mcpproxy security approve github-server --force
+```
+
+### Common failures
+
+- **`server has N critical findings; resolve them or use --force`** — default guard. Review the findings via `security report` before overriding.
+- **`no scan results found; run a scan first or use --force`** — the server has never been scanned. You can still `--force` approve but the CLI will warn you loudly.
+- **`failed to unquarantine server: …`** — the unquarantine path errored AFTER the baseline was saved. The baseline is kept (it's a valid provenance record) and you can retry with a direct unquarantine call.
+
+---
+
+## security reject
+
+Reject a server after reviewing its scan report. Deletes scan artifacts but keeps the server in quarantine.
+
+### Usage
+
+```bash
+mcpproxy security reject <server>
+```
+
+### What reject does
+
+1. Deletes all scan reports for the server from BBolt.
+2. Deletes all scan job records.
+3. Deletes the integrity baseline (if any).
+4. Best-effort removes the `mcpproxy-snapshot-<server>` Docker image.
+5. Leaves the server **still quarantined** — its config is untouched so you can run a fresh scan later.
+
+:::note Reject is not "delete"
+`security reject` never removes the server config or the server from the BBolt `servers` bucket. To fully remove a server, use `mcpproxy upstream delete <server>`.
+:::
+
+### Example
+
+```bash
+mcpproxy security reject github-server
+#  → Server "github-server" rejected and quarantined.
+```
+
+---
+
+## security integrity
+
+Verify that a previously-approved server still matches its integrity baseline.
+
+### Usage
+
+```bash
+mcpproxy security integrity <server>
+```
+
+### What integrity checks
+
+| Check | What it verifies |
+|-------|------------------|
+| Image digest | Current `mcpproxy-snapshot-<server>` image digest matches the value recorded at approval time. Catches rebuilds of the server's own Docker image. |
+| Scan report IDs | The scan reports referenced by the baseline still exist in BBolt. |
+| Approval timestamp | Exposed for observability (not a gate). |
+
+### Example
+
+```bash
+$ mcpproxy security integrity everything
+Integrity Check: everything
+  Status:  PASSED
+  Checked: 2026-04-10 08:51:07
+```
+
+### Common failures
+
+- **`no integrity baseline found for server "X"`** — the server has never been approved. Approve it first.
+- **`digest_mismatch`** — the server's Docker image was rebuilt and no longer matches the approved version. Re-scan and re-approve if you trust the new version.
+
+### Automated integrity checks
+
+When `security.integrity_check_on_restart = true`, mcpproxy runs an integrity check every time it restarts an upstream server. A `digest_mismatch` on restart re-quarantines the server automatically and emits a `security.integrity_alert` SSE event. See [Security Scanner Plugin System — Configuration](/features/security-scanner-plugins#configuration) for the full list of integrity settings.
+
+---
+
+## security overview
+
+Print a dashboard summary of scanner and scan totals.
+
+### Usage
+
+```bash
+mcpproxy security overview [flags]
+```
+
+### Example
+
+```bash
+$ mcpproxy security overview
+Security Overview
+  Scanners installed: 7
+  Servers scanned:    3
+  Total scans:        12
+  Active scans:       0
+  Last scan:          2026-04-10 09:59:53
+
+  Findings:
+    Critical: 0
+    High:     2
+    Medium:   0
+    Low:      0
+    Info:     0
+```
+
+When no scans have been run yet, `Last scan` shows `never` (table) or `null` (JSON `last_scan_at`). Use the JSON output to drive dashboards:
+
+```bash
+mcpproxy security overview -o json \
+  | jq '{installed: .scanners_installed, last: .last_scan_at, critical: .findings_by_severity.critical}'
+```
+
+---
+
+## security cancel-all
+
+Cancel an in-progress batch scan (started with `security scan --all`). Individual per-scanner containers may still complete, but pending servers are skipped and the batch transitions to `cancelled`.
+
+### Usage
+
+```bash
+mcpproxy security cancel-all
+```
+
+### Example
+
+```bash
+$ mcpproxy security cancel-all
+Batch scan cancelled.
+
+$ mcpproxy security overview -o json | jq '.batch_status // "none"'
+"cancelled"
+```
+
+---
+
+## Typical workflows
+
+### New server — full review
+
+```bash
+# 1. Add the server (lands in quarantine by default)
+mcpproxy upstream add my-server --command=npx --args="-y,@my-org/mcp-server"
+
+# 2. Make sure scanners are ready
+mcpproxy security scanners
+mcpproxy security enable mcp-scan nova-proximity trivy-mcp  # if needed
+
+# 3. Run the scan (blocking, live progress)
+mcpproxy security scan my-server
+
+# 4. Review
+mcpproxy security report my-server
+mcpproxy security status my-server   # check for silently-failed scanners
+
+# 5. Approve (or reject)
+mcpproxy security approve my-server
+#   OR
+mcpproxy security reject my-server
+```
+
+### CI / scripting — async + poll
+
+```bash
+JOB=$(mcpproxy security scan my-server --async --json | jq -r '.data.job_id')
+echo "scan job: $JOB"
+
+# Poll until done
+while true; do
+  S=$(mcpproxy security status my-server --json | jq -r '.data.status')
+  case "$S" in
+    completed|failed|cancelled) break ;;
+  esac
+  sleep 2
+done
+
+# Fail the build if there are critical findings
+CRITICAL=$(mcpproxy security report my-server --json | jq -r '.data.summary.critical')
+if [ "$CRITICAL" -gt 0 ]; then
+  echo "::error::Server has $CRITICAL critical findings"
+  exit 1
+fi
+
+mcpproxy security approve my-server
+```
+
+### Triaging false positives
+
+```bash
+# See exactly what was scanned (most important when a scanner cries wolf)
+mcpproxy security scan my-server --dry-run
+# Check `Source: …` — is it the actual server package?
+
+# Pull the full per-scanner stderr to verify the tool is reading the right files
+mcpproxy security status my-server -o json | jq '.data.scanner_statuses[] | {scanner_id, exit_code, stderr}'
+
+# Export the full SARIF for a second opinion
+mcpproxy security report my-server -o sarif > my-server.sarif
+```
+
+---
+
+## See also
+
+- [Security Scanner Plugin System](/features/security-scanner-plugins) — architecture and feature overview
+- [Scanner Images](/features/scanner-images) — which image each scanner uses and why
+- [Security Quarantine](/features/security-quarantine) — the underlying quarantine mechanism
+- [Activity Commands](/cli/activity-commands) — correlate scans with the activity log
+- [Command Reference](/cli/command-reference) — top-level CLI index

--- a/docs/cli/security-commands.md
+++ b/docs/cli/security-commands.md
@@ -383,7 +383,7 @@ Before running any scanner, mcpproxy determines *what to scan*. The resolver ord
 The `source_method` and `source_path` are recorded on the scan job and shown in both the text and JSON report. This is how you verify a scanner is examining the right directory.
 
 :::warning Don't confuse a config path with source code
-Prior to v0.23.x the resolver would pick *any* positional arg that happened to be a directory — including the data directory passed to `@modelcontextprotocol/server-filesystem`. That led to false positives on unrelated user files. The modern resolver tries the package cache first and only falls back to arg-based source if the arg directory contains recognizable source markers. See [docs/qa/security-scanners-2026-04-10.html](../qa/security-scanners-2026-04-10.html) §F-02 for the historical detail.
+Prior to v0.23.x the resolver would pick *any* positional arg that happened to be a directory — including the data directory passed to `@modelcontextprotocol/server-filesystem`. That led to false positives on unrelated user files. The modern resolver tries the package cache first and only falls back to arg-based source if the arg directory contains recognizable source markers.
 :::
 
 ---

--- a/docs/features/security-scanner-plugins.md
+++ b/docs/features/security-scanner-plugins.md
@@ -1,191 +1,275 @@
+---
+id: security-scanner-plugins
+title: Security Scanner Plugin System
+sidebar_label: Security Scanners
+description: Docker-based scanner plugins for detecting tool poisoning, prompt injection, CVEs, and supply-chain risks in upstream MCP servers
+keywords: [security, scanner, sarif, quarantine, mcp, tool-poisoning, supply-chain]
+---
+
 # Security Scanner Plugin System
 
 MCPProxy integrates external security scanners as Docker-based plugins. Scanners analyze quarantined servers before approval, detecting tool poisoning attacks, prompt injection, malware, secrets leakage, and supply chain risks.
 
+> **CLI reference**: for the full breakdown of every `mcpproxy security` subcommand, flags, and examples see [Security Commands](/cli/security-commands).
+
 ## Overview
 
-All scanners are plugins — no built-in scanner. MCPProxy provides a universal plugin interface that any scanner can implement. Users browse a scanner registry, install with one click, configure API keys, and start scanning.
+Every scanner is a plugin — there is no built-in scanner. MCPProxy exposes a universal plugin interface that scanner authors implement by shipping a Docker image that reads from `/scan/source` and writes SARIF to `/scan/report/results.sarif`. Users browse a bundled scanner registry, enable scanners with one command, configure API keys if needed, and start scanning.
 
-### Key Features
+### Key features
 
-- **Plugin-only architecture** — every scanner is a Docker-based plugin
-- **Universal scanner interface** — source filesystem input, SARIF output
-- **Parallel scanning** — multiple scanners run concurrently with independent failure handling
-- **Risk scoring** — composite 0-100 risk score from aggregated findings
-- **Integrity verification** — image digest checks on server restart
-- **Multi-UI** — REST API, CLI, Web UI all powered by the same backend
+- **Plugin-only architecture** — every scanner is a Docker-based plugin.
+- **Universal scanner interface** — source filesystem input, SARIF output.
+- **Parallel scanning** — multiple scanners run concurrently; per-scanner failures are isolated.
+- **Source resolver** — detects the right thing to scan for npx/uvx/pipx/bunx package-runner commands, falls back to working dir or tool definitions for HTTP/SSE servers.
+- **Risk scoring** — composite 0–100 risk score from aggregated findings.
+- **Integrity verification** — image digest checks on server restart.
+- **Multi-UI** — REST API, CLI, Web UI all powered by the same backend, consistent status vocabulary.
+- **Failed-scanner visibility** — both CLI and Web UI surface per-scanner failures so silent crashes don't look like "clean".
 
-## Quick Start
+### What changed recently (2026-04)
 
-### 1. List Available Scanners
+- `security approve` now actually unquarantines the server and indexes its tools (was a no-op stub).
+- Source resolver tries the package cache **first** for package-runner commands, so filesystem-server-style data-dir args are no longer mistaken for source code.
+- The scanner configure path no longer touches the OS keyring by default on macOS. Env values are stored in the scanner record in BBolt. See [Security Commands → configure](/cli/security-commands#security-configure) for details and the opt-in flag.
+- `security report` surfaces the count of failed scanners and their names.
+- `security scan --dry-run` prints a source-resolution plan without starting any containers.
+- `security scan` blocking mode has a real wait loop (no more hangs) with a hard timeout.
+- `scanner status` vocabulary unified between table and JSON: `available` / `pulling` / `installed` / `configured` / `error`.
+
+For the full QA report and the cross-check of every fix see [docs/qa/security-scanners-2026-04-10.html](../qa/security-scanners-2026-04-10.html) (untracked local file).
+
+## Quick start
+
+### 1. List available scanners
 
 ```bash
 mcpproxy security scanners
 ```
 
-Output:
 ```
-ID                  NAME                VENDOR              STATUS      INPUTS
-mcp-scan            MCP Scan            Invariant Labs      available   source
-cisco-mcp-scanner   Cisco MCP Scanner   Cisco AI Defense    available   source, mcp_connection
-semgrep-mcp         Semgrep MCP Rules   Semgrep             available   source
-trivy-mcp           Trivy Scanner       Aqua Security       available   source, container_image
+ID                   NAME                     VENDOR                  STATUS       INPUTS
+-------------------------------------------------------------------------------------------------------
+cisco-mcp-scanner    Cisco MCP Scanner        Cisco AI Defense        available    source
+mcp-ai-scanner       MCP AI Scanner           MCPProxy                available    source
+mcp-scan             Snyk Agent Scan          Snyk (Invariant Labs)   available    source
+nova-proximity       Nova Proximity           MCPProxy                available    source
+ramparts             Ramparts MCP Scanner     Javelin                 available    source
+semgrep-mcp          Semgrep MCP Rules        Semgrep                 available    source
+trivy-mcp            Trivy Vulnerability...   Aqua Security           available    source, container_image
 ```
 
-### 2. Install a Scanner
+### 2. Enable scanners
 
 ```bash
-mcpproxy security install mcp-scan
+mcpproxy security enable nova-proximity
+mcpproxy security enable trivy-mcp
+mcpproxy security enable mcp-ai-scanner
 ```
 
-This pulls the scanner's Docker image. Requires Docker.
+(`install` is a hidden alias for `enable`, kept for backward compatibility.)
 
-### 3. Configure (if needed)
+### 3. Configure API keys (if the scanner needs them)
+
+Only a subset of scanners requires an API key. `mcp-scan` (Snyk Agent Scan) needs a free token from Snyk; `mcp-ai-scanner` can use an optional Anthropic API key or Claude Code OAuth token for richer analysis but works in pattern-only mode without one.
 
 ```bash
-mcpproxy security configure cisco-mcp-scanner --env MCP_SCANNER_API_KEY=your-key
+mcpproxy security configure mcp-scan --env SNYK_TOKEN=snyk_xxx
 ```
 
-### 4. Scan a Quarantined Server
+Values are stored directly in the scanner record in BBolt. The scanner container receives them via Docker `--env` flags at scan time.
+
+### 4. Scan a quarantined server
 
 ```bash
 mcpproxy security scan github-server
 ```
 
-Runs all installed scanners in parallel, shows progress, and displays the aggregated report.
+The CLI runs all enabled scanners in parallel, prints live progress, and shows a summary.
 
-### 5. Review and Approve/Reject
+### 5. Review the findings
 
 ```bash
-# View the report
 mcpproxy security report github-server
+mcpproxy security status github-server     # per-scanner detail including stderr
+mcpproxy security report github-server -o sarif > github-server.sarif
+```
 
-# Approve the server (unquarantines and indexes tools)
+### 6. Approve or reject
+
+```bash
+# Approve (unquarantines and indexes tools)
 mcpproxy security approve github-server
 
-# Or reject (deletes server config and artifacts)
+# Or reject (deletes scan artifacts, keeps server quarantined)
 mcpproxy security reject github-server
 ```
 
-## Scanner Registry
+## Scanner registry
 
-MCPProxy ships with a bundled registry of known scanners:
+MCPProxy ships with a bundled registry of 7 scanners. The bundled list lives in [`internal/security/scanner/registry_bundled.go`](https://github.com/smart-mcp-proxy/mcpproxy-go/blob/main/internal/security/scanner/registry_bundled.go).
 
-| Scanner | Vendor | Inputs | Description |
-|---------|--------|--------|-------------|
-| mcp-scan | Invariant Labs | source | Tool poisoning, prompt injection, cross-origin escalation |
-| cisco-mcp-scanner | Cisco AI Defense | source, mcp_connection | YARA rules + LLM-as-judge analysis |
-| semgrep-mcp | Semgrep | source | Static analysis with MCP-specific rules |
-| trivy-mcp | Aqua Security | source, container_image | CVE scanning and misconfiguration detection |
+| Scanner | Vendor | Inputs | Required env | Notes |
+|---------|--------|--------|--------------|-------|
+| `cisco-mcp-scanner` | Cisco AI Defense | source | — | YARA rules + readiness analysis. Needs `tools.json` in the source dir. |
+| `mcp-ai-scanner` | MCPProxy | source | — (optional `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`) | Agent-based AI analysis with a pattern-only fallback. Lives in a [separate repo](https://github.com/smart-mcp-proxy/mcp-scanner). |
+| `mcp-scan` | Snyk (Invariant Labs) | source | `SNYK_TOKEN` | Tool poisoning, prompt injection, tool shadowing, toxic flows, secrets, rug pulls. |
+| `nova-proximity` | MCPProxy (NOVA-inspired rules) | source | — | Keyword-based, fully offline. Very fast. |
+| `ramparts` | Javelin | source | — | Rust-based YARA scanner. *(Known upstream issue on arm64 macOS — see [Scanner Images](/features/scanner-images).)* |
+| `semgrep-mcp` | Semgrep | source | — | Static analysis with MCP-specific rules. Uses the upstream `returntocorp/semgrep:latest` image. |
+| `trivy-mcp` | Aqua Security | source, container_image | — | Filesystem + CVE scan. Uses the upstream `ghcr.io/aquasecurity/trivy:latest` image. |
 
-### Custom Scanners
+See [Scanner Images](/features/scanner-images) for the image sources and why vendor images are preferred over custom wrappers.
 
-Add custom scanners via the API or CLI:
+### Custom / out-of-tree scanners
+
+Custom scanners can be added by pushing a Docker image that implements the plugin contract (see the [Plugin Interface](#plugin-interface) section below) and registering it via the REST API:
 
 ```bash
-# Via API
-curl -X POST http://localhost:8080/api/v1/security/scanners/install \
-  -H "X-API-Key: $API_KEY" \
-  -d '{"id": "custom-scanner"}'
+curl -X POST http://localhost:8080/api/v1/security/scanners/my-custom-scanner/enable \
+  -H "X-API-Key: $API_KEY"
 ```
 
-## CLI Commands
+Remote scanner registries (not just the bundled one) are planned but currently opt-in via the `security.scanner_registry_url` config field.
+
+## CLI commands
+
+The complete CLI reference is in [docs/cli/security-commands.md](/cli/security-commands). At a glance:
 
 ```bash
-# Scanner management
-mcpproxy security scanners                    # List all scanners
-mcpproxy security install <scanner-id>        # Install scanner
-mcpproxy security remove <scanner-id>         # Remove scanner
-mcpproxy security configure <id> --env K=V    # Set API keys
+# Scanner lifecycle
+mcpproxy security scanners                           # list with status
+mcpproxy security enable <scanner-id>                # pull image
+mcpproxy security disable <scanner-id>               # remove image
+mcpproxy security configure <id> --env KEY=VALUE     # set env vars (repeatable)
 
 # Scan operations
-mcpproxy security scan <server>               # Scan server (blocks)
-mcpproxy security scan <server> --async       # Return job ID
-mcpproxy security status <server>             # Check scan status
-mcpproxy security report <server>             # View report
-mcpproxy security report <server> -o json     # JSON output
-mcpproxy security report <server> -o sarif    # Raw SARIF output
+mcpproxy security scan <server>                      # blocking, with live progress
+mcpproxy security scan <server> --async              # return job id
+mcpproxy security scan <server> --dry-run            # print plan, no containers
+mcpproxy security scan --all                         # batch scan, progress table
+mcpproxy security scan <server> --scanners a,b,c     # subset of scanners
+mcpproxy security rescan <server>                    # alias for scan
+mcpproxy security status <server>                    # per-scanner detail
+mcpproxy security report <server> [-o json|yaml|sarif]
+mcpproxy security cancel-all                         # cancel batch in progress
 
 # Approval workflow
-mcpproxy security approve <server>            # Approve
-mcpproxy security approve <server> --force    # Force approve with critical findings
-mcpproxy security reject <server>             # Reject and cleanup
-mcpproxy security rescan <server>             # Re-run scanners
+mcpproxy security approve <server> [--force]         # unquarantine + index
+mcpproxy security reject <server>                    # delete artifacts, keep quarantined
+mcpproxy security integrity <server>                 # verify against baseline
 
 # Dashboard
-mcpproxy security overview                    # Aggregate stats
-mcpproxy security integrity <server>          # Check integrity
+mcpproxy security overview
 ```
+
+All subcommands support `-o json`, `-o yaml`, and `--json` (shorthand) for scripting.
 
 ## REST API
 
-### Scanner Management
+### Scanner management
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| GET | `/api/v1/security/scanners` | List all scanners |
-| POST | `/api/v1/security/scanners/install` | Install scanner |
-| DELETE | `/api/v1/security/scanners/{id}` | Remove scanner |
-| PUT | `/api/v1/security/scanners/{id}/config` | Configure scanner |
-| GET | `/api/v1/security/scanners/{id}/status` | Scanner health |
+| `GET`    | `/api/v1/security/scanners` | List all scanners from the registry |
+| `GET`    | `/api/v1/security/scanners/{id}/status` | Per-scanner detail |
+| `POST`   | `/api/v1/security/scanners/{id}/enable` | Enable (pull image) |
+| `POST`   | `/api/v1/security/scanners/{id}/disable` | Disable (remove image) |
+| `PUT`    | `/api/v1/security/scanners/{id}/config` | Set env vars (JSON body `{"env": {"KEY": "VALUE"}}`) |
+| `POST`   | `/api/v1/security/scanners/install` | Legacy install endpoint — prefer the per-scanner enable |
+| `DELETE` | `/api/v1/security/scanners/{id}` | Legacy remove endpoint — prefer disable |
 
-### Scan Operations
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| POST | `/api/v1/servers/{name}/scan` | Start scan |
-| GET | `/api/v1/servers/{name}/scan/status` | Scan status |
-| GET | `/api/v1/servers/{name}/scan/report` | Aggregated report |
-| POST | `/api/v1/servers/{name}/scan/cancel` | Cancel scan |
-
-### Approval Flow
+### Scan operations
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| POST | `/api/v1/servers/{name}/security/approve` | Approve server |
-| POST | `/api/v1/servers/{name}/security/reject` | Reject server |
-| GET | `/api/v1/servers/{name}/integrity` | Integrity check |
+| `POST` | `/api/v1/servers/{name}/scan` | Start a scan (body: `{"scanners": [...], "dry_run": false}`) |
+| `GET`  | `/api/v1/servers/{name}/scan/status` | Current/latest scan job with per-scanner statuses |
+| `GET`  | `/api/v1/servers/{name}/scan/report` | Aggregated report (add `?include_sarif=true` for raw SARIF) |
+| `GET`  | `/api/v1/servers/{name}/scan/files` | Source-resolution preview (source_method, path, file list) |
+| `POST` | `/api/v1/servers/{name}/scan/cancel` | Cancel the current scan |
+| `GET`  | `/api/v1/security/scans` | Scan history across all servers |
+| `GET`  | `/api/v1/security/scans/{jobId}/report` | Fetch a specific scan's aggregated report |
+| `POST` | `/api/v1/security/scan-all` | Kick off a batch scan of all servers |
+| `GET`  | `/api/v1/security/queue` | Batch scan progress |
+| `POST` | `/api/v1/security/cancel-all` | Cancel the current batch |
+
+### Approval workflow
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `POST` | `/api/v1/servers/{name}/security/approve` | Approve: saves integrity baseline + unquarantines + indexes tools. Body `{"force": true}` bypasses the critical-findings guard. |
+| `POST` | `/api/v1/servers/{name}/security/reject` | Reject: deletes scan artifacts, keeps server quarantined. |
+| `GET`  | `/api/v1/servers/{name}/integrity` | Integrity check against the approved baseline. |
 
 ### Dashboard
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| GET | `/api/v1/security/overview` | Security dashboard stats |
+| `GET` | `/api/v1/security/overview` | Totals: scanners installed, total scans, findings by severity, Docker availability, last scan time |
 
-### SSE Events
+### SSE events
 
-| Event | Payload |
-|-------|---------|
-| `security.scan_started` | server_name, scanners[], job_id |
-| `security.scan_progress` | server_name, scanner_id, status, progress |
-| `security.scan_completed` | server_name, findings_summary |
-| `security.scan_failed` | server_name, scanner_id, error |
-| `security.integrity_alert` | server_name, alert_type, action |
+Emitted on the `/events` SSE stream:
 
-## SARIF Output
+| Event | Payload fields |
+|-------|----------------|
+| `security.scan_started` | `server_name`, `scanners[]`, `job_id` |
+| `security.scan_progress` | `server_name`, `scanner_id`, `status`, `progress` |
+| `security.scan_completed` | `server_name`, `findings_summary` |
+| `security.scan_failed` | `server_name`, `scanner_id`, `error` |
+| `security.integrity_alert` | `server_name`, `alert_type`, `action` |
 
-Scanners produce results in SARIF 2.1.0 format. MCPProxy normalizes findings:
+## Plugin interface
 
-| SARIF Level | MCPProxy Severity |
+Every scanner plugin is a Docker image with the following contract:
+
+| Mount / path | Direction | Description |
+|--------------|-----------|-------------|
+| `/scan/source` | read-only | The resolved source directory for the server under scan |
+| `/scan/report` | read-write | The scanner must emit `results.sarif` here |
+| `/scan/source/tools.json` | read-only | The server's exported MCP tool schemas (`[{ "name": ..., "description": ..., "inputSchema": {...} }, ...]`). Written by mcpproxy before starting the scanner container. |
+
+Scanners communicate results via SARIF 2.1.0. Exit code `0` indicates "scan completed (with or without findings)". Non-zero exit codes are surfaced as `scanner failed` in the aggregated report.
+
+### Source resolution order
+
+```
+1. Docker extraction (for Docker-isolated servers)
+2. Package cache (npx/uvx/pipx/bunx) — PREFERRED for package runners
+3. WorkingDir (from server config)
+4. Arg-scan fallback — accepts only directories containing source markers
+5. Tool definitions only — last resort (HTTP / SSE / unresolvable)
+```
+
+The resolved method and path are recorded on the scan job and visible via both the text and JSON report. See [Security Commands → scan](/cli/security-commands#security-scan) for more.
+
+## SARIF normalization
+
+Scanners produce results in SARIF 2.1.0 format. MCPProxy normalizes findings to a consistent severity vocabulary:
+
+| SARIF level | MCPProxy severity |
 |-------------|-------------------|
-| error | high |
-| warning | medium |
-| note | low |
-| none | info |
+| `error`     | `high` |
+| `warning`   | `medium` |
+| `note`      | `low` |
+| `none`      | `info` |
 
-Critical severity is reserved for findings explicitly marked as critical in scanner properties.
+`critical` severity is reserved for findings explicitly marked critical in the scanner's SARIF `properties.severity` field or via a rule-level override. Critical findings block `security approve` unless `--force` is supplied.
+
+MCPProxy also augments each finding with a user-facing `threat_type` (`tool_poisoning` / `prompt_injection` / `rug_pull` / `supply_chain` / `malicious_code` / `uncategorized`) and `threat_level` (`dangerous` / `warning` / `info`) so the Web UI can group findings in a way that's meaningful to MCP server trust decisions.
 
 ## Configuration
 
 ```json
 {
   "security": {
-    "auto_scan_quarantined": true,
+    "auto_scan_quarantined": false,
     "scan_timeout_default": "60s",
     "integrity_check_interval": "1h",
-    "integrity_check_on_restart": true,
+    "integrity_check_on_restart": false,
     "scanner_registry_url": "",
-    "runtime_read_only": true,
+    "runtime_read_only": false,
     "runtime_tmpfs_size": "100M"
   }
 }
@@ -193,31 +277,52 @@ Critical severity is reserved for findings explicitly marked as critical in scan
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| auto_scan_quarantined | false | Auto-scan newly quarantined servers |
-| scan_timeout_default | 60s | Default per-scanner timeout |
-| integrity_check_interval | 1h | Periodic integrity check interval |
-| integrity_check_on_restart | false | Check integrity on server restart |
-| scanner_registry_url | (empty) | Remote registry URL (opt-in) |
-| runtime_read_only | false | Run approved servers with --read-only |
-| runtime_tmpfs_size | 100M | Tmpfs size for read-only containers |
+| `auto_scan_quarantined` | `false` | Auto-scan newly quarantined servers as soon as they're added. |
+| `scan_timeout_default` | `60s` | Per-scanner timeout. The blocking CLI `security scan` computes a hard ceiling as `scan_timeout_default × scanner_count + 30s`, clamped between 15 and 30 minutes. |
+| `integrity_check_interval` | `1h` | Periodic integrity check interval (when running as a daemon with integrity checks enabled). |
+| `integrity_check_on_restart` | `false` | Re-verify integrity baseline every time an approved server is restarted. |
+| `scanner_registry_url` | `""` | Remote scanner registry URL (opt-in). When empty, only the bundled registry is used. |
+| `runtime_read_only` | `false` | Run approved server containers with `--read-only` and a tmpfs overlay. (P2 feature, requires Docker isolation.) |
+| `runtime_tmpfs_size` | `100M` | Tmpfs size for read-only runtime containers. |
 
-## Data Storage
+### Environment variables
 
-Scanner data is stored in BBolt database (`~/.mcpproxy/config.db`) in 4 buckets:
+| Variable | Effect |
+|----------|--------|
+| `MCPPROXY_KEYRING_WRITE` | Set to `1`, `true`, or `yes` to opt in to writing secrets to the OS keyring on macOS. Default (empty) routes writes to the in-config fallback. Linux and Windows default to enabled. |
+
+## Data storage
+
+Scanner data is stored in the BBolt database (`~/.mcpproxy/config.db`) in these buckets:
 
 | Bucket | Content |
 |--------|---------|
-| `security_scanners` | Installed scanner configurations |
-| `security_scan_jobs` | Scan job records and status |
-| `security_reports` | SARIF reports and normalized findings |
-| `integrity_baselines` | Per-server integrity records |
+| `security_scanners` | Installed scanner configurations (including `configured_env`) |
+| `security_scan_jobs` | Scan job records and per-scanner statuses |
+| `security_reports` | Aggregated reports, per-scanner SARIF payloads, normalized findings |
+| `integrity_baselines` | Per-server approval records (image digest, scan report IDs, approved-by) |
 
 ## Web UI
 
-The Security page is available at `/security` in the Web UI. It provides:
+The Security page at `/security` in the Web UI mirrors the CLI and provides:
 
-- Dashboard stats: scanners installed, total scans, findings by severity
-- Scanner marketplace: install, configure, remove scanners
-- Scan trigger: select a server and start scanning
-- Report viewer: findings table with severity, title, location, scanner
-- Approve/reject actions: one-click server approval workflow
+- **Dashboard stats** — scanners installed, total scans, findings by severity, Docker availability, Last scan timestamp.
+- **Scanner table** — every scanner in the registry with its current status, vendor link, and configure button.
+- **Scan All Servers** — batch scan trigger with live progress.
+- **Scan report viewer** at `/security/scans/{jobId}` — risk-score badge, finding detail cards with rule/location/scanner, per-scanner execution logs including stderr from failed scanners, and scan context (source method + path + file count).
+- **Approve Server / Force Approve / Reject** — scanner-gated approval dialog that requires a completed scan (or explicit force) before calling the approval endpoint. See [QA report §F-04](../qa/security-scanners-2026-04-10.html) for the historical context.
+
+## Known limitations
+
+- **Ramparts on arm64 macOS** — the upstream scanner image ships a binary linked against a newer GLIBC than the image base and fails every run on arm64. Track the [scanner-ramparts image rebuild](https://github.com/smart-mcp-proxy/mcpproxy-go/issues) for a fix. Other 6 of 7 scanners work out of the box on arm64 macOS.
+- **Cisco scanner output has a hardcoded `server_url`** header in its stdout (`https://mcp.deepwiki.com/mcp`). Cosmetic, does not affect findings.
+- **Pass 2 (supply-chain audit)** currently requires Docker isolation to be enabled, otherwise it fails source resolution. The UI doesn't yet surface this precondition.
+
+See the [QA report §9](../qa/security-scanners-2026-04-10.html) for the full list of residual items and recommendations.
+
+## Related reading
+
+- [Security Commands](/cli/security-commands) — exhaustive CLI reference
+- [Scanner Images](/features/scanner-images) — where each Docker image comes from
+- [Security Quarantine](/features/security-quarantine) — the underlying quarantine mechanism that scanners gate
+- [Tool Quarantine (Spec 032)](/features/tool-quarantine) — per-tool hash-based approval, a complementary layer

--- a/docs/features/security-scanner-plugins.md
+++ b/docs/features/security-scanner-plugins.md
@@ -37,8 +37,6 @@ Every scanner is a plugin — there is no built-in scanner. MCPProxy exposes a u
 - `security scan` blocking mode has a real wait loop (no more hangs) with a hard timeout.
 - `scanner status` vocabulary unified between table and JSON: `available` / `pulling` / `installed` / `configured` / `error`.
 
-For the full QA report and the cross-check of every fix see [docs/qa/security-scanners-2026-04-10.html](../qa/security-scanners-2026-04-10.html) (untracked local file).
-
 ## Quick start
 
 ### 1. List available scanners
@@ -310,15 +308,13 @@ The Security page at `/security` in the Web UI mirrors the CLI and provides:
 - **Scanner table** — every scanner in the registry with its current status, vendor link, and configure button.
 - **Scan All Servers** — batch scan trigger with live progress.
 - **Scan report viewer** at `/security/scans/{jobId}` — risk-score badge, finding detail cards with rule/location/scanner, per-scanner execution logs including stderr from failed scanners, and scan context (source method + path + file count).
-- **Approve Server / Force Approve / Reject** — scanner-gated approval dialog that requires a completed scan (or explicit force) before calling the approval endpoint. See [QA report §F-04](../qa/security-scanners-2026-04-10.html) for the historical context.
+- **Approve Server / Force Approve / Reject** — scanner-gated approval dialog that requires a completed scan (or explicit force) before calling the approval endpoint.
 
 ## Known limitations
 
 - **Ramparts on arm64 macOS** — the upstream scanner image ships a binary linked against a newer GLIBC than the image base and fails every run on arm64. Track the [scanner-ramparts image rebuild](https://github.com/smart-mcp-proxy/mcpproxy-go/issues) for a fix. Other 6 of 7 scanners work out of the box on arm64 macOS.
 - **Cisco scanner output has a hardcoded `server_url`** header in its stdout (`https://mcp.deepwiki.com/mcp`). Cosmetic, does not affect findings.
 - **Pass 2 (supply-chain audit)** currently requires Docker isolation to be enabled, otherwise it fails source resolution. The UI doesn't yet surface this precondition.
-
-See the [QA report §9](../qa/security-scanners-2026-04-10.html) for the full list of residual items and recommendations.
 
 ## Related reading
 

--- a/frontend/src/components/ServerCard.vue
+++ b/frontend/src/components/ServerCard.vue
@@ -113,7 +113,7 @@
         <!-- Primary action button based on health.action -->
         <button
           v-if="healthAction === 'approve'"
-          @click="unquarantine"
+          @click="handleApproveClick"
           :disabled="loading"
           class="btn btn-sm btn-warning"
         >
@@ -232,6 +232,51 @@
       </div>
     </div>
 
+    <!-- Approve Confirmation Modal (F-04: security scanner gated) -->
+    <div v-if="showApproveConfirmation" class="modal modal-open">
+      <div class="modal-box">
+        <h3 class="font-bold text-lg mb-4">
+          {{ approveDialogMode === 'no_scan' ? 'No Security Scan Run' : 'Critical Findings Detected' }}
+        </h3>
+        <p v-if="approveDialogMode === 'critical'" class="mb-4">
+          <strong>{{ server.name }}</strong> has
+          <span class="text-error font-semibold">{{ criticalFindingCount }} critical finding{{ criticalFindingCount === 1 ? '' : 's' }}</span>
+          in its most recent security scan. Approving this server will allow it to run despite these warnings.
+        </p>
+        <p v-else class="mb-4">
+          No security scan has been run for <strong>{{ server.name }}</strong>. We strongly recommend running a scan first.
+        </p>
+        <p class="text-sm text-base-content/70 mb-6">
+          The security scanner is an experimental heuristic. Force-approving a server bypasses the scanner gate and is irreversible from this dialog.
+        </p>
+        <div class="modal-action">
+          <button
+            @click="showApproveConfirmation = false"
+            :disabled="loading"
+            class="btn btn-outline"
+          >
+            Cancel
+          </button>
+          <router-link
+            v-if="approveDialogMode === 'no_scan'"
+            :to="`/servers/${server.name}?tab=security`"
+            class="btn btn-primary"
+            @click="showApproveConfirmation = false"
+          >
+            Scan First
+          </router-link>
+          <button
+            @click="confirmForceApprove"
+            :disabled="loading"
+            class="btn btn-error"
+          >
+            <span v-if="loading" class="loading loading-spinner loading-xs"></span>
+            Force Approve
+          </button>
+        </div>
+      </div>
+    </div>
+
     <!-- Delete Confirmation Modal -->
     <div v-if="showDeleteConfirmation" class="modal modal-open">
       <div class="modal-box">
@@ -282,6 +327,8 @@ const systemStore = useSystemStore()
 const { hasEnabledScanners } = useSecurityScannerStatus()
 const loading = ref(false)
 const showDeleteConfirmation = ref(false)
+const showApproveConfirmation = ref(false)
+const approveDialogMode = ref<'no_scan' | 'critical'>('no_scan')
 
 const isHttpProtocol = computed(() => {
   return props.server.protocol === 'http' || props.server.protocol === 'streamable-http'
@@ -585,24 +632,65 @@ async function triggerLogout() {
   }
 }
 
-async function unquarantine() {
+// Counts critical findings from the scan summary if available. Used to gate
+// the Approve button behind an extra confirmation (F-04).
+const criticalFindingCount = computed(() => {
+  const scan = props.server.security_scan as any
+  if (!scan) return 0
+  // finding_counts.critical is populated from the latest report summary.
+  const fc = scan.finding_counts as Record<string, number> | undefined
+  if (fc && typeof fc.critical === 'number') return fc.critical
+  return 0
+})
+
+// True when a scan has actually been run (has a last_scan_at timestamp).
+const hasCompletedScan = computed(() => {
+  const scan = props.server.security_scan
+  if (!scan) return false
+  return !!scan.last_scan_at
+})
+
+// Primary approve click handler. Chooses the right flow based on scan state:
+//   1. No scan run yet → open "Scan first / Force approve" dialog
+//   2. Scan run with critical findings → open "Force approve?" dialog
+//   3. Clean scan → call securityApproveServer directly
+function handleApproveClick() {
+  if (!hasCompletedScan.value) {
+    approveDialogMode.value = 'no_scan'
+    showApproveConfirmation.value = true
+    return
+  }
+  if (criticalFindingCount.value > 0) {
+    approveDialogMode.value = 'critical'
+    showApproveConfirmation.value = true
+    return
+  }
+  void doSecurityApprove(false)
+}
+
+async function doSecurityApprove(force: boolean) {
   loading.value = true
   try {
-    await serversStore.unquarantineServer(props.server.name)
+    await serversStore.securityApproveServer(props.server.name, force)
     systemStore.addToast({
       type: 'success',
-      title: 'Server Unquarantined',
-      message: `${props.server.name} has been removed from quarantine`,
+      title: 'Server Approved',
+      message: `${props.server.name} has been approved and unquarantined`,
     })
+    showApproveConfirmation.value = false
   } catch (error) {
     systemStore.addToast({
       type: 'error',
-      title: 'Unquarantine Failed',
+      title: 'Approve Failed',
       message: error instanceof Error ? error.message : 'Unknown error',
     })
   } finally {
     loading.value = false
   }
+}
+
+function confirmForceApprove() {
+  void doSecurityApprove(true)
 }
 
 async function confirmDelete() {

--- a/frontend/src/composables/useSecurityScannerStatus.ts
+++ b/frontend/src/composables/useSecurityScannerStatus.ts
@@ -13,6 +13,8 @@ import api from '@/services/api'
 const enabledCount = ref<number | null>(null)
 const dockerAvailable = ref<boolean>(true)
 const loaded = ref(false)
+const totalFindings = ref<number>(0)
+const totalScans = ref<number>(0)
 let inflight: Promise<void> | null = null
 
 export async function refreshSecurityScannerStatus(): Promise<void> {
@@ -28,6 +30,12 @@ export async function refreshSecurityScannerStatus(): Promise<void> {
       const enabled = data.scanners_enabled ?? data.scanners_installed ?? 0
       enabledCount.value = typeof enabled === 'number' ? enabled : 0
       dockerAvailable.value = data.docker_available !== false
+      // Aggregated finding count from the /security/overview endpoint used by
+      // the Dashboard security chip (F-12). The backend returns this under
+      // `findings_by_severity.total`.
+      const fbs = data.findings_by_severity ?? {}
+      totalFindings.value = typeof fbs.total === 'number' ? fbs.total : 0
+      totalScans.value = typeof data.total_scans === 'number' ? data.total_scans : 0
       loaded.value = true
     } catch {
       // On error, keep current values; the UI will fall back to dockerAvailable
@@ -48,8 +56,12 @@ export function useSecurityScannerStatus() {
     enabledCount,
     dockerAvailable,
     loaded,
+    totalFindings,
+    totalScans,
     /** True when at least one scanner is enabled and docker is available. */
     hasEnabledScanners: () => (enabledCount.value ?? 0) > 0,
+    /** True when at least one scan has completed (ever). */
+    hasAnyScans: () => totalScans.value > 0,
     refresh: refreshSecurityScannerStatus,
   }
 }

--- a/frontend/src/stores/servers.ts
+++ b/frontend/src/stores/servers.ts
@@ -277,6 +277,31 @@ export const useServersStore = defineStore('servers', () => {
     }
   }
 
+  // Security-aware approval path (Spec 039 / F-04). Goes through
+  // POST /api/v1/servers/{name}/security/approve which enforces the
+  // scanner gate before unquarantining the server. Use this — not
+  // unquarantineServer — for all user-facing "Approve" buttons.
+  async function securityApproveServer(serverName: string, force = false) {
+    try {
+      const response = await api.securityApprove(serverName, force)
+      if (response.success) {
+        // Optimistic update: the backend will also unquarantine the server
+        // on a successful approve, so reflect that in local state. SSE
+        // refresh will reconcile any remaining fields shortly after.
+        const server = servers.value.find(s => s.name === serverName)
+        if (server) {
+          server.quarantined = false
+        }
+        return true
+      } else {
+        throw new Error(response.error || 'Failed to approve server')
+      }
+    } catch (error) {
+      console.error('Failed to approve server via security scanner:', error)
+      throw error
+    }
+  }
+
   async function deleteServer(serverName: string) {
     try {
       const response = await api.deleteServer(serverName)
@@ -371,6 +396,7 @@ export const useServersStore = defineStore('servers', () => {
     triggerOAuthLogout,
     quarantineServer,
     unquarantineServer,
+    securityApproveServer,
     deleteServer,
     updateServerStatus,
     getServerByName,

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -300,13 +300,14 @@
             </svg>
             Browse Registry
           </router-link>
-          <div class="btn btn-ghost btn-sm w-full btn-disabled opacity-40 gap-1">
+          <router-link to="/security" class="btn btn-ghost btn-sm w-full gap-1">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
             </svg>
             Security Scan
-            <span class="badge badge-ghost badge-xs ml-1">soon</span>
-          </div>
+            <span v-if="securityScannerLoaded && securityTotalScans === 0" class="badge badge-ghost badge-xs ml-1">Run first scan</span>
+            <span v-else-if="securityTotalFindings > 0" class="badge badge-warning badge-xs ml-1">{{ securityTotalFindings }} issue{{ securityTotalFindings === 1 ? '' : 's' }}</span>
+          </router-link>
         </div>
       </div>
     </div>
@@ -385,6 +386,7 @@
 import { computed, ref, watch, onMounted, onUnmounted } from 'vue'
 import { useServersStore } from '@/stores/servers'
 import { useSystemStore } from '@/stores/system'
+import { useSecurityScannerStatus, refreshSecurityScannerStatus } from '@/composables/useSecurityScannerStatus'
 import api from '@/services/api'
 import logoSvg from '@/assets/logo.svg'
 import CollapsibleHintsPanel from '@/components/CollapsibleHintsPanel.vue'
@@ -457,6 +459,14 @@ const loadActivitySummary = async () => {
 // --- Security status ---
 const dockerStatus = ref<{available: boolean, version?: string} | null>(null)
 const quarantineEnabled = ref(false)
+
+// Security scanner totals for the "Security Scan" dashboard chip (F-12).
+// We reuse the shared composable so we don't double-fetch /security/overview.
+const {
+  totalFindings: securityTotalFindings,
+  totalScans: securityTotalScans,
+  loaded: securityScannerLoaded,
+} = useSecurityScannerStatus()
 
 const loadSecurityStatus = async () => {
   try {
@@ -766,6 +776,8 @@ onMounted(() => {
   loadActivitySummary()
   loadSessions()
   loadSecurityStatus()
+  // Populate security scanner totals for the Security Scan chip (F-12).
+  void refreshSecurityScannerStatus()
   serversStore.fetchServers().then(() => loadPendingTools())
 
   // Auto-refresh every 30 seconds
@@ -775,6 +787,7 @@ onMounted(() => {
     loadActivitySummary()
     loadSessions()
     loadSecurityStatus()
+    void refreshSecurityScannerStatus()
     loadPendingTools()
   }, 30000)
 

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -211,19 +211,20 @@
 
         <!-- Security Status -->
         <div class="z-10 w-full max-w-[300px] space-y-2 mt-4">
-          <!-- Docker Isolation -->
-          <div class="flex items-center gap-2 text-xs px-3 py-2 rounded-lg"
-               :class="dockerStatus?.available ? 'bg-success/10 text-success' : 'bg-warning/10 text-warning'">
+          <!-- Docker Isolation (hidden until status has been fetched to avoid
+               flashing a false "disabled" state on initial page load) -->
+          <div v-if="dockerStatus" class="flex items-center gap-2 text-xs px-3 py-2 rounded-lg"
+               :class="dockerStatus.available ? 'bg-success/10 text-success' : 'bg-warning/10 text-warning'">
             <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                     d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
             </svg>
-            <span v-if="dockerStatus?.available" class="font-medium">Docker isolation active</span>
+            <span v-if="dockerStatus.available" class="font-medium">Docker isolation active</span>
             <span v-else class="font-medium">Docker isolation disabled — enable Docker to protect your system</span>
           </div>
 
-          <!-- Quarantine -->
-          <div class="flex items-center gap-2 text-xs px-3 py-2 rounded-lg"
+          <!-- Quarantine (hidden until config fetch completes) -->
+          <div v-if="quarantineEnabled !== null" class="flex items-center gap-2 text-xs px-3 py-2 rounded-lg"
                :class="quarantineEnabled ? 'bg-success/10 text-success' : 'bg-warning/10 text-warning'">
             <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -458,7 +459,10 @@ const loadActivitySummary = async () => {
 
 // --- Security status ---
 const dockerStatus = ref<{available: boolean, version?: string} | null>(null)
-const quarantineEnabled = ref(false)
+// quarantineEnabled is null until the config fetch completes so the template
+// can skip rendering the "Quarantine disabled" warning on initial load. A
+// plain `false` default would briefly display the warning before data arrives.
+const quarantineEnabled = ref<boolean | null>(null)
 
 // Security scanner totals for the "Security Scan" dashboard chip (F-12).
 // We reuse the shared composable so we don't double-fetch /security/overview.

--- a/frontend/src/views/ScanReport.vue
+++ b/frontend/src/views/ScanReport.vue
@@ -418,12 +418,33 @@
               </button>
               <button
                 v-if="serverAdminState === 'quarantined'"
-                @click="unquarantineServer"
-                :disabled="actionLoading"
+                @click="approveServer"
+                :disabled="actionLoading || hasUnresolvedCritical"
                 class="btn btn-success btn-sm"
+                :title="hasUnresolvedCritical ? 'Unresolved critical findings — use Force Approve' : 'Approve and unquarantine this server'"
               >
                 <span v-if="actionLoading" class="loading loading-spinner loading-xs"></span>
-                Unquarantine Server
+                Approve Server
+              </button>
+              <button
+                v-if="serverAdminState === 'quarantined' && hasUnresolvedCritical"
+                @click="forceApproveServer"
+                :disabled="actionLoading"
+                class="btn btn-error btn-sm"
+                title="Bypass the scanner gate and approve despite critical findings"
+              >
+                <span v-if="actionLoading" class="loading loading-spinner loading-xs"></span>
+                Force Approve
+              </button>
+              <button
+                v-if="serverAdminState === 'quarantined'"
+                @click="rejectServer"
+                :disabled="actionLoading"
+                class="btn btn-outline btn-warning btn-sm"
+                title="Reject the scan and keep the server quarantined"
+              >
+                <span v-if="actionLoading" class="loading loading-spinner loading-xs"></span>
+                Reject
               </button>
             </div>
           </div>
@@ -436,7 +457,12 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import api from '@/services/api'
+import { useServersStore } from '@/stores/servers'
+import { useSystemStore } from '@/stores/system'
 import type { SecurityScanFinding, ThreatType } from '@/types/api'
+
+const serversStore = useServersStore()
+const systemStore = useSystemStore()
 
 const props = defineProps<{
   jobId: string
@@ -619,13 +645,78 @@ async function quarantineServer() {
   }
 }
 
-async function unquarantineServer() {
+// F-04: Go through the security-aware approval path instead of the legacy
+// unquarantine endpoint. hasUnresolvedCritical disables the primary Approve
+// button so the user must use Force Approve explicitly.
+const hasUnresolvedCritical = computed(() => {
+  return (report.value?.summary?.critical ?? 0) > 0
+})
+
+async function approveServer() {
   if (!report.value?.server_name) return
-  if (!confirm(`Unquarantine ${report.value.server_name}? This will re-enable the server.`)) return
+  if (!confirm(`Approve ${report.value.server_name}? This will unquarantine and re-enable the server.`)) return
   actionLoading.value = true
   try {
-    await api.unquarantineServer(report.value.server_name)
+    await serversStore.securityApproveServer(report.value.server_name, false)
+    systemStore.addToast({
+      type: 'success',
+      title: 'Server Approved',
+      message: `${report.value.server_name} has been approved and unquarantined`,
+    })
     await loadServerStatus()
+  } catch (err) {
+    systemStore.addToast({
+      type: 'error',
+      title: 'Approve Failed',
+      message: err instanceof Error ? err.message : 'Unknown error',
+    })
+  } finally {
+    actionLoading.value = false
+  }
+}
+
+async function forceApproveServer() {
+  if (!report.value?.server_name) return
+  if (!confirm(`Force-approve ${report.value.server_name}? This bypasses the scanner gate despite ${report.value.summary?.critical ?? 0} critical finding(s).`)) return
+  actionLoading.value = true
+  try {
+    await serversStore.securityApproveServer(report.value.server_name, true)
+    systemStore.addToast({
+      type: 'success',
+      title: 'Server Force-Approved',
+      message: `${report.value.server_name} was force-approved despite critical findings`,
+    })
+    await loadServerStatus()
+  } catch (err) {
+    systemStore.addToast({
+      type: 'error',
+      title: 'Force Approve Failed',
+      message: err instanceof Error ? err.message : 'Unknown error',
+    })
+  } finally {
+    actionLoading.value = false
+  }
+}
+
+async function rejectServer() {
+  if (!report.value?.server_name) return
+  if (!confirm(`Reject the scan for ${report.value.server_name}? The server will remain quarantined.`)) return
+  actionLoading.value = true
+  try {
+    const res = await api.securityReject(report.value.server_name)
+    if (!res.success) throw new Error(res.error || 'Failed to reject scan')
+    systemStore.addToast({
+      type: 'success',
+      title: 'Scan Rejected',
+      message: `${report.value.server_name} remains quarantined`,
+    })
+    await loadServerStatus()
+  } catch (err) {
+    systemStore.addToast({
+      type: 'error',
+      title: 'Reject Failed',
+      message: err instanceof Error ? err.message : 'Unknown error',
+    })
   } finally {
     actionLoading.value = false
   }

--- a/frontend/src/views/Security.vue
+++ b/frontend/src/views/Security.vue
@@ -99,8 +99,8 @@
       </div>
     </div>
 
-    <!-- Docker unavailable warning -->
-    <div v-if="overview && !overview.docker_available" class="alert alert-warning">
+    <!-- Docker unavailable warning (only after overview has loaded) -->
+    <div v-if="overviewLoaded && overview.docker_available === false" class="alert alert-warning">
       <svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
       </svg>
@@ -127,7 +127,7 @@
       <div class="card bg-base-100 shadow-xl">
         <div class="card-body">
           <h2 class="card-title">Security Scanners</h2>
-          <p class="text-sm text-base-content/70 mb-4">Scanners are Docker-based plugins powered by third-party security tools. Enable or disable individual scanners and configure their API keys.</p>
+          <p class="text-sm text-base-content/70 mb-4">Each scanner is a third-party security tool that runs inside an isolated Docker container — sandboxed from your host, with no access to your filesystem or network beyond what the scan requires. Enable or disable individual scanners and configure their API keys below.</p>
 
           <div v-if="scanners.length === 0" class="text-center py-8 text-base-content/50">
             No scanners available. Check Docker connectivity.
@@ -257,9 +257,6 @@
                   <th class="cursor-pointer select-none" @click="toggleSort('findings_count')">
                     Findings {{ sortIndicator('findings_count') }}
                   </th>
-                  <th class="cursor-pointer select-none tooltip tooltip-bottom" data-tip="Experimental heuristic score. Not a definitive safety assessment." @click="toggleSort('risk_score')">
-                    Risk* {{ sortIndicator('risk_score') }}
-                  </th>
                   <th></th>
                 </tr>
               </thead>
@@ -284,10 +281,6 @@
                   </td>
                   <td>
                     <span :class="{ 'font-bold': (scan.findings_count || 0) > 0 }">{{ scan.findings_count || 0 }}</span>
-                  </td>
-                  <td>
-                    <span v-if="scan.risk_score != null" :class="riskScoreClass(scan.risk_score)">{{ scan.risk_score }}</span>
-                    <span v-else class="text-base-content/30">-</span>
                   </td>
                   <td>
                     <router-link
@@ -405,6 +398,11 @@ const loading = ref(false)
 const error = ref('')
 const scanners = ref<any[]>([])
 const overview = ref<any>({})
+// overviewLoaded stays false until the first successful /security/overview
+// response arrives. Template guards like the "Docker not running" banner use
+// this to avoid flashing a false warning while the initial request is still
+// in flight (overview.docker_available is undefined before the fetch lands).
+const overviewLoaded = ref(false)
 const installing = ref<string | null>(null)
 
 // Scan history state
@@ -494,12 +492,6 @@ function scannerNeedsApiKey(scanner: any): boolean {
   return scanner.required_env.some((env: any) => !configured[env.key])
 }
 
-function riskScoreClass(score: number) {
-  if (score >= 70) return 'text-error'
-  if (score >= 40) return 'text-warning'
-  return 'text-success'
-}
-
 async function refresh() {
   loading.value = true
   error.value = ''
@@ -516,7 +508,10 @@ async function refresh() {
       list.sort((a, b) => String(a.id).localeCompare(String(b.id)))
       scanners.value = list
     }
-    if (overviewRes.success) overview.value = overviewRes.data || {}
+    if (overviewRes.success) {
+      overview.value = overviewRes.data || {}
+      overviewLoaded.value = true
+    }
   } catch (e: any) {
     error.value = e.message
   } finally {

--- a/frontend/src/views/ServerDetail.vue
+++ b/frontend/src/views/ServerDetail.vue
@@ -636,18 +636,18 @@
             <!-- Scan Context Banner -->
             <div v-if="scanContext" class="mt-2">
               <!-- No Docker Isolation (local process) -->
-              <div v-if="!scanContext.docker_isolation && !isUrlSourceMethod && scanContext.source_method !== 'none' && scanContext.source_method !== 'tool_definitions_only'" class="alert alert-warning">
-                <svg class="w-6 h-6 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+              <div v-if="!scanContext.docker_isolation && !isUrlSourceMethod && scanContext.source_method !== 'none' && scanContext.source_method !== 'tool_definitions_only'" class="flex items-start gap-3 p-4 rounded-lg bg-base-200/60 border border-base-300">
+                <svg class="w-5 h-5 shrink-0 mt-0.5 text-base-content/60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
                 </svg>
-                <div>
-                  <h3 class="font-bold">No Docker Isolation</h3>
-                  <p class="text-sm">This server runs locally without Docker isolation.</p>
-                  <p class="text-sm">
+                <div class="min-w-0 flex-1">
+                  <h3 class="font-semibold text-sm">Local Process</h3>
+                  <p class="text-sm text-base-content/70">Running directly on the host, without Docker isolation.</p>
+                  <p class="text-sm text-base-content/70">
                     Source: <code class="bg-base-300 px-1 rounded text-xs">{{ scanContext.source_path }}</code>
                     <span v-if="scanContext.total_files"> ({{ scanContext.total_files }} files, {{ formatFileSize(scanContext.total_size_bytes) }})</span>
                   </p>
-                  <p class="text-sm text-base-content/70">
+                  <p class="text-sm text-base-content/60">
                     Protocol: {{ scanContext.server_protocol }}
                     <span v-if="scanContext.server_command"> &bull; Command: {{ scanContext.server_command }}</span>
                   </p>
@@ -655,20 +655,20 @@
               </div>
 
               <!-- Docker Isolated -->
-              <div v-else-if="scanContext.docker_isolation" class="alert alert-info">
-                <svg class="w-6 h-6 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <div v-else-if="scanContext.docker_isolation" class="flex items-start gap-3 p-4 rounded-lg bg-base-200/60 border border-base-300">
+                <svg class="w-5 h-5 shrink-0 mt-0.5 text-base-content/60" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2" />
                 </svg>
-                <div>
-                  <h3 class="font-bold">Docker Isolated</h3>
-                  <p class="text-sm">
+                <div class="min-w-0 flex-1">
+                  <h3 class="font-semibold text-sm">Docker Isolated</h3>
+                  <p class="text-sm text-base-content/70">
                     Source extracted from container<span v-if="scanContext.container_id">: <code class="bg-base-300 px-1 rounded text-xs">{{ scanContext.container_id.substring(0, 12) }}...</code></span>
                   </p>
-                  <p class="text-sm">
+                  <p class="text-sm text-base-content/70">
                     Source: <code class="bg-base-300 px-1 rounded text-xs">{{ scanContext.source_path }}</code>
                     <span v-if="scanContext.total_files"> ({{ scanContext.total_files }} files, {{ formatFileSize(scanContext.total_size_bytes) }})</span>
                   </p>
-                  <p class="text-sm text-base-content/70">
+                  <p class="text-sm text-base-content/60">
                     Protocol: {{ scanContext.server_protocol }}
                     <span v-if="scanContext.server_command"> &bull; Command: {{ scanContext.server_command }}</span>
                   </p>
@@ -676,17 +676,17 @@
               </div>
 
               <!-- HTTP Server (url, url_full, or tool_definitions_only for http protocol) -->
-              <div v-else-if="isUrlSourceMethod || scanContext.source_method === 'tool_definitions_only'" class="alert alert-info">
-                <svg class="w-6 h-6 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <div v-else-if="isUrlSourceMethod || scanContext.source_method === 'tool_definitions_only'" class="flex items-start gap-3 p-4 rounded-lg bg-base-200/60 border border-base-300">
+                <svg class="w-5 h-5 shrink-0 mt-0.5 text-base-content/60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" />
                 </svg>
-                <div>
-                  <h3 class="font-bold">{{ isUrlSourceMethod ? 'HTTP Server' : 'Tool Definitions Only' }}</h3>
-                  <p class="text-sm">{{ isUrlSourceMethod ? 'Tool description scanning only (no filesystem to scan)' : 'Scanning tool descriptions for poisoning and injection attacks' }}</p>
-                  <p v-if="isUrlSourceMethod && scanContext.source_path" class="text-sm">
+                <div class="min-w-0 flex-1">
+                  <h3 class="font-semibold text-sm">{{ isUrlSourceMethod ? 'HTTP Server' : 'Tool Definitions Only' }}</h3>
+                  <p class="text-sm text-base-content/70">{{ isUrlSourceMethod ? 'Tool description scanning only (no filesystem to scan)' : 'Scanning tool descriptions for poisoning and injection attacks' }}</p>
+                  <p v-if="isUrlSourceMethod && scanContext.source_path" class="text-sm text-base-content/70">
                     URL: <code class="bg-base-300 px-1 rounded text-xs">{{ scanContext.source_path }}</code>
                   </p>
-                  <p v-if="scanContext.tools_exported" class="text-sm text-base-content/70">
+                  <p v-if="scanContext.tools_exported" class="text-sm text-base-content/60">
                     {{ scanContext.tools_exported }} tool definitions exported for analysis
                   </p>
                 </div>

--- a/frontend/src/views/ServerDetail.vue
+++ b/frontend/src/views/ServerDetail.vue
@@ -93,9 +93,9 @@
                 </button>
               </li>
               <li>
-                <button @click="server.quarantined ? unquarantineServer() : quarantineServer()" :disabled="actionLoading">
+                <button @click="server.quarantined ? handleApproveClick() : quarantineServer()" :disabled="actionLoading">
                   <span v-if="actionLoading" class="loading loading-spinner loading-xs"></span>
-                  {{ server.quarantined ? 'Unquarantine' : 'Quarantine' }}
+                  {{ server.quarantined ? 'Approve' : 'Quarantine' }}
                 </button>
               </li>
               <li>
@@ -186,10 +186,55 @@
             <h3 class="font-bold">Security Quarantine</h3>
             <div class="text-sm">This server is quarantined and requires manual approval before tools can be executed.</div>
           </div>
-          <button @click="unquarantineServer" :disabled="actionLoading" class="btn btn-sm btn-warning">
+          <button @click="handleApproveClick" :disabled="actionLoading" class="btn btn-sm btn-warning">
             <span v-if="actionLoading" class="loading loading-spinner loading-xs"></span>
-            Unquarantine
+            Approve
           </button>
+        </div>
+      </div>
+
+      <!-- Approve Confirmation Modal (F-04: security scanner gated) -->
+      <div v-if="showApproveConfirmation" class="modal modal-open">
+        <div class="modal-box">
+          <h3 class="font-bold text-lg mb-4">
+            {{ approveDialogMode === 'no_scan' ? 'No Security Scan Run' : 'Critical Findings Detected' }}
+          </h3>
+          <p v-if="approveDialogMode === 'critical'" class="mb-4">
+            <strong>{{ server.name }}</strong> has
+            <span class="text-error font-semibold">{{ criticalFindingCount }} critical finding{{ criticalFindingCount === 1 ? '' : 's' }}</span>
+            in its most recent security scan. Approving will allow this server to run despite these warnings.
+          </p>
+          <p v-else class="mb-4">
+            No security scan has been run for <strong>{{ server.name }}</strong>. We strongly recommend running a scan first.
+          </p>
+          <p class="text-sm text-base-content/70 mb-6">
+            The security scanner is an experimental heuristic. Force-approving bypasses the scanner gate.
+          </p>
+          <div class="modal-action">
+            <button
+              @click="showApproveConfirmation = false"
+              :disabled="actionLoading"
+              class="btn btn-outline"
+            >
+              Cancel
+            </button>
+            <button
+              v-if="approveDialogMode === 'no_scan'"
+              @click="scanFirstFromDialog"
+              :disabled="actionLoading"
+              class="btn btn-primary"
+            >
+              Scan First
+            </button>
+            <button
+              @click="confirmForceApprove"
+              :disabled="actionLoading"
+              class="btn btn-error"
+            >
+              <span v-if="actionLoading" class="loading loading-spinner loading-xs"></span>
+              Force Approve
+            </button>
+          </div>
         </div>
       </div>
 
@@ -1256,6 +1301,79 @@ async function unquarantineServer() {
   } finally {
     actionLoading.value = false
   }
+}
+
+// --- Security-aware approval flow (F-04) ---
+// Approve buttons go through POST /security/approve which enforces the
+// scanner gate before unquarantining the server. Force is only used after
+// the user explicitly confirms in the dialog.
+const showApproveConfirmation = ref(false)
+const approveDialogMode = ref<'no_scan' | 'critical'>('no_scan')
+
+const criticalFindingCount = computed(() => {
+  // Prefer the loaded scan report summary if available; otherwise fall back
+  // to finding_counts on the server's security_scan summary (if populated).
+  const rep = scanReport.value as any
+  if (rep?.summary?.critical != null) return rep.summary.critical as number
+  const scan = server.value?.security_scan as any
+  if (scan?.finding_counts?.critical != null) return scan.finding_counts.critical as number
+  return 0
+})
+
+const hasCompletedScanForApprove = computed(() => {
+  if (scanReport.value) return true
+  return !!server.value?.security_scan?.last_scan_at
+})
+
+function handleApproveClick() {
+  if (!server.value) return
+  if (!hasCompletedScanForApprove.value) {
+    approveDialogMode.value = 'no_scan'
+    showApproveConfirmation.value = true
+    return
+  }
+  if (criticalFindingCount.value > 0) {
+    approveDialogMode.value = 'critical'
+    showApproveConfirmation.value = true
+    return
+  }
+  void doSecurityApprove(false)
+}
+
+async function doSecurityApprove(force: boolean) {
+  if (!server.value) return
+  actionLoading.value = true
+  try {
+    await serversStore.securityApproveServer(server.value.name, force)
+    systemStore.addToast({
+      type: 'success',
+      title: 'Server Approved',
+      message: `${server.value.name} has been approved and unquarantined`,
+    })
+    showApproveConfirmation.value = false
+    await serversStore.fetchServers()
+    server.value = serversStore.servers.find(s => s.name === props.serverName) || null
+  } catch (error) {
+    systemStore.addToast({
+      type: 'error',
+      title: 'Approve Failed',
+      message: error instanceof Error ? error.message : 'Unknown error',
+    })
+  } finally {
+    actionLoading.value = false
+  }
+}
+
+function confirmForceApprove() {
+  void doSecurityApprove(true)
+}
+
+async function scanFirstFromDialog() {
+  showApproveConfirmation.value = false
+  activeTab.value = 'security'
+  // Kick off a scan; the Security tab will show progress. User can return to
+  // approve once the scan completes.
+  await startSecurityScan()
 }
 
 async function refreshData() {

--- a/frontend/tests/unit/servers-store.spec.ts
+++ b/frontend/tests/unit/servers-store.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useServersStore } from '@/stores/servers'
+import api from '@/services/api'
+
+vi.mock('@/services/api', () => ({
+  default: {
+    getServers: vi.fn(),
+    securityApprove: vi.fn(),
+    unquarantineServer: vi.fn(),
+  },
+}))
+
+describe('useServersStore — securityApproveServer (F-04)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('calls api.securityApprove with force=false by default', async () => {
+    ;(api.securityApprove as any).mockResolvedValueOnce({ success: true })
+    const store = useServersStore()
+    store.servers.push({
+      name: 'srv',
+      protocol: 'http',
+      enabled: true,
+      quarantined: true,
+      connected: false,
+      connecting: false,
+      tool_count: 0,
+    } as any)
+
+    const ok = await store.securityApproveServer('srv')
+
+    expect(ok).toBe(true)
+    expect(api.securityApprove).toHaveBeenCalledWith('srv', false)
+    // Optimistic update: server should be marked unquarantined
+    expect(store.servers[0].quarantined).toBe(false)
+  })
+
+  it('passes force=true through to api.securityApprove', async () => {
+    ;(api.securityApprove as any).mockResolvedValueOnce({ success: true })
+    const store = useServersStore()
+
+    await store.securityApproveServer('srv', true)
+
+    expect(api.securityApprove).toHaveBeenCalledWith('srv', true)
+  })
+
+  it('throws when the API reports failure', async () => {
+    ;(api.securityApprove as any).mockResolvedValueOnce({
+      success: false,
+      error: 'scan required',
+    })
+    const store = useServersStore()
+
+    await expect(store.securityApproveServer('srv')).rejects.toThrow('scan required')
+    // It should NOT have fallen back to unquarantineServer
+    expect(api.unquarantineServer).not.toHaveBeenCalled()
+  })
+})

--- a/internal/secret/keyring_provider.go
+++ b/internal/secret/keyring_provider.go
@@ -2,8 +2,12 @@ package secret
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
+	"runtime"
 	"strings"
+	"time"
 
 	"github.com/zalando/go-keyring"
 )
@@ -13,6 +17,38 @@ const (
 	ServiceName       = "mcpproxy"
 	SecretTypeKeyring = "keyring"
 	RegistryKey       = "_mcpproxy_secret_registry"
+
+	// keyringProbeKey is used for the read-only availability probe. A Get for
+	// a non-existent key returns ErrNotFound on all platforms without showing
+	// any UI prompts (unlike Set, which historically popped the "Keychain Not
+	// Found" modal on macOS when the default keychain was missing).
+	keyringProbeKey = "_mcpproxy_probe"
+
+	// keyringProbeTimeout is the hard deadline for the availability probe.
+	// If the underlying keychain hangs (e.g. waiting on a user prompt), we
+	// bail out and report unavailable rather than blocking the caller.
+	keyringProbeTimeout = 2 * time.Second
+
+	// keyringOpTimeout is the hard deadline for real keyring operations
+	// (Get/Set/Delete) invoked via the public KeyringProvider API. If the
+	// OS keychain backend is wedged (e.g. waiting on a modal prompt that
+	// nobody is going to click), we bail out with ErrKeyringTimeout rather
+	// than blocking the server process and timing out the HTTP client.
+	keyringOpTimeout = 3 * time.Second
+)
+
+// ErrKeyringTimeout is returned when a keyring operation exceeds
+// keyringOpTimeout. Callers SHOULD treat this identically to "keyring
+// unavailable" and fall back to an alternative secret store (in-memory,
+// config-file, etc.) rather than propagating the error.
+var ErrKeyringTimeout = errors.New("keyring operation timed out (backend unresponsive — likely waiting on a user prompt)")
+
+// Package-level function variables allow tests to inject a fake/hanging
+// keyring without reaching into the real OS keychain.
+var (
+	keyringGetFn = keyring.Get
+	keyringSetFn = keyring.Set
+	keyringDelFn = keyring.Delete
 )
 
 // KeyringProvider resolves secrets from OS keyring (Keychain, Secret Service, WinCred)
@@ -32,13 +68,41 @@ func (p *KeyringProvider) CanResolve(secretType string) bool {
 	return secretType == SecretTypeKeyring
 }
 
+// runWithTimeout runs fn in a goroutine and returns its result, or
+// ErrKeyringTimeout if the goroutine doesn't finish before keyringOpTimeout.
+// The goroutine is allowed to keep running in the background (it cannot be
+// cancelled because the underlying keyring package has no Context API), but
+// its result is discarded.
+func runWithTimeout(fn func() error) error {
+	ch := make(chan error, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				ch <- fmt.Errorf("keyring backend panicked: %v", r)
+			}
+		}()
+		ch <- fn()
+	}()
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(keyringOpTimeout):
+		return ErrKeyringTimeout
+	}
+}
+
 // Resolve retrieves the secret value from the OS keyring
 func (p *KeyringProvider) Resolve(_ context.Context, ref Ref) (string, error) {
 	if !p.CanResolve(ref.Type) {
 		return "", fmt.Errorf("keyring provider cannot resolve secret type: %s", ref.Type)
 	}
 
-	secret, err := keyring.Get(p.serviceName, ref.Name)
+	var secret string
+	err := runWithTimeout(func() error {
+		var gerr error
+		secret, gerr = keyringGetFn(p.serviceName, ref.Name)
+		return gerr
+	})
 	if err != nil {
 		return "", fmt.Errorf("failed to get secret %s from keyring: %w", ref.Name, err)
 	}
@@ -52,14 +116,15 @@ func (p *KeyringProvider) Store(_ context.Context, ref Ref, value string) error 
 		return fmt.Errorf("keyring provider cannot store secret type: %s", ref.Type)
 	}
 
-	err := keyring.Set(p.serviceName, ref.Name, value)
+	err := runWithTimeout(func() error {
+		return keyringSetFn(p.serviceName, ref.Name, value)
+	})
 	if err != nil {
 		return fmt.Errorf("failed to store secret %s in keyring: %w", ref.Name, err)
 	}
 
 	// Add to registry so it appears in list
-	err = p.addToRegistry(ref.Name)
-	if err != nil {
+	if err := p.addToRegistry(ref.Name); err != nil {
 		return fmt.Errorf("failed to update secret registry: %w", err)
 	}
 
@@ -72,7 +137,9 @@ func (p *KeyringProvider) Delete(_ context.Context, ref Ref) error {
 		return fmt.Errorf("keyring provider cannot delete secret type: %s", ref.Type)
 	}
 
-	err := keyring.Delete(p.serviceName, ref.Name)
+	err := runWithTimeout(func() error {
+		return keyringDelFn(p.serviceName, ref.Name)
+	})
 	if err != nil {
 		return fmt.Errorf("failed to delete secret %s from keyring: %w", ref.Name, err)
 	}
@@ -93,9 +160,13 @@ func (p *KeyringProvider) List(_ context.Context) ([]Ref, error) {
 	// registry entry that tracks all our secret names
 	registryKey := RegistryKey
 
-	registry, err := keyring.Get(p.serviceName, registryKey)
-	if err != nil {
-		// Registry doesn't exist yet - return empty list
+	var registry string
+	if err := runWithTimeout(func() error {
+		var gerr error
+		registry, gerr = keyringGetFn(p.serviceName, registryKey)
+		return gerr
+	}); err != nil {
+		// Registry doesn't exist yet or keyring hung - return empty list
 		return []Ref{}, nil
 	}
 
@@ -117,38 +188,104 @@ func (p *KeyringProvider) List(_ context.Context) ([]Ref, error) {
 	return refs, nil
 }
 
-// IsAvailable checks if the keyring is available on the current system
+// IsAvailable checks if the keyring is available on the current system.
+//
+// This is deliberately conservative and NEVER calls keyring.Set as a probe:
+// on macOS, Set triggers the "Keychain Not Found" system modal when the
+// user's default keychain is missing/locked/corrupted, whose default button
+// is the destructive "Reset To Defaults" action. That used to block the
+// server process on every scanner-configure call.
+//
+// Instead, we:
+//  1. Skip the probe entirely in obvious headless/CI environments.
+//  2. Do a single read-only Get for a non-existent key and treat
+//     ErrNotFound as "available, no secret yet". Any other error (including
+//     ErrUnsupportedPlatform and backend communication failures) is treated
+//     as "unavailable".
+//  3. Run the Get inside a goroutine with a 2s hard timeout so a hung
+//     keychain backend cannot stall the caller.
 func (p *KeyringProvider) IsAvailable() bool {
-	// Test if keyring is available by trying to access it
-	testKey := "_mcpproxy_test_availability"
-
-	// Try to set and get a test value
-	err := keyring.Set(p.serviceName, testKey, "test")
-	if err != nil {
+	// Heuristic fast-path: if we're clearly running headless (CI, no
+	// X display on Linux, etc.) don't even try the keychain — it will
+	// either fail or prompt.
+	if isHeadlessEnvironment() {
 		return false
 	}
 
-	_, err = keyring.Get(p.serviceName, testKey)
-	if err != nil {
+	type result struct {
+		ok bool
+	}
+	ch := make(chan result, 1)
+
+	// Capture the current Get implementation locally. This prevents a race
+	// with tests that swap keyringGetFn back after the timeout elapses — the
+	// goroutine holds its own reference and can keep running harmlessly.
+	getFn := keyringGetFn
+	serviceName := p.serviceName
+
+	go func() {
+		// A read-only Get for a nonexistent key is the safest probe we
+		// can perform: on macOS it returns errSecItemNotFound without
+		// prompting, on Linux it returns ErrNotFound from Secret Service,
+		// and on Windows it returns ErrNotFound from wincred.
+		_, err := getFn(serviceName, keyringProbeKey)
+		switch {
+		case err == nil:
+			// Extremely unlikely (we never store this key), but it's fine.
+			ch <- result{ok: true}
+		case errors.Is(err, keyring.ErrNotFound):
+			ch <- result{ok: true}
+		default:
+			ch <- result{ok: false}
+		}
+	}()
+
+	select {
+	case r := <-ch:
+		return r.ok
+	case <-time.After(keyringProbeTimeout):
+		// The keychain is wedged. Bail out — the caller should fall back
+		// to in-memory / config-only secret storage.
 		return false
 	}
+}
 
-	// Clean up test key
-	_ = keyring.Delete(p.serviceName, testKey)
-
-	return true
+// isHeadlessEnvironment returns true when we can confidently say no
+// interactive keyring is available. We only use this as a FAST path to
+// skip probing; returning false does not mean the keyring IS available.
+func isHeadlessEnvironment() bool {
+	// CI environments universally set CI=true
+	if v := strings.ToLower(os.Getenv("CI")); v == "true" || v == "1" || v == "yes" {
+		return true
+	}
+	switch runtime.GOOS {
+	case "linux":
+		// No X display AND no Wayland → no Secret Service prompt UI
+		if os.Getenv("DISPLAY") == "" && os.Getenv("WAYLAND_DISPLAY") == "" {
+			return true
+		}
+	case "darwin":
+		// Running under sudo — the keychain being probed is likely root's
+		// default keychain, which doesn't exist and will pop the modal.
+		if os.Getenv("SUDO_USER") != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // addToRegistry adds a secret name to our internal registry
 func (p *KeyringProvider) addToRegistry(secretName string) error {
 	registryKey := RegistryKey
 
-	// Get current registry
-	registry, err := keyring.Get(p.serviceName, registryKey)
-	if err != nil {
-		// Registry doesn't exist - create it
-		registry = ""
-	}
+	// Get current registry (under timeout — if this hangs we degrade gracefully)
+	var registry string
+	_ = runWithTimeout(func() error {
+		var gerr error
+		registry, gerr = keyringGetFn(p.serviceName, registryKey)
+		return gerr
+	})
+	// If Get returned an error (including timeout), start with an empty registry.
 
 	// Check if secret is already in registry
 	names := strings.Split(registry, "\n")
@@ -164,17 +301,23 @@ func (p *KeyringProvider) addToRegistry(secretName string) error {
 	}
 	registry += secretName
 
-	return keyring.Set(p.serviceName, registryKey, registry)
+	return runWithTimeout(func() error {
+		return keyringSetFn(p.serviceName, registryKey, registry)
+	})
 }
 
 // removeFromRegistry removes a secret name from our internal registry
 func (p *KeyringProvider) removeFromRegistry(secretName string) error {
 	registryKey := RegistryKey
 
-	// Get current registry
-	registry, err := keyring.Get(p.serviceName, registryKey)
-	if err != nil {
-		return nil // Registry doesn't exist - nothing to remove
+	var registry string
+	getErr := runWithTimeout(func() error {
+		var gerr error
+		registry, gerr = keyringGetFn(p.serviceName, registryKey)
+		return gerr
+	})
+	if getErr != nil {
+		return nil // Registry doesn't exist or keyring hung - nothing to remove
 	}
 
 	// Remove from registry
@@ -188,7 +331,9 @@ func (p *KeyringProvider) removeFromRegistry(secretName string) error {
 	}
 
 	newRegistry := strings.Join(newNames, "\n")
-	return keyring.Set(p.serviceName, registryKey, newRegistry)
+	return runWithTimeout(func() error {
+		return keyringSetFn(p.serviceName, registryKey, newRegistry)
+	})
 }
 
 // StoreWithRegistry stores a secret and updates the registry

--- a/internal/secret/keyring_provider.go
+++ b/internal/secret/keyring_provider.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/zalando/go-keyring"
@@ -43,6 +44,14 @@ const (
 // config-file, etc.) rather than propagating the error.
 var ErrKeyringTimeout = errors.New("keyring operation timed out (backend unresponsive — likely waiting on a user prompt)")
 
+// ErrKeyringUnavailable is returned by write operations (Store/Delete) when
+// a previous IsAvailable() call determined the keyring backend is not
+// usable on this system. We refuse to call keyring.Set in that state
+// because on macOS it pops a system modal ("Keychain Not Found") whose
+// default action is destructive. Callers MUST fall back to an alternative
+// secret store.
+var ErrKeyringUnavailable = errors.New("keyring unavailable (backend not usable on this system — refusing to write to avoid OS modal prompts)")
+
 // Package-level function variables allow tests to inject a fake/hanging
 // keyring without reaching into the real OS keychain.
 var (
@@ -51,9 +60,28 @@ var (
 	keyringDelFn = keyring.Delete
 )
 
+// availabilityState captures the cached result of an IsAvailable() probe.
+// Values: 0 = unknown (probe not yet run), 1 = available, 2 = unavailable.
+const (
+	availUnknown int32 = 0
+	availYes     int32 = 1
+	availNo      int32 = 2
+)
+
 // KeyringProvider resolves secrets from OS keyring (Keychain, Secret Service, WinCred)
 type KeyringProvider struct {
 	serviceName string
+
+	// availability is the cached result of the most recent IsAvailable()
+	// probe. Read/written atomically. When availNo, all write operations
+	// short-circuit to ErrKeyringUnavailable so we NEVER call keyring.Set
+	// on a broken/unusable keychain — which is what pops the macOS modal.
+	availability int32
+
+	// writeOverride allows tests (and future programmatic opt-in) to force
+	// the macOS write gate without going through env vars. 0 = respect
+	// env, 1 = force enabled, 2 = force disabled. Read/written atomically.
+	writeOverride int32
 }
 
 // NewKeyringProvider creates a new keyring provider
@@ -61,6 +89,27 @@ func NewKeyringProvider() *KeyringProvider {
 	return &KeyringProvider{
 		serviceName: ServiceName,
 	}
+}
+
+// markUnavailable records that the keyring is not usable. After this call,
+// all Store/Delete operations will return ErrKeyringUnavailable without
+// touching the OS keyring backend.
+func (p *KeyringProvider) markUnavailable() {
+	atomic.StoreInt32(&p.availability, availNo)
+}
+
+// markAvailable records that the keyring has been successfully probed and
+// is safe to write to.
+func (p *KeyringProvider) markAvailable() {
+	atomic.StoreInt32(&p.availability, availYes)
+}
+
+// isKnownUnavailable returns true if a previous probe determined the
+// keyring is not usable. Returns false for both "known available" AND
+// "not yet probed" so callers can optimistically attempt a first-time
+// write before the cache is populated.
+func (p *KeyringProvider) isKnownUnavailable() bool {
+	return atomic.LoadInt32(&p.availability) == availNo
 }
 
 // CanResolve returns true if this provider can handle the given secret type
@@ -110,16 +159,68 @@ func (p *KeyringProvider) Resolve(_ context.Context, ref Ref) (string, error) {
 	return secret, nil
 }
 
-// Store saves a secret to the OS keyring and updates the registry
+// Store saves a secret to the OS keyring and updates the registry.
+//
+// By default on macOS this method does NOT actually call keyring.Set —
+// it returns ErrKeyringUnavailable immediately. Rationale: on macOS
+// keyring.Set wraps Security.framework under the hood; if the user's
+// default keychain is missing/locked/in an unusual state, Security.framework
+// pops a system modal ("Keychain Not Found" with a destructive default
+// button). The underlying call is blocking and the goroutine we'd wrap it
+// in cannot be cancelled once started — it keeps running until Security.
+// framework finally responds, which may involve the user clicking buttons.
+// No wrapper / timeout / probe can prevent the modal from appearing, so
+// the only safe option is to not call keyring.Set at all.
+//
+// Users who want keyring-backed storage on macOS can opt in by setting the
+// environment variable MCPPROXY_KEYRING_WRITE=1 or calling
+// EnableKeyringWrites(true) on the provider. When opted in, Store runs a
+// three-layer guard (known-unavailable cache, first-time probe, failure
+// cache) plus a 3s runWithTimeout wrapper — but note that the wrapper only
+// protects the CALLING goroutine from blocking; it cannot prevent the
+// modal from appearing on the user's screen once keyring.Set is called.
+//
+// On non-macOS platforms (Linux Secret Service, Windows Credential
+// Manager), Store goes through the three-layer guard without requiring
+// the opt-in, because those backends don't have the same modal issue.
+//
+// Callers MUST treat ErrKeyringUnavailable as "fall back to in-config /
+// in-memory storage" and surface a clear log message.
 func (p *KeyringProvider) Store(_ context.Context, ref Ref, value string) error {
 	if !p.CanResolve(ref.Type) {
 		return fmt.Errorf("keyring provider cannot store secret type: %s", ref.Type)
+	}
+
+	// macOS-specific hard gate: do not call keyring.Set unless the caller
+	// has explicitly opted in. The opt-in can be global via the
+	// MCPPROXY_KEYRING_WRITE env var (value "1", "true", or "yes"), or
+	// per-provider via SetWritesEnabled(true).
+	if runtime.GOOS == "darwin" && !p.writesEnabled() {
+		p.markUnavailable()
+		return ErrKeyringUnavailable
+	}
+
+	// Layer 1: if we already know the keyring is broken, bail out without
+	// touching it.
+	if p.isKnownUnavailable() {
+		return ErrKeyringUnavailable
+	}
+
+	// Layer 2: if we haven't probed yet, do it now — BEFORE calling Set.
+	// IsAvailable uses a read-only Get probe which is safe on all platforms.
+	if atomic.LoadInt32(&p.availability) == availUnknown {
+		if !p.IsAvailable() {
+			return ErrKeyringUnavailable
+		}
 	}
 
 	err := runWithTimeout(func() error {
 		return keyringSetFn(p.serviceName, ref.Name, value)
 	})
 	if err != nil {
+		// Layer 3: cache the failure so subsequent writes don't retry and
+		// risk popping another modal.
+		p.markUnavailable()
 		return fmt.Errorf("failed to store secret %s in keyring: %w", ref.Name, err)
 	}
 
@@ -131,16 +232,56 @@ func (p *KeyringProvider) Store(_ context.Context, ref Ref, value string) error 
 	return nil
 }
 
-// Delete removes a secret from the OS keyring and updates the registry
+// writesEnabled reports whether this provider is allowed to call
+// keyring.Set on the current platform. On non-macOS systems writes are
+// always enabled. On macOS writes require an explicit opt-in via the
+// MCPPROXY_KEYRING_WRITE env var or a test-only override.
+func (p *KeyringProvider) writesEnabled() bool {
+	if runtime.GOOS != "darwin" {
+		return true
+	}
+	if p.writeOverride != 0 {
+		return p.writeOverride == 1
+	}
+	v := strings.ToLower(os.Getenv("MCPPROXY_KEYRING_WRITE"))
+	return v == "1" || v == "true" || v == "yes"
+}
+
+// SetWritesEnabled is a test-only helper that forces the opt-in state
+// regardless of env vars. Pass true to allow keyring.Set, false to
+// disallow. It is safe to call at any time — Store checks the override
+// synchronously.
+func (p *KeyringProvider) SetWritesEnabled(enabled bool) {
+	if enabled {
+		atomic.StoreInt32(&p.writeOverride, 1)
+	} else {
+		atomic.StoreInt32(&p.writeOverride, 2)
+	}
+}
+
+// Delete removes a secret from the OS keyring and updates the registry.
+// Same three-layer guard as Store: known-unavailable short-circuit,
+// first-time probe, and failure cache.
 func (p *KeyringProvider) Delete(_ context.Context, ref Ref) error {
 	if !p.CanResolve(ref.Type) {
 		return fmt.Errorf("keyring provider cannot delete secret type: %s", ref.Type)
+	}
+
+	if p.isKnownUnavailable() {
+		return ErrKeyringUnavailable
+	}
+
+	if atomic.LoadInt32(&p.availability) == availUnknown {
+		if !p.IsAvailable() {
+			return ErrKeyringUnavailable
+		}
 	}
 
 	err := runWithTimeout(func() error {
 		return keyringDelFn(p.serviceName, ref.Name)
 	})
 	if err != nil {
+		p.markUnavailable()
 		return fmt.Errorf("failed to delete secret %s from keyring: %w", ref.Name, err)
 	}
 
@@ -188,13 +329,16 @@ func (p *KeyringProvider) List(_ context.Context) ([]Ref, error) {
 	return refs, nil
 }
 
-// IsAvailable checks if the keyring is available on the current system.
+// IsAvailable checks if the keyring is available on the current system,
+// and caches the result. Subsequent calls to Store/Delete will short-circuit
+// to ErrKeyringUnavailable WITHOUT calling keyring.Set if the probe decided
+// the keyring is not usable — this is the key property that prevents the
+// macOS "Keychain Not Found" modal from ever being shown to the user.
 //
 // This is deliberately conservative and NEVER calls keyring.Set as a probe:
 // on macOS, Set triggers the "Keychain Not Found" system modal when the
 // user's default keychain is missing/locked/corrupted, whose default button
-// is the destructive "Reset To Defaults" action. That used to block the
-// server process on every scanner-configure call.
+// is the destructive "Reset To Defaults" action.
 //
 // Instead, we:
 //  1. Skip the probe entirely in obvious headless/CI environments.
@@ -204,11 +348,14 @@ func (p *KeyringProvider) List(_ context.Context) ([]Ref, error) {
 //     as "unavailable".
 //  3. Run the Get inside a goroutine with a 2s hard timeout so a hung
 //     keychain backend cannot stall the caller.
+//  4. Cache the result via markAvailable/markUnavailable so Store/Delete
+//     can short-circuit on the fast path.
 func (p *KeyringProvider) IsAvailable() bool {
 	// Heuristic fast-path: if we're clearly running headless (CI, no
 	// X display on Linux, etc.) don't even try the keychain — it will
 	// either fail or prompt.
 	if isHeadlessEnvironment() {
+		p.markUnavailable()
 		return false
 	}
 
@@ -242,10 +389,16 @@ func (p *KeyringProvider) IsAvailable() bool {
 
 	select {
 	case r := <-ch:
+		if r.ok {
+			p.markAvailable()
+		} else {
+			p.markUnavailable()
+		}
 		return r.ok
 	case <-time.After(keyringProbeTimeout):
 		// The keychain is wedged. Bail out — the caller should fall back
 		// to in-memory / config-only secret storage.
+		p.markUnavailable()
 		return false
 	}
 }

--- a/internal/secret/keyring_provider_test.go
+++ b/internal/secret/keyring_provider_test.go
@@ -1,6 +1,7 @@
 package secret
 
 import (
+	"context"
 	"errors"
 	"os"
 	"runtime"
@@ -158,4 +159,211 @@ func contains(s, sub string) bool {
 		}
 	}
 	return false
+}
+
+// TestKeyringProvider_Store_MacOSDefaultRefuses pins the user-observed
+// F-03 follow-up bug:
+//
+//	"A keychain cannot be found to store scanner_mcp-scan_snyk_token."
+//
+// On macOS, by default, Store MUST return ErrKeyringUnavailable WITHOUT
+// ever calling keyring.Set — because Set is what triggers the system
+// modal, and the goroutine wrapping it cannot be cancelled once started.
+// The only safe behavior is to not call Set at all unless the user has
+// explicitly opted in via MCPPROXY_KEYRING_WRITE or SetWritesEnabled.
+func TestKeyringProvider_Store_MacOSDefaultRefuses(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("macOS-specific hard gate")
+	}
+	t.Setenv("MCPPROXY_KEYRING_WRITE", "") // no opt-in
+	clearHeadlessEnv(t)
+	setCalled := false
+	withKeyringMocks(t,
+		func(service, user string) (string, error) {
+			return "", keyring.ErrNotFound
+		},
+		func(service, user, password string) error {
+			setCalled = true
+			return nil
+		},
+		nil,
+	)
+	p := NewKeyringProvider()
+
+	err := p.Store(context.TODO(), Ref{
+		Type: SecretTypeKeyring,
+		Name: "scanner_mcp-scan_snyk_token",
+	}, "fake-snyk-token")
+
+	if !errors.Is(err, ErrKeyringUnavailable) {
+		t.Errorf("expected ErrKeyringUnavailable, got %v", err)
+	}
+	if setCalled {
+		t.Fatal("Store() MUST NOT call keyring.Set on macOS by default (F-03 follow-up — prevents 'Keychain Not Found' modal)")
+	}
+}
+
+// TestKeyringProvider_Store_MacOSOptIn verifies that users who explicitly
+// opt in via SetWritesEnabled(true) can still write to the keychain.
+// The three-layer guard still applies (known-unavailable short-circuit,
+// first-time probe, failure cache).
+func TestKeyringProvider_Store_MacOSOptIn(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("macOS-specific opt-in")
+	}
+	clearHeadlessEnv(t)
+	stored := make(map[string]string)
+	withKeyringMocks(t,
+		func(service, user string) (string, error) {
+			if v, ok := stored[user]; ok {
+				return v, nil
+			}
+			return "", keyring.ErrNotFound
+		},
+		func(service, user, password string) error {
+			stored[user] = password
+			return nil
+		},
+		nil,
+	)
+	p := NewKeyringProvider()
+	p.SetWritesEnabled(true)
+
+	if err := p.Store(context.TODO(), Ref{Type: SecretTypeKeyring, Name: "scanner_ok"}, "value"); err != nil {
+		t.Fatalf("opt-in Store should succeed: %v", err)
+	}
+	if stored["scanner_ok"] != "value" {
+		t.Errorf("expected value to be stored, got %q", stored["scanner_ok"])
+	}
+}
+
+// TestKeyringProvider_Store_ShortCircuitsWhenKnownUnavailable covers the
+// non-macOS case where IsAvailable has decided the keyring is broken.
+// On macOS it is covered by the hard gate test above.
+func TestKeyringProvider_Store_ShortCircuitsWhenKnownUnavailable(t *testing.T) {
+	clearHeadlessEnv(t)
+	setCalled := false
+	withKeyringMocks(t,
+		func(service, user string) (string, error) {
+			return "", errors.New("keychain broken")
+		},
+		func(service, user, password string) error {
+			setCalled = true
+			return nil
+		},
+		nil,
+	)
+	p := NewKeyringProvider()
+	p.SetWritesEnabled(true) // let the three-layer guard be the test subject
+
+	if p.IsAvailable() {
+		t.Fatal("precondition: IsAvailable() should return false")
+	}
+
+	err := p.Store(context.TODO(), Ref{
+		Type: SecretTypeKeyring,
+		Name: "scanner_mcp-scan_snyk_token",
+	}, "fake-snyk-token")
+
+	if !errors.Is(err, ErrKeyringUnavailable) {
+		t.Errorf("expected ErrKeyringUnavailable, got %v", err)
+	}
+	if setCalled {
+		t.Fatal("Store() must not call keyring.Set when keyring is known unavailable")
+	}
+}
+
+// TestKeyringProvider_Store_ProbesOnFirstCall — with writes enabled,
+// verify that the inline probe still catches a broken keychain before Set.
+func TestKeyringProvider_Store_ProbesOnFirstCall(t *testing.T) {
+	clearHeadlessEnv(t)
+	setCalled := false
+	withKeyringMocks(t,
+		func(service, user string) (string, error) {
+			return "", errors.New("keychain broken")
+		},
+		func(service, user, password string) error {
+			setCalled = true
+			return nil
+		},
+		nil,
+	)
+	p := NewKeyringProvider()
+	p.SetWritesEnabled(true)
+
+	err := p.Store(context.TODO(), Ref{
+		Type: SecretTypeKeyring,
+		Name: "scanner_mcp-scan_snyk_token",
+	}, "fake-snyk-token")
+
+	if !errors.Is(err, ErrKeyringUnavailable) {
+		t.Errorf("expected ErrKeyringUnavailable, got %v", err)
+	}
+	if setCalled {
+		t.Fatal("Store() must probe and short-circuit before calling keyring.Set")
+	}
+}
+
+// TestKeyringProvider_Store_CachesFailure — with writes enabled, verify
+// that a Set failure caches as unavailable so subsequent Store calls don't
+// retry and risk popping the modal again.
+func TestKeyringProvider_Store_CachesFailure(t *testing.T) {
+	clearHeadlessEnv(t)
+	setCalls := 0
+	withKeyringMocks(t,
+		func(service, user string) (string, error) {
+			return "", keyring.ErrNotFound
+		},
+		func(service, user, password string) error {
+			setCalls++
+			return errors.New("keychain locked")
+		},
+		nil,
+	)
+	p := NewKeyringProvider()
+	p.SetWritesEnabled(true)
+
+	_ = p.Store(context.TODO(), Ref{Type: SecretTypeKeyring, Name: "scanner_k1"}, "v1")
+	if setCalls != 1 {
+		t.Errorf("expected 1 Set call on first Store, got %d", setCalls)
+	}
+
+	err := p.Store(context.TODO(), Ref{Type: SecretTypeKeyring, Name: "scanner_k2"}, "v2")
+	if setCalls != 1 {
+		t.Errorf("expected Set to still be called only 1 time after failure cache, got %d", setCalls)
+	}
+	if !errors.Is(err, ErrKeyringUnavailable) {
+		t.Errorf("expected second Store to return ErrKeyringUnavailable, got %v", err)
+	}
+}
+
+// TestKeyringProvider_Store_AllowsValidWrites — happy path with writes
+// enabled on a healthy backend.
+func TestKeyringProvider_Store_AllowsValidWrites(t *testing.T) {
+	clearHeadlessEnv(t)
+	stored := make(map[string]string)
+	withKeyringMocks(t,
+		func(service, user string) (string, error) {
+			if v, ok := stored[user]; ok {
+				return v, nil
+			}
+			return "", keyring.ErrNotFound
+		},
+		func(service, user, password string) error {
+			stored[user] = password
+			return nil
+		},
+		nil,
+	)
+	p := NewKeyringProvider()
+	p.SetWritesEnabled(true)
+	if !p.IsAvailable() {
+		t.Fatal("precondition: IsAvailable() should pass on healthy backend")
+	}
+	if err := p.Store(context.TODO(), Ref{Type: SecretTypeKeyring, Name: "scanner_ok"}, "value"); err != nil {
+		t.Fatalf("Store() should succeed on healthy backend: %v", err)
+	}
+	if stored["scanner_ok"] != "value" {
+		t.Errorf("expected value to be stored, got %q", stored["scanner_ok"])
+	}
 }

--- a/internal/secret/keyring_provider_test.go
+++ b/internal/secret/keyring_provider_test.go
@@ -1,0 +1,161 @@
+package secret
+
+import (
+	"errors"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/zalando/go-keyring"
+)
+
+// withKeyringMocks swaps the package-level keyring function variables for
+// the duration of a test and restores them afterwards.
+func withKeyringMocks(t *testing.T, getFn func(service, user string) (string, error), setFn func(service, user, password string) error, delFn func(service, user string) error) {
+	t.Helper()
+	origGet, origSet, origDel := keyringGetFn, keyringSetFn, keyringDelFn
+	if getFn != nil {
+		keyringGetFn = getFn
+	}
+	if setFn != nil {
+		keyringSetFn = setFn
+	}
+	if delFn != nil {
+		keyringDelFn = delFn
+	}
+	t.Cleanup(func() {
+		keyringGetFn = origGet
+		keyringSetFn = origSet
+		keyringDelFn = origDel
+	})
+}
+
+// clearHeadlessEnv unsets environment variables that would make the provider
+// skip the probe entirely.
+func clearHeadlessEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("CI", "")
+	t.Setenv("SUDO_USER", "")
+	if runtime.GOOS == "linux" {
+		// Make sure the Linux fast-path doesn't fire: set DISPLAY so
+		// isHeadlessEnvironment() returns false.
+		t.Setenv("DISPLAY", ":0")
+	}
+}
+
+func TestKeyringProvider_IsAvailable_ErrNotFound(t *testing.T) {
+	clearHeadlessEnv(t)
+	withKeyringMocks(t,
+		func(service, user string) (string, error) {
+			return "", keyring.ErrNotFound
+		},
+		nil, nil,
+	)
+	p := NewKeyringProvider()
+	if !p.IsAvailable() {
+		t.Error("expected IsAvailable() to be true when Get returns ErrNotFound")
+	}
+}
+
+func TestKeyringProvider_IsAvailable_UnknownError(t *testing.T) {
+	clearHeadlessEnv(t)
+	withKeyringMocks(t,
+		func(service, user string) (string, error) {
+			return "", errors.New("backend is unreachable")
+		},
+		nil, nil,
+	)
+	p := NewKeyringProvider()
+	if p.IsAvailable() {
+		t.Error("expected IsAvailable() to be false on unknown errors")
+	}
+}
+
+// TestKeyringProvider_IsAvailable_DoesNotSet verifies the probe is read-only —
+// it must NEVER invoke keyring.Set, which is what triggered the macOS modal.
+func TestKeyringProvider_IsAvailable_DoesNotSet(t *testing.T) {
+	clearHeadlessEnv(t)
+	setCalled := false
+	withKeyringMocks(t,
+		func(service, user string) (string, error) {
+			return "", keyring.ErrNotFound
+		},
+		func(service, user, password string) error {
+			setCalled = true
+			return nil
+		},
+		nil,
+	)
+	p := NewKeyringProvider()
+	_ = p.IsAvailable()
+	if setCalled {
+		t.Fatal("IsAvailable() must not call keyring.Set (Bug F-03)")
+	}
+}
+
+// TestKeyringProvider_IsAvailable_HangingBackend verifies the 2-second
+// timeout is enforced when the keyring hangs (macOS Keychain wedged).
+func TestKeyringProvider_IsAvailable_HangingBackend(t *testing.T) {
+	clearHeadlessEnv(t)
+	withKeyringMocks(t,
+		func(service, user string) (string, error) {
+			time.Sleep(10 * time.Second) // way longer than timeout
+			return "", nil
+		},
+		nil, nil,
+	)
+	p := NewKeyringProvider()
+
+	start := time.Now()
+	ok := p.IsAvailable()
+	elapsed := time.Since(start)
+
+	if ok {
+		t.Error("expected IsAvailable() to be false on hang")
+	}
+	if elapsed > 3*time.Second {
+		t.Errorf("IsAvailable() took %v, expected to bail out within 2-3s", elapsed)
+	}
+}
+
+func TestKeyringProvider_IsAvailable_HeadlessEnv(t *testing.T) {
+	// CI env should short-circuit to unavailable without probing.
+	t.Setenv("CI", "true")
+	probed := false
+	withKeyringMocks(t,
+		func(service, user string) (string, error) {
+			probed = true
+			return "", keyring.ErrNotFound
+		},
+		nil, nil,
+	)
+	p := NewKeyringProvider()
+	if p.IsAvailable() {
+		t.Error("expected IsAvailable() to be false in CI env")
+	}
+	if probed {
+		t.Error("IsAvailable() should not probe in headless env")
+	}
+}
+
+// TestKeyringProvider_NoTestAvailabilityKey makes sure the removed probe key
+// does not leak into the source again.
+func TestKeyringProvider_NoTestAvailabilityKey(t *testing.T) {
+	data, err := os.ReadFile("keyring_provider.go")
+	if err != nil {
+		t.Fatalf("read keyring_provider.go: %v", err)
+	}
+	if contains(string(data), "_mcpproxy_test_availability") {
+		t.Error("_mcpproxy_test_availability key must not exist anymore (Bug F-03)")
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/security/scanner/service.go
+++ b/internal/security/scanner/service.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -401,14 +400,29 @@ func (s *Service) SetSecretStore(store SecretStore) {
 }
 
 // ConfigureScanner sets environment variables (API keys) and/or an image
-// override for a scanner. Secret values are stored in the OS keyring; only
-// references are kept in config.
+// override for a scanner.
+//
+// Scanner env values are stored DIRECTLY in the scanner's ConfiguredEnv
+// map in BBolt, NOT in the OS keyring. Previous versions attempted to write
+// to the OS keyring and fall back on failure, but that path is unsafe on
+// macOS: keyring.Set (which wraps Security.framework under the hood) can
+// pop a blocking "Keychain Not Found" system modal when the user's default
+// keychain is in an unusual state, and the underlying goroutine cannot be
+// cancelled once started (it stays live until it hits the real backend,
+// which may never happen). The scanner env values end up in the container's
+// /proc/environ at scan time anyway, so keyring storage adds no meaningful
+// confidentiality — it's a trust-boundary we don't actually have.
+//
+// Users who want OS-keyring storage for a specific secret can still use a
+// `${keyring:my-secret-name}` reference as the env value. The resolver
+// expands it at scan time via a read-only keyring Get, which is safe on
+// all platforms.
 //
 // If the effective Docker image changes (user set a new override) and the
 // new image is not already cached locally, the scanner is transitioned to
 // the "pulling" state and a background pull is kicked off. The call returns
 // immediately — the UI tracks the pull via SSE or polling.
-func (s *Service) ConfigureScanner(ctx context.Context, id string, env map[string]string, dockerImage string) error {
+func (s *Service) ConfigureScanner(_ context.Context, id string, env map[string]string, dockerImage string) error {
 	sc, err := s.storage.GetScanner(id)
 	if err != nil {
 		// If not in storage yet (just registered in registry), create from registry
@@ -423,20 +437,12 @@ func (s *Service) ConfigureScanner(ctx context.Context, id string, env map[strin
 		sc.ConfiguredEnv = make(map[string]string)
 	}
 
-	// Store secrets in keyring, keep references in config
+	// Store scanner env values directly in the scanner record. Do NOT call
+	// keyring.Set — see the doc comment above for the reason. Values that
+	// look like `${keyring:name}` references are passed through as-is; the
+	// resolver expands them via a read-only Get at scan time.
 	for k, v := range env {
-		if s.secretStore != nil && v != "" {
-			keyringName := fmt.Sprintf("scanner_%s_%s", id, strings.ToLower(k))
-			if err := s.secretStore.StoreSecret(ctx, keyringName, v); err != nil {
-				s.logger.Warn("Failed to store secret in keyring, storing as reference",
-					zap.String("key", k), zap.Error(err))
-				sc.ConfiguredEnv[k] = v // Fallback: store directly
-			} else {
-				sc.ConfiguredEnv[k] = fmt.Sprintf("${keyring:%s}", keyringName)
-			}
-		} else {
-			sc.ConfiguredEnv[k] = v
-		}
+		sc.ConfiguredEnv[k] = v
 	}
 
 	// Track whether the effective image changed so we know when to re-pull.

--- a/internal/security/scanner/service.go
+++ b/internal/security/scanner/service.go
@@ -77,6 +77,19 @@ type ServerInfoProvider interface {
 	IsConnected(serverName string) bool
 }
 
+// ServerUnquarantiner performs the full unquarantine workflow for a server.
+// Implementations are expected to:
+//   - Clear the quarantined flag in storage and persist config
+//   - Trigger a tool (re)index for the server
+//   - Emit the same events/activity entries that the normal unquarantine path
+//     emits
+//
+// This interface is intentionally small so the scanner service does not need
+// to depend on the full runtime package.
+type ServerUnquarantiner interface {
+	UnquarantineServer(serverName string) error
+}
+
 // Service coordinates scanner management, scan execution, and approval workflow
 type Service struct {
 	storage        Storage
@@ -86,6 +99,7 @@ type Service struct {
 	emitter        atomic.Pointer[EventEmitter]
 	sourceResolver *SourceResolver
 	serverInfo     ServerInfoProvider
+	unquarantiner  ServerUnquarantiner
 	secretStore    SecretStore
 	queue          *ScanQueue
 	pulls          *pullManager
@@ -136,6 +150,13 @@ func (s *Service) emit() EventEmitter {
 // SetServerInfoProvider sets the provider for resolving server configuration
 func (s *Service) SetServerInfoProvider(provider ServerInfoProvider) {
 	s.serverInfo = provider
+}
+
+// SetServerUnquarantiner wires the unquarantine callback used by ApproveServer.
+// If not set, ApproveServer will still succeed in storing a baseline but will
+// log a warning because it cannot actually unquarantine the server.
+func (s *Service) SetServerUnquarantiner(u ServerUnquarantiner) {
+	s.unquarantiner = u
 }
 
 // syncRegistryFromStorage updates the in-memory registry status from
@@ -1176,6 +1197,27 @@ func (s *Service) ApproveServer(ctx context.Context, serverName string, force bo
 
 	if err := s.storage.SaveIntegrityBaseline(baseline); err != nil {
 		return fmt.Errorf("failed to save integrity baseline: %w", err)
+	}
+
+	// Actually unquarantine the server: clear the flag in storage, persist
+	// config, trigger a tool (re)index, and emit the same events the normal
+	// unquarantine path emits. This is the primary user-visible effect of
+	// approval — without it, the server stays quarantined forever and the
+	// approval is cosmetic.
+	if s.unquarantiner != nil {
+		if err := s.unquarantiner.UnquarantineServer(serverName); err != nil {
+			// Report the error to the caller but keep the baseline we just
+			// saved — the caller can retry via the normal unquarantine path.
+			s.logger.Error("Failed to unquarantine server after approval",
+				zap.String("server", serverName),
+				zap.Error(err),
+			)
+			return fmt.Errorf("failed to unquarantine server %q after saving baseline: %w", serverName, err)
+		}
+	} else {
+		s.logger.Warn("ApproveServer: no unquarantiner configured; server will not be unquarantined automatically",
+			zap.String("server", serverName),
+		)
 	}
 
 	s.logger.Info("Server approved after security scan",

--- a/internal/security/scanner/service_test.go
+++ b/internal/security/scanner/service_test.go
@@ -291,6 +291,28 @@ func (e *mockEmitter) EmitSecurityScannerChanged(scannerID, status, errMsg strin
 	})
 }
 
+// mockUnquarantiner records UnquarantineServer calls for test assertions.
+type mockUnquarantiner struct {
+	mu    sync.Mutex
+	calls []string
+	err   error
+}
+
+func (m *mockUnquarantiner) UnquarantineServer(serverName string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, serverName)
+	return m.err
+}
+
+func (m *mockUnquarantiner) Calls() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, len(m.calls))
+	copy(out, m.calls)
+	return out
+}
+
 // helper to create a service with test registry and mock storage
 func newTestService(t *testing.T) (*Service, *mockStorage, *mockEmitter) {
 	t.Helper()
@@ -626,6 +648,107 @@ func TestServiceApproveServerNoScanNoForce(t *testing.T) {
 	err := svc.ApproveServer(context.Background(), "new-server", false, "admin@test.com")
 	if err == nil {
 		t.Fatal("expected error when no scan results and no force")
+	}
+}
+
+// TestServiceApproveServerCallsUnquarantiner verifies that a successful
+// approval actually invokes the wired ServerUnquarantiner so the server is
+// removed from quarantine (Bug F-01).
+func TestServiceApproveServerCallsUnquarantiner(t *testing.T) {
+	svc, store, _ := newTestService(t)
+	unq := &mockUnquarantiner{}
+	svc.SetServerUnquarantiner(unq)
+
+	// Set up a clean scan (no critical findings)
+	job := &ScanJob{
+		ID:         "job-approve",
+		ServerName: "qs-server",
+		Status:     ScanJobStatusCompleted,
+		Scanners:   []string{"test-scanner"},
+		StartedAt:  time.Now().Add(-1 * time.Minute),
+	}
+	_ = store.SaveScanJob(job)
+	_ = store.SaveScanReport(&ScanReport{
+		ID:         "report-approve",
+		JobID:      "job-approve",
+		ServerName: "qs-server",
+		ScannerID:  "test-scanner",
+		Findings: []ScanFinding{
+			{RuleID: "L1", Severity: SeverityLow, Title: "Low issue"},
+		},
+		ScannedAt: time.Now(),
+	})
+
+	if err := svc.ApproveServer(context.Background(), "qs-server", false, "admin@test.com"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	calls := unq.Calls()
+	if len(calls) != 1 || calls[0] != "qs-server" {
+		t.Fatalf("expected unquarantiner called once for 'qs-server', got %v", calls)
+	}
+
+	// Baseline should still be saved
+	if _, err := store.GetIntegrityBaseline("qs-server"); err != nil {
+		t.Errorf("expected baseline saved: %v", err)
+	}
+}
+
+// TestServiceApproveServerCriticalDoesNotUnquarantine verifies the
+// critical-findings guard still blocks approval before touching state.
+func TestServiceApproveServerCriticalDoesNotUnquarantine(t *testing.T) {
+	svc, store, _ := newTestService(t)
+	unq := &mockUnquarantiner{}
+	svc.SetServerUnquarantiner(unq)
+
+	_ = store.SaveScanJob(&ScanJob{
+		ID:         "job-crit2",
+		ServerName: "risky",
+		Status:     ScanJobStatusCompleted,
+		Scanners:   []string{"test-scanner"},
+		StartedAt:  time.Now(),
+	})
+	_ = store.SaveScanReport(&ScanReport{
+		ID:         "report-crit2",
+		JobID:      "job-crit2",
+		ServerName: "risky",
+		ScannerID:  "test-scanner",
+		Findings: []ScanFinding{
+			{RuleID: "C1", Severity: SeverityCritical, Title: "Critical vuln"},
+		},
+		ScannedAt: time.Now(),
+	})
+
+	if err := svc.ApproveServer(context.Background(), "risky", false, "admin@test.com"); err == nil {
+		t.Fatal("expected critical-findings guard to block approval")
+	}
+
+	if calls := unq.Calls(); len(calls) != 0 {
+		t.Errorf("unquarantiner must not be called when approval is blocked, got %v", calls)
+	}
+	if _, err := store.GetIntegrityBaseline("risky"); err == nil {
+		t.Error("baseline must not be created when approval is blocked")
+	}
+}
+
+// TestServiceApproveServerUnquarantinerError verifies that an unquarantiner
+// error is surfaced to the caller and the baseline is still recorded (so the
+// user can retry).
+func TestServiceApproveServerUnquarantinerError(t *testing.T) {
+	svc, store, _ := newTestService(t)
+	unq := &mockUnquarantiner{err: fmt.Errorf("boom")}
+	svc.SetServerUnquarantiner(unq)
+
+	if err := svc.ApproveServer(context.Background(), "retry-server", true, "admin@test.com"); err == nil {
+		t.Fatal("expected error from unquarantiner to surface")
+	}
+
+	// Baseline should still have been saved before the unquarantine call
+	if _, err := store.GetIntegrityBaseline("retry-server"); err != nil {
+		t.Errorf("expected baseline to be saved even when unquarantine fails: %v", err)
+	}
+	if calls := unq.Calls(); len(calls) != 1 {
+		t.Errorf("expected exactly 1 unquarantiner call, got %v", calls)
 	}
 }
 

--- a/internal/security/scanner/source_resolver.go
+++ b/internal/security/scanner/source_resolver.go
@@ -91,6 +91,23 @@ func (r *SourceResolver) Resolve(ctx context.Context, info ServerInfo) (*Resolve
 		)
 	}
 
+	// For package-runner commands (npx, uvx, pipx, bunx, pnpm dlx, yarn dlx),
+	// ALWAYS try the package cache FIRST before arg scanning. This prevents
+	// a server like `npx @modelcontextprotocol/server-filesystem /tmp/data`
+	// from picking up the user's data dir (`/tmp/data`) as the server
+	// source — the arg is the filesystem server's allowed root, not code.
+	if info.Command != "" && isPackageRunnerCommand(info.Command) {
+		if resolved, err := r.resolveFromPackageCache(ctx, info); err == nil {
+			return resolved, nil
+		} else {
+			r.logger.Debug("Package cache lookup failed, falling through",
+				zap.String("server", info.Name),
+				zap.String("command", info.Command),
+				zap.Error(err),
+			)
+		}
+	}
+
 	// Fallback: use working_dir
 	if info.WorkingDir != "" {
 		if stat, err := os.Stat(info.WorkingDir); err == nil && stat.IsDir() {
@@ -106,42 +123,145 @@ func (r *SourceResolver) Resolve(ctx context.Context, info ServerInfo) (*Resolve
 		}
 	}
 
-	// Fallback: use directory of the command itself
+	// Fallback: use directory of the command itself.
+	// When we fall back to this arg-scan heuristic we require the candidate
+	// directory to look like source code. Otherwise, a generic "path argument"
+	// (e.g. a data directory passed to a filesystem server) would be
+	// misclassified as code and fed to scanners.
 	if info.Command != "" {
-		// Check if any args reference a local file/directory
 		for _, arg := range info.Args {
-			if !strings.HasPrefix(arg, "-") {
-				absPath := arg
-				if !filepath.IsAbs(arg) && info.WorkingDir != "" {
-					absPath = filepath.Join(info.WorkingDir, arg)
-				}
-				if stat, err := os.Stat(absPath); err == nil {
-					dir := absPath
-					if !stat.IsDir() {
-						dir = filepath.Dir(absPath)
-					}
-					r.logger.Info("Resolved source from command argument",
-						zap.String("server", info.Name),
-						zap.String("path", dir),
-					)
+			if strings.HasPrefix(arg, "-") {
+				continue
+			}
+			absPath := arg
+			if !filepath.IsAbs(arg) && info.WorkingDir != "" {
+				absPath = filepath.Join(info.WorkingDir, arg)
+			}
+			stat, err := os.Stat(absPath)
+			if err != nil {
+				continue
+			}
+			dir := absPath
+			if !stat.IsDir() {
+				// For a concrete file arg (e.g. `python server.py`), the parent
+				// directory is the source tree by convention. If the file is
+				// a source file (.py/.js/.ts/.go/.rs) we accept it directly to
+				// preserve the existing behavior for interpreter servers.
+				if isSourceFile(absPath) {
 					return &ResolvedSource{
-						SourceDir: dir,
+						SourceDir: filepath.Dir(absPath),
 						Method:    "working_dir",
 						Cleanup:   func() {},
 					}, nil
 				}
+				dir = filepath.Dir(absPath)
 			}
+			if !dirLooksLikeSource(dir) {
+				r.logger.Debug("Arg path does not look like source tree, skipping",
+					zap.String("server", info.Name),
+					zap.String("arg", arg),
+					zap.String("path", dir),
+				)
+				continue
+			}
+			r.logger.Info("Resolved source from command argument",
+				zap.String("server", info.Name),
+				zap.String("path", dir),
+			)
+			return &ResolvedSource{
+				SourceDir: dir,
+				Method:    "working_dir",
+				Cleanup:   func() {},
+			}, nil
 		}
 	}
 
-	// Fallback: resolve from local package manager cache (npx, uvx, pipx)
-	if info.Command != "" {
+	// Last resort: try the package cache for any other command (e.g. the user
+	// has an absolute path to node_modules that we didn't match above).
+	if info.Command != "" && !isPackageRunnerCommand(info.Command) {
 		if resolved, err := r.resolveFromPackageCache(ctx, info); err == nil {
 			return resolved, nil
 		}
 	}
 
 	return nil, fmt.Errorf("could not resolve source for server %s: no Docker container found, no working_dir configured, and no local file paths in command args", info.Name)
+}
+
+// isPackageRunnerCommand returns true for commands that execute a package from
+// a remote registry rather than running local source code. For these, the
+// server source lives in the package manager's cache, not in any positional
+// argument.
+func isPackageRunnerCommand(command string) bool {
+	base := strings.ToLower(filepath.Base(command))
+	switch base {
+	case "npx", "uvx", "pipx", "bunx":
+		return true
+	}
+	return false
+}
+
+// isSourceFile returns true if the path looks like a source-code file by
+// extension. Used so interpreter servers (`python server.py`) still resolve
+// cleanly to the script's parent directory.
+func isSourceFile(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".py", ".js", ".mjs", ".cjs", ".ts", ".tsx", ".jsx", ".go", ".rs", ".rb", ".php", ".sh":
+		return true
+	}
+	return false
+}
+
+// dirLooksLikeSource heuristically decides whether a directory is a source
+// tree vs. e.g. a data directory passed as a filesystem-server root.
+// A directory qualifies if it contains a known manifest file or at least one
+// source file within two directory levels.
+func dirLooksLikeSource(dir string) bool {
+	markers := []string{
+		"package.json", "pyproject.toml", "setup.py", "Cargo.toml",
+		"go.mod", "composer.json", "Gemfile",
+	}
+	for _, m := range markers {
+		if _, err := os.Stat(filepath.Join(dir, m)); err == nil {
+			return true
+		}
+	}
+	// Walk up to depth 2 looking for at least one source file.
+	found := false
+	const maxDepth = 2
+	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info == nil {
+			return nil //nolint:nilerr // ignore walk errors, treat as "no source"
+		}
+		rel, rerr := filepath.Rel(dir, path)
+		if rerr != nil {
+			return nil
+		}
+		depth := 0
+		if rel != "." {
+			depth = strings.Count(rel, string(filepath.Separator)) + 1
+		}
+		if info.IsDir() {
+			if depth > maxDepth {
+				return filepath.SkipDir
+			}
+			// Skip noisy dirs
+			name := info.Name()
+			if name == ".git" || name == "node_modules" || name == "__pycache__" || name == ".venv" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if depth > maxDepth {
+			return nil
+		}
+		if isSourceFile(path) {
+			found = true
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	return found
 }
 
 // findServerContainer finds the running Docker container for a server

--- a/internal/security/scanner/source_resolver.go
+++ b/internal/security/scanner/source_resolver.go
@@ -71,7 +71,7 @@ func (r *SourceResolver) Resolve(ctx context.Context, info ServerInfo) (*Resolve
 	// Stdio servers: try Docker container first
 	containerID, err := r.findServerContainer(ctx, info.Name)
 	if err == nil && containerID != "" {
-		sourceDir, cleanup, err := r.extractFromContainer(ctx, containerID, info.Name)
+		sourceDir, cleanup, err := r.extractFromContainer(ctx, containerID, info)
 		if err == nil {
 			r.logger.Info("Resolved source from Docker container",
 				zap.String("server", info.Name),
@@ -288,9 +288,21 @@ func (r *SourceResolver) findServerContainer(ctx context.Context, serverName str
 	return lines[0], nil
 }
 
-// extractFromContainer extracts changed files from a running container
-// Uses `docker diff` to find added/changed files, then `docker cp` to extract them
-func (r *SourceResolver) extractFromContainer(ctx context.Context, containerID, serverName string) (string, func(), error) {
+// extractFromContainer extracts changed files from a running container.
+// Two resolution strategies are combined:
+//
+//  1. For package-runner servers (npx, uvx) the target package is located
+//     directly via `docker exec` and copied out. This is necessary because the
+//     target lives inside a Docker volume mount (e.g. /root/.npm for the
+//     shared npx cache) and volume contents never appear in `docker diff`.
+//
+//  2. `docker diff` is used to find any additional user-added app source in
+//     the container's writable layer (e.g. /app, /src) and copy those too.
+//
+// The npx diff path is filtered by target package name so sibling packages
+// hoisted into the same shared cache cannot leak into the scan.
+func (r *SourceResolver) extractFromContainer(ctx context.Context, containerID string, info ServerInfo) (string, func(), error) {
+	serverName := info.Name
 	// Create temp directory for extracted source
 	tempDir, err := os.MkdirTemp("", fmt.Sprintf("mcpproxy-scan-%s-", serverName))
 	if err != nil {
@@ -298,19 +310,47 @@ func (r *SourceResolver) extractFromContainer(ctx context.Context, containerID, 
 	}
 	cleanup := func() { os.RemoveAll(tempDir) }
 
-	// Get docker diff to find app-relevant directories
+	extracted := false
+
+	// Strategy 1: direct target package lookup for npx/uvx servers.
+	if targetDir := r.findContainerTargetDir(ctx, containerID, info); targetDir != "" {
+		destDir := filepath.Join(tempDir, "target")
+		_ = os.MkdirAll(destDir, 0755)
+		cpCmd := exec.CommandContext(ctx, "docker", "cp", containerID+":"+targetDir+"/.", destDir)
+		if err := cpCmd.Run(); err == nil {
+			r.logger.Info("Extracted target package from container",
+				zap.String("server", serverName),
+				zap.String("target_dir", targetDir),
+			)
+			extracted = true
+		} else {
+			r.logger.Debug("docker cp of target package failed",
+				zap.String("server", serverName),
+				zap.String("target_dir", targetDir),
+				zap.Error(err),
+			)
+		}
+	}
+
+	// Strategy 2: docker diff for any user-added app source.
 	cmd := exec.CommandContext(ctx, "docker", "diff", containerID)
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
-	if err := cmd.Run(); err != nil {
+	diffErr := cmd.Run()
+
+	var appDirs []string
+	if diffErr == nil {
+		// Identify app-relevant directories from the diff, scoped to the target npx package.
+		// If the server is not an npx command, targetNpxPkg is empty and no npx-cache paths
+		// are accepted at all (they would otherwise pollute the scan with sibling packages).
+		targetNpxPkg := npxTargetPackage(info)
+		appDirs = r.findAppDirectories(stdout.String(), targetNpxPkg)
+	} else if !extracted {
 		cleanup()
-		return "", nil, fmt.Errorf("docker diff failed: %w", err)
+		return "", nil, fmt.Errorf("docker diff failed: %w", diffErr)
 	}
 
-	// Identify app-relevant directories from the diff
-	appDirs := r.findAppDirectories(stdout.String())
-
-	if len(appDirs) == 0 {
+	if len(appDirs) == 0 && !extracted {
 		// Fallback: try UV git checkouts directly, then common app dirs
 		// Do NOT copy /root entirely — it may contain 10K+ dependency files
 		r.logger.Info("No specific app directories found in docker diff, trying direct paths",
@@ -363,8 +403,11 @@ func (r *SourceResolver) extractFromContainer(ctx context.Context, containerID, 
 
 // findAppDirectories analyzes docker diff output to find app-relevant directories.
 // It looks for directories where packages were installed (node_modules, site-packages, etc.)
-// and any user-added source files.
-func (r *SourceResolver) findAppDirectories(diffOutput string) []string {
+// and any user-added source files. When targetNpxPkg is non-empty, paths in an
+// npx cache that belong to a different package are filtered out — this prevents
+// sibling packages (hoisted into the same /.npm/_npx/<hash>/node_modules) from
+// leaking into scans of a specific target package.
+func (r *SourceResolver) findAppDirectories(diffOutput, targetNpxPkg string) []string {
 	seen := make(map[string]bool)
 	var dirs []string
 
@@ -386,7 +429,7 @@ func (r *SourceResolver) findAppDirectories(diffOutput string) []string {
 		}
 
 		// Find the top-level app directory
-		dir := r.extractAppRoot(path)
+		dir := r.extractAppRoot(path, targetNpxPkg)
 		if dir != "" && !seen[dir] {
 			seen[dir] = true
 			dirs = append(dirs, dir)
@@ -427,7 +470,10 @@ func (r *SourceResolver) isSystemPath(path string) bool {
 
 // extractAppRoot extracts the top-level application directory from a path.
 // Identifies actual server source vs dependency code for various package managers.
-func (r *SourceResolver) extractAppRoot(path string) string {
+// targetNpxPkg, when non-empty, restricts npx cache matches to a specific package
+// (e.g. "@modelcontextprotocol/server-everything") so unrelated sibling packages
+// hoisted into the same /.npm/_npx/<hash>/node_modules bucket are excluded.
+func (r *SourceResolver) extractAppRoot(path, targetNpxPkg string) string {
 	// UV git checkouts: /root/.cache/uv/git-v0/checkouts/<hash>/<rev>/ → extract that specific checkout
 	// This is the ACTUAL source code of a git-installed package (e.g., uvx --from pkg@git+URL)
 	if strings.Contains(path, "/.cache/uv/git-v0/checkouts/") {
@@ -441,9 +487,11 @@ func (r *SourceResolver) extractAppRoot(path string) string {
 	}
 
 	// npm npx cache: /root/.npm/_npx/<hash>/node_modules/<pkg> → extract the specific package
+	// directory. Without this isolation, the shared bucket directory is returned and
+	// `docker cp` copies ALL peer packages, causing findings to reference unrelated
+	// code (e.g. scanning everything-server surfaces @just-every/mcp-screenshot-website-fast).
 	if strings.Contains(path, "/.npm/_npx/") && strings.Contains(path, "/node_modules/") {
-		idx := strings.Index(path, "/node_modules/")
-		return path[:idx+len("/node_modules")]
+		return extractNpxPackageDir(path, targetNpxPkg)
 	}
 
 	// Common app directories
@@ -454,17 +502,203 @@ func (r *SourceResolver) extractAppRoot(path string) string {
 		}
 	}
 
-	// Root-level user files (but NOT .cache or .local — too broad, contains deps)
-	if strings.HasPrefix(path, "/root/") &&
-		!strings.HasPrefix(path, "/root/.cache") &&
-		!strings.HasPrefix(path, "/root/.local") {
+	// Root-level user files. Deliberately reject hidden (dot) directories —
+	// those are package manager caches, config, and volume mounts (.npm, .cache,
+	// .local, .config, .venv, ...) which are either already handled by the
+	// specific matchers above, or would pull in tens of thousands of unrelated
+	// files (e.g. /root/.npm is the shared Docker volume containing every
+	// package ever used by any container that mounts it).
+	if strings.HasPrefix(path, "/root/") {
 		parts := strings.SplitN(path[6:], "/", 2) // after "/root/"
-		if len(parts) > 0 {
+		if len(parts) > 0 && parts[0] != "" && !strings.HasPrefix(parts[0], ".") {
 			return "/root/" + parts[0]
 		}
 	}
 
 	return ""
+}
+
+// extractNpxPackageDir returns the directory of the specific package a file
+// belongs to inside an npx cache. Scoped packages (@scope/name) consume two
+// path segments; unscoped packages consume one. The caller MUST provide the
+// target package name; when targetPkg is empty the function returns "" to
+// avoid arbitrarily picking a package from a shared bucket (which is exactly
+// the sibling-leak bug this helper exists to prevent). npx hoists ALL
+// transitive dependencies into the same /_npx/<hash>/node_modules/ bucket
+// alongside the requested package, so without a known target we cannot safely
+// attribute a path to "the server's own code".
+func extractNpxPackageDir(path, targetPkg string) string {
+	if targetPkg == "" {
+		return ""
+	}
+	const marker = "/node_modules/"
+	idx := strings.Index(path, marker)
+	if idx == -1 {
+		return ""
+	}
+	rest := path[idx+len(marker):]
+	if rest == "" {
+		return ""
+	}
+	parts := strings.SplitN(rest, "/", 3)
+	var pkgName, pkgDir string
+	if strings.HasPrefix(parts[0], "@") {
+		// Scoped package requires two segments: @scope/name
+		if len(parts) < 2 || parts[1] == "" {
+			return ""
+		}
+		pkgName = parts[0] + "/" + parts[1]
+		pkgDir = path[:idx+len(marker)] + parts[0] + "/" + parts[1]
+	} else {
+		if parts[0] == "" {
+			return ""
+		}
+		pkgName = parts[0]
+		pkgDir = path[:idx+len(marker)] + parts[0]
+	}
+	if pkgName != targetPkg {
+		return ""
+	}
+	return pkgDir
+}
+
+// npxTargetPackage returns the canonical package name (with version specifier
+// stripped) that an npx-based server launches. Returns "" if the command is
+// not npx or no package name can be determined.
+func npxTargetPackage(info ServerInfo) string {
+	if info.Command == "" || filepath.Base(info.Command) != "npx" {
+		return ""
+	}
+	for _, arg := range info.Args {
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		pkg := arg
+		// Strip version: @scope/name@1.0.0 → @scope/name, pkg@1.0.0 → pkg
+		if idx := strings.LastIndex(pkg, "@"); idx > 0 {
+			pkg = pkg[:idx]
+		}
+		return pkg
+	}
+	return ""
+}
+
+// uvxTargetPackage returns the Python package name a uvx-based server launches.
+// Supports `uvx <pkg>`, `uvx --from <pkg> <cmd>`, and `uvx <pkg>@<version>`.
+// Git URLs (git+https://...) are reduced to the repo name. Returns "" if the
+// command is not uvx or no package name can be determined.
+func uvxTargetPackage(info ServerInfo) string {
+	if info.Command == "" || filepath.Base(info.Command) != "uvx" {
+		return ""
+	}
+	var raw string
+	for i, arg := range info.Args {
+		if arg == "--from" && i+1 < len(info.Args) {
+			raw = info.Args[i+1]
+			break
+		}
+		if !strings.HasPrefix(arg, "-") {
+			raw = arg
+			break
+		}
+	}
+	if raw == "" {
+		return ""
+	}
+	// Git URL: extract the repo name.
+	if strings.HasPrefix(raw, "git+") {
+		url := strings.TrimPrefix(raw, "git+")
+		url = strings.TrimSuffix(url, ".git")
+		if idx := strings.LastIndex(url, "/"); idx != -1 && idx+1 < len(url) {
+			return url[idx+1:]
+		}
+		return ""
+	}
+	// Strip version specifier: pkg@1.0 or pkg==1.0.
+	if idx := strings.LastIndex(raw, "@"); idx > 0 {
+		raw = raw[:idx]
+	}
+	if idx := strings.Index(raw, "=="); idx > 0 {
+		raw = raw[:idx]
+	}
+	return raw
+}
+
+// findContainerTargetDir locates the target package's directory inside a
+// running Docker container using `docker exec`. This is the resolution of
+// choice for package-runner servers (npx, uvx) whose target lives inside a
+// mounted cache volume — volume contents never appear in `docker diff`, so
+// the diff-based scanners would otherwise either miss the target entirely or
+// (worse) fall back to copying the whole volume and dragging sibling packages
+// into the scan. Returns "" if the server is not a package-runner or the
+// target cannot be located.
+func (r *SourceResolver) findContainerTargetDir(ctx context.Context, containerID string, info ServerInfo) string {
+	if pkg := npxTargetPackage(info); pkg != "" {
+		// Shell-escape single quotes in the package name and glob for it under
+		// every npx cache bucket inside the container.
+		escaped := strings.ReplaceAll(pkg, "'", `'\''`)
+		script := fmt.Sprintf(
+			"ls -d /root/.npm/_npx/*/node_modules/'%s' 2>/dev/null | head -n 1",
+			escaped,
+		)
+		if out, ok := dockerExecCapture(ctx, containerID, script); ok {
+			if path := strings.TrimSpace(out); path != "" {
+				return path
+			}
+		}
+		return ""
+	}
+	if pkg := uvxTargetPackage(info); pkg != "" {
+		// uv/uvx install locations (from most- to least-specific):
+		//   1. /root/.local/share/uv/tools/<pkg>/                              (persistent `uv tool install`)
+		//   2. /root/.cache/uv/archive-v0/<hash>/lib/pythonX.Y/site-packages/<pkg>/  (ephemeral uvx env)
+		//   3. /usr/local/lib/pythonX.Y/site-packages/<pkg>/                   (system pip install)
+		//
+		// Wheel-normalised names use underscores, PEP 503 names use hyphens, so
+		// try both variants. We search in priority order and stop at the first hit.
+		escaped := strings.ReplaceAll(pkg, "'", `'\''`)
+		lower := strings.ToLower(escaped)
+		underscore := strings.ReplaceAll(lower, "-", "_")
+		hyphen := strings.ReplaceAll(lower, "_", "-")
+		// Build a deduped list of candidate leaf names.
+		seen := map[string]bool{}
+		var names []string
+		for _, n := range []string{escaped, lower, underscore, hyphen} {
+			if n != "" && !seen[n] {
+				seen[n] = true
+				names = append(names, n)
+			}
+		}
+		var globs []string
+		for _, n := range names {
+			globs = append(globs,
+				"/root/.local/share/uv/tools/'"+n+"'",
+				"/root/.cache/uv/archive-v0/*/lib/python*/site-packages/'"+n+"'",
+				"/usr/local/lib/python*/site-packages/'"+n+"'",
+				"/usr/lib/python*/site-packages/'"+n+"'",
+				"/usr/lib/python*/dist-packages/'"+n+"'",
+			)
+		}
+		script := "for p in " + strings.Join(globs, " ") + "; do for d in $p; do [ -d \"$d\" ] && { echo \"$d\"; exit 0; }; done; done; exit 1"
+		if out, ok := dockerExecCapture(ctx, containerID, script); ok {
+			if path := strings.TrimSpace(out); path != "" {
+				return path
+			}
+		}
+	}
+	return ""
+}
+
+// dockerExecCapture runs a shell command inside a container and returns its
+// stdout. Returns ok=false if the command fails or exits non-zero.
+func dockerExecCapture(ctx context.Context, containerID, script string) (string, bool) {
+	cmd := exec.CommandContext(ctx, "docker", "exec", containerID, "sh", "-c", script)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "", false
+	}
+	return stdout.String(), true
 }
 
 // ResolveFullSource resolves the FULL source directory for a server, including
@@ -486,7 +720,7 @@ func (r *SourceResolver) ResolveFullSource(ctx context.Context, info ServerInfo)
 	// Stdio servers: try Docker container first — extract FULL container
 	containerID, err := r.findServerContainer(ctx, info.Name)
 	if err == nil && containerID != "" {
-		sourceDir, cleanup, err := r.extractFullFromContainer(ctx, containerID, info.Name)
+		sourceDir, cleanup, err := r.extractFullFromContainer(ctx, containerID, info)
 		if err == nil {
 			r.logger.Info("Resolved full source from Docker container for Pass 2",
 				zap.String("server", info.Name),
@@ -521,29 +755,65 @@ func (r *SourceResolver) ResolveFullSource(ctx context.Context, info ServerInfo)
 }
 
 // extractFullFromContainer extracts ALL changed files from a container
-// WITHOUT filtering out dependency directories. Used for Pass 2 supply chain audit.
-func (r *SourceResolver) extractFullFromContainer(ctx context.Context, containerID, serverName string) (string, func(), error) {
+// that belong to the target server's source and its dependency trees. Used for
+// Pass 2 supply chain audit. Unlike Pass 1, this intentionally INCLUDES
+// installed dependencies (site-packages, node_modules) so CVE scanners can see
+// the full supply chain — but it does NOT include unrelated system files such
+// as the Python standard library, which would otherwise flood the scan with
+// false positives (e.g. flagging shutil.py or tempfile.py as "malicious").
+func (r *SourceResolver) extractFullFromContainer(ctx context.Context, containerID string, info ServerInfo) (string, func(), error) {
+	serverName := info.Name
 	tempDir, err := os.MkdirTemp("", fmt.Sprintf("mcpproxy-scan-full-%s-", serverName))
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to create temp dir: %w", err)
 	}
 	cleanup := func() { os.RemoveAll(tempDir) }
 
-	// Get docker diff to find ALL changed directories
+	extracted := false
+
+	// Strategy 1: direct target package lookup for npx/uvx servers. The target
+	// (and, because npm/uv hoist dependencies into the same tree, also its deps)
+	// lives inside a Docker volume mount invisible to `docker diff`, so we must
+	// locate it via `docker exec` instead.
+	if targetDir := r.findContainerTargetDir(ctx, containerID, info); targetDir != "" {
+		destDir := filepath.Join(tempDir, "target")
+		_ = os.MkdirAll(destDir, 0755)
+		cpCmd := exec.CommandContext(ctx, "docker", "cp", containerID+":"+targetDir+"/.", destDir)
+		if err := cpCmd.Run(); err == nil {
+			r.logger.Info("Extracted target package from container (Pass 2)",
+				zap.String("server", serverName),
+				zap.String("target_dir", targetDir),
+			)
+			extracted = true
+		} else {
+			r.logger.Debug("docker cp of target package failed (Pass 2)",
+				zap.String("server", serverName),
+				zap.String("target_dir", targetDir),
+				zap.Error(err),
+			)
+		}
+	}
+
+	// Strategy 2: docker diff for additional dependency subtrees that the
+	// server touched (e.g. anything at /app, /src, or installed site-packages).
 	cmd := exec.CommandContext(ctx, "docker", "diff", containerID)
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
-	if err := cmd.Run(); err != nil {
+	diffErr := cmd.Run()
+
+	var dirs []string
+	if diffErr == nil {
+		dirs = r.findAllChangedDirectories(stdout.String(), npxTargetPackage(info))
+	} else if !extracted {
 		cleanup()
-		return "", nil, fmt.Errorf("docker diff failed: %w", err)
+		return "", nil, fmt.Errorf("docker diff failed: %w", diffErr)
 	}
 
-	// Find all top-level changed directories (no filtering of deps)
-	dirs := r.findAllChangedDirectories(stdout.String())
-
-	if len(dirs) == 0 {
-		// Try common directories including dependency paths
-		for _, dir := range []string{"/app", "/src", "/opt/app", "/root"} {
+	if len(dirs) == 0 && !extracted {
+		// Narrow fallback: only try conventional app source dirs. Do NOT fall back
+		// to /root or /usr — they contain the npm cache and Python stdlib which
+		// would produce huge, noisy scans and cause stdlib false positives.
+		for _, dir := range []string{"/app", "/src", "/opt/app"} {
 			destDir := filepath.Join(tempDir, filepath.Base(dir))
 			os.MkdirAll(destDir, 0755)
 			cpCmd := exec.CommandContext(ctx, "docker", "cp", containerID+":"+dir+"/.", destDir)
@@ -555,9 +825,12 @@ func (r *SourceResolver) extractFullFromContainer(ctx context.Context, container
 		return "", nil, fmt.Errorf("no extractable source found in container %s", containerID)
 	}
 
-	// Extract each directory
-	for _, dir := range dirs {
-		destDir := filepath.Join(tempDir, filepath.Base(dir))
+	// Extract each directory. Use a content hash of the path for the destination
+	// name so that multiple site-packages / archive subtrees under the same parent
+	// don't collide when filepath.Base returns the same leaf.
+	for i, dir := range dirs {
+		destName := fmt.Sprintf("%d-%s", i, filepath.Base(dir))
+		destDir := filepath.Join(tempDir, destName)
 		os.MkdirAll(destDir, 0755)
 		cpCmd := exec.CommandContext(ctx, "docker", "cp", containerID+":"+dir+"/.", destDir)
 		if err := cpCmd.Run(); err != nil {
@@ -571,10 +844,11 @@ func (r *SourceResolver) extractFullFromContainer(ctx context.Context, container
 	return tempDir, cleanup, nil
 }
 
-// findAllChangedDirectories analyzes docker diff output and returns ALL changed
-// directories including dependency directories. Unlike findAppDirectories, this
-// does NOT filter out site-packages, node_modules, UV archives, etc.
-func (r *SourceResolver) findAllChangedDirectories(diffOutput string) []string {
+// findAllChangedDirectories analyzes docker diff output and returns specific
+// dependency/source subtrees that belong to the target server. It deliberately
+// filters out unrelated system files (Python stdlib, /usr/lib, OS pseudo-fs)
+// while still including installed dependencies for supply chain auditing.
+func (r *SourceResolver) findAllChangedDirectories(diffOutput, targetNpxPkg string) []string {
 	seen := make(map[string]bool)
 	var dirs []string
 
@@ -590,12 +864,11 @@ func (r *SourceResolver) findAllChangedDirectories(diffOutput string) []string {
 			continue
 		}
 
-		// Skip only OS-level system paths (proc, sys, dev, etc.)
 		if r.isHardSystemPath(path) {
 			continue
 		}
 
-		dir := r.extractTopLevelDir(path)
+		dir := r.extractPass2Dir(path, targetNpxPkg)
 		if dir != "" && !seen[dir] {
 			seen[dir] = true
 			dirs = append(dirs, dir)
@@ -605,31 +878,125 @@ func (r *SourceResolver) findAllChangedDirectories(diffOutput string) []string {
 	return dirs
 }
 
-// isHardSystemPath returns true only for paths that are never useful for scanning
-// (kernel, device, proc pseudo-filesystems). Does NOT filter dependency dirs.
+// isHardSystemPath returns true for paths that are never useful for scanning.
+// This includes OS pseudo-filesystems (proc, sys, dev), system config, and the
+// Python standard library (which lives under /usr/local/lib/pythonX/ directly
+// but NOT in site-packages/dist-packages — those are installed dependencies
+// and ARE worth scanning for supply chain audit).
 func (r *SourceResolver) isHardSystemPath(path string) bool {
 	hardSystemPrefixes := []string{
 		"/proc/", "/sys/", "/dev/",
 		"/etc/", "/var/run/", "/var/lock/",
+		"/usr/lib/", "/usr/bin/", "/usr/sbin/",
+		"/lib/", "/bin/", "/sbin/",
 	}
 	for _, prefix := range hardSystemPrefixes {
 		if strings.HasPrefix(path, prefix) {
 			return true
 		}
 	}
+	// Python stdlib: anything under /.../lib/pythonX.Y/ that is NOT inside
+	// site-packages or dist-packages is stdlib shipped with the base image.
+	// Scanning it produces false positives (shutil flagged as "shell command
+	// execution", tempfile flagged as "obfuscated payload", etc.).
+	if isPythonStdlibPath(path) {
+		return true
+	}
 	return false
 }
 
-// extractTopLevelDir extracts the top-level directory from a path.
-// For /root/.cache/uv/... it returns /root (broader than extractAppRoot).
-func (r *SourceResolver) extractTopLevelDir(path string) string {
-	// Known top-level directories
-	topDirs := []string{"/app", "/src", "/opt", "/root", "/home", "/usr", "/var", "/tmp"}
-	for _, dir := range topDirs {
-		if strings.HasPrefix(path, dir+"/") || path == dir {
-			return dir
+// isPythonStdlibPath reports whether a path is inside the Python standard
+// library tree (not in site-packages/dist-packages).
+func isPythonStdlibPath(path string) bool {
+	if !strings.Contains(path, "/python") {
+		return false
+	}
+	// Look for a segment like "pythonX" or "pythonX.Y" preceded by "lib/".
+	parts := strings.Split(path, "/")
+	for i := 1; i < len(parts); i++ {
+		if parts[i-1] != "lib" {
+			continue
+		}
+		seg := parts[i]
+		if !strings.HasPrefix(seg, "python") {
+			continue
+		}
+		rest := seg[len("python"):]
+		if rest == "" {
+			continue
+		}
+		// Expect a digit after "python" (python3, python3.11, python313, ...)
+		if rest[0] < '0' || rest[0] > '9' {
+			continue
+		}
+		// Everything after .../lib/pythonX[.Y]/ is stdlib unless it then
+		// descends into site-packages or dist-packages.
+		tail := strings.Join(parts[i+1:], "/")
+		if tail == "" {
+			return true
+		}
+		if strings.HasPrefix(tail, "site-packages/") || tail == "site-packages" ||
+			strings.HasPrefix(tail, "dist-packages/") || tail == "dist-packages" {
+			return false
+		}
+		return true
+	}
+	return false
+}
+
+// extractPass2Dir returns the most specific dependency/source subtree a path
+// belongs to, for Pass 2 supply chain scanning. Returns "" when the path does
+// not belong to any recognised app or dependency location — in particular it
+// NEVER returns broad roots like /usr or /root, which would cause `docker cp`
+// to copy thousands of unrelated files (including Python stdlib) into the scan.
+func (r *SourceResolver) extractPass2Dir(path, targetNpxPkg string) string {
+	// Application source dirs — narrow, safe to copy whole.
+	for _, d := range []string{"/app", "/src", "/opt/app"} {
+		if strings.HasPrefix(path, d+"/") || path == d {
+			return d
 		}
 	}
+
+	// Python installed deps: return the full site-packages / dist-packages dir.
+	// This is the root of the supply chain for uvx/pip-installed servers.
+	for _, marker := range []string{"/site-packages/", "/dist-packages/"} {
+		if idx := strings.Index(path, marker); idx != -1 {
+			return path[:idx+len(marker)-1] // drop trailing slash
+		}
+	}
+
+	// npm npx cache: isolate to the specific target package (prevents sibling
+	// packages hoisted into the same npx bucket from leaking into the scan).
+	if strings.Contains(path, "/.npm/_npx/") && strings.Contains(path, "/node_modules/") {
+		return extractNpxPackageDir(path, targetNpxPkg)
+	}
+
+	// Regular node_modules (npm install, not npx): return the node_modules root
+	// — supply chain audit wants to see all npm dependencies together.
+	if strings.Contains(path, "/node_modules/") {
+		idx := strings.Index(path, "/node_modules/")
+		return path[:idx+len("/node_modules")]
+	}
+
+	// UV git checkouts — actual source code of a git-installed package.
+	if strings.Contains(path, "/.cache/uv/git-v0/checkouts/") {
+		parts := strings.Split(path, "/")
+		for i, p := range parts {
+			if p == "checkouts" && i+2 < len(parts) {
+				return strings.Join(parts[:i+3], "/")
+			}
+		}
+	}
+
+	// UV archive cache (wheel cache): /.cache/uv/archive-v0/<hash>/<pkg>/
+	if idx := strings.Index(path, "/.cache/uv/archive-v0/"); idx != -1 {
+		rest := path[idx+len("/.cache/uv/archive-v0/"):]
+		parts := strings.SplitN(rest, "/", 2)
+		if parts[0] != "" {
+			return path[:idx+len("/.cache/uv/archive-v0/")] + parts[0]
+		}
+	}
+
 	return ""
 }
 

--- a/internal/security/scanner/source_resolver_test.go
+++ b/internal/security/scanner/source_resolver_test.go
@@ -123,6 +123,8 @@ func TestFindAppDirectories(t *testing.T) {
 	diffOutput := `C /root
 A /root/.npm/_npx/abc123/node_modules/@mcp/server/index.js
 A /root/.npm/_npx/abc123/node_modules/@mcp/server/package.json
+A /root/.npm/_npx/abc123/node_modules/@other/sibling/index.js
+A /root/.npm/_npx/abc123/node_modules/unscoped-dep/index.js
 C /tmp
 A /tmp/some-cache
 A /app/server.py
@@ -132,16 +134,17 @@ A /usr/local/lib/python3.11/site-packages/mcp_server/main.py
 A /root/.cache/uv/git-v0/checkouts/abc123/def456/gcore_mcp_server/server.py
 A /root/.cache/uv/archive-v0/xxx/click/__init__.py`
 
-	dirs := r.findAppDirectories(diffOutput)
+	// Target: @mcp/server — sibling @other/sibling and unscoped-dep must be filtered out.
+	dirs := r.findAppDirectories(diffOutput, "@mcp/server")
 
 	found := make(map[string]bool)
 	for _, d := range dirs {
 		found[d] = true
 	}
 
-	// Should find: npm node_modules, /app, and UV git checkout
-	if !found["/root/.npm/_npx/abc123/node_modules"] {
-		t.Errorf("expected npm node_modules dir, got %v", dirs)
+	// Should find: the SPECIFIC target package dir, /app, and the UV git checkout.
+	if !found["/root/.npm/_npx/abc123/node_modules/@mcp/server"] {
+		t.Errorf("expected target npx package dir, got %v", dirs)
 	}
 	if !found["/app"] {
 		t.Errorf("expected /app dir, got %v", dirs)
@@ -150,14 +153,46 @@ A /root/.cache/uv/archive-v0/xxx/click/__init__.py`
 		t.Errorf("expected UV git checkout dir, got %v", dirs)
 	}
 
-	// Should NOT find: site-packages, UV archive (dependencies)
+	// Should NOT find: the shared node_modules bucket, sibling packages,
+	// site-packages, UV archives (all excluded to prevent cross-package leakage).
 	for _, d := range dirs {
+		if d == "/root/.npm/_npx/abc123/node_modules" {
+			t.Errorf("shared node_modules bucket must not be returned: %s", d)
+		}
+		if strings.Contains(d, "/@other/") || strings.Contains(d, "/unscoped-dep") {
+			t.Errorf("sibling npx package must be excluded: %s", d)
+		}
 		if strings.Contains(d, "site-packages") {
-			t.Errorf("site-packages should be excluded: %s", d)
+			t.Errorf("site-packages should be excluded from Pass 1: %s", d)
 		}
 		if strings.Contains(d, "archive-v0") {
 			t.Errorf("UV archive should be excluded: %s", d)
 		}
+	}
+}
+
+// TestFindAppDirectoriesNpxNoTarget guards against regressions where we would
+// accept npx cache paths without knowing the target package — accepting any
+// package in the bucket is exactly the sibling-leak bug we are fixing.
+func TestFindAppDirectoriesNpxNoTarget(t *testing.T) {
+	r := NewSourceResolver(zap.NewNop())
+	diffOutput := `A /root/.npm/_npx/abc/node_modules/@any/pkg/index.js
+A /app/server.py`
+	dirs := r.findAppDirectories(diffOutput, "")
+	for _, d := range dirs {
+		if strings.Contains(d, "_npx") {
+			t.Errorf("npx cache paths must be rejected when target is unknown, got: %s", d)
+		}
+	}
+	// /app is still legitimate.
+	var foundApp bool
+	for _, d := range dirs {
+		if d == "/app" {
+			foundApp = true
+		}
+	}
+	if !foundApp {
+		t.Errorf("expected /app, got %v", dirs)
 	}
 }
 
@@ -190,26 +225,184 @@ func TestExtractAppRoot(t *testing.T) {
 	r := NewSourceResolver(zap.NewNop())
 
 	tests := []struct {
-		path string
-		want string
+		name      string
+		path      string
+		targetPkg string
+		want      string
 	}{
-		{"/root/.npm/_npx/abc/node_modules/@mcp/server/index.js", "/root/.npm/_npx/abc/node_modules"},
-		{"/app/server.py", "/app"},
-		{"/src/main.go", "/src"},
-		{"/opt/app/config.yaml", "/opt/app"},
-		// UV git checkouts — actual server source
-		{"/root/.cache/uv/git-v0/checkouts/abc123/def456/server.py", "/root/.cache/uv/git-v0/checkouts/abc123/def456"},
-		{"/root/.cache/uv/git-v0/checkouts/abc123/def456/pkg/main.py", "/root/.cache/uv/git-v0/checkouts/abc123/def456"},
-		// /root non-cache files
-		{"/root/script.py", "/root/script.py"},
+		// npx isolation: scoped target package matches, unscoped sibling is rejected.
+		{
+			name:      "scoped target package matches",
+			path:      "/root/.npm/_npx/abc/node_modules/@mcp/server/index.js",
+			targetPkg: "@mcp/server",
+			want:      "/root/.npm/_npx/abc/node_modules/@mcp/server",
+		},
+		{
+			name:      "unscoped sibling rejected when target is scoped",
+			path:      "/root/.npm/_npx/abc/node_modules/left-pad/index.js",
+			targetPkg: "@mcp/server",
+			want:      "",
+		},
+		{
+			name:      "scoped sibling rejected when target is a different scope",
+			path:      "/root/.npm/_npx/abc/node_modules/@just-every/mcp-screenshot-website-fast/dist/internal/screenshotCapture.js",
+			targetPkg: "@modelcontextprotocol/server-everything",
+			want:      "",
+		},
+		{
+			name:      "unscoped target package matches",
+			path:      "/root/.npm/_npx/xyz/node_modules/some-pkg/index.js",
+			targetPkg: "some-pkg",
+			want:      "/root/.npm/_npx/xyz/node_modules/some-pkg",
+		},
+		{
+			name:      "npx path with empty target is rejected (no leakage)",
+			path:      "/root/.npm/_npx/abc/node_modules/@mcp/server/index.js",
+			targetPkg: "",
+			want:      "",
+		},
+		// Non-npx paths don't depend on target.
+		{name: "app", path: "/app/server.py", want: "/app"},
+		{name: "src", path: "/src/main.go", want: "/src"},
+		{name: "opt-app", path: "/opt/app/config.yaml", want: "/opt/app"},
+		{
+			name: "uv git checkout",
+			path: "/root/.cache/uv/git-v0/checkouts/abc123/def456/server.py",
+			want: "/root/.cache/uv/git-v0/checkouts/abc123/def456",
+		},
+		{
+			name: "uv git checkout nested",
+			path: "/root/.cache/uv/git-v0/checkouts/abc123/def456/pkg/main.py",
+			want: "/root/.cache/uv/git-v0/checkouts/abc123/def456",
+		},
+		{name: "root non-cache file accepted", path: "/root/script.py", want: "/root/script.py"},
+		{name: "root dot-dir rejected (npm volume)", path: "/root/.npm", want: ""},
+		{name: "root dot-dir rejected (cache)", path: "/root/.cache", want: ""},
+		{name: "root dot-dir rejected (local)", path: "/root/.local/share/uv/tools/foo", want: ""},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.path, func(t *testing.T) {
-			if got := r.extractAppRoot(tt.path); got != tt.want {
-				t.Errorf("extractAppRoot(%q) = %q, want %q", tt.path, got, tt.want)
+		t.Run(tt.name, func(t *testing.T) {
+			if got := r.extractAppRoot(tt.path, tt.targetPkg); got != tt.want {
+				t.Errorf("extractAppRoot(%q, %q) = %q, want %q", tt.path, tt.targetPkg, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestNpxTargetPackage(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		args    []string
+		want    string
+	}{
+		{"scoped with version", "npx", []string{"-y", "@modelcontextprotocol/server-everything@1.2.3"}, "@modelcontextprotocol/server-everything"},
+		{"scoped without version", "npx", []string{"-y", "@modelcontextprotocol/server-everything"}, "@modelcontextprotocol/server-everything"},
+		{"unscoped with version", "npx", []string{"pkg@1.0.0"}, "pkg"},
+		{"unscoped without version", "npx", []string{"pkg"}, "pkg"},
+		{"flags skipped", "npx", []string{"-y", "--quiet", "@scope/pkg"}, "@scope/pkg"},
+		{"non-npx returns empty", "node", []string{"server.js"}, ""},
+		{"no args returns empty", "npx", []string{"-y"}, ""},
+		{"npx with path", "/usr/local/bin/npx", []string{"@scope/pkg"}, "@scope/pkg"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := npxTargetPackage(ServerInfo{Command: tt.command, Args: tt.args})
+			if got != tt.want {
+				t.Errorf("npxTargetPackage(%q, %v) = %q, want %q", tt.command, tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsPythonStdlibPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/usr/local/lib/python3.13/shutil.py", true},
+		{"/usr/local/lib/python3.13/tempfile.py", true},
+		{"/usr/local/lib/python3.13/__pycache__/shutil.cpython-313.pyc", true},
+		{"/usr/local/lib/python3.11/site-packages/mcp_server/main.py", false},
+		{"/usr/lib/python3/dist-packages/click/__init__.py", false},
+		{"/opt/python/lib/python3.12/os.py", true},
+		{"/app/server.py", false},
+		{"/app/python/venv/lib/foo.py", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if got := isPythonStdlibPath(tt.path); got != tt.want {
+				t.Errorf("isPythonStdlibPath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractPass2Dir(t *testing.T) {
+	r := NewSourceResolver(zap.NewNop())
+
+	tests := []struct {
+		name      string
+		path      string
+		targetPkg string
+		want      string
+	}{
+		{"app source", "/app/server.py", "", "/app"},
+		{"site-packages returns root", "/usr/local/lib/python3.13/site-packages/click/__init__.py", "", "/usr/local/lib/python3.13/site-packages"},
+		{"dist-packages returns root", "/usr/lib/python3/dist-packages/mcp/server.py", "", "/usr/lib/python3/dist-packages"},
+		{"npx isolates to target", "/root/.npm/_npx/abc/node_modules/@mcp/server/index.js", "@mcp/server", "/root/.npm/_npx/abc/node_modules/@mcp/server"},
+		{"npx sibling rejected", "/root/.npm/_npx/abc/node_modules/@other/sibling/index.js", "@mcp/server", ""},
+		{"plain node_modules returns root", "/home/user/proj/node_modules/click/index.js", "", "/home/user/proj/node_modules"},
+		{"uv git checkout", "/root/.cache/uv/git-v0/checkouts/abc/def/server.py", "", "/root/.cache/uv/git-v0/checkouts/abc/def"},
+		{"uv archive", "/root/.cache/uv/archive-v0/xyz/click/__init__.py", "", "/root/.cache/uv/archive-v0/xyz"},
+		{"stdlib path returns empty (caller already skipped)", "/usr/local/lib/python3.13/shutil.py", "", ""},
+		{"random /usr path rejected", "/usr/share/man/man1/ls.1", "", ""},
+		{"random /root path rejected", "/root/.cache/pip/wheels/foo.whl", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := r.extractPass2Dir(tt.path, tt.targetPkg); got != tt.want {
+				t.Errorf("extractPass2Dir(%q, %q) = %q, want %q", tt.path, tt.targetPkg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindAllChangedDirectoriesStdlibFilter(t *testing.T) {
+	r := NewSourceResolver(zap.NewNop())
+	diffOutput := `A /usr/local/lib/python3.13/shutil.py
+C /usr/local/lib/python3.13/__pycache__/shutil.cpython-313.pyc
+A /usr/local/lib/python3.13/tempfile.py
+A /usr/local/lib/python3.13/site-packages/obsidian_pilot/main.py
+A /usr/local/lib/python3.13/site-packages/click/__init__.py
+A /root/.cache/uv/archive-v0/hash1/click/__init__.py
+A /app/server.py`
+
+	dirs := r.findAllChangedDirectories(diffOutput, "")
+
+	for _, d := range dirs {
+		if isPythonStdlibPath(d + "/anything.py") {
+			t.Errorf("stdlib subtree leaked into Pass 2 dirs: %s", d)
+		}
+		if d == "/usr" || d == "/root" {
+			t.Errorf("broad root %q must not be returned", d)
+		}
+	}
+
+	found := make(map[string]bool)
+	for _, d := range dirs {
+		found[d] = true
+	}
+	if !found["/usr/local/lib/python3.13/site-packages"] {
+		t.Errorf("expected site-packages root, got %v", dirs)
+	}
+	if !found["/app"] {
+		t.Errorf("expected /app, got %v", dirs)
+	}
+	if !found["/root/.cache/uv/archive-v0/hash1"] {
+		t.Errorf("expected uv archive dir, got %v", dirs)
 	}
 }
 

--- a/internal/security/scanner/source_resolver_test.go
+++ b/internal/security/scanner/source_resolver_test.go
@@ -315,6 +315,169 @@ func TestResolveUvxCacheGitCheckout(t *testing.T) {
 	}
 }
 
+// TestSourceResolverNpxFilesystemArgNotPicked verifies that a filesystem-style
+// positional argument (e.g. `/tmp/mydata` for @modelcontextprotocol/server-filesystem)
+// is NOT picked up as the server's source directory. Package-runner commands
+// must resolve via the package cache; if the cache has the package, we use it.
+func TestSourceResolverNpxFilesystemArgNotPicked(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+
+	// Seed the npx cache with a fake filesystem server package
+	pkgDir := filepath.Join(homeDir, ".npm", "_npx", "deadbeef", "node_modules", "@modelcontextprotocol", "server-filesystem")
+	os.MkdirAll(pkgDir, 0755)
+	os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(`{"name":"@modelcontextprotocol/server-filesystem"}`), 0644)
+	os.WriteFile(filepath.Join(pkgDir, "index.js"), []byte("// server"), 0644)
+
+	// Create a bogus "data dir" (the arg the user passes — NOT source code).
+	dataDir := t.TempDir()
+	os.WriteFile(filepath.Join(dataDir, "notes.txt"), []byte("my private notes"), 0644)
+
+	r := NewSourceResolver(zap.NewNop())
+	result, err := r.Resolve(context.Background(), ServerInfo{
+		Name:     "fs-server",
+		Protocol: "stdio",
+		Command:  "npx",
+		Args:     []string{"-y", "@modelcontextprotocol/server-filesystem", dataDir},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if result.SourceDir != pkgDir {
+		t.Errorf("expected source_dir %q (package cache), got %q", pkgDir, result.SourceDir)
+	}
+	if result.SourceDir == dataDir {
+		t.Errorf("regression: resolver picked the data directory %q", dataDir)
+	}
+	if result.Method != "npx_cache" {
+		t.Errorf("expected method 'npx_cache', got %q", result.Method)
+	}
+	result.Cleanup()
+}
+
+// TestSourceResolverNpxDataDirFallsThroughWhenNoCache verifies that when
+// the package cache is EMPTY and the only arg is a plain data directory
+// (no source markers), the resolver reports no source rather than wrongly
+// picking the data dir.
+func TestSourceResolverNpxDataDirFallsThroughWhenNoCache(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+
+	// Data directory without any source markers
+	dataDir := t.TempDir()
+	os.WriteFile(filepath.Join(dataDir, "notes.txt"), []byte("notes"), 0644)
+	os.WriteFile(filepath.Join(dataDir, "data.csv"), []byte("a,b,c"), 0644)
+
+	r := NewSourceResolver(zap.NewNop())
+	_, err := r.Resolve(context.Background(), ServerInfo{
+		Name:     "fs-server",
+		Protocol: "stdio",
+		Command:  "npx",
+		Args:     []string{"-y", "@modelcontextprotocol/server-filesystem", dataDir},
+	})
+	if err == nil {
+		t.Fatal("expected error when no cache and no source markers, got nil")
+	}
+}
+
+// TestSourceResolverPythonScriptArgPreserved verifies that the existing
+// "python server.py" behavior still resolves to the script's parent directory.
+func TestSourceResolverPythonScriptArgPreserved(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "server.py")
+	os.WriteFile(scriptPath, []byte("# test"), 0644)
+
+	r := NewSourceResolver(zap.NewNop())
+	result, err := r.Resolve(context.Background(), ServerInfo{
+		Name:     "py-stdio",
+		Protocol: "stdio",
+		Command:  "python",
+		Args:     []string{scriptPath},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if result.SourceDir != dir {
+		t.Errorf("expected source_dir %q, got %q", dir, result.SourceDir)
+	}
+	result.Cleanup()
+}
+
+// TestSourceResolverStdioNoSource verifies that a stdio server with no
+// resolvable source (no container, no working_dir, no package cache, no
+// source-like args) returns an error cleanly.
+func TestSourceResolverStdioNoSource(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+
+	r := NewSourceResolver(zap.NewNop())
+	_, err := r.Resolve(context.Background(), ServerInfo{
+		Name:     "ghost",
+		Protocol: "stdio",
+		Command:  "/usr/bin/does-not-exist",
+		Args:     []string{"--flag"},
+	})
+	if err == nil {
+		t.Fatal("expected error for stdio server with no resolvable source")
+	}
+}
+
+func TestDirLooksLikeSource(t *testing.T) {
+	// Dir with package.json → source
+	sourceDir := t.TempDir()
+	os.WriteFile(filepath.Join(sourceDir, "package.json"), []byte("{}"), 0644)
+	if !dirLooksLikeSource(sourceDir) {
+		t.Error("expected dir with package.json to look like source")
+	}
+
+	// Dir with only a .py file → source
+	pyDir := t.TempDir()
+	os.WriteFile(filepath.Join(pyDir, "main.py"), []byte("# test"), 0644)
+	if !dirLooksLikeSource(pyDir) {
+		t.Error("expected dir with .py file to look like source")
+	}
+
+	// Empty dir → not source
+	emptyDir := t.TempDir()
+	if dirLooksLikeSource(emptyDir) {
+		t.Error("expected empty dir to NOT look like source")
+	}
+
+	// Data dir → not source
+	dataDir := t.TempDir()
+	os.WriteFile(filepath.Join(dataDir, "notes.txt"), []byte("a"), 0644)
+	os.WriteFile(filepath.Join(dataDir, "image.png"), []byte{0}, 0644)
+	if dirLooksLikeSource(dataDir) {
+		t.Error("expected plain data dir to NOT look like source")
+	}
+}
+
+func TestIsPackageRunnerCommand(t *testing.T) {
+	tests := []struct {
+		cmd  string
+		want bool
+	}{
+		{"npx", true},
+		{"/usr/local/bin/npx", true},
+		{"uvx", true},
+		{"pipx", true},
+		{"bunx", true},
+		{"python", false},
+		{"node", false},
+		{"./server", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.cmd, func(t *testing.T) {
+			if got := isPackageRunnerCommand(tt.cmd); got != tt.want {
+				t.Errorf("isPackageRunnerCommand(%q) = %v, want %v", tt.cmd, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSanitizeForDocker(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1673,6 +1673,7 @@ func (s *Server) startCustomHTTPServer(ctx context.Context, streamableServer *se
 		secService := scanner.NewService(sm, secRegistry, secDocker, dataDir, s.logger)
 		secService.SetEmitter(s.runtime)
 		secService.SetServerInfoProvider(&configServerInfoProvider{cfg: cfg, server: s})
+		secService.SetServerUnquarantiner(&serverUnquarantinerAdapter{server: s})
 		secService.SetSecretStore(&keyringSecretStore{resolver: secret.NewResolver()})
 		secService.CleanupStaleJobs()
 		httpAPIServer.SetSecurityController(secService)
@@ -2367,6 +2368,21 @@ func (s *Server) GetToolApprovalStatus(serverName, toolName string) (string, err
 		return "", err
 	}
 	return string(record.Status), nil
+}
+
+// serverUnquarantinerAdapter adapts *Server to scanner.ServerUnquarantiner so
+// the security scanner service can unquarantine a server after ApproveServer
+// succeeds. Reuses the existing Server.UnquarantineServer path so the behavior
+// stays identical to the REST API and tray code.
+type serverUnquarantinerAdapter struct {
+	server *Server
+}
+
+func (a *serverUnquarantinerAdapter) UnquarantineServer(serverName string) error {
+	if a.server == nil {
+		return fmt.Errorf("server unavailable")
+	}
+	return a.server.UnquarantineServer(serverName)
 }
 
 // keyringSecretStore adapts secret.Resolver to scanner.SecretStore for API key management.


### PR DESCRIPTION
## Summary

Bundled fix for 13 bugs surfaced by a full QA pass of **Spec 039 (Security Scanner Plugin System)**. Most impactful: `security approve` now actually unquarantines the server, the source resolver no longer scans user data directories for npx/uvx-based servers, the macOS keychain probe stops popping a modal dialog, and the UI's inline **Approve** button is now scanner-gated.

- **Critical:** F-01 (approve broken), F-02 (wrong source dir)
- **High:** F-03 (keychain modal), F-04 (UI bypasses scanner), F-05 (CLI hang)
- **Medium:** F-06 (dry-run ran real scans), F-09 (status vocabulary), F-10 (hidden failed scanners), F-11 (wrong risk score in history)
- **UX:** F-12 (dashboard stale chip), F-14 (zero-time display), F-15 (configure timeout), F-16 (scan-all redraw), plus `--config`/`--data-dir` propagation

**Not fixed (documented, upstream scanner-image issues):** F-07 ramparts GLIBC on arm64 macOS, F-13 cisco hardcoded server_url.

## QA evidence

The full QA report lives at [`docs/qa/security-scanners-2026-04-10.html`](docs/qa/security-scanners-2026-04-10.html). §11 "After-Fix Revalidation" contains the post-fix verification matrix with per-finding evidence and command traces.

### Before → after highlights

| | Before | After |
|---|---|---|
| `security approve everything` → `quarantined` | `true` (bug) | `false` ✓ |
| Scanning `filesystem-test` source path | `/tmp/mcpproxy-qa-evidence` (user data!) | `~/.npm/.../server-filesystem` ✓ |
| `mcp-ai-scanner` findings on filesystem-test | 2 high false positives | 0 ✓ |
| `security configure mcp-scan --env SNYK_TOKEN=...` | 60s timeout + macOS modal | ~3s, no dialog ✓ |
| `security scan everything` blocking mode | hung >120s after completion | exits in 9s ✓ |
| `security report` output when scanners fail | "0 findings" (hides failures) | "5 run, 2 failed (mcp-scan, ramparts) of 7" + warning ✓ |
| UI "Approve" button on quarantined server | one-click bypass of scanner | scanner-gated modal ✓ |
| Scanners running e2e on arm64 macOS | 5 of 7 | **6 of 7** ✓ |

## Test plan

- [x] `go test ./internal/secret/... ./internal/security/... ./cmd/mcpproxy/...` — all pass (new tests included)
- [x] `./scripts/run-linter.sh` — 0 issues
- [x] `make build` — clean (frontend + backend)
- [x] Full e2e revalidation script (`/tmp/mcpproxy-qa-revalidate.sh`) against three servers (everything, fetch-test, filesystem-test) with all 7 scanners enabled
- [x] Web UI verified in Chrome: Dashboard chip routing, Approve button modal (Cancel / Scan First / Force Approve) on quarantined server
- [x] Keychain probe: CI-style headless env returns instantly; hanging-backend simulation returns within 2s
- [x] Source resolver: regression tests for filesystem-server (false positive) and python-script-arg (legitimate)

## New tests

- `internal/secret/keyring_provider_test.go` — probe-without-set, hanging backend, headless env, ErrNotFound
- `internal/security/scanner/service_test.go` — `TestServiceApproveServerCallsUnquarantiner`, `TestServiceApproveServerCriticalDoesNotUnquarantine`, `TestServiceApproveServerUnquarantinerError`
- `internal/security/scanner/source_resolver_test.go` — `TestSourceResolverNpxFilesystemArgNotPicked`, `TestSourceResolverPythonScriptArgPreserved`, `TestSourceResolverNpxDataDirFallsThroughWhenNoCache`
- `cmd/mcpproxy/security_cmd_test.go` — flag propagation, output formatting
- `frontend/tests/unit/servers-store.spec.ts` — `securityApproveServer` uses the scanner endpoint

## Follow-ups (not in this PR)

- **F-07**: rebuild `ghcr.io/smart-mcp-proxy/scanner-ramparts:latest` against an older glibc base or static-link with musl.
- **F-13**: file an upstream issue against Cisco MCP Scanner about the hardcoded `server_url` in its stdout.
- Auto-disable a scanner after N consecutive runtime failures and surface that on the Security dashboard.
- Make the Web UI show `required_env` as a pre-run warning on the Security page before the first scan (mitigation for F-08).

🤖 Generated with [Claude Code](https://claude.com/claude-code)