### PR TITLE
fix(macos-tray): pass MCPPROXY_KEYRING_WRITE to bundled core (#409)

### DIFF
--- a/native/macos/MCPProxy/MCPProxy/Core/CoreProcessManager.swift
+++ b/native/macos/MCPProxy/MCPProxy/Core/CoreProcessManager.swift
@@ -329,6 +329,10 @@ actor CoreProcessManager {
         env.removeValue(forKey: "MCPPROXY_API_KEY")
         // Enable socket communication
         env["MCPPROXY_SOCKET"] = "true"
+        // Tray-launched core is allowed to write to macOS Keychain — user
+        // explicitly opened the GUI app, so OS prompts are expected.
+        // See issue #409 / internal/secret/keyring_provider.go.
+        env["MCPPROXY_KEYRING_WRITE"] = "1"
         proc.environment = env
 
         // Capture stderr for error diagnostics


### PR DESCRIPTION
## Summary

Fixes #409.

## Symptom

On macOS, when the tray app launches the bundled core process, every secret-store call fails with:

```
keyring unavailable (backend not usable on this system — refusing to write to avoid OS modal prompts)
```

CLI invocations work because users can manually run `MCPPROXY_KEYRING_WRITE=1 mcpproxy ...`, but tray-launched cores have no such opportunity.

## Root Cause

`internal/secret/keyring_provider.go` has a Darwin-only safety gate around `keyring.Set`:

```go
if runtime.GOOS == "darwin" && !p.writesEnabled() {
    p.markUnavailable()
    return ErrKeyringUnavailable
}
```

`writesEnabled()` only returns true when `MCPPROXY_KEYRING_WRITE` is `1`/`true`/`yes` (or the test override is set).

This gate is correct in principle — without it, a misconfigured macOS Keychain backend can pop a synchronous, uncancellable OS modal dialog from inside `keyring.Set`, blocking the calling goroutine indefinitely with no way to recover. The opt-in env var lets users explicitly accept that risk.

The Swift tray launcher (`CoreProcessManager.launchCore`) was passing `MCPPROXY_SOCKET=true` but **not** `MCPPROXY_KEYRING_WRITE`, so the bundled core could never write secrets to the Keychain.

## Why the tray is the right context to enable this

When a user explicitly opens the GUI tray app, OS Keychain prompts are expected and desired — that's the whole point of running the app. The tray is the trusted, intentional launcher for the bundled core, so it should opt in on the user's behalf.

## Change

One line in `native/macos/MCPProxy/MCPProxy/Core/CoreProcessManager.swift`:

```swift
env["MCPPROXY_KEYRING_WRITE"] = "1"
```

…added next to the existing `MCPPROXY_SOCKET` setting, with a comment pointing back to issue #409 and `internal/secret/keyring_provider.go` for context.

## Test plan

- [x] `go test ./internal/secret/... -race` — passes
- [x] Swift tray builds: `swiftc -target arm64-apple-macosx13.0 -O ...` produces a valid arm64 Mach-O binary
- [ ] Manual: launch tray app, add a secret via Web UI, confirm it writes to Keychain (verify in Keychain Access.app under service `mcpproxy`)
- [ ] Manual: confirm "keyring unavailable" error no longer appears in `~/Library/Logs/mcpproxy/main.log` after tray-launched core starts

## Notes

- No Swift tests touch `CoreProcessManager` (`grep` of `MCPProxyTests/` returns nothing for `CoreProcessManager`/`launchCore`/`MCPPROXY_SOCKET`), so no test addition was warranted for a one-line env-var change. The Swift build itself verifies the syntax.
- Personal-edition Go build still succeeds (pre-commit hook ran `go build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)