### PR TITLE
feat(config): add per-server annotation_defaults for upstream tools

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -206,6 +206,11 @@ type ServerConfig struct {
 	Updated        time.Time         `json:"updated,omitempty" mapstructure:"updated"`
 	Isolation      *IsolationConfig  `json:"isolation,omitempty" mapstructure:"isolation"`               // Per-server isolation settings
 	ReconnectOnUse bool              `json:"reconnect_on_use,omitempty" mapstructure:"reconnect-on-use"` // Attempt reconnection when a tool call targets a disconnected server
+
+	// AnnotationDefaults provides fallback tool annotations for upstream servers
+	// that don't supply their own. Individual hint fields are applied only when
+	// the upstream tool has nil for that specific hint (per-field merge).
+	AnnotationDefaults *ToolAnnotations `json:"annotation_defaults,omitempty" mapstructure:"annotation-defaults"`
 }
 
 // OAuthConfig represents OAuth configuration for a server

--- a/internal/upstream/core/annotation_defaults_test.go
+++ b/internal/upstream/core/annotation_defaults_test.go
@@ -1,0 +1,98 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestMergeAnnotationDefaults_NilDst(t *testing.T) {
+	// When dst has all nil hints, defaults fill them in
+	dst := &config.ToolAnnotations{}
+	defaults := &config.ToolAnnotations{
+		ReadOnlyHint:    boolPtr(false),
+		DestructiveHint: boolPtr(false),
+		OpenWorldHint:   boolPtr(true),
+	}
+	mergeAnnotationDefaults(dst, defaults)
+
+	assert.Equal(t, boolPtr(false), dst.ReadOnlyHint)
+	assert.Equal(t, boolPtr(false), dst.DestructiveHint)
+	assert.Equal(t, boolPtr(true), dst.OpenWorldHint)
+	assert.Nil(t, dst.IdempotentHint) // not in defaults
+}
+
+func TestMergeAnnotationDefaults_UpstreamWins(t *testing.T) {
+	// Explicit upstream values are never overridden
+	dst := &config.ToolAnnotations{
+		ReadOnlyHint:    boolPtr(true),
+		DestructiveHint: boolPtr(true),
+	}
+	defaults := &config.ToolAnnotations{
+		ReadOnlyHint:    boolPtr(false),
+		DestructiveHint: boolPtr(false),
+		OpenWorldHint:   boolPtr(false),
+	}
+	mergeAnnotationDefaults(dst, defaults)
+
+	assert.Equal(t, boolPtr(true), dst.ReadOnlyHint)   // upstream wins
+	assert.Equal(t, boolPtr(true), dst.DestructiveHint) // upstream wins
+	assert.Equal(t, boolPtr(false), dst.OpenWorldHint)  // filled from defaults
+}
+
+func TestMergeAnnotationDefaults_TitleMerge(t *testing.T) {
+	dst := &config.ToolAnnotations{Title: ""}
+	defaults := &config.ToolAnnotations{Title: "Default Title"}
+	mergeAnnotationDefaults(dst, defaults)
+	assert.Equal(t, "Default Title", dst.Title)
+
+	// Existing title preserved
+	dst2 := &config.ToolAnnotations{Title: "Upstream Title"}
+	mergeAnnotationDefaults(dst2, defaults)
+	assert.Equal(t, "Upstream Title", dst2.Title)
+}
+
+func TestAnnotationDefaults_NoDefaultsNoAnnotations(t *testing.T) {
+	// Backward compat: no defaults configured, no upstream annotations → stays nil
+	var serverDefaults *config.ToolAnnotations = nil
+	var toolAnnotations *config.ToolAnnotations = nil
+
+	// Simulates the logic in client.go
+	if serverDefaults != nil {
+		if toolAnnotations == nil {
+			toolAnnotations = &config.ToolAnnotations{}
+		}
+		mergeAnnotationDefaults(toolAnnotations, serverDefaults)
+	}
+
+	assert.Nil(t, toolAnnotations)
+}
+
+func TestAnnotationDefaults_FullCopy(t *testing.T) {
+	// No upstream annotations + defaults set → full copy from defaults
+	defaults := &config.ToolAnnotations{
+		ReadOnlyHint:    boolPtr(false),
+		DestructiveHint: boolPtr(false),
+		IdempotentHint:  boolPtr(true),
+		OpenWorldHint:   boolPtr(true),
+		Title:           "Default",
+	}
+
+	// Simulates the nil-annotations branch in client.go
+	result := &config.ToolAnnotations{
+		Title:           defaults.Title,
+		ReadOnlyHint:    defaults.ReadOnlyHint,
+		DestructiveHint: defaults.DestructiveHint,
+		IdempotentHint:  defaults.IdempotentHint,
+		OpenWorldHint:   defaults.OpenWorldHint,
+	}
+
+	assert.Equal(t, boolPtr(false), result.ReadOnlyHint)
+	assert.Equal(t, boolPtr(false), result.DestructiveHint)
+	assert.Equal(t, boolPtr(true), result.IdempotentHint)
+	assert.Equal(t, boolPtr(true), result.OpenWorldHint)
+	assert.Equal(t, "Default", result.Title)
+}

