### PR TITLE
fix(macos-tray): show "Loading…" instead of "No servers configured" during cold start

### DIFF
--- a/native/macos/MCPProxy/MCPProxy/MCPProxyApp.swift
+++ b/native/macos/MCPProxy/MCPProxy/MCPProxyApp.swift
@@ -720,6 +720,7 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate, NS
                 appState.connectedCount = 0
                 appState.totalServers = 0
                 appState.totalTools = 0
+                appState.serversLoaded = false
                 appState.apiClient = nil
                 updateStatusIcon()
                 rebuildMenu()

--- a/native/macos/MCPProxy/MCPProxy/State/AppState.swift
+++ b/native/macos/MCPProxy/MCPProxy/State/AppState.swift
@@ -46,6 +46,13 @@ final class AppState: ObservableObject {
     @Published var totalServers: Int = 0
     @Published var totalTools: Int = 0
 
+    /// Set to true once the tray has received its first response from
+    /// `/api/v1/servers`. Used by `statusSummary` to distinguish "haven't
+    /// fetched yet" from "fetched and the list is genuinely empty", so the
+    /// menu shows "Loading…" instead of misleading "No servers configured"
+    /// during the cold-start window after the core becomes reachable.
+    @Published var serversLoaded: Bool = false
+
     // MARK: Activity & security (ActivityEntry from Models.swift)
 
     @Published var recentActivity: [ActivityEntry] = []
@@ -165,6 +172,9 @@ final class AppState: ObservableObject {
         if isStopped { return "Stopped" }
         switch coreState {
         case .connected:
+            if !serversLoaded {
+                return "Loading…"
+            }
             if totalServers == 0 {
                 return "No servers configured"
             }
@@ -195,6 +205,7 @@ final class AppState: ObservableObject {
         if connectedCount != newConnected { connectedCount = newConnected }
         if totalTools != newTools { totalTools = newTools }
         if quarantinedToolsCount != newQuarantined { quarantinedToolsCount = newQuarantined }
+        if !serversLoaded { serversLoaded = true }
     }
 
     /// Replace the recent activity list.

--- a/native/macos/MCPProxy/MCPProxyTests/AppStateStatusSummaryTests.swift
+++ b/native/macos/MCPProxy/MCPProxyTests/AppStateStatusSummaryTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import MCPProxy
+
+@MainActor
+final class AppStateStatusSummaryTests: XCTestCase {
+
+    /// The cold-start case the user reported: core just transitioned to
+    /// `.connected` but the first `/api/v1/servers` response hasn't arrived
+    /// yet. The header must say "Loading…" — not the misleading
+    /// "No servers configured".
+    func testConnectedBeforeFirstFetchShowsLoading() {
+        let state = AppState()
+        state.coreState = .connected
+        // serversLoaded defaults to false, totalServers to 0
+        XCTAssertEqual(state.statusSummary, "Loading…")
+    }
+
+    /// Once a (possibly empty) server list has come back from the API, the
+    /// header should reflect reality: the user really has zero servers
+    /// configured, and we should say so.
+    func testConnectedAfterEmptyFetchShowsNoServersConfigured() {
+        let state = AppState()
+        state.coreState = .connected
+        state.updateServers([])
+        XCTAssertTrue(state.serversLoaded)
+        XCTAssertEqual(state.statusSummary, "No servers configured")
+    }
+
+    /// After a real fetch returns a populated list the header switches to
+    /// the standard "X/Y servers, Z tools" format.
+    func testConnectedAfterFetchWithServersShowsCounts() throws {
+        let state = AppState()
+        state.coreState = .connected
+        state.updateServers([Self.makeServer(name: "s1", connected: true, toolCount: 7)])
+        XCTAssertEqual(state.statusSummary, "1/1 servers, 7 tools")
+    }
+
+    /// The explicit "Stopped" state must always win over loading/connected
+    /// substates so the user always sees the truth when they have manually
+    /// stopped the core.
+    func testStoppedTakesPrecedenceOverLoading() {
+        let state = AppState()
+        state.coreState = .connected
+        state.isStopped = true
+        XCTAssertEqual(state.statusSummary, "Stopped")
+    }
+
+    // MARK: - Helpers
+
+    private static func makeServer(name: String, connected: Bool, toolCount: Int) -> ServerStatus {
+        let json = """
+        {
+            "id": "\(name)",
+            "name": "\(name)",
+            "protocol": "http",
+            "enabled": true,
+            "connected": \(connected),
+            "quarantined": false,
+            "tool_count": \(toolCount)
+        }
+        """.data(using: .utf8)!
+        // Decoding via the canonical Codable path keeps this test robust to
+        // future field additions on ServerStatus.
+        // swiftlint:disable:next force_try
+        return try! JSONDecoder().decode(ServerStatus.self, from: json)
+    }
+}


### PR DESCRIPTION
## Summary
- On a fresh launch the tray transitions to `.connected` as soon as the core's Unix socket responds, but `/api/v1/servers` can take several seconds to return a populated list (config parsing, MCP server bring-up, the first SSE `servers.changed` event).
- During that ~20s window the menu header read **"No servers configured"** — misleading the user when servers actually were configured (see screenshot in issue).
- Track whether we've ever received a server-list response, and show **"Loading…"** until that's true. Real "0 servers configured" still renders correctly once a response (even an empty one) arrives.

## Changes
- `AppState`: new `@Published serversLoaded: Bool` flag, set to `true` inside `updateServers(...)` on the first call.
- `statusSummary`: when `coreState == .connected && !serversLoaded`, return `"Loading…"`. Existing `Stopped` / `connected with N servers` / real-empty paths unchanged.
- `MCPProxyApp.stopCoreAction`: reset `serversLoaded = false` alongside the other state-clearing on explicit Stop, so a restart goes through the loading state cleanly.
- `MCPProxyTests/AppStateStatusSummaryTests.swift`: new XCTest covering all four cases — connected-before-fetch (Loading…), connected-after-empty-fetch (No servers configured), connected-with-servers (counts), Stopped takes precedence.

## Test plan
- [x] `xargs swiftc -typecheck` over the full `MCPProxy/**/*.swift` tree — zero errors (only pre-existing warnings).
- [x] Full `swiftc -emit-executable` build of the tray binary succeeds.
- [ ] CI — `Test macOS Build` workflow + Swift unit tests on macos-15 runner.
- [ ] Manual smoke: install signed build, restart Mac, confirm tray header reads "Loading…" for the first few seconds and then transitions to "N/M servers, K tools".

## Notes for the reviewer
- Visual cold-start verification with the dev bundle (`com.smartmcpproxy.mcpproxy.dev`) was blocked by the first-run dialog gating the launch sequence on a fresh bundle ID; the unit tests are the canonical signal here. The fix also passes when the **first** `/api/v1/servers` response is empty — we accept the brief flicker to "No servers configured" because the periodic refresh and SSE corrected it within seconds, and that flicker is the right answer for a genuinely empty config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)