### PR TITLE
fix(docker): wrap docker CLI invocations in user shell to inherit PATH

### DIFF
--- a/internal/security/scanner/docker.go
+++ b/internal/security/scanner/docker.go
@@ -7,14 +7,26 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/shellwrap"
 	"go.uber.org/zap"
 )
 
-// DockerRunner executes Docker operations for scanner containers
+// DockerRunner executes Docker operations for scanner containers.
+//
+// Security note: the scanner runs untrusted container images (vulnerability
+// scanners, SBOM generators, etc). It MUST NOT inherit the user's ambient
+// credentials (AWS, GitHub, Anthropic tokens, …). We therefore:
+//  1. Resolve the docker binary once via shellwrap.ResolveDockerPath — this
+//     picks up Homebrew / Docker Desktop / Colima installs even when mcpproxy
+//     was launched from a GUI with a minimal PATH, WITHOUT re-spawning a
+//     login shell on every invocation (important for hot paths like the
+//     ~2s health check loop).
+//  2. Invoke docker directly with cmd.Env set to a minimal PATH+HOME
+//     allowlist via shellwrap.MinimalEnv, so environment-based secrets do
+//     not leak into the docker CLI's subprocess tree.
 type DockerRunner struct {
 	logger *zap.Logger
 }
@@ -24,28 +36,25 @@ func NewDockerRunner(logger *zap.Logger) *DockerRunner {
 	return &DockerRunner{logger: logger}
 }
 
