### PR TITLE
feat: auto-clean deprecated config fields on startup

### DIFF
--- a/internal/config/deprecated.go
+++ b/internal/config/deprecated.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 )
 
@@ -51,4 +52,71 @@ func CheckDeprecatedFields(configPath string) []DeprecatedField {
 		}
 	}
 	return found
+}
+
+// CleanDeprecatedFields removes deprecated keys from the config file on disk.
+// It creates a .bak backup before modifying the file. If no deprecated fields
+// are found, the file is not touched and no backup is created.
+// Returns the list of removed fields, or nil if nothing was changed.
+func CleanDeprecatedFields(configPath string) ([]DeprecatedField, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading config: %w", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, nil // unparseable config — leave it alone
+	}
+
+	// Find which deprecated keys are present.
+	var found []DeprecatedField
+	for _, df := range deprecatedFields {
+		if _, exists := raw[df.JSONKey]; exists {
+			found = append(found, df)
+		}
+	}
+	if len(found) == 0 {
+		return nil, nil
+	}
+
+	// Preserve original file permissions.
+	info, err := os.Stat(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("stat config: %w", err)
+	}
+	perm := info.Mode().Perm()
+
+	// Create backup before modifying.
+	backupPath := configPath + ".bak"
+	if err := os.WriteFile(backupPath, data, perm); err != nil {
+		return nil, fmt.Errorf("creating backup: %w", err)
+	}
+
+	// Remove deprecated keys.
+	for _, df := range found {
+		delete(raw, df.JSONKey)
+	}
+
+	// Marshal back with indentation.
+	cleaned, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshaling cleaned config: %w", err)
+	}
+	cleaned = append(cleaned, '\n')
+
+	// Write to temp file then rename for atomicity.
+	tmpPath := configPath + ".tmp"
+	if err := os.WriteFile(tmpPath, cleaned, perm); err != nil {
+		return nil, fmt.Errorf("writing cleaned config: %w", err)
+	}
+	if err := os.Rename(tmpPath, configPath); err != nil {
+		os.Remove(tmpPath) // best-effort cleanup
+		return nil, fmt.Errorf("replacing config: %w", err)
+	}
+
+	return found, nil
 }

--- a/internal/config/deprecated_test.go
+++ b/internal/config/deprecated_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -87,4 +88,159 @@ func TestCheckDeprecatedFields_InvalidJSON(t *testing.T) {
 
 	found := CheckDeprecatedFields(cfgPath)
 	assert.Nil(t, found)
+}
+
+func TestCleanDeprecatedFields(t *testing.T) {
+	tests := []struct {
+		name         string
+		configJSON   string
+		wantRemoved  []string
+		wantKeepKeys []string
+		wantBackup   bool
+		wantNoModify bool // file should not be touched
+	}{
+		{
+			name:         "removes all deprecated fields",
+			configJSON:   `{"listen": ":8080", "top_k": 5, "enable_tray": true, "features": {"enable_runtime": true}}`,
+			wantRemoved:  []string{"top_k", "enable_tray", "features"},
+			wantKeepKeys: []string{"listen"},
+			wantBackup:   true,
+		},
+		{
+			name:         "removes only top_k",
+			configJSON:   `{"listen": ":8080", "tools_limit": 15, "top_k": 5}`,
+			wantRemoved:  []string{"top_k"},
+			wantKeepKeys: []string{"listen", "tools_limit"},
+			wantBackup:   true,
+		},
+		{
+			name:         "no deprecated fields - no backup created",
+			configJSON:   `{"listen": ":8080", "tools_limit": 15}`,
+			wantRemoved:  nil,
+			wantKeepKeys: []string{"listen", "tools_limit"},
+			wantNoModify: true,
+		},
+		{
+			name:         "preserves nested objects and arrays",
+			configJSON:   `{"listen": ":8080", "top_k": 5, "mcpServers": [{"name": "github", "url": "https://example.com"}]}`,
+			wantRemoved:  []string{"top_k"},
+			wantKeepKeys: []string{"listen", "mcpServers"},
+			wantBackup:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cfgPath := filepath.Join(dir, "mcp_config.json")
+			err := os.WriteFile(cfgPath, []byte(tt.configJSON), 0644)
+			require.NoError(t, err)
+
+			removed, err := CleanDeprecatedFields(cfgPath)
+			require.NoError(t, err)
+
+			// Check removed fields
+			if tt.wantRemoved == nil {
+				assert.Empty(t, removed)
+			} else {
+				removedKeys := make([]string, len(removed))
+				for i, r := range removed {
+					removedKeys[i] = r.JSONKey
+				}
+				assert.ElementsMatch(t, tt.wantRemoved, removedKeys)
+			}
+
+			// Check backup file
+			backupPath := cfgPath + ".bak"
+			if tt.wantBackup {
+				backupData, err := os.ReadFile(backupPath)
+				require.NoError(t, err, "backup file should exist")
+				assert.JSONEq(t, tt.configJSON, string(backupData), "backup should match original")
+			} else {
+				_, err := os.Stat(backupPath)
+				assert.True(t, os.IsNotExist(err), "backup should not exist when no fields removed")
+			}
+
+			// Check cleaned config still has expected keys
+			cleanedData, err := os.ReadFile(cfgPath)
+			require.NoError(t, err)
+			var cleanedMap map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(cleanedData, &cleanedMap))
+
+			for _, key := range tt.wantKeepKeys {
+				assert.Contains(t, cleanedMap, key, "key %q should be preserved", key)
+			}
+			for _, key := range tt.wantRemoved {
+				assert.NotContains(t, cleanedMap, key, "key %q should be removed", key)
+			}
+		})
+	}
+}
+
+func TestCleanDeprecatedFields_MissingFile(t *testing.T) {
+	removed, err := CleanDeprecatedFields("/nonexistent/config.json")
+	assert.NoError(t, err)
+	assert.Nil(t, removed)
+}
+
+func TestCleanDeprecatedFields_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "bad.json")
+	err := os.WriteFile(cfgPath, []byte("not json"), 0644)
+	require.NoError(t, err)
+
+	removed, err := CleanDeprecatedFields(cfgPath)
+	assert.NoError(t, err)
+	assert.Nil(t, removed)
+}
+
+func TestCleanDeprecatedFields_PreservesFilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "mcp_config.json")
+	err := os.WriteFile(cfgPath, []byte(`{"listen": ":8080", "top_k": 5}`), 0600)
+	require.NoError(t, err)
+
+	removed, err := CleanDeprecatedFields(cfgPath)
+	require.NoError(t, err)
+	assert.Len(t, removed, 1)
+
+	// Check that file permissions are preserved
+	info, err := os.Stat(cfgPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}
+
+func TestCleanDeprecatedFields_ReadOnlyDir(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "mcp_config.json")
+	err := os.WriteFile(cfgPath, []byte(`{"listen": ":8080", "top_k": 5}`), 0644)
+	require.NoError(t, err)
+
+	// Make directory read-only so backup/tmp writes fail.
+	require.NoError(t, os.Chmod(dir, 0555))
+	t.Cleanup(func() { os.Chmod(dir, 0755) }) // restore for cleanup
+
+	_, err = CleanDeprecatedFields(cfgPath)
+	assert.Error(t, err, "should fail when directory is read-only")
+}
+
+func TestCleanDeprecatedFields_OutputIsValidJSON(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "mcp_config.json")
+	original := `{"listen":":8080","api_key":"secret","top_k":5,"enable_tray":true,"mcpServers":[{"name":"test","url":"http://localhost"}]}`
+	err := os.WriteFile(cfgPath, []byte(original), 0644)
+	require.NoError(t, err)
+
+	_, err = CleanDeprecatedFields(cfgPath)
+	require.NoError(t, err)
+
+	// Verify the output is valid, parseable JSON
+	cleanedData, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(cleanedData, &parsed), "cleaned config must be valid JSON")
+
+	// Verify it's nicely indented (contains newlines)
+	assert.Contains(t, string(cleanedData), "\n", "output should be indented")
 }

