### PR TITLE
fix(macos-tray): preserve bool fields on server PATCH + refresh after save

### DIFF
--- a/internal/httpapi/patch_server_test.go
+++ b/internal/httpapi/patch_server_test.go
@@ -1,0 +1,131 @@
+package httpapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// mockPatchServerController captures the updates passed to UpdateServer so we
+// can assert that PATCH requests preserve existing bool fields when the
+// request body omits them.
+type mockPatchServerController struct {
+	baseController
+	apiKey          string
+	existingServer  *config.ServerConfig
+	capturedUpdates *config.ServerConfig
+}
+
+func (m *mockPatchServerController) GetCurrentConfig() any {
+	return &config.Config{APIKey: m.apiKey}
+}
+
+func (m *mockPatchServerController) GetConfig() (*config.Config, error) {
+	if m.existingServer == nil {
+		return &config.Config{}, nil
+	}
+	return &config.Config{
+		Servers: []*config.ServerConfig{m.existingServer},
+	}, nil
+}
+
+func (m *mockPatchServerController) UpdateServer(_ context.Context, _ string, updates *config.ServerConfig) error {
+	// Capture a shallow copy so subsequent mutations by the handler don't
+	// surprise the assertion.
+	clone := *updates
+	m.capturedUpdates = &clone
+	return nil
+}
+
+// TestHandlePatchServer_ArgsOnlyPreservesBools is a regression test for the
+// macOS tray bug where editing a server's Args on the detail page silently
+// disabled the server. The PATCH handler had been zeroing Enabled /
+// Quarantined / ReconnectOnUse whenever the request body omitted them,
+// because `config.ServerConfig` uses non-pointer bools whose zero value
+// cannot be distinguished from "not set".
+func TestHandlePatchServer_ArgsOnlyPreservesBools(t *testing.T) {
+	logger := zap.NewNop().Sugar()
+	mockCtrl := &mockPatchServerController{
+		apiKey: "test-key",
+		existingServer: &config.ServerConfig{
+			Name:           "github",
+			Protocol:       "stdio",
+			Command:        "npx",
+			Args:           []string{"old-arg"},
+			Enabled:        true,
+			Quarantined:    false,
+			ReconnectOnUse: true,
+		},
+	}
+	srv := NewServer(mockCtrl, logger, nil)
+
+	// Simulate the macOS tray saving only the Args field.
+	body, _ := json.Marshal(map[string]any{
+		"args": []string{"new-arg-1", "new-arg-2"},
+	})
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/servers/github", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", "test-key")
+	w := httptest.NewRecorder()
+
+	srv.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "Expected 200 OK, body=%s", w.Body.String())
+	require.NotNil(t, mockCtrl.capturedUpdates, "UpdateServer should have been called")
+
+	assert.Equal(t, []string{"new-arg-1", "new-arg-2"}, mockCtrl.capturedUpdates.Args,
+		"Args should reflect the PATCH body")
+	assert.True(t, mockCtrl.capturedUpdates.Enabled,
+		"Enabled must be preserved from existing server (was true) when PATCH omits it")
+	assert.False(t, mockCtrl.capturedUpdates.Quarantined,
+		"Quarantined must be preserved from existing server (was false)")
+	assert.True(t, mockCtrl.capturedUpdates.ReconnectOnUse,
+		"ReconnectOnUse must be preserved from existing server (was true) when PATCH omits it")
+}
+
+// TestHandlePatchServer_ExplicitBoolsTakePrecedence verifies that the
+// preservation logic does not clobber bools the request explicitly sets.
+func TestHandlePatchServer_ExplicitBoolsTakePrecedence(t *testing.T) {
+	logger := zap.NewNop().Sugar()
+	mockCtrl := &mockPatchServerController{
+		apiKey: "test-key",
+		existingServer: &config.ServerConfig{
+			Name:           "github",
+			Protocol:       "stdio",
+			Enabled:        true,
+			Quarantined:    false,
+			ReconnectOnUse: true,
+		},
+	}
+	srv := NewServer(mockCtrl, logger, nil)
+
+	enabled := false
+	body, _ := json.Marshal(map[string]any{
+		"enabled": enabled,
+	})
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/servers/github", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", "test-key")
+	w := httptest.NewRecorder()
+
+	srv.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "Expected 200 OK, body=%s", w.Body.String())
+	require.NotNil(t, mockCtrl.capturedUpdates)
+
+	assert.False(t, mockCtrl.capturedUpdates.Enabled,
+		"Enabled must reflect the explicit request value (false)")
+	assert.False(t, mockCtrl.capturedUpdates.Quarantined,
+		"Quarantined must be preserved from existing server (was false)")
+	assert.True(t, mockCtrl.capturedUpdates.ReconnectOnUse,
+		"ReconnectOnUse must be preserved from existing server (was true)")
+}

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -1302,6 +1302,21 @@ func (s *Server) handlePatchServer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Pre-fetch existing server so we can preserve bool fields the request
+	// did not explicitly set. `config.ServerConfig` uses non-pointer bools
+	// whose zero value cannot be distinguished from "not set" by the time
+	// the update reaches the controller — without this, a PATCH body like
+	// `{"args": [...]}` silently disables a previously-enabled server.
+	var existingSrv *config.ServerConfig
+	if cfg, err := s.controller.GetConfig(); err == nil && cfg != nil {
+		for _, sc := range cfg.Servers {
+			if sc != nil && sc.Name == serverName {
+				existingSrv = sc
+				break
+			}
+		}
+	}
+
 	// Build partial update config - only set fields that were provided
 	updates := &config.ServerConfig{Name: serverName}
 	hasUpdates := false
