### PR TITLE
feat(webui): show version + check-for-updates below sidebar logo (#392)

### DIFF
--- a/frontend/src/components/SidebarNav.vue
+++ b/frontend/src/components/SidebarNav.vue
@@ -42,6 +42,44 @@
         </svg>
       </button>
 
+      <!-- Version + Check for updates (expanded sidebar only) -->
+      <div
+        v-if="!collapsed && systemStore.version"
+        class="px-4 pt-2 pb-3 border-b border-base-300"
+        data-testid="sidebar-version-block"
+      >
+        <div class="flex items-center gap-2 text-xs text-base-content/60">
+          <span class="font-mono" data-testid="sidebar-version">v{{ displayVersion }}</span>
+          <span
+            v-if="systemStore.updateAvailable"
+            class="badge badge-xs badge-primary"
+            :title="latestVersionTitle"
+          >
+            update
+          </span>
+        </div>
+        <button
+          type="button"
+          @click="handleCheckForUpdates"
+          :disabled="systemStore.checkingForUpdates"
+          class="btn btn-ghost btn-xs mt-1 w-full justify-start gap-1.5 px-1 font-normal text-[11px] text-base-content/70 hover:text-base-content"
+          data-testid="sidebar-check-updates"
+          :title="updateStatusTitle"
+        >
+          <svg
+            v-if="!systemStore.checkingForUpdates"
+            class="w-3.5 h-3.5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0A8.003 8.003 0 014.582 15H9" />
+          </svg>
+          <span v-else class="loading loading-spinner loading-xs"></span>
+          <span>{{ systemStore.checkingForUpdates ? 'Checking…' : updateButtonLabel }}</span>
+        </button>
+      </div>
+
       <!-- Navigation Menu -->
       <nav
         class="flex-1 overflow-y-auto overflow-x-hidden"
@@ -232,17 +270,8 @@
         </div>
       </div>
 
-      <!-- Footer: version + theme + feedback -->
+      <!-- Footer: theme + feedback (version is shown under the logo at the top) -->
       <div class="border-t border-base-300 py-2" :class="collapsed ? 'px-1' : 'px-3'">
-        <!-- Version (hidden when collapsed) -->
-        <div
-          v-if="!collapsed && systemStore.version"
-          class="px-2 pt-1 pb-2 text-[11px] text-base-content/50 flex items-center gap-1.5"
-        >
-          <span class="font-mono">{{ systemStore.version }}</span>
-          <span v-if="systemStore.updateAvailable" class="badge badge-xs badge-primary">update</span>
-        </div>
-
         <!-- Action row: Theme + Feedback -->
         <div
           class="flex items-stretch gap-1"
@@ -318,6 +347,35 @@ const systemStore = useSystemStore()
 const authStore = useAuthStore()
 
 const collapsed = computed(() => systemStore.sidebarCollapsed)
+
+// Strip a leading "v" so the template can format consistently as `v<version>`.
+const displayVersion = computed(() => systemStore.version.replace(/^v/i, ''))
+
+const latestVersionTitle = computed(() => {
+  const latest = systemStore.latestVersion
+  return latest ? `Latest release: ${latest}` : 'Update available'
+})
+
+const updateButtonLabel = computed(() =>
+  systemStore.updateAvailable ? 'Update available — view release' : 'Check for updates'
+)
+
+const updateStatusTitle = computed(() => {
+  const ts = systemStore.updateCheckedAt
+  if (!ts) return 'Check for updates on GitHub'
+  const d = new Date(ts)
+  return `Last checked ${d.toLocaleString()}`
+})
+
+async function handleCheckForUpdates() {
+  // If an update is already known, open the release page instead of re-checking.
+  const releaseUrl = systemStore.info?.update?.release_url
+  if (systemStore.updateAvailable && releaseUrl) {
+    window.open(releaseUrl, '_blank', 'noopener,noreferrer')
+    return
+  }
+  await systemStore.checkForUpdates()
+}
 
 // --- Inline SVG icon components (Heroicons outline style, stroke=currentColor) ---
 // Kept local to this file so the sidebar remains self-contained. Each icon is a

--- a/frontend/src/components/SidebarNav.vue
+++ b/frontend/src/components/SidebarNav.vue
@@ -10,7 +10,7 @@
         class="border-b border-base-300 flex items-center"
         :class="collapsed ? 'px-2 py-4 justify-center' : 'px-4 py-4 justify-between'"
       >
-        <router-link to="/" class="flex items-center gap-2 min-w-0" :title="collapsed ? 'MCPProxy' : ''">
+        <router-link to="/" class="flex items-center gap-2 min-w-0" :title="logoTitle">
           <img src="/src/assets/logo.svg" alt="MCPProxy Logo" class="w-8 h-8 shrink-0" />
           <div v-show="!collapsed" class="min-w-0">
             <span class="text-lg font-bold truncate block leading-tight">MCPProxy</span>
@@ -42,29 +42,35 @@
         </svg>
       </button>
 
-      <!-- Version + Check for updates (expanded sidebar only) -->
+      <!-- Version + Check for updates (expanded sidebar only). Single-line layout:
+           version on the left, action on the right. In collapsed mode the
+           version appears in the logo tooltip instead. -->
       <div
         v-if="!collapsed && systemStore.version"
-        class="px-4 pt-2 pb-3 border-b border-base-300"
+        class="px-3 py-2 border-b border-base-300 flex items-center gap-2"
         data-testid="sidebar-version-block"
       >
-        <div class="flex items-center gap-2 text-xs text-base-content/60">
-          <span class="font-mono" data-testid="sidebar-version">v{{ displayVersion }}</span>
-          <span
-            v-if="systemStore.updateAvailable"
-            class="badge badge-xs badge-primary"
-            :title="latestVersionTitle"
-          >
-            update
-          </span>
-        </div>
+        <span
+          class="font-mono text-xs text-base-content/60 shrink-0"
+          data-testid="sidebar-version"
+        >
+          v{{ displayVersion }}
+        </span>
+        <span
+          v-if="systemStore.updateAvailable"
+          class="badge badge-xs badge-primary shrink-0"
+          :title="latestVersionTitle"
+        >
+          update
+        </span>
         <button
           type="button"
           @click="handleCheckForUpdates"
           :disabled="systemStore.checkingForUpdates"
-          class="btn btn-ghost btn-xs mt-1 w-full justify-start gap-1.5 px-1 font-normal text-[11px] text-base-content/70 hover:text-base-content"
+          class="btn btn-ghost btn-xs ml-auto gap-1 px-1.5 font-normal text-[11px] text-base-content/70 hover:text-base-content"
           data-testid="sidebar-check-updates"
           :title="updateStatusTitle"
+          :aria-label="updateButtonLabel"
         >
           <svg
             v-if="!systemStore.checkingForUpdates"
@@ -76,7 +82,7 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0A8.003 8.003 0 014.582 15H9" />
           </svg>
           <span v-else class="loading loading-spinner loading-xs"></span>
-          <span>{{ systemStore.checkingForUpdates ? 'Checking…' : updateButtonLabel }}</span>
+          <span class="truncate">{{ updateCompactLabel }}</span>
         </button>
       </div>
 
@@ -351,14 +357,29 @@ const collapsed = computed(() => systemStore.sidebarCollapsed)
 // Strip a leading "v" so the template can format consistently as `v<version>`.
 const displayVersion = computed(() => systemStore.version.replace(/^v/i, ''))
 
+// Tooltip shown on hover over the logo/home link. In collapsed sidebar mode
+// this is the only surface that communicates the running version.
+const logoTitle = computed(() => {
+  const v = systemStore.version
+  return v ? `MCPProxy ${v}` : 'MCPProxy'
+})
+
 const latestVersionTitle = computed(() => {
   const latest = systemStore.latestVersion
   return latest ? `Latest release: ${latest}` : 'Update available'
 })
 
+// Full button label, used as aria-label and full tooltip state.
 const updateButtonLabel = computed(() =>
   systemStore.updateAvailable ? 'Update available — view release' : 'Check for updates'
 )
+
+// Compact label used in the sidebar row so the button fits on the same line
+// as the version string.
+const updateCompactLabel = computed(() => {
+  if (systemStore.checkingForUpdates) return 'Checking…'
+  return systemStore.updateAvailable ? 'View release' : 'Check'
+})
 
 const updateStatusTitle = computed(() => {
   const ts = systemStore.updateCheckedAt

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -547,8 +547,9 @@ class APIService {
   }
 
   // Info endpoint (version and update information)
-  async getInfo(): Promise<APIResponse<InfoResponse>> {
-    return this.request<InfoResponse>('/api/v1/info')
+  async getInfo(opts?: { refresh?: boolean }): Promise<APIResponse<InfoResponse>> {
+    const url = opts?.refresh ? '/api/v1/info?refresh=true' : '/api/v1/info'
+    return this.request<InfoResponse>(url)
   }
 
   // Activity Log endpoints (RFC-003)

--- a/frontend/src/stores/system.ts
+++ b/frontend/src/stores/system.ts
@@ -21,6 +21,8 @@ export const useSystemStore = defineStore('system', () => {
   const toasts = ref<Toast[]>([])
   const info = ref<InfoResponse | null>(null)
   const routing = ref<RoutingInfo | null>(null)
+  const checkingForUpdates = ref(false)
+  const updateCheckedAt = ref<string | null>(null)
 
   // Available themes
   const themes: Theme[] = [
@@ -378,9 +380,49 @@ export const useSystemStore = defineStore('system', () => {
       const response = await api.getInfo()
       if (response.success && response.data) {
         info.value = response.data
+        if (response.data.update?.checked_at) {
+          updateCheckedAt.value = response.data.update.checked_at
+        }
       }
     } catch (error) {
       console.error('Failed to fetch info:', error)
+    }
+  }
+
+  async function checkForUpdates(): Promise<{ ok: boolean; error?: string }> {
+    if (checkingForUpdates.value) return { ok: false, error: 'already checking' }
+    checkingForUpdates.value = true
+    try {
+      const response = await api.getInfo({ refresh: true })
+      if (response.success && response.data) {
+        info.value = response.data
+        updateCheckedAt.value = response.data.update?.checked_at ?? new Date().toISOString()
+        const checkErr = response.data.update?.check_error
+        if (checkErr) {
+          addToast({ type: 'error', title: 'Update check failed', message: checkErr })
+          return { ok: false, error: checkErr }
+        }
+        if (response.data.update?.available) {
+          addToast({
+            type: 'info',
+            title: 'Update available',
+            message: response.data.update.latest_version || '',
+          })
+        } else {
+          addToast({ type: 'success', title: 'You are running the latest version.' })
+        }
+        return { ok: true }
+      }
+      const err = response.error || 'Request failed'
+      addToast({ type: 'error', title: 'Update check failed', message: err })
+      return { ok: false, error: err }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error)
+      console.error('Failed to check for updates:', error)
+      addToast({ type: 'error', title: 'Update check failed', message: msg })
+      return { ok: false, error: msg }
+    } finally {
+      checkingForUpdates.value = false
     }
   }
 
@@ -407,6 +449,8 @@ export const useSystemStore = defineStore('system', () => {
     themes,
     info,
     routing,
+    checkingForUpdates,
+    updateCheckedAt,
 
     // Computed
     isRunning,
@@ -430,5 +474,6 @@ export const useSystemStore = defineStore('system', () => {
     clearToasts,
     fetchInfo,
     fetchRouting,
+    checkForUpdates,
   }
 })


### PR DESCRIPTION
## Summary
- Surface the current MCPProxy version directly under the sidebar logo, fulfilling the user-feedback request in #392.
- Add a "Check for updates" button just below the version that calls `/api/v1/info?refresh=true` and toasts the result.
- When an update is already detected, the same button switches to "Update available — view release" and opens the GitHub release URL in a new tab.

## Implementation notes
- `frontend/src/services/api.ts` — `getInfo({ refresh })` now supports the forced-refresh query param that the backend already honored.
- `frontend/src/stores/system.ts` — new `checkForUpdates()` action, `checkingForUpdates` state, and `updateCheckedAt` timestamp; unified toast UX.
- `frontend/src/components/SidebarNav.vue` — new version + action block below the logo (expanded sidebar only); removed the now-duplicate version line in the footer.

No backend changes — the `/api/v1/info` endpoint already returned `update.{available,latest_version,release_url,checked_at}` and accepted `?refresh=true`.

## Test plan
- [x] `npm run type-check` passes (no TypeScript diagnostics).
- [x] `make build` produces a clean binary.
- [x] Playwright headless verification:
  - [x] Version `v0.24.6` rendered under the logo, button visible.
  - [x] Click → `GET /api/v1/info?refresh=true` returns 200, success toast "You are running the latest version." renders.
  - [x] When `/api/v1/info` returns `update.available=true`, the button label becomes "Update available — view release" and clicking opens the release URL in a new tab.
- [ ] CI green.

Closes #392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)