### PR TITLE
fix(upstream/stdio): surface stderr + real reason on MCP init failure

### DIFF
--- a/internal/upstream/core/client.go
+++ b/internal/upstream/core/client.go
@@ -79,6 +79,13 @@ type Client struct {
 	stderrMonitoringCancel context.CancelFunc
 	stderrMonitoringWG     sync.WaitGroup
 
+	// Ring buffer of recent stderr lines from the subprocess.
+	// Populated by monitorStderr; surfaced in initialize failure messages so
+	// users don't have to hunt through server logs to see why the child
+	// process never responded.
+	recentStderrMu sync.Mutex
+	recentStderr   []string
+
 	// Process monitoring (for stdio transport)
 	processCmd           *exec.Cmd
 	processGroupID       int // Process group ID for proper cleanup

--- a/internal/upstream/core/connection_lifecycle.go
+++ b/internal/upstream/core/connection_lifecycle.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -27,6 +28,7 @@ func (c *Client) initialize(ctx context.Context) error {
 			zap.String("formatted_json", string(reqBytes)))
 	}
 
+	initStart := time.Now()
 	serverInfo, err := c.client.Initialize(ctx, initRequest)
 	if err != nil {
 		// Log initialization failure to server-specific log
@@ -45,7 +47,19 @@ func (c *Client) initialize(ctx context.Context) error {
 				zap.Error(err))
 		}
 
-		return fmt.Errorf("MCP initialize failed: %w", err)
+		// Surface the useful context that the raw "context deadline exceeded"
+		// swallows: how long we waited and whatever the child process wrote
+		// to stderr before dying. Non-timeout errors pass through unchanged.
+		if errors.Is(err, context.DeadlineExceeded) {
+			waited := time.Since(initStart).Round(100 * time.Millisecond)
+			stderrBlock := c.formatRecentStderr()
+			if stderrBlock != "" {
+				return fmt.Errorf("server did not respond to MCP initialize within %s (subprocess may have crashed or printed to stderr instead of stdout); recent stderr:\n%s", waited, stderrBlock)
+			}
+			return fmt.Errorf("server did not respond to MCP initialize within %s and produced no stderr output (check that the command starts an MCP server and not a help banner)", waited)
+		}
+
+		return err
 	}
 
 	// Log response for trace debugging - use main logger for CLI debug mode

--- a/internal/upstream/core/connection_stdio.go
+++ b/internal/upstream/core/connection_stdio.go
@@ -10,14 +10,40 @@ import (
 
 	"github.com/mark3labs/mcp-go/client"
 	uptransport "github.com/mark3labs/mcp-go/client/transport"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/shellwrap"
 	"go.uber.org/zap"
 )
 
+// packageRunnerNoArgs lists commands that behave as "runner for a package
+// named on the command line" — invoking them with no args prints help and
+// exits, which manifests downstream as an opaque "context deadline exceeded"
+// on MCP initialize. We fail fast instead.
+var packageRunnerNoArgs = map[string]string{
+	"uvx":  "the Python package to run (e.g. [\"obsidian-mcp\"])",
+	"npx":  "the npm package to run (e.g. [\"-y\", \"some-mcp-server\"])",
+	"pipx": "the subcommand and package (e.g. [\"run\", \"obsidian-mcp\"])",
+}
+
+// validateStdioConfig runs cheap pre-flight checks on a stdio server
+// configuration before launching a subprocess. Separated out so it can be
+// unit-tested without exercising the full connection path.
+func validateStdioConfig(cfg *config.ServerConfig) error {
+	if cfg.Command == "" {
+		return fmt.Errorf("no command specified for stdio transport")
+	}
+	if len(cfg.Args) == 0 {
+		if hint, ok := packageRunnerNoArgs[cfg.Command]; ok {
+			return fmt.Errorf("server %q: command %q has no args — %s is required", cfg.Name, cfg.Command, hint)
+		}
+	}
+	return nil
+}
+
 // connectStdio establishes a stdio transport connection to an MCP server
 func (c *Client) connectStdio(ctx context.Context) error {
-	if c.config.Command == "" {
-		return fmt.Errorf("no command specified for stdio transport")
+	if err := validateStdioConfig(c.config); err != nil {
+		return err
 	}
 
 	// Validate working directory if specified
@@ -240,7 +266,14 @@ func (c *Client) connectStdio(ctx context.Context) error {
 			}
 			c.processGroupID = 0
 		}
-		return fmt.Errorf("MCP initialize failed for stdio transport: %w", err)
+		// Do not re-prefix with another "MCP initialize failed" — the
+		// inner error from initialize() already carries a human-readable
+		// message. Attach just the transport-level context (command that
+		// was launched and whether Docker isolation was in effect) so
+		// users can tell from one log line whether to look at the host
+		// command or the Docker layer.
+		return fmt.Errorf("stdio transport (command=%q, docker_isolation=%t): %w",
+			c.config.Command, c.isDockerCommand, err)
 	}
 
 	// CRITICAL FIX: Extract underlying process from mcp-go transport for lifecycle management

