### PR TITLE
security(headers): redact sensitive header values in upstream_servers list and /api/v1/servers

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -163,6 +163,15 @@ type Config struct {
 	// Security scanner settings (Spec 039)
 	Security *SecurityConfig `json:"security,omitempty" mapstructure:"security"`
 
+	// RevealSecretHeaders, when true, disables the redaction of sensitive
+	// header values (Authorization, X-API-Key, Cookie, …) in responses from
+	// the `upstream_servers` MCP tool and the `/api/v1/servers` REST API.
+	// Default false — sensitive header values are surfaced as
+	// `***REDACTED***` so an MCP agent cannot read Bearer tokens / API keys
+	// out of another upstream's config. Set to true if a downstream tool
+	// needs the raw values (e.g. a UI that round-trips PUT replaces).
+	RevealSecretHeaders bool `json:"reveal_secret_headers,omitempty" mapstructure:"reveal-secret-headers"`
+
 	// Server edition multi-user configuration (only meaningful with -tags server)
 	Teams *TeamsConfig `json:"teams,omitempty" mapstructure:"teams" swaggerignore:"true"`
 }

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/contracts"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/logs"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/management"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/oauth"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/observability"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/reqcontext"
 	internalRuntime "github.com/smart-mcp-proxy/mcpproxy-go/internal/runtime"
