### PR TITLE
fix(cli): expand security scan report output

### DIFF
--- a/cmd/mcpproxy/security_cmd.go
+++ b/cmd/mcpproxy/security_cmd.go
@@ -1393,16 +1393,27 @@ func runSecurityReport(_ *cobra.Command, args []string) error {
 	}
 
 	// F-10: also fetch /scan/status (best-effort) so we can name the scanners
-	// that failed. The aggregated report has counts but only sometimes carries
-	// per-scanner names; the live job status is the authoritative source.
-	failedNames := fetchFailedScannerNames(client, ctx, serverName)
-	return printReportTable(serverName, report, failedNames)
+	// that failed AND surface the per-scanner error message. The aggregated
+	// report has counts but only sometimes carries per-scanner names; the
+	// live job status is the authoritative source.
+	failed := fetchFailedScannerInfo(client, ctx, serverName)
+	return printReportTable(serverName, report, failed)
 }
 
-// fetchFailedScannerNames returns the IDs of scanners that did not complete
-// in the most recent scan job for `serverName`. Returns nil on any error so
-// the caller can render the report without per-scanner names.
-func fetchFailedScannerNames(client *cliclient.Client, ctx context.Context, serverName string) []string {
+// failedScannerInfo carries a failed scanner's ID and the error that the
+// scanner runtime recorded for it. The error is rendered in the human-readable
+// report so the user can tell e.g. that `ramparts` failed because of a glibc
+// version mismatch — previously the CLI showed only the scanner name and the
+// user had to dig into log files to find the cause.
+type failedScannerInfo struct {
+	ID    string
+	Error string
+}
+
+// fetchFailedScannerInfo returns information about scanners that did not
+// complete in the most recent scan job for `serverName`. Returns nil on any
+// error so the caller can render the report without per-scanner names.
+func fetchFailedScannerInfo(client *cliclient.Client, ctx context.Context, serverName string) []failedScannerInfo {
 	resp, err := client.DoRaw(ctx, http.MethodGet, "/api/v1/servers/"+serverName+"/scan/status", nil)
 	if err != nil {
 		return nil
@@ -1427,16 +1438,21 @@ func fetchFailedScannerNames(client *cliclient.Client, ctx context.Context, serv
 	if !ok {
 		return nil
 	}
-	var failed []string
+	var failed []failedScannerInfo
 	for _, s := range scannerStatuses {
 		ss, ok := s.(map[string]interface{})
 		if !ok {
 			continue
 		}
 		if getMapString(ss, "status") == "failed" {
-			if name := getMapString(ss, "scanner_id"); name != "" {
-				failed = append(failed, name)
+			id := getMapString(ss, "scanner_id")
+			if id == "" {
+				continue
 			}
+			failed = append(failed, failedScannerInfo{
+				ID:    id,
+				Error: getMapString(ss, "error"),
+			})
 		}
 	}
 	return failed
@@ -1705,17 +1721,19 @@ func printScanSummary(client *cliclient.Client, ctx context.Context, serverName 
 	}
 
 	fmt.Printf("Scan completed for %q.\n\n", serverName)
-	failedNames := fetchFailedScannerNames(client, ctx, serverName)
-	return printReportTable(serverName, report, failedNames)
+	failed := fetchFailedScannerInfo(client, ctx, serverName)
+	return printReportTable(serverName, report, failed)
 }
 
 // printReportTable prints a human-readable report with two-pass scan support.
 //
-// failedScannerNames (F-10) is the list of scanner IDs that failed in the most
-// recent scan job, sourced from /scan/status (the report itself only carries
-// counts). When non-empty, the table shows a "Scanners: X run, Y failed" line
-// and a yellow warn line about incomplete coverage.
-func printReportTable(serverName string, report map[string]interface{}, failedScannerNames []string) error {
+// failedScanners (F-10) is the list of scanner IDs+errors that failed in the
+// most recent scan job, sourced from /scan/status (the report itself only
+// carries counts). When non-empty, the table shows a "Scanners: X run, Y
+// failed" line, a yellow warn line about incomplete coverage, and per-scanner
+// error reasons so the user can see WHY a scanner failed without grepping
+// log files.
+func printReportTable(serverName string, report map[string]interface{}, failedScanners []failedScannerInfo) error {
 	riskScore := "?"
 	if rs, ok := report["risk_score"].(float64); ok {
 		riskScore = fmt.Sprintf("%d", int(rs))
@@ -1739,12 +1757,26 @@ func printReportTable(serverName string, report map[string]interface{}, failedSc
 	scannersTotal := int(getMapFloat(report, "scanners_total"))
 	if scannersTotal > 0 {
 		line := fmt.Sprintf("Scanners:    %d run, %d failed", scannersRun, scannersFailed)
-		if scannersFailed > 0 && len(failedScannerNames) > 0 {
-			line += " (" + strings.Join(failedScannerNames, ", ") + ")"
+		if scannersFailed > 0 && len(failedScanners) > 0 {
+			names := make([]string, 0, len(failedScanners))
+			for _, f := range failedScanners {
+				names = append(names, f.ID)
+			}
+			line += " (" + strings.Join(names, ", ") + ")"
 		}
 		line += fmt.Sprintf(" of %d", scannersTotal)
 		fmt.Println(line)
 	}
+
+	// Scan context: show the user what was actually scanned. Without this the
+	// terse "0 findings" / "1 finding" output gives no signal as to whether
+	// the scan looked at real source code (docker_extract), a working_dir
+	// fallback, or just the synthetic tool definitions (tool_definitions_only).
+	// That distinction is critical when triaging a finding — a "Malicious
+	// Code" hit located at tools.json:85 means something very different from
+	// the same hit located at server.py:42.
+	printScanContextSection(report)
+
 	fmt.Println()
 
 	// F-10: warn the user when coverage is incomplete so they don't approve
@@ -1756,6 +1788,21 @@ func printReportTable(serverName string, report map[string]interface{}, failedSc
 			warn = "\x1b[33m" + warn + "\x1b[0m"
 		}
 		fmt.Println(warn)
+		// Show the actual error message for each failed scanner so users can
+		// diagnose without digging through ~/Library/Logs/mcpproxy/main.log.
+		for _, f := range failedScanners {
+			if f.Error == "" {
+				continue
+			}
+			msg := f.Error
+			if len(msg) > 240 {
+				msg = msg[:240] + "..."
+			}
+			// Single-line: replace newlines so a multi-line stderr capture
+			// doesn't break the indented layout.
+			msg = strings.ReplaceAll(msg, "\n", " ")
+			fmt.Printf("  - %s: %s\n", f.ID, msg)
+		}
 		fmt.Println()
 	}
 
@@ -1813,6 +1860,52 @@ func printReportTable(serverName string, report map[string]interface{}, failedSc
 	return nil
 }
 
+// printScanContextSection renders a one-block summary of *what* the scanners
+// looked at (source method, files, container, tool definitions exported).
+// This is the most important context for triaging a finding: a HIGH-severity
+// finding located at tools.json from a tool_definitions_only scan is a very
+// different signal from the same finding located at server.py from a
+// docker_extract scan.
+func printScanContextSection(report map[string]interface{}) {
+	ctx, ok := report["scan_context"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	method := getMapString(ctx, "source_method")
+	if method == "" && getMapString(ctx, "server_protocol") == "" {
+		return // nothing useful to render
+	}
+
+	fmt.Println()
+	fmt.Println("Scan Context")
+	if method != "" {
+		fmt.Printf("  Source:           %s\n", method)
+	}
+	if path := getMapString(ctx, "source_path"); path != "" {
+		fmt.Printf("  Path:             %s\n", path)
+	}
+	if proto := getMapString(ctx, "server_protocol"); proto != "" {
+		fmt.Printf("  Protocol:         %s\n", proto)
+	}
+	if di, ok := ctx["docker_isolation"].(bool); ok {
+		fmt.Printf("  Docker isolation: %t\n", di)
+	}
+	if cid := getMapString(ctx, "container_id"); cid != "" {
+		// Truncate full SHA256 container IDs to 12 chars (docker's standard).
+		short := cid
+		if len(short) > 12 {
+			short = short[:12]
+		}
+		fmt.Printf("  Container:        %s\n", short)
+	}
+	if tf, ok := ctx["total_files"].(float64); ok && int(tf) > 0 {
+		fmt.Printf("  Files scanned:    %d\n", int(tf))
+	}
+	if te, ok := ctx["tools_exported"].(float64); ok && int(te) > 0 {
+		fmt.Printf("  Tools analyzed:   %d\n", int(te))
+	}
+}
+
 // printFindingsList prints a list of findings in the CLI report format.
 func printFindingsList(findings []interface{}) {
 	for _, f := range findings {
@@ -1823,12 +1916,16 @@ func printFindingsList(findings []interface{}) {
 		severity := strings.ToUpper(getMapString(finding, "severity"))
 		ruleID := getMapString(finding, "rule_id")
 		title := getMapString(finding, "title")
+		description := getMapString(finding, "description")
 		location := getMapString(finding, "location")
 		scannerName := getMapString(finding, "scanner")
 		helpURI := getMapString(finding, "help_uri")
 		pkg := getMapString(finding, "package_name")
 		installed := getMapString(finding, "installed_version")
 		fixed := getMapString(finding, "fixed_version")
+		threatLevel := getMapString(finding, "threat_level")
+		threatType := getMapString(finding, "threat_type")
+		category := getMapString(finding, "category")
 
 		// Main line: [SEVERITY] CVE-ID: title (scanner)
 		label := title
@@ -1836,14 +1933,53 @@ func printFindingsList(findings []interface{}) {
 			label = ruleID
 		}
 		line := fmt.Sprintf("  [%s] %s", severity, label)
+		if cvss, ok := finding["cvss_score"].(float64); ok && cvss > 0 {
+			line += fmt.Sprintf(" CVSS=%.1f", cvss)
+		}
 		if scannerName != "" {
 			line += " (" + scannerName + ")"
 		}
 		fmt.Println(line)
 
+		// Title (when ruleID is the headline label)
+		if title != "" && label == ruleID {
+			fmt.Println("         Title:    " + title)
+		}
+
+		// Description: this is the long-form rule explanation. Previously the
+		// CLI rendered ONLY the rule ID, leaving users to look up what e.g.
+		// "MCP-MC-001" meant. Showing the description here mirrors the Web UI.
+		if description != "" && description != title {
+			desc := description
+			if len(desc) > 240 {
+				desc = desc[:240] + "..."
+			}
+			desc = strings.ReplaceAll(desc, "\n", " ")
+			fmt.Println("         What:     " + desc)
+		}
+
+		// Threat classification context (already used in the Web UI but absent
+		// from CLI output until now). Helps users distinguish a tool-poisoning
+		// finding from an obfuscated-code finding from a CVE.
+		if threatType != "" || threatLevel != "" || category != "" {
+			parts := []string{}
+			if threatLevel != "" {
+				parts = append(parts, threatLevel)
+			}
+			if threatType != "" {
+				parts = append(parts, threatType)
+			}
+			if category != "" && category != threatType {
+				parts = append(parts, "category="+category)
+			}
+			if len(parts) > 0 {
+				fmt.Println("         Threat:   " + strings.Join(parts, " · "))
+			}
+		}
+
 		// Package info
 		if pkg != "" {
-			pkgLine := "         Package: " + pkg
+			pkgLine := "         Package:  " + pkg
 			if installed != "" {
 				pkgLine += " v" + installed
 			}
@@ -1860,7 +1996,7 @@ func printFindingsList(findings []interface{}) {
 
 		// Link to advisory
 		if helpURI != "" {
-			fmt.Println("         Details: " + helpURI)
+			fmt.Println("         Details:  " + helpURI)
 		}
 
 		// Evidence (triggering content)

--- a/cmd/mcpproxy/security_cmd_test.go
+++ b/cmd/mcpproxy/security_cmd_test.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -147,4 +151,181 @@ func TestClearPreviousLines(t *testing.T) {
 	// the function doesn't panic on edge cases.
 	clearPreviousLines(0)
 	clearPreviousLines(-1)
+}
+
+// captureStdout runs fn and returns whatever fn writes to os.Stdout. Used to
+// assert that human-readable scan output renders all the fields we promise
+// (description, threat info, scan context, failed-scanner reasons).
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	fn()
+	w.Close()
+	return <-done
+}
+
+// TestPrintFindingsListRendersDescription guards the regression that prompted
+// this change: previously the CLI rendered only the rule ID, and a user
+// staring at "[HIGH] MCP-MC-001 (mcp-ai-scanner)" had no way to learn what
+// the rule actually meant without leaving the terminal. Description text
+// must appear inline.
+func TestPrintFindingsListRendersDescription(t *testing.T) {
+	out := captureStdout(t, func() {
+		printFindingsList([]interface{}{
+			map[string]interface{}{
+				"severity":     "high",
+				"rule_id":      "MCP-MC-001",
+				"title":        "Obfuscated code pattern",
+				"description":  "Source code contains obfuscated or encoded payloads that may hide malicious behavior",
+				"location":     "tools.json:85",
+				"scanner":      "mcp-ai-scanner",
+				"threat_level": "dangerous",
+				"threat_type":  "malicious_code",
+				"cvss_score":   7.5,
+			},
+		})
+	})
+
+	wants := []string{
+		"[HIGH] MCP-MC-001",
+		"CVSS=7.5",
+		"(mcp-ai-scanner)",
+		"Title:    Obfuscated code pattern",
+		"What:     Source code contains obfuscated",
+		"Threat:",
+		"dangerous",
+		"malicious_code",
+		"Location: tools.json:85",
+	}
+	for _, w := range wants {
+		if !strings.Contains(out, w) {
+			t.Errorf("output missing %q\n--- output ---\n%s", w, out)
+		}
+	}
+}
+
+// TestPrintFindingsListSkipsEmptyFields ensures we don't print empty
+// "Title:", "What:", "Threat:" rows for findings that lack those fields —
+// the CLI should remain compact for plain CVE-style findings.
+func TestPrintFindingsListSkipsEmptyFields(t *testing.T) {
+	out := captureStdout(t, func() {
+		printFindingsList([]interface{}{
+			map[string]interface{}{
+				"severity": "high",
+				"rule_id":  "CVE-2024-0001",
+				"title":    "CVE-2024-0001",
+				"location": "node_modules/foo/index.js",
+			},
+		})
+	})
+
+	if strings.Contains(out, "What:") {
+		t.Errorf("expected no 'What:' row when description == title; got:\n%s", out)
+	}
+	if strings.Contains(out, "Threat:") {
+		t.Errorf("expected no 'Threat:' row when threat_level/type/category are absent; got:\n%s", out)
+	}
+}
+
+// TestPrintScanContextSection verifies that the scan-context block renders
+// the source method, container, and file/tool counts. This is the signal
+// users need to triage a finding (e.g. is "tools.json:85" from a real Docker
+// extraction or just from a tool_definitions_only fallback?).
+func TestPrintScanContextSection(t *testing.T) {
+	out := captureStdout(t, func() {
+		printScanContextSection(map[string]interface{}{
+			"scan_context": map[string]interface{}{
+				"source_method":    "docker_extract",
+				"source_path":      "/tmp/mcpproxy-scan-foo-123",
+				"server_protocol":  "stdio",
+				"docker_isolation": true,
+				"container_id":     "f10556008f694b70fcfc7bc157481fab0329811488e06ba8bb5b65df7c12bd0c",
+				"total_files":      float64(21),
+				"tools_exported":   float64(28),
+			},
+		})
+	})
+
+	wants := []string{
+		"Scan Context",
+		"Source:           docker_extract",
+		"Path:             /tmp/mcpproxy-scan-foo-123",
+		"Protocol:         stdio",
+		"Docker isolation: true",
+		"Container:        f10556008f69", // truncated to 12 chars
+		"Files scanned:    21",
+		"Tools analyzed:   28",
+	}
+	for _, w := range wants {
+		if !strings.Contains(out, w) {
+			t.Errorf("scan context missing %q\n--- output ---\n%s", w, out)
+		}
+	}
+}
+
+// TestPrintScanContextSectionSkipsZero verifies that the renderer omits
+// counts that are zero so we don't emit misleading "0 files scanned" lines
+// for URL-protocol scans that never have a file count.
+func TestPrintScanContextSectionSkipsZero(t *testing.T) {
+	out := captureStdout(t, func() {
+		printScanContextSection(map[string]interface{}{
+			"scan_context": map[string]interface{}{
+				"source_method":  "url",
+				"total_files":    float64(0),
+				"tools_exported": float64(0),
+			},
+		})
+	})
+	if strings.Contains(out, "Files scanned:") {
+		t.Errorf("expected no 'Files scanned:' row when count is 0; got:\n%s", out)
+	}
+	if strings.Contains(out, "Tools analyzed:") {
+		t.Errorf("expected no 'Tools analyzed:' row when count is 0; got:\n%s", out)
+	}
+}
+
+// TestPrintReportTableRendersFailedScannerReasons guards the most actionable
+// improvement in the new output: when a scanner fails, we now show WHY it
+// failed (e.g. "GLIBC_2.39 not found"), so users don't have to grep main.log
+// to figure out why a scan came back partial.
+func TestPrintReportTableRendersFailedScannerReasons(t *testing.T) {
+	report := map[string]interface{}{
+		"job_id":          "scan-foo-1",
+		"risk_score":      float64(25),
+		"scanned_at":      "2026-04-26T17:39:05Z",
+		"scanners_run":    float64(3),
+		"scanners_failed": float64(1),
+		"scanners_total":  float64(4),
+		"findings":        []interface{}{},
+	}
+	failed := []failedScannerInfo{
+		{ID: "ramparts", Error: "scanner ramparts produced no output (exit code: 1, stderr: ramparts: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by ramparts))"},
+	}
+	out := captureStdout(t, func() {
+		_ = printReportTable("foo", report, failed)
+	})
+
+	for _, w := range []string{
+		"WARNING: Scan coverage incomplete",
+		"- ramparts:",
+		"GLIBC_2.39",
+	} {
+		if !strings.Contains(out, w) {
+			t.Errorf("expected %q in output; got:\n%s", w, out)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

`mcpproxy security scan` output was too terse to triage findings — only [SEVERITY] RULE-ID (scanner) + Location was rendered. The aggregated report API already carries description, threat_level/type, CVSS, scan context, and per-scanner errors; this PR plumbs those through to the human-readable formatter.

## Real-world before/after

User reported obsidian-pilot scan returned:

```
Scanners:    3 run, 1 failed (ramparts) of 4
=== Security Scan (Pass 1) ===
  1 finding(s)
  [HIGH] MCP-MC-001 (mcp-ai-scanner)
         Location: tools.json:85
```

…with no clue what MCP-MC-001 means or why ramparts failed. After this PR:

```
Scanners:    3 run, 1 failed (ramparts) of 4
Scan Context
  Source:           tool_definitions_only
  Path:             /tmp/mcpproxy-scan-tools-foo-123
  Protocol:         stdio
  Tools analyzed:   28
WARNING: Scan coverage incomplete: 1 of 4 scanners did not run
  - ramparts: scanner ramparts produced no output (exit code: 1, stderr:
    ramparts: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found ...)

  [HIGH] MCP-MC-001 CVSS=7.5 (mcp-ai-scanner)
         Title:    Obfuscated code pattern
         What:     Source code contains obfuscated or encoded payloads ...
         Threat:   dangerous · malicious_code
         Location: tools.json:85
```

## Changes

- `fetchFailedScannerNames` → `fetchFailedScannerInfo` so the failure **error** travels alongside the **id**.
- `printReportTable`: new "Scan Context" block (source method, path, protocol, docker isolation, container short-id, files scanned, tools analyzed). Failed-scanner block now lists each scanner's error reason as a bulleted line.
- `printFindingsList`: surfaces description, threat_level/threat_type/category, and CVSS score. Empty rows are suppressed so plain CVE findings stay compact.

## Test plan

- [x] `TestPrintFindingsListRendersDescription` — guards the regression: rule_id alone is not enough, description+threat must appear inline.
- [x] `TestPrintFindingsListSkipsEmptyFields` — compact output for plain CVEs.
- [x] `TestPrintScanContextSection` — full context renders, container ID truncates to 12 chars (docker convention).
- [x] `TestPrintScanContextSectionSkipsZero` — no misleading "0 files scanned" for URL scans.
- [x] `TestPrintReportTableRendersFailedScannerReasons` — guards the most actionable improvement: failed-scanner error reasons appear in the report.
- [x] `go test ./cmd/mcpproxy/ -count=1` passes.
- [x] `golangci-lint run ./cmd/mcpproxy/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)