--- a/internal/upstream/core/error_messages_test.go
+++ b/internal/upstream/core/error_messages_test.go
@@ -1,0 +1,145 @@
+package core
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateStdioConfigRejectsPackageRunnerWithNoArgs(t *testing.T) {
+	// Reproduces the obsidian-pilot misconfiguration: `uvx` with no args
+	// would previously launch a subprocess that prints help to stderr
+	// and then time out MCP initialize ~60s later with an opaque
+	// "context deadline exceeded". We should fail fast instead.
+	cases := []struct {
+		command        string
+		wantHintSubstr string
+	}{
+		{"uvx", "Python package"},
+		{"npx", "npm package"},
+		{"pipx", "subcommand and package"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.command, func(t *testing.T) {
+			err := validateStdioConfig(&config.ServerConfig{
+				Name:    "obsidian-pilot",
+				Command: tc.command,
+				// Args intentionally nil.
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "has no args")
+			assert.Contains(t, err.Error(), tc.wantHintSubstr)
+			assert.Contains(t, err.Error(), "obsidian-pilot",
+				"error should name the offending server")
+		})
+	}
+}
+
+func TestValidateStdioConfigAllowsKnownRunnerWithArgs(t *testing.T) {
+	// Positive control: uvx WITH args must pass the pre-flight guard.
+	err := validateStdioConfig(&config.ServerConfig{
+		Name:    "ok",
+		Command: "uvx",
+		Args:    []string{"some-package"},
+	})
+	assert.NoError(t, err)
+}
+
+func TestValidateStdioConfigAllowsGenericCommandWithNoArgs(t *testing.T) {
+	// A raw binary path with no args is legitimate — some servers are
+	// self-contained binaries. Only the known package-runner commands
+	// should trigger the no-args guard.
+	err := validateStdioConfig(&config.ServerConfig{
+		Name:    "ok",
+		Command: "/usr/local/bin/my-mcp-server",
+	})
+	assert.NoError(t, err)
+}
+
+func TestValidateStdioConfigRejectsEmptyCommand(t *testing.T) {
+	err := validateStdioConfig(&config.ServerConfig{Name: "x"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no command specified")
+}
+
+func TestRecordRecentStderrRingBuffer(t *testing.T) {
+	c := &Client{}
+
+	// Push more than the cap and verify we retain the last N in order.
+	total := maxRecentStderrLines + 5
+	for i := 0; i < total; i++ {
+		c.recordRecentStderr(lineN(i))
+	}
+
+	snap := c.RecentStderrSnapshot()
+	require.Len(t, snap, maxRecentStderrLines)
+	assert.Equal(t, lineN(total-maxRecentStderrLines), snap[0],
+		"oldest retained line should be total-max")
+	assert.Equal(t, lineN(total-1), snap[len(snap)-1],
+		"newest line should be the last appended")
+}
+
+func TestRecordRecentStderrTruncatesLongLines(t *testing.T) {
+	c := &Client{}
+	huge := strings.Repeat("x", maxStderrLineLen*3)
+	c.recordRecentStderr(huge)
+
+	snap := c.RecentStderrSnapshot()
+	require.Len(t, snap, 1)
+	// Truncated lines get a trailing ellipsis rune.
+	assert.LessOrEqual(t, len(snap[0]), maxStderrLineLen+len("…"))
+	assert.True(t, strings.HasSuffix(snap[0], "…"),
+		"truncated line should end with ellipsis")
+}
+
+func TestRecordRecentStderrIgnoresEmpty(t *testing.T) {
+	c := &Client{}
+	c.recordRecentStderr("")
+	assert.Nil(t, c.RecentStderrSnapshot())
+}
+
+func TestFormatRecentStderrEmpty(t *testing.T) {
+	c := &Client{}
+	assert.Equal(t, "", c.formatRecentStderr())
+}
+
+func TestFormatRecentStderrIndented(t *testing.T) {
+	c := &Client{}
+	c.recordRecentStderr("first line")
+	c.recordRecentStderr("second line")
+
+	got := c.formatRecentStderr()
+	// Each line prefixed with "  | " so the block is visually separated
+	// in wrapped error messages.
+	assert.Equal(t, "  | first line\n  | second line", got)
+}
+
+func lineN(i int) string {
+	return "line-" + itoa(i)
+}
+
+// Minimal int→string helper to avoid pulling strconv just for tests.
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	neg := false
+	if i < 0 {
+		neg = true
+		i = -i
+	}
+	buf := make([]byte, 0, 8)
+	for i > 0 {
+		buf = append([]byte{byte('0' + i%10)}, buf...)
+		i /= 10
+	}
+	if neg {
+		buf = append([]byte{'-'}, buf...)
+	}
+	return string(buf)
+}

--- a/internal/upstream/core/monitoring.go
+++ b/internal/upstream/core/monitoring.go
@@ -11,6 +11,17 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	// maxRecentStderrLines bounds the per-client ring buffer of recent
+	// stderr output. Kept small because this is meant for the last few
+	// lines before a failure — not a log archive.
+	maxRecentStderrLines = 20
+	// maxStderrLineLen truncates individual lines stored in the ring
+	// buffer to protect memory against a misbehaving child that spews
+	// huge single lines (e.g. a base64-encoded traceback).
+	maxStderrLineLen = 512
+)
+
 // StartStderrMonitoring starts monitoring stderr output and logging it
 func (c *Client) StartStderrMonitoring() {
 	if c.stderr == nil || c.transportType != transportStdio {
@@ -151,6 +162,8 @@ func (c *Client) monitorStderr() {
 			if c.upstreamLogger != nil {
 				c.upstreamLogger.Info("stderr", zap.String("message", line))
 			}
+
+			c.recordRecentStderr(line)
 		}
 	}
 
@@ -242,6 +255,52 @@ waitLoop:
 	c.logger.Debug("Docker logs monitoring ended",
 		zap.String("server", c.config.Name),
 		zap.String("container_id", shortContainerID(containerID)))
+}
+
+// recordRecentStderr appends a stderr line to the bounded ring buffer.
+func (c *Client) recordRecentStderr(line string) {
+	if line == "" {
+		return
+	}
+	if len(line) > maxStderrLineLen {
+		line = line[:maxStderrLineLen] + "…"
+	}
+	c.recentStderrMu.Lock()
+	defer c.recentStderrMu.Unlock()
+	c.recentStderr = append(c.recentStderr, line)
+	if overflow := len(c.recentStderr) - maxRecentStderrLines; overflow > 0 {
+		c.recentStderr = append([]string(nil), c.recentStderr[overflow:]...)
+	}
+}
+
+// RecentStderrSnapshot returns a copy of the recent stderr lines captured
+// from the child process. Returns nil if nothing has been captured yet.
+func (c *Client) RecentStderrSnapshot() []string {
+	c.recentStderrMu.Lock()
+	defer c.recentStderrMu.Unlock()
+	if len(c.recentStderr) == 0 {
+		return nil
+	}
+	out := make([]string, len(c.recentStderr))
+	copy(out, c.recentStderr)
+	return out
+}
+
+// formatRecentStderr returns a human-readable, indented block of recent
+// stderr lines suitable for embedding in an error message. Empty when no
+// stderr has been captured.
+func (c *Client) formatRecentStderr() string {
+	lines := c.RecentStderrSnapshot()
+	if len(lines) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, l := range lines {
+		b.WriteString("  | ")
+		b.WriteString(l)
+		b.WriteByte('\n')
+	}
+	return strings.TrimRight(b.String(), "\n")
 }
 
 func shortContainerID(id string) string {


### PR DESCRIPTION
## Summary

Stdio MCP servers that never respond to initialize have historically produced a useless error:

```
MCP initialize failed for stdio transport: MCP initialize failed: transport error: context deadline exceeded
```

The per-server log was 30+ minutes of identical reconnect errors with nothing from the subprocess. A misconfigured \`uvx\`/\`npx\` invocation (args missing) looked identical to a real hang.

## Changes

1. **Fail fast** for \`uvx\`/\`npx\`/\`pipx\` with no args (extracted \`validateStdioConfig\` so it's testable without a subprocess).
2. **Ring-buffer** the last 20 stderr lines per client (bounded, mutex-protected).
3. **Humanize** \`initialize()\` timeout errors — include elapsed wait and the captured stderr block.
4. **De-duplicate** the \"MCP initialize failed\" prefix; add \`command=\` + \`docker_isolation=\` to the outer stdio wrap.

## New error examples

Misconfigured runner (caught at connect time):
\`\`\`
server \"obsidian-pilot\": command \"uvx\" has no args — the Python package to run (e.g. [\"obsidian-mcp\"]) is required
\`\`\`

Real timeout with stderr captured:
\`\`\`
stdio transport (command=\"uvx\", docker_isolation=true): server did not respond to MCP initialize within 60s (subprocess may have crashed or printed to stderr instead of stdout); recent stderr:
  | Usage: uvx [OPTIONS] COMMAND [ARGS]...
  | Try 'uvx --help' for help.
\`\`\`

## Test plan

- [x] 9 new unit tests pass (\`go test ./internal/upstream/core/ -run \"TestValidateStdioConfig|TestRecordRecent|TestFormatRecent\"\`)
- [x] Full \`internal/upstream/core\` suite green
- [x] \`go build ./...\` clean, \`go vet ./...\` clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)