### PR TITLE
fix(installer+docker): launch tray with clean env, harden docker probe

### DIFF
--- a/frontend/src/views/ServerDetail.vue
+++ b/frontend/src/views/ServerDetail.vue
@@ -571,7 +571,7 @@
           <div class="space-y-6">
             <!-- Header: Scan button + Risk Score -->
             <div class="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4">
-              <div class="tooltip tooltip-left" :data-tip="!dockerAvailable ? 'Docker is required to run security scanners' : (!hasEnabledScanners() ? 'No scanners enabled — install one from Security Scanners' : '')">
+              <div class="tooltip tooltip-bottom" :data-tip="!dockerAvailable ? 'Docker is required to run security scanners' : (!hasEnabledScanners() ? 'No scanners enabled — install one from Security Scanners' : '')">
                 <button
                   v-if="hasEnabledScanners()"
                   @click="startSecurityScan"

--- a/internal/shellwrap/shellwrap.go
+++ b/internal/shellwrap/shellwrap.go
@@ -124,71 +124,175 @@ func WrapWithUserShell(logger *zap.Logger, command string, args []string) (shell
 
 // --- Docker path resolution ---------------------------------------------
 
+// dockerPathNegativeTTL bounds how long a failed lookup is cached. We retry
+// after this window so a transient failure (e.g. mcpproxy started from a
+// PKInstallSandbox where /bin/sh -l is restricted, then later able to find
+// docker once the install context drains) self-heals instead of poisoning
+// the process for its entire lifetime. Successes are cached forever.
+//
+// var (not const) so tests can drop it to zero for retry-behavior coverage.
+var dockerPathNegativeTTL = 60 * time.Second
+
 var (
-	dockerPathOnce sync.Once
-	dockerPath     string
-	dockerPathErr  error
+	dockerPathMu        sync.Mutex
+	dockerPath          string
+	dockerPathErr       error
+	dockerPathHasResult bool
+	dockerPathExpires   time.Time // zero for cached success (never expires)
 )
 
-// ResolveDockerPath returns the absolute path to the `docker` binary. The
-// result is cached for the process lifetime so that repeated calls from hot
-// paths (health checks, connection diagnostics) do not re-spawn a login shell
-// on every invocation.
+// wellKnownDockerPathsFn returns docker install locations to probe directly
+// when neither $PATH nor the user's login shell exposes a docker binary.
+// Exposed as a package variable so tests can stub the list.
+var wellKnownDockerPathsFn = defaultWellKnownDockerPaths
+
+func defaultWellKnownDockerPaths() []string {
+	switch runtime.GOOS {
+	case "darwin":
+		// Order matters: prefer the bundle binary (always present when
+		// Docker Desktop is installed) over /usr/local/bin/docker which is
+		// merely a symlink Docker Desktop creates and may be missing when
+		// /usr/local/bin is not writable (Docker falls back to ~/.docker/bin
+		// in that case — see docker/for-mac#6168).
+		paths := []string{
+			"/Applications/Docker.app/Contents/Resources/bin/docker", // canonical bundle binary
+			"/usr/local/bin/docker",                                  // Docker Desktop symlink (when present)
+			"/opt/homebrew/bin/docker",                               // Apple Silicon Homebrew
+			"/opt/podman/bin/docker",                                 // Podman shim
+		}
+		if home, err := os.UserHomeDir(); err == nil && home != "" {
+			paths = append(paths,
+				home+"/.docker/bin/docker",   // Docker Desktop fallback when /usr/local/bin not writable
+				home+"/.orbstack/bin/docker", // OrbStack
+			)
+		}
+		return paths
+	case "linux":
+		return []string{
+			"/usr/bin/docker",
+			"/usr/local/bin/docker",
+			"/snap/bin/docker",
+		}
+	}
+	return nil
+}
+
+// probeWellKnownDocker returns the first existing executable from the
+// well-known docker install locations, or "" if none qualify.
+func probeWellKnownDocker(logger *zap.Logger) string {
+	for _, candidate := range wellKnownDockerPathsFn() {
+		info, err := os.Stat(candidate)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		if info.Mode()&0o111 == 0 {
+			continue
+		}
+		if logger != nil {
+			logger.Debug("shellwrap: resolved docker via well-known path",
+				zap.String("path", candidate))
+		}
+		return candidate
+	}
+	return ""
+}
+
+// ResolveDockerPath returns the absolute path to the `docker` binary.
+// Successful resolutions are cached for the process lifetime; failed
+// resolutions are cached only for dockerPathNegativeTTL so a transient
+// failure (e.g. PKInstallSandbox at process start) does not permanently
+// disable docker discovery for the daemon.
 //
 // Resolution order:
 //  1. exec.LookPath("docker") — cheap, works when mcpproxy was started from
-//     a terminal or when the LaunchAgent PATH already contains docker.
-//  2. Fallback: ask the user's login shell `command -v docker` so we pick up
-//     Homebrew / Colima / Docker Desktop installs that only exist in the
-//     interactive PATH. This fallback is only run once.
+//     a terminal or when launchd's PATH already contains docker.
+//  2. Probe well-known install locations directly (Docker Desktop's bundle
+//     binary, /usr/local/bin/docker symlink, Apple Silicon Homebrew,
+//     ~/.docker/bin, OrbStack, snap, etc.). Avoids the fragile login-shell
+//     dance when the binary is at a predictable path.
+//  3. Last resort: ask the user's login shell `command -v docker` so we pick
+//     up Colima or other non-standard installs only present in the
+//     interactive PATH. Skipped on Windows.
 func ResolveDockerPath(logger *zap.Logger) (string, error) {
-	dockerPathOnce.Do(func() {
-		// Fast path: ask Go's standard PATH lookup first.
-		if p, err := exec.LookPath("docker"); err == nil && p != "" {
-			dockerPath = p
-			if logger != nil {
-				logger.Debug("shellwrap: resolved docker via PATH", zap.String("path", p))
-			}
-			return
-		}
+	dockerPathMu.Lock()
+	defer dockerPathMu.Unlock()
 
-		// Slow path: shell out once via the user's login shell.
-		if runtime.GOOS == osWindows {
-			dockerPathErr = fmt.Errorf("docker not found in PATH")
-			return
+	// Honor cache: keep successful resolutions forever; treat failures as
+	// retryable after dockerPathNegativeTTL.
+	if dockerPathHasResult {
+		if dockerPathErr == nil {
+			return dockerPath, nil
 		}
+		if !dockerPathExpires.IsZero() && time.Now().Before(dockerPathExpires) {
+			return dockerPath, dockerPathErr
+		}
+	}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-
-		shell, shellArgs := WrapWithUserShell(logger, "command", []string{"-v", "docker"})
-		cmd := exec.CommandContext(ctx, shell, shellArgs...)
-		out, err := cmd.Output()
-		if err != nil {
-			dockerPathErr = fmt.Errorf("login-shell docker lookup failed: %w", err)
-			return
-		}
-		resolved := strings.TrimSpace(string(out))
-		if resolved == "" {
-			dockerPathErr = fmt.Errorf("docker not found in login shell PATH")
-			return
-		}
-		dockerPath = resolved
-		if logger != nil {
-			logger.Debug("shellwrap: resolved docker via login shell",
-				zap.String("path", resolved))
-		}
-	})
-	return dockerPath, dockerPathErr
+	path, err := resolveDockerPathUncached(logger)
+	dockerPath = path
+	dockerPathErr = err
+	dockerPathHasResult = true
+	if err != nil {
+		dockerPathExpires = time.Now().Add(dockerPathNegativeTTL)
+	} else {
+		dockerPathExpires = time.Time{}
+	}
+	return path, err
 }
 
-// resetDockerPathCacheForTest is used by tests to probe the sync.Once
-// behaviour. It is intentionally unexported and only referenced from
+func resolveDockerPathUncached(logger *zap.Logger) (string, error) {
+	// Fast path: ask Go's standard PATH lookup first.
+	if p, err := exec.LookPath("docker"); err == nil && p != "" {
+		if logger != nil {
+			logger.Debug("shellwrap: resolved docker via PATH", zap.String("path", p))
+		}
+		return p, nil
+	}
+
+	// Well-known path probe: covers PKG-installer / launchd / sandboxed
+	// contexts where $SHELL=/bin/sh and the user's interactive PATH
+	// customizations are unreachable, but Docker Desktop is installed at
+	// a standard location. Cheap (just os.Stat) and reliable.
+	if p := probeWellKnownDocker(logger); p != "" {
+		return p, nil
+	}
+
+	// Slow path: shell out via the user's login shell. Only useful for
+	// non-standard installs (Colima, custom prefixes); skipped on Windows.
+	if runtime.GOOS == osWindows {
+		return "", fmt.Errorf("docker not found in PATH or well-known locations")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	shell, shellArgs := WrapWithUserShell(logger, "command", []string{"-v", "docker"})
+	cmd := exec.CommandContext(ctx, shell, shellArgs...)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("login-shell docker lookup failed: %w", err)
+	}
+	resolved := strings.TrimSpace(string(out))
+	if resolved == "" {
+		return "", fmt.Errorf("docker not found in login shell PATH")
+	}
+	if logger != nil {
+		logger.Debug("shellwrap: resolved docker via login shell",
+			zap.String("path", resolved))
+	}
+	return resolved, nil
+}
+
+// resetDockerPathCacheForTest is used by tests to clear the cache between
+// scenarios. It is intentionally unexported and only referenced from
 // shellwrap_test.go.
 func resetDockerPathCacheForTest() {
-	dockerPathOnce = sync.Once{}
+	dockerPathMu.Lock()
+	defer dockerPathMu.Unlock()
 	dockerPath = ""
 	dockerPathErr = nil
+	dockerPathHasResult = false
+	dockerPathExpires = time.Time{}
 }
 
 // --- Login-shell PATH capture --------------------------------------------

--- a/internal/shellwrap/shellwrap_test.go
+++ b/internal/shellwrap/shellwrap_test.go
@@ -138,6 +138,11 @@ func TestResolveDockerPath_ShellFallback(t *testing.T) {
 	ambient := t.TempDir()
 	t.Setenv("PATH", ambient)
 
+	// Stub well-known paths to nothing so the shell fallback is the path under test.
+	prev := wellKnownDockerPathsFn
+	wellKnownDockerPathsFn = func() []string { return nil }
+	t.Cleanup(func() { wellKnownDockerPathsFn = prev })
+
 	// Fake $SHELL emits the absolute path via `command -v docker` — the
 	// fallback issues `<shell> -l -c 'command -v docker'` and trims the output.
 	shellDir := t.TempDir()
@@ -150,7 +155,8 @@ func TestResolveDockerPath_ShellFallback(t *testing.T) {
 }
 
 // TestResolveDockerPath_NotFoundAnywhere verifies the error path when docker
-// is missing from both ambient PATH and the login shell.
+// is missing from ambient PATH, the login shell, and well-known install
+// locations.
 func TestResolveDockerPath_NotFoundAnywhere(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("unix-only fixture")
@@ -164,9 +170,83 @@ func TestResolveDockerPath_NotFoundAnywhere(t *testing.T) {
 	fakeShell := writeFakeShell(t, shellDir, "")
 	t.Setenv("SHELL", fakeShell)
 
+	// Stub the well-known paths to a list that cannot exist.
+	prev := wellKnownDockerPathsFn
+	wellKnownDockerPathsFn = func() []string { return []string{filepath.Join(t.TempDir(), "no-such-docker")} }
+	t.Cleanup(func() { wellKnownDockerPathsFn = prev })
+
 	got, err := ResolveDockerPath(nil)
-	assert.Error(t, err, "should error when docker is neither on PATH nor in login shell")
+	assert.Error(t, err, "should error when docker is missing from PATH, login shell, and well-known paths")
 	assert.Empty(t, got)
+}
+
+// TestResolveDockerPath_NegativeTTLRetry verifies that a failed resolution
+// is retried after dockerPathNegativeTTL elapses, so a transient install-time
+// failure does not permanently disable docker discovery for the daemon.
+func TestResolveDockerPath_NegativeTTLRetry(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-only fixture")
+	}
+	resetDockerPathCacheForTest()
+	t.Cleanup(resetDockerPathCacheForTest)
+
+	// Make negative cache effectively immediate so the second call re-probes.
+	prevTTL := dockerPathNegativeTTL
+	dockerPathNegativeTTL = 0
+	t.Cleanup(func() { dockerPathNegativeTTL = prevTTL })
+
+	// Empty well-known list during the FIRST call so it fails.
+	prevPaths := wellKnownDockerPathsFn
+	wellKnownDockerPathsFn = func() []string { return nil }
+	t.Cleanup(func() { wellKnownDockerPathsFn = prevPaths })
+
+	t.Setenv("PATH", t.TempDir())
+	shellDir := t.TempDir()
+	fakeShell := writeFakeShell(t, shellDir, "")
+	t.Setenv("SHELL", fakeShell)
+
+	_, err := ResolveDockerPath(nil)
+	require.Error(t, err, "first call should fail (no docker anywhere)")
+
+	// Now publish a fake docker via well-known paths. The cached failure
+	// must NOT block the retry.
+	dockerDir := t.TempDir()
+	want := writeFakeDocker(t, dockerDir)
+	wellKnownDockerPathsFn = func() []string { return []string{want} }
+
+	got, err := ResolveDockerPath(nil)
+	require.NoError(t, err, "second call must retry after negative TTL elapses")
+	assert.Equal(t, want, got)
+}
+
+// TestResolveDockerPath_WellKnownPathFallback simulates a PKG-installer
+// context: docker is missing from $PATH and the login shell emits nothing,
+// but Docker Desktop installed a binary at a well-known path. The fallback
+// must find it without invoking the shell.
+func TestResolveDockerPath_WellKnownPathFallback(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("well-known path fallback is unix-only")
+	}
+	resetDockerPathCacheForTest()
+	t.Cleanup(resetDockerPathCacheForTest)
+
+	dockerDir := t.TempDir()
+	want := writeFakeDocker(t, dockerDir)
+
+	// Ambient PATH excludes dockerDir.
+	t.Setenv("PATH", t.TempDir())
+
+	// Stub well-known paths to point at our fake docker.
+	prev := wellKnownDockerPathsFn
+	wellKnownDockerPathsFn = func() []string { return []string{want} }
+	t.Cleanup(func() { wellKnownDockerPathsFn = prev })
+
+	// Sabotage the shell so we can prove the well-known fallback ran first.
+	t.Setenv("SHELL", "/nonexistent/shell-must-not-be-invoked")
+
+	got, err := ResolveDockerPath(nil)
+	require.NoError(t, err, "well-known fallback must succeed when docker exists at a known path")
+	assert.Equal(t, want, got)
 }
 
 func TestMinimalEnv_DropsSecrets(t *testing.T) {

--- a/packaging/macos/postinstall.sh
+++ b/packaging/macos/postinstall.sh
@@ -14,6 +14,15 @@
 # bucket. The flag is cleared after the very first heartbeat is built —
 # subsequent heartbeats report launch_source=login_item or =tray.
 #
+# **Critical**: we launch via `launchctl asuser <uid> ... env -i ...` so the
+# tray app starts in the user's GUI bootstrap context with a clean env. A
+# bare `open -a` invoked from postinstall propagates the PKInstallSandbox
+# environment (PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/libexec, SHELL=/bin/sh,
+# INSTALLER_*) into the launched app and every child it spawns — that broke
+# Docker discovery in the long-running mcpproxy core (sync.Once permanently
+# cached the failed lookup). The clean-env launch mirrors what users get when
+# they double-click the app from Finder.
+#
 # This script is idempotent: re-running it simply re-launches the app.
 # Existing instances stay up (`open -a` activates rather than duplicating).
 #
@@ -30,6 +39,40 @@ if [ ! -d "$APP_PATH" ]; then
     exit 1
 fi
 
-open -a "$APP_PATH" --env MCPPROXY_LAUNCHED_BY=installer
+# Resolve the actual console user (the human who triggered the install) and
+# their uid. $USER inside postinstall is the human's account, but LOGNAME is
+# typically root and the env is sandboxed.
+REAL_USER="${USER:-}"
+if [ -z "$REAL_USER" ] || [ "$REAL_USER" = "root" ]; then
+    REAL_USER=$(stat -f%Su /dev/console)
+fi
+REAL_UID=$(id -u "$REAL_USER" 2>/dev/null || echo "")
+USER_HOME=$(/usr/bin/dscl . -read "/Users/$REAL_USER" NFSHomeDirectory 2>/dev/null | awk '{print $2}')
+[ -z "$USER_HOME" ] && USER_HOME=$(eval echo "~$REAL_USER")
+
+# Sane PATH covering Docker Desktop (/usr/local/bin), Apple Silicon Homebrew
+# (/opt/homebrew/bin), system tools, and the standard system bins. This is
+# the env launchd would give a normal user GUI session.
+SANE_PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+if [ -n "$REAL_UID" ] && [ "$REAL_UID" != "0" ]; then
+    # Preferred path: bootstrap into the user's GUI session with `launchctl
+    # asuser` so the app inherits launchd's per-user env, then `env -i` wipes
+    # any inherited installer vars before invoking `open`.
+    /bin/launchctl asuser "$REAL_UID" /usr/bin/env -i \
+        HOME="$USER_HOME" \
+        USER="$REAL_USER" \
+        LOGNAME="$REAL_USER" \
+        PATH="$SANE_PATH" \
+        /usr/bin/open -a "$APP_PATH" --env MCPPROXY_LAUNCHED_BY=installer
+else
+    # Fallback for unusual installers (no real user, e.g. CI imaging): launch
+    # with a clean PATH but skip the asuser hop. This still avoids leaking
+    # PKInstallSandbox env into the long-running daemon.
+    /usr/bin/env -i \
+        HOME="$USER_HOME" \
+        PATH="$SANE_PATH" \
+        /usr/bin/open -a "$APP_PATH" --env MCPPROXY_LAUNCHED_BY=installer
+fi
 
 exit 0

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -133,9 +133,51 @@ echo "📖 Get started: mcpproxy --help"
 # activation bucket, so a crash between install and heartbeat is recovered
 # from on next startup. See packaging/macos/postinstall.sh for the standalone
 # version of this step.
+#
+# Critical: launch via `launchctl asuser <uid> env -i …` so the tray app
+# (and its core child) start in the user's GUI bootstrap context with a
+# clean env. A bare `open -a` from a postinstall script propagates the
+# PKInstallSandbox env (minimal PATH, SHELL=/bin/sh, INSTALLER_*) into the
+# long-running daemon — which broke Docker discovery in mcpproxy core. The
+# clean-env launch mimics what users get when they double-click from Finder.
+APP_BUNDLE=""
 if [ -d "/Applications/MCPProxy.app" ]; then
-    log "Launching MCPProxy tray tagged as installer-launched"
-    open -a "/Applications/MCPProxy.app" --env MCPPROXY_LAUNCHED_BY=installer || true
+    APP_BUNDLE="/Applications/MCPProxy.app"
+elif [ -d "/Applications/mcpproxy.app" ]; then
+    # Some build paths produce the lowercase-named bundle.
+    APP_BUNDLE="/Applications/mcpproxy.app"
+fi
+
+if [ -n "$APP_BUNDLE" ]; then
+    log "Launching mcpproxy tray (installer-tagged) with clean env: $APP_BUNDLE"
+
+    REAL_USER="${USER:-}"
+    if [ -z "$REAL_USER" ] || [ "$REAL_USER" = "root" ]; then
+        REAL_USER=$(stat -f%Su /dev/console 2>/dev/null || echo "")
+    fi
+    REAL_UID=""
+    USER_HOME=""
+    if [ -n "$REAL_USER" ]; then
+        REAL_UID=$(id -u "$REAL_USER" 2>/dev/null || echo "")
+        USER_HOME=$(/usr/bin/dscl . -read "/Users/$REAL_USER" NFSHomeDirectory 2>/dev/null | awk '{print $2}')
+        [ -z "$USER_HOME" ] && USER_HOME=$(eval echo "~$REAL_USER")
+    fi
+
+    SANE_PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+    if [ -n "$REAL_UID" ] && [ "$REAL_UID" != "0" ]; then
+        /bin/launchctl asuser "$REAL_UID" /usr/bin/env -i \
+            HOME="$USER_HOME" \
+            USER="$REAL_USER" \
+            LOGNAME="$REAL_USER" \
+            PATH="$SANE_PATH" \
+            /usr/bin/open -a "$APP_BUNDLE" --env MCPPROXY_LAUNCHED_BY=installer || true
+    else
+        /usr/bin/env -i \
+            HOME="${USER_HOME:-/var/empty}" \
+            PATH="$SANE_PATH" \
+            /usr/bin/open -a "$APP_BUNDLE" --env MCPPROXY_LAUNCHED_BY=installer || true
+    fi
 fi
 
 exit 0


### PR DESCRIPTION
## Summary
- Postinstall scripts now launch the tray via `launchctl asuser <uid> env -i …` so the app starts in the user's GUI bootstrap with a clean PATH instead of inheriting the PKInstallSandbox env (PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/libexec, SHELL=/bin/sh, INSTALLER_*).
- `shellwrap.ResolveDockerPath` replaces `sync.Once` with a TTL'd cache (success cached forever, failure 60s) so a transient install-time failure self-heals instead of poisoning the daemon for its lifetime.
- New well-known-paths probe between the exec.LookPath fast path and the slow login-shell fallback. Probes Docker Desktop's bundle binary first, then `/usr/local/bin/docker`, `~/.docker/bin/docker`, Apple Silicon Homebrew, OrbStack, snap.
- Revert tooltip-left → tooltip-bottom on the Scan Now button (PR #407 over-corrected; the button is on the LEFT of the security tab content so tooltip-left ended up under the sidebar).

## Why this matters
Users installing v0.26.x via the PKG were ending up with a long-running mcpproxy core that could not find Docker even though Docker Desktop was running. Symptoms:
- Web UI's "Scan Now" button disabled with the explanation tooltip hidden under the left sidebar.
- `mcpproxy security scan <server>` returned `all scanners failed` in ~1s with per-scanner error `Docker image ... is not available locally` — even when every image was present in `docker images`.
- `/api/v1/diagnostics` showed `docker_status.error: exec: "docker": executable file not found in $PATH`.

Root cause was a chain: PKG postinstall → `open -a MCPProxy.app` propagated installer env → tray app → forked `mcpproxy serve` with no Docker locations on PATH → first `ResolveDockerPath` call failed → `sync.Once` cached the failure for the lifetime of the daemon. Restarting via the tray (normal user session) fixed it but the user shouldn't have to know that.

Apple's recommended pattern (per `launchctl(1)`, packaging guidelines, and prior art in Tailscale / Colima / OrbStack) is to launch under `launchctl asuser` with `EnvironmentVariables.PATH` set explicitly so children never inherit the sandbox env. That's what this PR does for the postinstall path; the Go-side TTL cache + well-known-paths probe is defense-in-depth in case any other context (LaunchAgent, manual launchctl, etc.) ends up with a similarly minimal PATH.

## Files
- `frontend/src/views/ServerDetail.vue` — tooltip-left → tooltip-bottom
- `internal/shellwrap/shellwrap.go` — TTL cache + well-known-paths probe
- `internal/shellwrap/shellwrap_test.go` — new tests for retry + well-known fallback
- `packaging/macos/postinstall.sh` — clean-env launch via launchctl asuser
- `scripts/postinstall.sh` — clean-env launch via launchctl asuser

## Test plan
- [x] `go test ./internal/shellwrap/... -count=1 -race` — all tests pass including new `TestResolveDockerPath_NegativeTTLRetry` and `TestResolveDockerPath_WellKnownPathFallback`
- [x] `go build ./cmd/mcpproxy` (personal) and `go build -tags server ./cmd/mcpproxy` (server) — both clean
- [x] `bash -n` syntax check on both postinstall scripts
- [x] Frontend builds clean
- [ ] Manual verification on macOS post-install: re-install PKG, confirm `mcpproxy security scan` works immediately and Web UI's "Scan Now" is enabled
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)