### PR TITLE
fix(docker): probe detects Docker via full path when PATH is minimal

### DIFF
--- a/internal/management/diagnostics.go
+++ b/internal/management/diagnostics.go
@@ -7,9 +7,12 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/contracts"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/health"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/shellwrap"
 )
 
 // extractHealthFromMap extracts health status from a server map.
@@ -168,7 +171,6 @@ func (s *service) Doctor(ctx context.Context) (*contracts.Diagnostics, error) {
 	return diag, nil
 }
 
-
 // checkDockerDaemon checks if Docker daemon is available and returns status.
 // This implements T042: helper for checking Docker availability.
 func (s *service) checkDockerDaemon() *contracts.DockerStatus {
@@ -176,11 +178,22 @@ func (s *service) checkDockerDaemon() *contracts.DockerStatus {
 		Available: false,
 	}
 
-	// Try to run `docker info` to check daemon availability
+	// Try to run `docker info` to check daemon availability.
+	// Resolve docker via shellwrap so we find Docker Desktop / Homebrew /
+	// Colima installs even when mcpproxy was launched from a tray /
+	// LaunchAgent with a minimal inherited PATH.
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "docker", "info", "--format", "{{.ServerVersion}}")
+	var logger *zap.Logger
+	if s.logger != nil {
+		logger = s.logger.Desugar()
+	}
+	dockerBin, resolveErr := shellwrap.ResolveDockerPath(logger)
+	if resolveErr != nil || dockerBin == "" {
+		dockerBin = "docker"
+	}
+	cmd := exec.CommandContext(ctx, dockerBin, "info", "--format", "{{.ServerVersion}}")
 	output, err := cmd.Output()
 
 	if err != nil {
@@ -221,4 +234,3 @@ func getStringFromMap(m map[string]interface{}, key string) string {
 	}
 	return ""
 }