--- a/internal/config/deprecated_test.go
+++ b/internal/config/deprecated_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -195,6 +196,9 @@ func TestCleanDeprecatedFields_InvalidJSON(t *testing.T) {
 }
 
 func TestCleanDeprecatedFields_PreservesFilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix file permissions not applicable on Windows")
+	}
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "mcp_config.json")
 	err := os.WriteFile(cfgPath, []byte(`{"listen": ":8080", "top_k": 5}`), 0600)
@@ -211,6 +215,9 @@ func TestCleanDeprecatedFields_PreservesFilePermissions(t *testing.T) {
 }
 
 func TestCleanDeprecatedFields_ReadOnlyDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix directory permissions not applicable on Windows")
+	}
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "mcp_config.json")
 	err := os.WriteFile(cfgPath, []byte(`{"listen": ":8080", "top_k": 5}`), 0644)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -188,12 +188,17 @@ func New(cfg *config.Config, cfgPath string, logger *zap.Logger) (*Runtime, erro
 			zap.Int("cleanup_interval_min", cfg.ActivityCleanupIntervalMin))
 	}
 
-	// Log warnings for deprecated config fields
-	if deprecated := config.CheckDeprecatedFields(cfgPath); len(deprecated) > 0 {
-		for _, df := range deprecated {
-			logger.Warn("Deprecated config field",
+	// Auto-clean deprecated config fields (backup created at .bak before modification).
+	if removed, err := config.CleanDeprecatedFields(cfgPath); err != nil {
+		logger.Warn("Failed to auto-clean deprecated config fields", zap.Error(err))
+	} else if len(removed) > 0 {
+		logger.Info("Auto-cleaned deprecated config fields",
+			zap.String("backup", cfgPath+".bak"),
+			zap.Int("fields_removed", len(removed)))
+		for _, df := range removed {
+			logger.Info("Removed deprecated field",
 				zap.String("field", df.JSONKey),
-				zap.String("message", df.Message),
+				zap.String("reason", df.Message),
 				zap.String("replacement", df.Replacement))
 		}
 	}


### PR DESCRIPTION
## Summary
- On startup, MCPProxy now automatically removes deprecated config keys (`top_k`, `enable_tray`, `features`) from `mcp_config.json`
- Creates a `.bak` backup of the original config file before any modification
- No-op if no deprecated fields are found (no backup created, no file touched)
- Atomic write (tmp file + rename) preserves original file permissions

## Motivation
Telemetry showed `doctor_checks.deprecated_configs` failing in 100% of doctor runs (1,031 fails, 0 passes). Every user has stale deprecated fields. This eliminates the problem at source instead of just warning.

## Test plan
- [x] Unit tests for `CleanDeprecatedFields` (9 test cases: removal, backup, idempotency, permissions, read-only dir, invalid JSON, missing file, valid output)
- [x] Manual test: started mcpproxy with deprecated config, verified backup created and fields removed
- [x] Manual test: second startup produces no cleanup (idempotent)
- [x] `go test -race ./internal/config/ ./internal/runtime/` — all pass
- [x] `./scripts/run-linter.sh` — 0 issues
- [x] Both personal and server editions build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)