@@ -1041,6 +1042,12 @@ func (s *Server) handleGetServers(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		// Redact sensitive header values unless explicitly opted out via
+		// `reveal_secret_headers: true` in config. See config.Config field
+		// for rationale — the same redaction is applied to the
+		// `upstream_servers` MCP tool's list output.
+		s.redactServerHeaders(serverValues)
+
 		// Dereference stats pointer
 		var statsValue contracts.ServerStats
 		if stats != nil {
@@ -1069,6 +1076,9 @@ func (s *Server) handleGetServers(w http.ResponseWriter, r *http.Request) {
 	// Enrich with quarantine stats
 	s.enrichServersWithQuarantineStats(servers)
 
+	// See note above the management-service path for rationale.
+	s.redactServerHeaders(servers)
+
 	stats := contracts.ConvertUpstreamStatsToServerStats(s.controller.GetUpstreamStats())
 
 	response := contracts.GetServersResponse{
@@ -1077,6 +1087,22 @@ func (s *Server) handleGetServers(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.writeSuccess(w, response)
+}
+
+// redactServerHeaders walks each server in the slice and replaces sensitive
+// header values (Authorization, X-API-Key, Cookie, etc.) with `***REDACTED***`.
+// Skips redaction entirely when `reveal_secret_headers: true` is set in the
+// loaded config, matching the behaviour of the `upstream_servers` MCP tool.
+func (s *Server) redactServerHeaders(servers []contracts.Server) {
+	cfg, err := s.controller.GetConfig()
+	if err == nil && cfg != nil && cfg.RevealSecretHeaders {
+		return
+	}
+	for i := range servers {
+		if len(servers[i].Headers) > 0 {
+			servers[i].Headers = oauth.RedactStringHeaders(servers[i].Headers)
+		}
+	}
 }
 
 // enrichServersWithQuarantineStats adds quarantine metrics (pending/changed tool counts)

--- a/internal/oauth/logging.go
+++ b/internal/oauth/logging.go
@@ -90,6 +90,27 @@ func RedactHeaders(headers http.Header) map[string]string {
 	return redacted
 }
 
+// RedactStringHeaders is the map[string]string analogue of RedactHeaders, for
+// the per-server config form (cfg.Headers) used in the upstream_servers MCP
+// tool and the /api/v1/servers REST response. Returns a new map; the input
+// is not mutated. Returns nil for nil input so JSON callers can keep emitting
+// `null` rather than `{}` if they were doing so before.
+func RedactStringHeaders(headers map[string]string) map[string]string {
+	if headers == nil {
+		return nil
+	}
+	redacted := make(map[string]string, len(headers))
+	for key, value := range headers {
+		lowerKey := strings.ToLower(key)
+		if sensitiveHeaders[lowerKey] {
+			redacted[key] = "***REDACTED***"
+		} else {
+			redacted[key] = RedactSensitiveData(value)
+		}
+	}
+	return redacted
+}
+
 // RedactURL redacts sensitive query parameters from a URL string.
 func RedactURL(urlStr string) string {
 	if urlStr == "" {

--- a/internal/oauth/logging_test.go
+++ b/internal/oauth/logging_test.go
@@ -104,6 +104,58 @@ func TestRedactHeaders(t *testing.T) {
 	})
 }
 
+func TestRedactStringHeaders(t *testing.T) {
+	t.Run("redacts a bearer authorization", func(t *testing.T) {
+		headers := map[string]string{
+			"Authorization":  "Bearer fake-test-token-not-a-real-secret",
+			"X-MCP-Toolsets": "pull_requests",
+		}
+		got := RedactStringHeaders(headers)
+		assert.Equal(t, "***REDACTED***", got["Authorization"])
+		assert.Equal(t, "pull_requests", got["X-MCP-Toolsets"])
+	})
+
+	t.Run("redacts x-api-key", func(t *testing.T) {
+		got := RedactStringHeaders(map[string]string{"X-Api-Key": "secret"})
+		assert.Equal(t, "***REDACTED***", got["X-Api-Key"])
+	})
+
+	t.Run("redacts cookie and set-cookie", func(t *testing.T) {
+		got := RedactStringHeaders(map[string]string{
+			"Cookie":     "session=abc",
+			"Set-Cookie": "session=abc; Path=/",
+		})
+		assert.Equal(t, "***REDACTED***", got["Cookie"])
+		assert.Equal(t, "***REDACTED***", got["Set-Cookie"])
+	})
+
+	t.Run("preserves non-sensitive headers", func(t *testing.T) {
+		got := RedactStringHeaders(map[string]string{"Content-Type": "application/json"})
+		assert.Equal(t, "application/json", got["Content-Type"])
+	})
+
+	t.Run("case insensitive header matching", func(t *testing.T) {
+		got := RedactStringHeaders(map[string]string{"AUTHORIZATION": "Bearer x"})
+		assert.Equal(t, "***REDACTED***", got["AUTHORIZATION"])
+	})
+
+	t.Run("nil input returns nil", func(t *testing.T) {
+		assert.Nil(t, RedactStringHeaders(nil))
+	})
+
+	t.Run("empty input returns empty map", func(t *testing.T) {
+		got := RedactStringHeaders(map[string]string{})
+		assert.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+
+	t.Run("does not mutate input", func(t *testing.T) {
+		input := map[string]string{"Authorization": "Bearer secret"}
+		_ = RedactStringHeaders(input)
+		assert.Equal(t, "Bearer secret", input["Authorization"], "input should be unchanged")
+	})
+}
+
 func TestRedactURL(t *testing.T) {
 	t.Run("redacts access_token in URL", func(t *testing.T) {
 		url := "https://example.com/callback?access_token=secret123&state=xyz"

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -2380,10 +2380,15 @@ func TestE2E_PatchDeepMergesEnvAndHeaders(t *testing.T) {
 	assert.Equal(t, "another_value", envMap["ANOTHER_VAR"], "ANOTHER_VAR must be preserved")
 	assert.Equal(t, "new_value", envMap["NEW_VAR"], "NEW_VAR must be added")
 
-	// CRITICAL: Verify existing headers are preserved (deep merge)
+	// CRITICAL: Verify existing headers are preserved (deep merge).
+	// The Authorization value is redacted in the API response by default
+	// (see config.RevealSecretHeaders) — we assert the key is still present
+	// to confirm the merge kept it; non-sensitive headers retain their
+	// actual values, which confirms both that merge worked AND that
+	// redaction is scoped to sensitive header names only.
 	headersMap, ok := foundServer["headers"].(map[string]interface{})
 	require.True(t, ok, "Headers should be a map")
-	assert.Equal(t, "Bearer token", headersMap["Authorization"], "Authorization must be preserved")
+	assert.Equal(t, "***REDACTED***", headersMap["Authorization"], "Authorization should be present (key preserved by merge) but redacted in API output")
 	assert.Equal(t, "custom-value", headersMap["X-Custom"], "X-Custom must be preserved")
 	assert.Equal(t, "new-header-value", headersMap["X-New-Header"], "X-New-Header must be added")
 
@@ -2491,10 +2496,13 @@ func TestE2E_MultipleEnableDisablePreservesConfig(t *testing.T) {
 	assert.Equal(t, "secret", envMap["API_KEY"], "API_KEY must be preserved")
 	assert.Equal(t, "true", envMap["DEBUG"], "DEBUG must be preserved")
 
-	// Verify headers
+	// Verify headers — Authorization is redacted in API output by default
+	// (config.RevealSecretHeaders defaults to false). The key is still
+	// present, which confirms the underlying merge preserved the value
+	// across the 5 toggles.
 	headersMap, ok := foundServer["headers"].(map[string]interface{})
 	require.True(t, ok, "headers should be a map")
-	assert.Equal(t, "Bearer token", headersMap["Authorization"], "Authorization must be preserved")
+	assert.Equal(t, "***REDACTED***", headersMap["Authorization"], "Authorization key must be preserved across toggles (value redacted in API output)")
 
 	// Verify isolation - in list response, isolation is under docker_isolation.server_isolation
 	dockerIsolation, ok := foundServer["docker_isolation"].(map[string]interface{})

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -19,6 +19,7 @@ import (
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/index"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/jsruntime"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/logs"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/oauth"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/registries"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/reqcontext"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/server/tokens"
@@ -2482,7 +2483,17 @@ func (p *MCPProxyServer) handleListUpstreams(ctx context.Context) (*mcp.CallTool
 
 	// Enhance server list with connection status and Docker isolation info
 	enhancedServers := make([]map[string]interface{}, len(servers))
+	revealHeaders := p.config != nil && p.config.RevealSecretHeaders
 	for i, server := range servers {
+		// Redact sensitive header values (Authorization, X-API-Key, Cookie,
+		// etc.) before surfacing them through the MCP tool. An MCP agent
+		// inside a sandbox should never be able to read another upstream's
+		// Bearer token via `upstream_servers list`. Operators who genuinely
+		// need to see them can set `reveal_secret_headers: true` in config.
+		headers := server.Headers
+		if !revealHeaders {
+			headers = oauth.RedactStringHeaders(server.Headers)
+		}
 		serverMap := map[string]interface{}{
 			"name":        server.Name,
 			"protocol":    server.Protocol,
@@ -2490,7 +2501,7 @@ func (p *MCPProxyServer) handleListUpstreams(ctx context.Context) (*mcp.CallTool
 			"args":        server.Args,
 			"url":         server.URL,
 			"env":         server.Env,
-			"headers":     server.Headers,
+			"headers":     headers,
 			"enabled":     server.Enabled,
 			"quarantined": server.Quarantined,
 			"created":     server.Created,


### PR DESCRIPTION
# Pull Request

## Description
Both the upstream_servers MCP tool's list operation and the REST GET /api/v1/servers endpoint were returning the per-server Headers map verbatim — so any caller of those endpoints (an MCP
  agent inside a sandbox, a local tool with the API key, the Web UI, the macOS tray) could read Authorization: Bearer <token>, X-API-Key, session cookies, and other secrets out of another
  upstream's config.

  Concretely observed: a sandboxed MCP agent calling mcpproxy:upstream_servers operation=list got back a registered GitHub server's Authorization: Bearer ghp_… PAT in plaintext.

### What changes

  - internal/oauth/logging.go — new RedactStringHeaders(map[string]string) map[string]string that mirrors the existing RedactHeaders(http.Header) helper but takes the form actually used in
  cfg.Headers. Same sensitiveHeaders allowlist, same ***REDACTED*** marker, returns a copy (input not mutated).
  - internal/server/mcp.go (handleListUpstreams) — redacts the headers field on every server entry before serialising the tool result.
  - internal/httpapi/server.go (handleGetServers) — new private redactServerHeaders helper applied in both the management-service code path and the legacy fallback before writeSuccess.
  - internal/config/config.go — new RevealSecretHeaders bool field (reveal_secret_headers JSON / reveal-secret-headers mapstructure key, default false). Setting it to true opts out of redaction
   for users who genuinely need raw values surfaced (e.g. a custom UI that round-trips full PUT replaces).

  Sensitive header names redacted (case-insensitive, list lives in oauth.sensitiveHeaders): Authorization, X-API-Key, Cookie, Set-Cookie, X-Access-Token, X-Refresh-Token, X-Auth-Token,
  Proxy-Authorization.

 ### What does NOT change

  PATCH / merge semantics. The underlying stored cfg.Headers is untouched — only the read-side response is redacted. So upstream_servers operation=patch continues to deep-merge by name; only
  the value displayed in subsequent reads is masked. Existing callers that omit unchanged fields keep working exactly as before.

 ### Migration

  None. Existing config files keep working; reveal_secret_headers defaults to false. To opt out: {"reveal_secret_headers": true} in mcp_config.json.

## Testing

Unit tests added in internal/oauth/logging_test.go (TestRedactStringHeaders, 8 sub-tests): redacts Bearer Authorization, redacts X-Api-Key, redacts Cookie/Set-Cookie, preserves non-sensitive
  headers (Content-Type), case-insensitive header name matching, nil input returns nil, empty input returns empty map, input map is not mutated.

  E2E tests updated in internal/server/e2e_test.go:
  - TestE2E_PatchDeepMergesEnvAndHeaders — now asserts Authorization == "***REDACTED***" (key preserved by merge, value masked in API output) while X-Custom and X-New-Header retain their actual
   values, validating both that merge semantics still work and that redaction is scoped to the sensitive-name list.
  - TestE2E_MultipleEnableDisablePreservesConfig — same pattern: Authorization key survives 5 enable/disable toggles, with the value redacted in read-back.

  Local test runs (clean):
  ok  github.com/smart-mcp-proxy/mcpproxy-go/internal/oauth
  ok  github.com/smart-mcp-proxy/mcpproxy-go/internal/server    (incl. the two E2E tests above)
  ok  github.com/smart-mcp-proxy/mcpproxy-go/internal/httpapi
  ok  github.com/smart-mcp-proxy/mcpproxy-go/internal/config
  ok  github.com/smart-mcp-proxy/mcpproxy-go/internal/contracts
  go build ./... clean.

  Manual verification: end-to-end call against the running proxy now returns ***REDACTED*** for the GitHub server's Authorization header (previously returned the live PAT).

- [x] I have tested these changes locally
- [x] I have added/updated tests that prove my fix is effective or my feature works
- [x] All existing tests pass