### PR TITLE
fix(telemetry): normalize version string to always carry v prefix

### DIFF
--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -94,7 +94,7 @@ func New(cfg *config.Config, cfgPath, version, edition string, logger *zap.Logge
 	return &Service{
 		config:            cfg,
 		cfgPath:           cfgPath,
-		version:           version,
+		version:           normalizeVersion(version),
 		edition:           edition,
 		endpoint:          cfg.GetTelemetryEndpoint(),
 		logger:            logger,
@@ -376,4 +376,31 @@ func isValidSemver(v string) bool {
 		v = "v" + v
 	}
 	return semver.IsValid(v)
+}
+
+// normalizeVersion ensures semver version strings carry a leading "v" prefix.
+//
+// Official mcpproxy releases embed versions like "v0.22.0", but third-party
+// builds (e.g. custom Dockerfiles using `--build-arg VERSION=0.22.0`) drop the
+// prefix. Without normalization, the telemetry dashboard shows both forms as
+// separate rows. We normalize on the emit side so both collapse into one.
+//
+// Rules:
+//   - Empty string is returned unchanged.
+//   - If the string is already a valid semver with "v" prefix, returned unchanged.
+//   - If the string becomes a valid semver once prefixed, the prefixed form is returned.
+//   - Otherwise (not a valid semver at all, e.g. "dev"), returned unchanged so that
+//     downstream isValidSemver filtering still rejects it and debug logs retain the
+//     original garbage value.
+func normalizeVersion(v string) string {
+	if v == "" {
+		return v
+	}
+	if strings.HasPrefix(v, "v") {
+		return v
+	}
+	if semver.IsValid("v" + v) {
+		return "v" + v
+	}
+	return v
 }

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -214,6 +214,54 @@ func TestIsValidSemver(t *testing.T) {
 	}
 }
 
+func TestNormalizeVersion(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"already prefixed", "v0.24.2", "v0.24.2"},
+		{"missing prefix added", "0.22.0", "v0.22.0"},
+		{"invalid unchanged", "dev", "dev"},
+		{"empty unchanged", "", ""},
+		{"prerelease already prefixed", "v1.2.3-rc.1", "v1.2.3-rc.1"},
+		{"prerelease missing prefix added", "1.2.3-rc.1", "v1.2.3-rc.1"},
+		{"garbage unchanged", "development", "development"},
+		{"latest unchanged", "latest", "latest"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeVersion(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizeVersion(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNewNormalizesVersion verifies that the New constructor applies
+// normalizeVersion to s.version so downstream payloads never see a
+// bare "0.22.0" form.
+func TestNewNormalizesVersion(t *testing.T) {
+	cfg := &config.Config{}
+	logger := zap.NewNop()
+
+	svc := New(cfg, "", "0.22.0", "personal", logger)
+	if svc.version != "v0.22.0" {
+		t.Errorf("Expected s.version=v0.22.0 after normalization, got %q", svc.version)
+	}
+
+	svc2 := New(cfg, "", "v0.22.0", "personal", logger)
+	if svc2.version != "v0.22.0" {
+		t.Errorf("Expected prefixed version to remain v0.22.0, got %q", svc2.version)
+	}
+
+	svc3 := New(cfg, "", "dev", "personal", logger)
+	if svc3.version != "dev" {
+		t.Errorf("Expected invalid 'dev' to remain unchanged, got %q", svc3.version)
+	}
+}
+
 func TestEnsureAnonymousID(t *testing.T) {
 	cfg := &config.Config{}
 


### PR DESCRIPTION
## Symptom

The telemetry dashboard displays two separate rows for the same mcpproxy release — e.g. `0.22.0` and `v0.22.0` — splitting the cohort and making install counts look deceptively small for each variant.

## Cause

`internal/telemetry/telemetry.go` bakes `main.version` into `s.version` at construction time and emits it verbatim in the heartbeat payload (`payload.Version = s.version`). Official release builds inject `v`-prefixed versions, but third-party/community builds using custom Dockerfiles with `--build-arg VERSION=0.22.0` drop the prefix. Both forms are valid semver once normalized, both pass `isValidSemver` (which already tolerates the missing prefix for validation), and both reach the dashboard as distinct strings.

## Fix

Add a `normalizeVersion(string) string` helper in `internal/telemetry/telemetry.go` that:

- returns the input unchanged if empty,
- returns it unchanged if it already starts with `v`,
- prepends `v` if `"v" + input` is a valid semver,
- returns the input unchanged otherwise (so garbage values like `dev` / `development` still fail downstream `isValidSemver` and are never emitted, and debug logs retain the original string).

Apply it at the single central point — the `New` constructor — so every downstream consumer of `s.version` (heartbeat payload, upgrade-funnel cursor in `advanceUpgradeFunnel`, the `telemetry show-payload` command, dev-build skip check) sees the same normalized form.

Scope is limited to `internal/telemetry/`. No behavior change for release builds that already use the `v` prefix.

## Test plan

- [x] `go test ./internal/telemetry/... -race` — all green (3.2s)
- [x] `go build ./...` — personal edition builds clean
- [x] `go build -tags server ./...` — server edition builds clean
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./internal/telemetry/...` — 0 issues
- [x] New unit tests `TestNormalizeVersion` (8 cases: already prefixed, bare semver, invalid `dev`, empty, prerelease prefixed/bare, `development`, `latest`) and `TestNewNormalizesVersion` (constructor path)
- [ ] After merge: verify next release's telemetry dashboard collapses `0.x.y` + `v0.x.y` into a single row

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>