@@ -1337,14 +1352,20 @@ func (s *Server) handlePatchServer(w http.ResponseWriter, r *http.Request) {
 	if req.Enabled != nil {
 		updates.Enabled = *req.Enabled
 		hasUpdates = true
+	} else if existingSrv != nil {
+		updates.Enabled = existingSrv.Enabled
 	}
 	if req.Quarantined != nil {
 		updates.Quarantined = *req.Quarantined
 		hasUpdates = true
+	} else if existingSrv != nil {
+		updates.Quarantined = existingSrv.Quarantined
 	}
 	if req.ReconnectOnUse != nil {
 		updates.ReconnectOnUse = *req.ReconnectOnUse
 		hasUpdates = true
+	} else if existingSrv != nil {
+		updates.ReconnectOnUse = existingSrv.ReconnectOnUse
 	}
 	if req.Isolation != nil {
 		updates.Isolation = req.Isolation.toConfig()

--- a/native/macos/MCPProxy/MCPProxy/Views/ServerDetailView.swift
+++ b/native/macos/MCPProxy/MCPProxy/Views/ServerDetailView.swift
@@ -955,6 +955,9 @@ struct ServerDetailView: View {
             try await client.updateServer(server.name, updates: updates)
             isEditing = false
             actionMessage = "Server configuration updated. Restart may be required."
+            // Pull the updated config back so the Config tab shows the newly
+            // saved values instead of the pre-edit snapshot.
+            await refreshServer()
         } catch {
             editError = "Failed to save: \(error.localizedDescription)"
         }


### PR DESCRIPTION
## Summary

Editing only the **Args** field on the macOS tray's Server Detail page silently disabled the server, and the UI kept showing the old args so the user concluded "args not saved".

## Root causes

**Backend (`internal/httpapi/server.go`):** `handlePatchServer` built `*config.ServerConfig` from the request, but `config.ServerConfig` uses non-pointer bools whose zero value can't be distinguished from "not set". When the tray PATCHed `{"args":[...]}` without `enabled`/`quarantined`/`reconnect_on_use`, the controller's `UpdateServer` unconditionally wrote those bools to `false`, flipping a previously-enabled server off.

**Frontend (`ServerDetailView.swift`):** `saveEdits()` never refreshed the server state after a successful PATCH, so the Config tab kept rendering the pre-edit snapshot.

## Fix

- Pre-fetch existing server via `GetConfig()` in the PATCH handler and fall back to its bool values when the request body omits them.
- `await refreshServer()` after `updateServer()` succeeds in `ServerDetailView.saveEdits()`.

## Verification

**Unit test** (`internal/httpapi/patch_server_test.go`) — asserts the bug scenario:
- PATCH `{"args":[...]}` with existing `enabled=true, reconnect_on_use=true` → all three bools preserved.
- PATCH `{"enabled":false}` → only `enabled` changes; others preserved.

**Integration against both binaries**:

| Binary | Before | After PATCH `{"args":[...]}` |
|--------|--------|-------|
| Old (current main) | args=old, enabled=**true** | args=new, enabled=**false** ← bug |
| New (this PR) | args=old, enabled=**true** | args=new, enabled=**true** ← fixed |

## Test plan
- [x] `go test ./internal/httpapi/... -race` passes
- [x] New regression tests fail on main, pass with fix
- [x] End-to-end curl reproduction against both binaries (see table above)
- [x] Swift tray builds without errors
- [ ] Manual: edit Args on Server Detail → Save → Args tab reflects new values immediately, server stays enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)