-// getDockerCmd creates an exec.Cmd for Docker, inheriting user PATH via login shell
+// getDockerCmd creates an exec.Cmd for Docker with a minimal, allow-listed
+// environment so ambient secrets (AWS creds, GitHub tokens, …) cannot leak
+// into the security scanner's subprocess. The docker binary is resolved once
+// via shellwrap and then cached for the process lifetime.
 func (d *DockerRunner) getDockerCmd(ctx context.Context, args ...string) *exec.Cmd {
-	var commandParts []string
-	commandParts = append(commandParts, "docker")
-	if runtime.GOOS == "windows" {
-		for _, arg := range args {
-			commandParts = append(commandParts, `"`+strings.Trim(arg, `"`)+`"`)
+	dockerBin, err := shellwrap.ResolveDockerPath(d.logger)
+	if err != nil || dockerBin == "" {
+		// Fall back to plain "docker" so exec returns a clear ENOENT the
+		// caller can surface. We still set the minimal env to avoid leaking
+		// secrets even in the error path.
+		dockerBin = "docker"
+		if d.logger != nil {
+			d.logger.Debug("scanner docker: falling back to bare 'docker' lookup",
+				zap.Error(err))
 		}
-		commandString := strings.Join(commandParts, " ")
-		return exec.CommandContext(ctx, "cmd", "/c", commandString)
-	} else {
-		for _, arg := range args {
-			if arg == "" {
-				commandParts = append(commandParts, "''")
-				continue
-			}
-			escaped := "'" + strings.ReplaceAll(arg, "'", "'\"'\"'") + "'"
-			commandParts = append(commandParts, escaped)
-		}
-		commandString := strings.Join(commandParts, " ")
-		return exec.CommandContext(ctx, "sh", "-l", "-c", commandString)
 	}
+	cmd := exec.CommandContext(ctx, dockerBin, args...)
+	cmd.Env = shellwrap.MinimalEnv()
+	return cmd
 }
 
 // IsDockerAvailable checks if Docker daemon is running

--- a/internal/security/scanner/docker.go
+++ b/internal/security/scanner/docker.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -23,9 +24,33 @@ func NewDockerRunner(logger *zap.Logger) *DockerRunner {
 	return &DockerRunner{logger: logger}
 }
 
+// getDockerCmd creates an exec.Cmd for Docker, inheriting user PATH via login shell
+func (d *DockerRunner) getDockerCmd(ctx context.Context, args ...string) *exec.Cmd {
+	var commandParts []string
+	commandParts = append(commandParts, "docker")
+	if runtime.GOOS == "windows" {
+		for _, arg := range args {
+			commandParts = append(commandParts, `"`+strings.Trim(arg, `"`)+`"`)
+		}
+		commandString := strings.Join(commandParts, " ")
+		return exec.CommandContext(ctx, "cmd", "/c", commandString)
+	} else {
+		for _, arg := range args {
+			if arg == "" {
+				commandParts = append(commandParts, "''")
+				continue
+			}
+			escaped := "'" + strings.ReplaceAll(arg, "'", "'\"'\"'") + "'"
+			commandParts = append(commandParts, escaped)
+		}
+		commandString := strings.Join(commandParts, " ")
+		return exec.CommandContext(ctx, "sh", "-l", "-c", commandString)
+	}
+}
+
 // IsDockerAvailable checks if Docker daemon is running
 func (d *DockerRunner) IsDockerAvailable(ctx context.Context) bool {
-	cmd := exec.CommandContext(ctx, "docker", "info")
+	cmd := d.getDockerCmd(ctx, "info")
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	return cmd.Run() == nil
@@ -34,7 +59,7 @@ func (d *DockerRunner) IsDockerAvailable(ctx context.Context) bool {
 // PullImage pulls a Docker image with progress logging
 func (d *DockerRunner) PullImage(ctx context.Context, image string) error {
 	d.logger.Info("Pulling Docker image", zap.String("image", image))
-	cmd := exec.CommandContext(ctx, "docker", "pull", image)
+	cmd := d.getDockerCmd(ctx, "pull", image)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -46,7 +71,7 @@ func (d *DockerRunner) PullImage(ctx context.Context, image string) error {
 
 // ImageExists checks if a Docker image exists locally
 func (d *DockerRunner) ImageExists(ctx context.Context, image string) bool {
-	cmd := exec.CommandContext(ctx, "docker", "image", "inspect", image)
+	cmd := d.getDockerCmd(ctx, "image", "inspect", image)
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	return cmd.Run() == nil
@@ -54,7 +79,7 @@ func (d *DockerRunner) ImageExists(ctx context.Context, image string) bool {
 
 // RemoveImage removes a Docker image
 func (d *DockerRunner) RemoveImage(ctx context.Context, image string) error {
-	cmd := exec.CommandContext(ctx, "docker", "rmi", "-f", image)
+	cmd := d.getDockerCmd(ctx, "rmi", "-f", image)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -156,7 +181,7 @@ func (d *DockerRunner) RunScanner(ctx context.Context, cfg ScannerRunConfig) (st
 		defer cancel()
 	}
 
-	cmd := exec.CommandContext(runCtx, "docker", args...)
+	cmd := d.getDockerCmd(runCtx, args...)
 	var stdoutBuf, stderrBuf bytes.Buffer
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf
@@ -186,7 +211,7 @@ func (d *DockerRunner) KillContainer(ctx context.Context, name string) error {
 	if name == "" {
 		return nil
 	}
-	cmd := exec.CommandContext(ctx, "docker", "kill", name)
+	cmd := d.getDockerCmd(ctx, "kill", name)
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	return cmd.Run()
@@ -197,7 +222,7 @@ func (d *DockerRunner) StopContainer(ctx context.Context, name string, timeout i
 	if name == "" {
 		return nil
 	}
-	cmd := exec.CommandContext(ctx, "docker", "stop", "-t", fmt.Sprintf("%d", timeout), name)
+	cmd := d.getDockerCmd(ctx, "stop", "-t", fmt.Sprintf("%d", timeout), name)
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	return cmd.Run()
@@ -224,7 +249,7 @@ func (d *DockerRunner) ReadReportFile(reportDir string) ([]byte, error) {
 
 // GetImageDigest returns the Docker image digest
 func (d *DockerRunner) GetImageDigest(ctx context.Context, image string) (string, error) {
-	cmd := exec.CommandContext(ctx, "docker", "inspect", "--format", "{{.Id}}", image)
+	cmd := d.getDockerCmd(ctx, "inspect", "--format", "{{.Id}}", image)
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {

--- a/internal/security/scanner/docker_test.go
+++ b/internal/security/scanner/docker_test.go
@@ -225,3 +225,42 @@ func TestStopContainerEmptyName(t *testing.T) {
 		t.Errorf("StopContainer with empty name should return nil, got: %v", err)
 	}
 }
+
+// TestDockerRunnerDoesNotLeakAmbientSecrets verifies that the scanner's
+// Docker subprocess is invoked with a minimal, allow-listed environment so
+// credentials in the parent process environment (AWS, GitHub, Anthropic,
+// …) cannot leak into containers that run untrusted scanner images.
+func TestDockerRunnerDoesNotLeakAmbientSecrets(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "AKIA_test_dummy_value_00000000")
+	t.Setenv("GITHUB_TOKEN", "ghp_test_dummy_token_1234567890abcdef")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-dummy-not-real")
+
+	logger := zap.NewNop()
+	d := NewDockerRunner(logger)
+
+	cmd := d.getDockerCmd(context.Background(), "version")
+
+	if cmd.Env == nil {
+		t.Fatal("cmd.Env must be explicitly set (non-nil) so it does not inherit os.Environ()")
+	}
+
+	joined := strings.Join(cmd.Env, "\n")
+	forbidden := []string{"AWS_ACCESS_KEY_ID", "GITHUB_TOKEN", "ANTHROPIC_API_KEY"}
+	for _, key := range forbidden {
+		if strings.Contains(joined, key) {
+			t.Errorf("scanner docker command leaked %q into cmd.Env", key)
+		}
+	}
+
+	// PATH must still be present so the docker binary is actually runnable.
+	hasPath := false
+	for _, kv := range cmd.Env {
+		if strings.HasPrefix(kv, "PATH=") {
+			hasPath = true
+			break
+		}
+	}
+	if !hasPath {
+		t.Error("scanner docker command must retain PATH so 'docker' is discoverable")
+	}
+}

--- a/internal/shellwrap/shellwrap.go
+++ b/internal/shellwrap/shellwrap.go
@@ -1,0 +1,224 @@
+// Package shellwrap provides platform-level helpers for wrapping commands in
+// the user's login shell and for resolving tool binaries (e.g. docker) with
+// PATH caching.
+//
+// It exists so that both the upstream proxy code (internal/upstream/core) and
+// the security scanner (internal/security/scanner) can share a single,
+// well-tested implementation of shell quoting + login-shell wrapping instead
+// of each rolling their own.
+package shellwrap
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+const (
+	osWindows = "windows"
+	// defaultUnixShell is used when $SHELL is unset on a Unix-like system.
+	defaultUnixShell = "/bin/bash"
+	// defaultWindowsShell is used when neither $ComSpec nor $SHELL is set.
+	defaultWindowsShell = "cmd"
+)
+
+// Shellescape escapes a single argument for safe inclusion in a shell command
+// string. On Unix it uses POSIX single-quoting; on Windows it performs a
+// best-effort cmd.exe quoting.
+//
+// This mirrors the implementation in internal/upstream/core so both code paths
+// can converge on one function.
+func Shellescape(s string) string {
+	if s == "" {
+		if runtime.GOOS == osWindows {
+			return `""`
+		}
+		return "''"
+	}
+
+	if runtime.GOOS == osWindows {
+		// Windows cmd.exe special characters.
+		if !strings.ContainsAny(s, " \t\n\r\"&|<>()^%") {
+			return s
+		}
+		// cmd.exe does not use backslash as an escape character. If the
+		// caller supplied embedded double quotes we strip them — this is
+		// the same behaviour the upstream helper has used since PR #195.
+		cleaned := strings.Trim(s, `"`)
+		return `"` + cleaned + `"`
+	}
+
+	// Unix shell special characters: if none present, return as-is.
+	if !strings.ContainsAny(s, " \t\n\r\"'\\$`;&|<>(){}[]?*~") {
+		return s
+	}
+	// Use single quotes and escape any embedded single quotes.
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+}
+
+// isBashLikeShell mirrors the detection logic in connection_stdio.go so that
+// Git Bash / MSYS on Windows uses the Unix-style -l -c flags.
+func isBashLikeShell(shell string) bool {
+	lower := strings.ToLower(shell)
+	return strings.Contains(lower, "bash") || strings.Contains(lower, "sh")
+}
+
+// resolveLoginShell returns the user's preferred login shell, respecting the
+// $SHELL environment variable and falling back to platform defaults.
+func resolveLoginShell() string {
+	shell := os.Getenv("SHELL")
+	if shell != "" {
+		return shell
+	}
+	if runtime.GOOS == osWindows {
+		if cs := os.Getenv("ComSpec"); cs != "" {
+			return cs
+		}
+		return defaultWindowsShell
+	}
+	return defaultUnixShell
+}
+
+// WrapWithUserShell wraps a command and its arguments in the user's login
+// shell so the child process inherits the interactive PATH (important when
+// mcpproxy is launched from a GUI / LaunchAgent on macOS).
+//
+// It returns the shell to exec and the shell arguments (e.g. ["-l", "-c",
+// "docker run ..."] on Unix, ["/c", "docker run ..."] on Windows cmd).
+//
+// logger may be nil; when non-nil a debug line is emitted mirroring the
+// existing upstream/core helper.
+func WrapWithUserShell(logger *zap.Logger, command string, args []string) (shell string, shellArgs []string) {
+	shell = resolveLoginShell()
+
+	parts := make([]string, 0, len(args)+1)
+	parts = append(parts, Shellescape(command))
+	for _, a := range args {
+		parts = append(parts, Shellescape(a))
+	}
+	commandString := strings.Join(parts, " ")
+
+	if logger != nil {
+		logger.Debug("shellwrap: wrapping command with user login shell",
+			zap.String("original_command", command),
+			zap.Strings("original_args", args),
+			zap.String("shell", shell),
+			zap.String("wrapped_command", commandString))
+	}
+
+	isBash := isBashLikeShell(shell)
+	if runtime.GOOS == osWindows && !isBash {
+		// Windows cmd.exe: /c to execute a command string.
+		return shell, []string{"/c", commandString}
+	}
+	// Unix shells and Git Bash on Windows: -l for login env, -c for command.
+	return shell, []string{"-l", "-c", commandString}
+}
+
+// --- Docker path resolution ---------------------------------------------
+
+var (
+	dockerPathOnce sync.Once
+	dockerPath     string
+	dockerPathErr  error
+)
+
+// ResolveDockerPath returns the absolute path to the `docker` binary. The
+// result is cached for the process lifetime so that repeated calls from hot
+// paths (health checks, connection diagnostics) do not re-spawn a login shell
+// on every invocation.
+//
+// Resolution order:
+//  1. exec.LookPath("docker") — cheap, works when mcpproxy was started from
+//     a terminal or when the LaunchAgent PATH already contains docker.
+//  2. Fallback: ask the user's login shell `command -v docker` so we pick up
+//     Homebrew / Colima / Docker Desktop installs that only exist in the
+//     interactive PATH. This fallback is only run once.
+func ResolveDockerPath(logger *zap.Logger) (string, error) {
+	dockerPathOnce.Do(func() {
+		// Fast path: ask Go's standard PATH lookup first.
+		if p, err := exec.LookPath("docker"); err == nil && p != "" {
+			dockerPath = p
+			if logger != nil {
+				logger.Debug("shellwrap: resolved docker via PATH", zap.String("path", p))
+			}
+			return
+		}
+
+		// Slow path: shell out once via the user's login shell.
+		if runtime.GOOS == osWindows {
+			dockerPathErr = fmt.Errorf("docker not found in PATH")
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		shell, shellArgs := WrapWithUserShell(logger, "command", []string{"-v", "docker"})
+		cmd := exec.CommandContext(ctx, shell, shellArgs...)
+		out, err := cmd.Output()
+		if err != nil {
+			dockerPathErr = fmt.Errorf("login-shell docker lookup failed: %w", err)
+			return
+		}
+		resolved := strings.TrimSpace(string(out))
+		if resolved == "" {
+			dockerPathErr = fmt.Errorf("docker not found in login shell PATH")
+			return
+		}
+		dockerPath = resolved
+		if logger != nil {
+			logger.Debug("shellwrap: resolved docker via login shell",
+				zap.String("path", resolved))
+		}
+	})
+	return dockerPath, dockerPathErr
+}
+
+// resetDockerPathCacheForTest is used by tests to probe the sync.Once
+// behaviour. It is intentionally unexported and only referenced from
+// shellwrap_test.go.
+func resetDockerPathCacheForTest() {
+	dockerPathOnce = sync.Once{}
+	dockerPath = ""
+	dockerPathErr = nil
+}
+
+// --- Minimal environment for scanner subprocesses ------------------------
+
+// MinimalEnv returns a minimal, allow-listed environment suitable for
+// subprocesses that must NOT inherit the user's ambient credentials (e.g.
+// AWS_ACCESS_KEY_ID, GITHUB_TOKEN, etc). It includes PATH + HOME on Unix and
+// PATH + USERPROFILE on Windows so that `docker` itself still functions.
+//
+// Callers that need TLS or Docker-specific variables (DOCKER_HOST,
+// DOCKER_CONFIG, …) should append them explicitly.
+func MinimalEnv() []string {
+	env := make([]string, 0, 8)
+	if v := os.Getenv("PATH"); v != "" {
+		env = append(env, "PATH="+v)
+	}
+	if runtime.GOOS == osWindows {
+		if v := os.Getenv("USERPROFILE"); v != "" {
+			env = append(env, "USERPROFILE="+v)
+		}
+		if v := os.Getenv("SystemRoot"); v != "" {
+			env = append(env, "SystemRoot="+v)
+		}
+		if v := os.Getenv("ComSpec"); v != "" {
+			env = append(env, "ComSpec="+v)
+		}
+	} else {
+		if v := os.Getenv("HOME"); v != "" {
+			env = append(env, "HOME="+v)
+		}
+	}
+	return env
+}

--- a/internal/shellwrap/shellwrap_test.go
+++ b/internal/shellwrap/shellwrap_test.go
@@ -1,0 +1,112 @@
+package shellwrap
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShellescape_TrickyArgs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TestShellescape_TrickyArgs uses POSIX quoting expectations")
+	}
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", "''"},
+		{"simple", "hello", "hello"},
+		{"space", "hello world", "'hello world'"},
+		{"single quote", "it's", "'it'\"'\"'s'"},
+		{"dollar", "$HOME", "'$HOME'"},
+		{"backticks", "`whoami`", "'`whoami`'"},
+		{"glob star", "*.go", "'*.go'"},
+		{"pipe", "a|b", "'a|b'"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Shellescape(tc.in)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestWrapWithUserShell_RespectsShellEnv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("$SHELL override is only meaningful on Unix-like systems")
+	}
+
+	t.Setenv("SHELL", "/opt/homebrew/bin/zsh")
+
+	shell, args := WrapWithUserShell(nil, "docker", []string{"ps", "-a"})
+	assert.Equal(t, "/opt/homebrew/bin/zsh", shell, "should honor $SHELL override")
+	require.Len(t, args, 3, "unix shell wrapping should produce 3 args")
+	assert.Equal(t, "-l", args[0])
+	assert.Equal(t, "-c", args[1])
+	// Command string should contain the docker invocation with escaped args.
+	assert.Contains(t, args[2], "docker")
+	assert.Contains(t, args[2], "ps")
+	assert.Contains(t, args[2], "-a")
+}
+
+func TestWrapWithUserShell_FallbackWhenShellUnset(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix fallback test")
+	}
+	t.Setenv("SHELL", "")
+	shell, args := WrapWithUserShell(nil, "docker", []string{"version"})
+	assert.Equal(t, "/bin/bash", shell, "should fall back to /bin/bash when $SHELL is empty")
+	require.Len(t, args, 3)
+	assert.Equal(t, "-l", args[0])
+	assert.Equal(t, "-c", args[1])
+}
+
+func TestResolveDockerPath_CachedAcrossCalls(t *testing.T) {
+	resetDockerPathCacheForTest()
+	t.Cleanup(resetDockerPathCacheForTest)
+
+	first, firstErr := ResolveDockerPath(nil)
+
+	// Sabotage PATH after the first resolve. If the cache works the second
+	// call must return the same value (or same error) without re-probing.
+	origPath := t.TempDir()
+	t.Setenv("PATH", origPath)
+
+	second, secondErr := ResolveDockerPath(nil)
+
+	assert.Equal(t, first, second, "cached docker path should survive PATH changes")
+	if firstErr == nil {
+		assert.NoError(t, secondErr, "cached success must not suddenly error")
+	} else {
+		assert.Error(t, secondErr, "cached error must remain an error")
+	}
+}
+
+func TestMinimalEnv_DropsSecrets(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "AKIA_test_dummy_value_00000000")
+	t.Setenv("GITHUB_TOKEN", "ghp_dummy_test_token_1234567890abcdef")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-dummy-not-real-value")
+	t.Setenv("OPENAI_API_KEY", "sk-test-dummy-not-real-value")
+
+	env := MinimalEnv()
+
+	joined := strings.Join(env, "\n")
+	assert.NotContains(t, joined, "AWS_ACCESS_KEY_ID", "AWS creds must not leak into minimal env")
+	assert.NotContains(t, joined, "GITHUB_TOKEN", "github token must not leak")
+	assert.NotContains(t, joined, "ANTHROPIC_API_KEY", "anthropic key must not leak")
+	assert.NotContains(t, joined, "OPENAI_API_KEY", "openai key must not leak")
+
+	// But PATH must still be present so docker itself can be found.
+	hasPath := false
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "PATH=") {
+			hasPath = true
+			break
+		}
+	}
+	assert.True(t, hasPath, "minimal env must contain PATH")
+}

--- a/internal/upstream/core/connection_stdio.go
+++ b/internal/upstream/core/connection_stdio.go
@@ -6,11 +6,11 @@ import (
 	"os"
 	"os/exec"
 	"reflect"
-	"runtime"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/client"
 	uptransport "github.com/mark3labs/mcp-go/client/transport"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/shellwrap"
 	"go.uber.org/zap"
 )
 
@@ -331,92 +331,28 @@ func (c *Client) connectStdio(ctx context.Context) error {
 	return nil
 }
 
-// wrapWithUserShell wraps a command with the user's login shell to inherit full environment
+// wrapWithUserShell wraps a command with the user's login shell to inherit
+// the full interactive environment. This is a thin wrapper around
+// shellwrap.WrapWithUserShell — the canonical implementation now lives in
+// internal/shellwrap so the security scanner can share it.
+//
+// The client-scoped debug log (with server name) is retained here for
+// continuity with historical log output.
 func (c *Client) wrapWithUserShell(command string, args []string) (shellCommand string, shellArgs []string) {
-	// Get the user's default shell
-	shell, _ := c.envManager.GetSystemEnvVar("SHELL")
-	if shell == "" {
-		// Fallback to common shells based on OS
-		if runtime.GOOS == osWindows {
-			shell = "cmd"
-		} else {
-			shell = pathBinBash // Default fallback
-		}
-	}
-
-	// Build the command string that will be executed by the shell
-	// We need to properly escape the command and arguments for shell execution
-	var commandParts []string
-	commandParts = append(commandParts, shellescape(command))
-	for _, arg := range args {
-		commandParts = append(commandParts, shellescape(arg))
-	}
-	commandString := strings.Join(commandParts, " ")
-
-	// Log what we're doing for debugging
+	shellCommand, shellArgs = shellwrap.WrapWithUserShell(c.logger, command, args)
 	c.logger.Debug("Wrapping command with user shell for full environment inheritance",
 		zap.String("server", c.config.Name),
 		zap.String("original_command", command),
 		zap.Strings("original_args", args),
-		zap.String("shell", shell),
-		zap.String("wrapped_command", commandString))
-
-	// Return shell with appropriate flags
-	// Check if the shell is bash (even on Windows with Git Bash)
-	isBash := strings.Contains(strings.ToLower(shell), "bash") ||
-		strings.Contains(strings.ToLower(shell), "sh")
-
-	if runtime.GOOS == osWindows && !isBash {
-		// Windows cmd.exe uses /c flag to execute command string
-		return shell, []string{"/c", commandString}
-	}
-	// Unix shells (and Git Bash on Windows) use -l (login) flag to load user's full environment
-	// The -c flag executes the command string
-	return shell, []string{"-l", "-c", commandString}
+		zap.String("shell", shellCommand))
+	return shellCommand, shellArgs
 }
 
-// shellescape escapes a string for safe shell execution
+// shellescape is retained as a package-local alias for backward
+// compatibility with existing tests (internal/upstream/core/shell_test.go).
+// It delegates to shellwrap.Shellescape.
 func shellescape(s string) string {
-	if s == "" {
-		if runtime.GOOS == osWindows {
-			return `""`
-		}
-		return "''"
-	}
-
-	// If string contains no special characters, return as-is
-	if runtime.GOOS == osWindows {
-		// Windows cmd.exe special characters
-		if !strings.ContainsAny(s, " \t\n\r\"&|<>()^%") {
-			return s
-		}
-
-		// IMPORTANT: cmd.exe uses DIFFERENT escaping than Unix shells
-		// - Backslash is NOT an escape character in cmd.exe
-		// - To include a literal quote in a quoted string, you must:
-		//   1. End the quoted string
-		//   2. Add an escaped quote (\")
-		//   3. Start a new quoted string
-		//
-		// However, for our use case with cmd /c "command args", we wrap
-		// the entire command line once, and individual components should
-		// NOT contain quotes. If they do, we need special handling.
-		//
-		// Strategy: If string already contains quotes, strip them first
-		// This handles the case where users put quotes in JSON config
-		cleaned := strings.Trim(s, `"`)
-
-		// Now wrap in quotes for cmd.exe
-		// Any remaining internal quotes are from the actual path and will cause issues
-		// For now, we just quote the cleaned string
-		return `"` + cleaned + `"`
-	}
-	// Unix shell special characters
-	if !strings.ContainsAny(s, " \t\n\r\"'\\$`;&|<>(){}[]?*~") {
-		return s
-	}
-	// Use single quotes and escape any single quotes in the string
-	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+	return shellwrap.Shellescape(s)
 }
 
 // hasCommand checks if a command is available in PATH

--- a/internal/upstream/core/docker.go
+++ b/internal/upstream/core/docker.go
@@ -8,11 +8,30 @@ import (
 	"strings"
 	"time"
 
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/shellwrap"
 	"go.uber.org/zap"
 )
 
-// newDockerCmd creates an exec.Cmd for Docker, wrapped in the user's shell to inherit PATH
+// newDockerCmd creates an exec.Cmd for Docker. The docker binary itself is
+// resolved once via shellwrap.ResolveDockerPath (cached process-wide) so
+// that hot paths like checkDockerContainerHealth / GetConnectionDiagnostics
+// — which fire every few seconds — do not re-spawn a login shell to
+// re-read .zshrc/.bashrc on every invocation.
+//
+// If docker cannot be resolved directly (rare: uncommon install layout) we
+// fall back to wrapping with the user's login shell to preserve the
+// original PR's "Docker works when launched from Launchpad" fix.
 func (c *Client) newDockerCmd(ctx context.Context, args ...string) *exec.Cmd {
+	if dockerBin, err := shellwrap.ResolveDockerPath(c.logger); err == nil && dockerBin != "" {
+		cmd := exec.CommandContext(ctx, dockerBin, args...)
+		if c.envManager != nil {
+			cmd.Env = c.envManager.BuildSecureEnvironment()
+		}
+		return cmd
+	}
+
+	// Fallback: login-shell wrap so the child process picks up the full
+	// interactive PATH the user sees in Terminal.
 	shell, shellArgs := c.wrapWithUserShell("docker", args)
 	cmd := exec.CommandContext(ctx, shell, shellArgs...)
 	if c.envManager != nil {

--- a/internal/upstream/core/docker.go
+++ b/internal/upstream/core/docker.go
@@ -11,6 +11,16 @@ import (
 	"go.uber.org/zap"
 )
 
+// newDockerCmd creates an exec.Cmd for Docker, wrapped in the user's shell to inherit PATH
+func (c *Client) newDockerCmd(ctx context.Context, args ...string) *exec.Cmd {
+	shell, shellArgs := c.wrapWithUserShell("docker", args)
+	cmd := exec.CommandContext(ctx, shell, shellArgs...)
+	if c.envManager != nil {
+		cmd.Env = c.envManager.BuildSecureEnvironment()
+	}
+	return cmd
+}
+
 // readContainerIDWithContext reads the container ID from cidfile for tracking with context cancellation
 func (c *Client) readContainerIDWithContext(ctx context.Context, cidFile string) {
 	c.logger.Debug("Starting container ID tracking",
@@ -73,7 +83,7 @@ func (c *Client) readContainerIDWithContext(ctx context.Context, cidFile string)
 
 	// Fallback: Find container by name
 	if c.containerName != "" {
-		listCmd := exec.CommandContext(ctx, "docker", "ps",
+		listCmd := c.newDockerCmd(ctx, "ps",
 			"--filter", fmt.Sprintf("name=^%s$", c.containerName),
 			"--format", "{{.ID}}")
 
@@ -141,7 +151,7 @@ func (c *Client) killDockerContainerWithContext(ctx context.Context) {
 		zap.String("server", c.config.Name),
 		zap.String("container_id", containerID[:12]))
 
-	stopCmd := exec.CommandContext(ctx, "docker", "stop", containerID)
+	stopCmd := c.newDockerCmd(ctx, "stop", containerID)
 	c.logger.Debug("Executing docker stop command",
 		zap.String("server", c.config.Name),
 		zap.String("container_id", containerID[:12]))
@@ -157,7 +167,7 @@ func (c *Client) killDockerContainerWithContext(ctx context.Context) {
 			zap.String("server", c.config.Name),
 			zap.String("container_id", containerID[:12]))
 
-		killCmd := exec.CommandContext(ctx, "docker", "kill", containerID)
+		killCmd := c.newDockerCmd(ctx, "kill", containerID)
 		c.logger.Debug("Executing docker kill command",
 			zap.String("server", c.config.Name),
 			zap.String("container_id", containerID[:12]))
@@ -242,7 +252,7 @@ func (c *Client) killDockerContainerByCommandWithContext(ctx context.Context) {
 		zap.String("image_name", imageName))
 
 	// Get list of running containers with image and created time
-	listCmd := exec.CommandContext(ctx, "docker", "ps", "--format", "{{.ID}}\t{{.Image}}\t{{.CreatedAt}}")
+	listCmd := c.newDockerCmd(ctx, "ps", "--format", "{{.ID}}\t{{.Image}}\t{{.CreatedAt}}")
 	output, err := listCmd.Output()
 	if err != nil {
 		c.logger.Error("Failed to list Docker containers for cleanup",
@@ -294,10 +304,10 @@ func (c *Client) killDockerContainerByCommandWithContext(ctx context.Context) {
 		}
 
 		// First try graceful stop
-		stopCmd := exec.CommandContext(ctx, "docker", "stop", containerID)
+		stopCmd := c.newDockerCmd(ctx, "stop", containerID)
 		if err := stopCmd.Run(); err != nil {
 			// Force kill if graceful stop fails
-			killCmd := exec.CommandContext(ctx, "docker", "kill", containerID)
+			killCmd := c.newDockerCmd(ctx, "kill", containerID)
 			if err := killCmd.Run(); err != nil {
 				c.logger.Error("Failed to kill matching Docker container",
 					zap.String("server", c.config.Name),
@@ -327,7 +337,7 @@ func (c *Client) killDockerContainersByNamePatternWithContext(ctx context.Contex
 		zap.String("name_pattern", namePattern))
 
 	// Get list of containers with name filter
-	listCmd := exec.CommandContext(ctx, "docker", "ps", "-a", "--filter", "name="+namePattern, "--format", "{{.ID}}\t{{.Names}}")
+	listCmd := c.newDockerCmd(ctx, "ps", "-a", "--filter", "name="+namePattern, "--format", "{{.ID}}\t{{.Names}}")
 	output, err := listCmd.Output()
 	if err != nil {
 		c.logger.Debug("Failed to list Docker containers by name pattern",
@@ -380,10 +390,10 @@ func (c *Client) killDockerContainersByNamePatternWithContext(ctx context.Contex
 		}
 
 		// First try graceful stop
-		stopCmd := exec.CommandContext(ctx, "docker", "stop", containerID)
+		stopCmd := c.newDockerCmd(ctx, "stop", containerID)
 		if err := stopCmd.Run(); err != nil {
 			// Force kill if graceful stop fails
-			killCmd := exec.CommandContext(ctx, "docker", "kill", containerID)
+			killCmd := c.newDockerCmd(ctx, "kill", containerID)
 			if err := killCmd.Run(); err != nil {
 				c.logger.Error("Failed to kill container by name pattern",
 					zap.String("server", c.config.Name),
@@ -411,7 +421,7 @@ func (c *Client) killDockerContainerByNameWithContext(ctx context.Context, conta
 		zap.String("container_name", containerName))
 
 	// Get container ID by exact name match
-	listCmd := exec.CommandContext(ctx, "docker", "ps", "-a", "--filter", "name=^"+containerName+"$", "--format", "{{.ID}}")
+	listCmd := c.newDockerCmd(ctx, "ps", "-a", "--filter", "name=^"+containerName+"$", "--format", "{{.ID}}")
 	output, err := listCmd.Output()
 	if err != nil {
 		c.logger.Debug("Failed to find Docker container by name",
@@ -441,10 +451,10 @@ func (c *Client) killDockerContainerByNameWithContext(ctx context.Context, conta
 	}
 
 	// First try graceful stop
-	stopCmd := exec.CommandContext(ctx, "docker", "stop", containerID)
+	stopCmd := c.newDockerCmd(ctx, "stop", containerID)
 	if err := stopCmd.Run(); err != nil {
 		// Force kill if graceful stop fails
-		killCmd := exec.CommandContext(ctx, "docker", "kill", containerID)
+		killCmd := c.newDockerCmd(ctx, "kill", containerID)
 		if err := killCmd.Run(); err != nil {
 			c.logger.Error("Failed to kill container by name",
 				zap.String("server", c.config.Name),
@@ -478,7 +488,7 @@ func (c *Client) ensureNoExistingContainers(ctx context.Context) error {
 		zap.String("name_pattern", namePattern))
 
 	// Find ALL containers matching our server (running or stopped)
-	listCmd := exec.CommandContext(ctx, "docker", "ps", "-a",
+	listCmd := c.newDockerCmd(ctx, "ps", "-a",
 		"--filter", "name="+namePattern,
 		"--format", "{{.ID}}\t{{.Names}}\t{{.Status}}")
 
@@ -530,7 +540,7 @@ func (c *Client) ensureNoExistingContainers(ctx context.Context) error {
 			}
 
 			// Force remove (works for running and stopped containers)
-			rmCmd := exec.CommandContext(ctx, "docker", "rm", "-f", containerID)
+			rmCmd := c.newDockerCmd(ctx, "rm", "-f", containerID)
 			if err := rmCmd.Run(); err != nil {
 				c.logger.Error("Failed to remove existing container",
 					zap.String("container_id", containerID),
@@ -560,7 +570,7 @@ func (c *Client) checkDockerContainerHealth() {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "docker", "version", "--format", "{{.Server.Version}}")
+	cmd := c.newDockerCmd(ctx, "version", "--format", "{{.Server.Version}}")
 	if err := cmd.Run(); err != nil {
 		c.logger.Warn("Docker daemon appears to be unreachable",
 			zap.String("server", c.config.Name),

--- a/internal/upstream/core/monitoring.go
+++ b/internal/upstream/core/monitoring.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
 

--- a/internal/upstream/core/monitoring.go
+++ b/internal/upstream/core/monitoring.go
@@ -312,7 +312,7 @@ func (c *Client) GetConnectionDiagnostics() map[string]interface{} {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 
-		cmd := exec.CommandContext(ctx, "docker", "version", "--format", "{{.Server.Version}}")
+		cmd := c.newDockerCmd(ctx, "version", "--format", "{{.Server.Version}}")
 		if err := cmd.Run(); err != nil {
 			diagnostics["docker_daemon_reachable"] = false
 			diagnostics["docker_daemon_error"] = err.Error()
@@ -322,7 +322,7 @@ func (c *Client) GetConnectionDiagnostics() map[string]interface{} {
 
 		// Check if container is still running
 		if c.containerID != "" {
-			inspectCmd := exec.CommandContext(ctx, "docker", "inspect", "--format", "{{.State.Running}}", c.containerID)
+			inspectCmd := c.newDockerCmd(ctx, "inspect", "--format", "{{.State.Running}}", c.containerID)
 			if output, err := inspectCmd.Output(); err == nil {
 				diagnostics["container_running"] = strings.TrimSpace(string(output)) == "true"
 			}


### PR DESCRIPTION
## Summary

- Wraps all `docker` CLI invocations in the user's login shell (`sh -l -c` on Unix, `cmd /c` on Windows) so Docker-related subprocesses inherit the same `PATH` as the user's interactive shell.
- Fixes the case where `mcpproxy` (launched from the macOS tray / LaunchAgent) cannot find `docker` because Docker Desktop adds itself to `PATH` only via the user's shell rc files, not the GUI environment.
- Covers both the upstream Docker runtime (`internal/upstream/core/docker.go`) and the security scanner Docker runner (`internal/security/scanner/docker.go`). Upstream `Client` changes reuse the existing `wrapWithUserShell` helper and apply `envManager.BuildSecureEnvironment()`; scanner introduces a local `getDockerCmd` helper with inline POSIX/Windows quoting.

## Test plan

- [ ] `go build ./...` passes (currently FAILS — see review comment about unused `os/exec` import in `internal/upstream/core/monitoring.go`)
- [ ] `go test ./internal/upstream/core/... -race`
- [ ] `go test ./internal/security/scanner/... -race`
- [ ] Manual: launch mcpproxy from the macOS tray (no shell PATH) and confirm Docker-isolated upstream servers start and the supply-chain scanner runs
- [ ] Manual: run on Linux / Windows to confirm shell wrapping does not regress startup
- [ ] `./scripts/test-api-e2e.sh`