--- a/internal/upstream/core/client.go
+++ b/internal/upstream/core/client.go
@@ -302,6 +302,21 @@ func (c *Client) ListTools(ctx context.Context) ([]*config.ToolMetadata, error) 
 			}
 		}
 
+		// Apply per-server annotation defaults for tools without annotations
+		if c.config.AnnotationDefaults != nil {
+			if toolMeta.Annotations == nil {
+				toolMeta.Annotations = &config.ToolAnnotations{
+					Title:           c.config.AnnotationDefaults.Title,
+					ReadOnlyHint:    c.config.AnnotationDefaults.ReadOnlyHint,
+					DestructiveHint: c.config.AnnotationDefaults.DestructiveHint,
+					IdempotentHint:  c.config.AnnotationDefaults.IdempotentHint,
+					OpenWorldHint:   c.config.AnnotationDefaults.OpenWorldHint,
+				}
+			} else {
+				mergeAnnotationDefaults(toolMeta.Annotations, c.config.AnnotationDefaults)
+			}
+		}
+
 		// Compute hash for tool change detection
 		// Hash is based on serverName + toolName + inputSchema
 		toolMeta.Hash = hash.ComputeToolHash(c.config.Name, tool.Name, tool.Description, tool.InputSchema)
@@ -725,4 +740,24 @@ func containsString(str, substr string) bool {
 		}
 	}
 	return false
+}
+
+// mergeAnnotationDefaults fills nil hint fields in dst from defaults.
+// Explicit upstream values are never overridden.
+func mergeAnnotationDefaults(dst, defaults *config.ToolAnnotations) {
+	if dst.ReadOnlyHint == nil && defaults.ReadOnlyHint != nil {
+		dst.ReadOnlyHint = defaults.ReadOnlyHint
+	}
+	if dst.DestructiveHint == nil && defaults.DestructiveHint != nil {
+		dst.DestructiveHint = defaults.DestructiveHint
+	}
+	if dst.IdempotentHint == nil && defaults.IdempotentHint != nil {
+		dst.IdempotentHint = defaults.IdempotentHint
+	}
+	if dst.OpenWorldHint == nil && defaults.OpenWorldHint != nil {
+		dst.OpenWorldHint = defaults.OpenWorldHint
+	}
+	if dst.Title == "" && defaults.Title != "" {
+		dst.Title = defaults.Title
+	}
 }


### PR DESCRIPTION
## Summary

- Add `annotation_defaults` field to `ServerConfig` that provides fallback tool annotations for upstream servers that don't supply their own
- Per-field merge: only nil hints are filled from defaults, explicit upstream values are never overridden
- Fixes incorrect `call_with` routing and broken annotation-based filtering for third-party MCP servers

## Problem

Third-party MCP servers (GitHub, Obsidian, kontur-diadoc) don't provide tool annotations. mcpproxy-go treats nil annotations as `destructiveHint=true` + `openWorldHint=true` by default (per MCP spec). This means:
- `read_only_only: true` filter hides ALL their tools (including safe read/list operations)
- `call_with` routes everything to `call_tool_read` (even `merge_pull_request`, `delete_note`)
- LETHAL TRIFECTA warning fires constantly (alarm fatigue)

## Changes

- `internal/config/config.go`: Add `AnnotationDefaults *ToolAnnotations` to `ServerConfig`
- `internal/upstream/core/client.go`: Apply defaults during tool discovery, add `mergeAnnotationDefaults()` helper
- `internal/upstream/core/annotation_defaults_test.go`: 5 test cases covering nil, full copy, merge, and backward compat

## Example config

```json
{
  "mcpServers": [{
    "name": "github",
    "command": "npx",
    "args": ["@modelcontextprotocol/server-github"],
    "annotation_defaults": {
      "destructiveHint": false,
      "openWorldHint": true
    }
  }]
}
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/upstream/core/... -run AnnotationDefaults -v` — all pass
- [ ] Manual: configure GitHub server with `annotation_defaults`, verify `retrieve_tools` returns correct annotations and `call_with` values