### PR TITLE
fix(webui): prevent Scan Now tooltip clipping at right edge

### DIFF
--- a/frontend/src/views/ServerDetail.vue
+++ b/frontend/src/views/ServerDetail.vue
@@ -571,7 +571,7 @@
           <div class="space-y-6">
             <!-- Header: Scan button + Risk Score -->
             <div class="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4">
-              <div class="tooltip" :data-tip="!dockerAvailable ? 'Docker is required to run security scanners' : (!hasEnabledScanners() ? 'No scanners enabled — install one from Security Scanners' : '')">
+              <div class="tooltip tooltip-left" :data-tip="!dockerAvailable ? 'Docker is required to run security scanners' : (!hasEnabledScanners() ? 'No scanners enabled — install one from Security Scanners' : '')">
                 <button
                   v-if="hasEnabledScanners()"
                   @click="startSecurityScan"


### PR DESCRIPTION
## Summary
- Adds DaisyUI `tooltip-left` to the Scan Now button so the tooltip extends inward instead of outward
- Fixes the global `overflow-x: hidden` on `#app` and `.drawer-content` clipping the tooltip when the button sits near the right edge of the viewport
- Disabled-gate logic and Docker requirement unchanged — presentation-only fix

## Test plan
- [x] `npm run build` clean (134 modules, 1.71s)
- [ ] Manually verify in browser: full tooltip text visible on disabled Scan Now button (Docker unavailable / no scanners enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)