### PR TITLE
fix(macos-tray): Secrets page blanks entire window (#418 regression)

### DIFF
--- a/native/macos/MCPProxy/MCPProxy/Views/SecretsView.swift
+++ b/native/macos/MCPProxy/MCPProxy/Views/SecretsView.swift
@@ -351,7 +351,7 @@ struct SecretsView: View {
                     .accessibilityIdentifier("secrets-success-copy")
                 }
             }
-            Spacer()
+            .frame(maxWidth: .infinity, alignment: .leading)
             Button {
                 successBannerTask?.cancel()
                 lastStoredReference = nil
@@ -383,9 +383,10 @@ struct SecretsView: View {
                 Text("This list shows secrets that are referenced from a server config (\u{0024}{keyring:NAME}). Adding a secret here stores its value — to make a server use it, also add the reference to that server's env block.")
                     .font(.scaled(.caption, scale: fontScale))
                     .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                    .lineLimit(nil)
+                    .multilineTextAlignment(.leading)
             }
-            Spacer()
+            .frame(maxWidth: .infinity, alignment: .leading)
             Button {
                 showConfigFirstHint = false
             } label: {


### PR DESCRIPTION
## Summary

- Clicking **Secrets** in the macOS tray app's main window blanked the entire window — sidebar items disappeared too, leaving the user with no way to navigate back. Other pages (Dashboard, Servers, Activity Log, Configuration) worked fine.
- Reproduced on v0.26.1 (the build that shipped #418). User confirmed it worked before #418.
- Root cause: the new \`configFirstHintBanner\` (rendered by default on first navigation to Secrets) combined \`.fixedSize(horizontal: false, vertical: true)\` on a long wrapping Text with a trailing \`Spacer()\` in the same HStack. That layout is ambiguous in SwiftUI; \`NavigationSplitView\` propagates the failure up and renders the entire split (sidebar included) blank.
- Surprising part: accessibility tree (AX API) showed the full SwiftUI hierarchy with all 6 secrets, banners, and stat badges — but the CALayer rendered nothing. That mismatch was the key clue: views were *constructed* but layout/paint failed at the host view level.

## Fix

Drop the trailing \`Spacer()\` and give the inner \`VStack\` \`.frame(maxWidth: .infinity, alignment: .leading)\` so the close button still sits flush right without a Spacer. Replaced \`.fixedSize(horizontal: false, vertical: true)\` with \`.lineLimit(nil) + .multilineTextAlignment(.leading)\` to preserve wrapping without the axis-pin conflict. Applied the same structural change preventively to \`successBanner\` (only shown post-Save, but uses the identical Spacer-in-HStack pattern).

## Test plan

- [ ] Build tray: \`cd native/macos/MCPProxy && swiftc ... -o /tmp/MCPProxy ...\`
- [ ] Replace \`MCPProxy.app/Contents/MacOS/MCPProxy\` with the new binary; ad-hoc re-sign with \`codesign --force --deep --sign - MCPProxy.app\`
- [ ] Launch app, open main window via tray → click each sidebar item; all five pages render
- [ ] Click **Secrets** → Config-first hint banner shows above the stats/filter; sidebar stays visible; long body text wraps correctly
- [ ] Click "Add Secret" → save → success banner appears with reference syntax + copy button; sidebar stays visible
- [ ] Click X on the hint banner → it dismisses; no layout jump

🤖 Generated with [Claude Code](https://claude.com/claude-code)