-

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -31,6 +31,7 @@ import (
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/secret"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/security"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/server/tokens"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/shellwrap"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/telemetry"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/truncate"
@@ -2340,7 +2341,15 @@ func (r *Runtime) IsDockerAvailable() bool {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "docker", "info", "--format", "{{.ServerVersion}}")
+	// Resolve docker via shellwrap so we find Docker Desktop / Homebrew /
+	// Colima installs even when mcpproxy was launched from a LaunchAgent /
+	// tray with a minimal inherited PATH (see issue: tray "Docker daemon not
+	// available" warning despite healthy daemon + socket).
+	dockerBin, resolveErr := shellwrap.ResolveDockerPath(r.logger)
+	if resolveErr != nil || dockerBin == "" {
+		dockerBin = "docker"
+	}
+	cmd := exec.CommandContext(ctx, dockerBin, "info", "--format", "{{.ServerVersion}}")
 	err := cmd.Run()
 	newResult := err == nil
 

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -22,6 +22,7 @@ import (
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/registries"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/reqcontext"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/server/tokens"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/shellwrap"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/telemetry"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/transport"
@@ -2725,7 +2726,13 @@ func (p *MCPProxyServer) checkDockerAvailable() bool {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "docker", "info")
+	// Resolve docker via shellwrap so tray-launched processes with a minimal
+	// inherited PATH still find Docker Desktop / Homebrew / Colima installs.
+	dockerBin, resolveErr := shellwrap.ResolveDockerPath(p.logger)
+	if resolveErr != nil || dockerBin == "" {
+		dockerBin = "docker"
+	}
+	cmd := exec.CommandContext(ctx, dockerBin, "info")
 
 	err := cmd.Run()
 	available := err == nil

--- a/internal/shellwrap/shellwrap_test.go
+++ b/internal/shellwrap/shellwrap_test.go
@@ -88,6 +88,87 @@ func TestResolveDockerPath_CachedAcrossCalls(t *testing.T) {
 	}
 }
 
+// writeFakeDocker writes a no-op executable at <dir>/docker so ResolveDockerPath
+// can find "docker" on a controlled PATH.
+func writeFakeDocker(t *testing.T, dir string) string {
+	t.Helper()
+	script := "#!/bin/sh\nexit 0\n"
+	p := filepath.Join(dir, "docker")
+	require.NoError(t, os.WriteFile(p, []byte(script), 0o755))
+	return p
+}
+
+// TestResolveDockerPath_FastPath verifies that when docker is present on
+// ambient PATH, ResolveDockerPath returns it without invoking the login
+// shell fallback.
+func TestResolveDockerPath_FastPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-only fixture")
+	}
+	resetDockerPathCacheForTest()
+	t.Cleanup(resetDockerPathCacheForTest)
+
+	dir := t.TempDir()
+	want := writeFakeDocker(t, dir)
+	t.Setenv("PATH", dir)
+	// If the fast path were skipped and the shell fallback ran, it would
+	// invoke this (broken) shell and fail — the assertion below would catch it.
+	t.Setenv("SHELL", "/nonexistent/shell-must-not-be-invoked")
+
+	got, err := ResolveDockerPath(nil)
+	require.NoError(t, err)
+	assert.Equal(t, want, got, "should resolve docker via exec.LookPath without shell fallback")
+}
+
+// TestResolveDockerPath_ShellFallback simulates the tray/LaunchAgent scenario:
+// docker is NOT on the ambient PATH but IS on the user's login-shell PATH.
+// The shell fallback must recover the absolute path.
+func TestResolveDockerPath_ShellFallback(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("login-shell fallback is unix-only")
+	}
+	resetDockerPathCacheForTest()
+	t.Cleanup(resetDockerPathCacheForTest)
+
+	// Stash the fake docker somewhere that is NOT on ambient PATH.
+	dockerDir := t.TempDir()
+	dockerPath := writeFakeDocker(t, dockerDir)
+
+	// Ambient PATH deliberately excludes dockerDir (mimicking launchd minimal PATH).
+	ambient := t.TempDir()
+	t.Setenv("PATH", ambient)
+
+	// Fake $SHELL emits the absolute path via `command -v docker` — the
+	// fallback issues `<shell> -l -c 'command -v docker'` and trims the output.
+	shellDir := t.TempDir()
+	fakeShell := writeFakeShell(t, shellDir, dockerPath)
+	t.Setenv("SHELL", fakeShell)
+
+	got, err := ResolveDockerPath(nil)
+	require.NoError(t, err, "shell fallback must succeed when login shell emits the docker path")
+	assert.Equal(t, dockerPath, got, "should return the path emitted by the login shell")
+}
+
+// TestResolveDockerPath_NotFoundAnywhere verifies the error path when docker
+// is missing from both ambient PATH and the login shell.
+func TestResolveDockerPath_NotFoundAnywhere(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-only fixture")
+	}
+	resetDockerPathCacheForTest()
+	t.Cleanup(resetDockerPathCacheForTest)
+
+	t.Setenv("PATH", t.TempDir())
+	// Login shell that emits nothing — mimics `command -v docker` returning empty.
+	shellDir := t.TempDir()
+	fakeShell := writeFakeShell(t, shellDir, "")
+	t.Setenv("SHELL", fakeShell)
+
+	got, err := ResolveDockerPath(nil)
+	assert.Error(t, err, "should error when docker is neither on PATH nor in login shell")
+	assert.Empty(t, got)
+}
+
 func TestMinimalEnv_DropsSecrets(t *testing.T) {
 	t.Setenv("AWS_ACCESS_KEY_ID", "AKIA_test_dummy_value_00000000")
 	t.Setenv("GITHUB_TOKEN", "ghp_dummy_test_token_1234567890abcdef")


### PR DESCRIPTION
## Summary

Tray-launched mcpproxy inherits launchd's minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`). Three Docker probe sites shell out to bare `docker`, and `exec.LookPath` fails because Docker Desktop installs its CLI at `/usr/local/bin/docker` — producing the spurious warning:

```
Docker isolation is enabled but Docker daemon is not available
```

even when Docker Desktop is running with a healthy daemon + socket.

## Fix

Retrofit three probe sites to use the existing `shellwrap.ResolveDockerPath` helper (already used by `internal/security/scanner/docker.go`):
- `internal/runtime/runtime.go` (`IsDockerAvailable`)
- `internal/server/mcp.go` (`checkDockerAvailable`)
- `internal/management/diagnostics.go` (`checkDockerDaemon`)

`ResolveDockerPath` tries `exec.LookPath` first (covers well-configured environments), then falls back to invoking the user's login shell to discover their real PATH — recovering Docker Desktop's install location without requiring `DOCKER_HOST` or symlink configuration.

## Repro

```bash
PATH=/usr/bin:/bin:/usr/sbin:/sbin docker info
# exit 127 — reproduces the tray's environment
```

After the fix: probe finds `/usr/local/bin/docker` via shell fallback, `/api/v1/docker/status` returns `docker_available:true`.

## Verification

- Three new unit tests cover `ResolveDockerPath` (fast path, shell fallback, not-found)
- Build + vet green for both personal and server editions
- Existing `shellwrap`, `management`, `security/scanner` tests green with `-race`

## Non-goals

- Does not add `DOCKER_HOST` to the tray's launchd plist (separate concern).
- Does not change socket path handling — daemon + socket were healthy; only CLI discovery was broken.
- Does not touch the CLI scanner at `internal/security/scanner/docker.go` (already uses ResolveDockerPath).