### PR TITLE
fix(diagnostics): point error docs links to docs.mcpproxy.app

### DIFF
--- a/docs/errors/MCPX_CONFIG_DEPRECATED_FIELD.md
+++ b/docs/errors/MCPX_CONFIG_DEPRECATED_FIELD.md
@@ -1,23 +1,55 @@
-# MCPX_CONFIG_DEPRECATED_FIELD
+---
+id: MCPX_CONFIG_DEPRECATED_FIELD
+title: MCPX_CONFIG_DEPRECATED_FIELD
+sidebar_label: DEPRECATED_FIELD
+description: Your mcpproxy config uses a deprecated field that will be removed in a future release.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_CONFIG_DEPRECATED_FIELD`
+
+**Severity:** warn
+**Domain:** Config
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_CONFIG_DEPRECATED_FIELD`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+mcpproxy parsed your config (`~/.mcpproxy/mcp_config.json`) successfully, but
+detected a field that has been renamed or replaced. The current release still
+honours the old field; a future release will not.
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+### Preview the migration
+
+The error panel includes a **Preview migration (dry-run)** fix-step. CLI:
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_CONFIG_DEPRECATED_FIELD --server <name>    # dry-run by default for destructive fixes
+mcpproxy config migrate --dry-run
 ```
+
+This prints the diff that would be applied. Review it, then apply:
+
+```bash
+mcpproxy config migrate
+```
+
+A `.bak` is written next to the original file.
+
+### Manual migration
+
+If you prefer to edit the file by hand, the warning message names the exact
+field. The most common renames:
+
+| Old | New |
+|---|---|
+| `mcpServers[].docker_isolation` (bool) | `mcpServers[].isolation.enabled` |
+| `top_k` (deprecated) | `tools_limit` |
+| `enable_quarantine` | `quarantine_enabled` |
+
+### Suppress the warning until you migrate
+
+Deprecated fields keep working. If you can't migrate today, the warning is
+informational — there's no operational impact in this release.
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [Configuration → config file](../configuration/config-file.md)

--- a/docs/errors/MCPX_CONFIG_MISSING_SECRET.md
+++ b/docs/errors/MCPX_CONFIG_MISSING_SECRET.md
@@ -1,23 +1,65 @@
-# MCPX_CONFIG_MISSING_SECRET
+---
+id: MCPX_CONFIG_MISSING_SECRET
+title: MCPX_CONFIG_MISSING_SECRET
+sidebar_label: MISSING_SECRET
+description: An upstream config refers to a secret that does not exist in the secret store.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_CONFIG_MISSING_SECRET`
+
+**Severity:** error
+**Domain:** Config
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_CONFIG_MISSING_SECRET`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+The upstream config references a secret (typically via `${SECRET:NAME}` in
+`env` or `headers`), but the secret was not found in the active secret store
+when mcpproxy tried to start that server.
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+### List what's defined
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_CONFIG_MISSING_SECRET --server <name>    # dry-run by default for destructive fixes
+mcpproxy secret list
+```
+
+If the name you referenced isn't there, add it.
+
+### Add the missing secret
+
+```bash
+mcpproxy secret set <NAME>           # prompts for the value, never echoed
+```
+
+Secrets are stored in the OS keychain on macOS / Windows and in an encrypted
+file on Linux.
+
+### Check the reference syntax
+
+```jsonc
+{
+  // env values support ${SECRET:NAME} expansion:
+  "env": { "GITHUB_TOKEN": "${SECRET:github_personal_token}" },
+
+  // headers do too:
+  "headers": { "Authorization": "Bearer ${SECRET:my_api_key}" }
+}
+```
+
+Plain string values are used as-is (no expansion).
+
+### Migration from inline secrets
+
+If you previously stored secrets inline and want to move them into the secret
+store:
+
+```bash
+mcpproxy secret set github_personal_token < /dev/stdin <<<"ghp_xxx"
+# Then update the config to use ${SECRET:github_personal_token}
 ```
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [Configuration → environment variables](../configuration/environment-variables.md)
+- [`MCPX_CONFIG_PARSE_ERROR`](MCPX_CONFIG_PARSE_ERROR.md)

--- a/docs/errors/MCPX_CONFIG_PARSE_ERROR.md
+++ b/docs/errors/MCPX_CONFIG_PARSE_ERROR.md
@@ -1,23 +1,54 @@
-# MCPX_CONFIG_PARSE_ERROR
+---
+id: MCPX_CONFIG_PARSE_ERROR
+title: MCPX_CONFIG_PARSE_ERROR
+sidebar_label: PARSE_ERROR
+description: mcpproxy could not parse the configuration file as JSON.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_CONFIG_PARSE_ERROR`
+
+**Severity:** error
+**Domain:** Config
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_CONFIG_PARSE_ERROR`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+mcpproxy reads `~/.mcpproxy/mcp_config.json` (or the path you configured) on
+startup and on every change. The file failed JSON parsing — usually a
+trailing comma, an unquoted key, or a stray character.
+
+mcpproxy refuses to start with a broken config rather than silently loading a
+partial state.
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+### Validate the JSON
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_CONFIG_PARSE_ERROR --server <name>    # dry-run by default for destructive fixes
+jq . ~/.mcpproxy/mcp_config.json
 ```
+
+`jq` will print the line/column of the first parse error. Common offenders:
+
+- Trailing comma after the last item in an array or object.
+- Smart quotes pasted from a doc tool instead of `"`.
+- Comment lines (JSON has no comments).
+- Two top-level objects without an enclosing wrapper.
+
+### Restore from backup
+
+mcpproxy writes `.bak` files when applying migrations / web-UI edits:
+
+```bash
+ls ~/.mcpproxy/*.bak
+cp ~/.mcpproxy/mcp_config.json.bak ~/.mcpproxy/mcp_config.json
+```
+
+### Edit via the web UI
+
+If you're not comfortable hand-editing JSON, edit through the web UI: it
+applies changes atomically and never leaves the file in a broken state.
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [Configuration → config file](../configuration/config-file.md)
+- [`MCPX_CONFIG_MISSING_SECRET`](MCPX_CONFIG_MISSING_SECRET.md)

--- a/docs/errors/MCPX_DOCKER_DAEMON_DOWN.md
+++ b/docs/errors/MCPX_DOCKER_DAEMON_DOWN.md
@@ -1,23 +1,64 @@
-# MCPX_DOCKER_DAEMON_DOWN
+---
+id: MCPX_DOCKER_DAEMON_DOWN
+title: MCPX_DOCKER_DAEMON_DOWN
+sidebar_label: DAEMON_DOWN
+description: The Docker daemon is not reachable; isolated upstream servers cannot run.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_DOCKER_DAEMON_DOWN`
+
+**Severity:** error
+**Domain:** Docker
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_DOCKER_DAEMON_DOWN`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+A server is configured with `isolation.enabled: true` (or auto-detected as
+needing isolation), but mcpproxy could not connect to the Docker daemon. The
+upstream server cannot start without Docker.
+
+## Common causes
+
+- Docker Desktop is installed but not running (macOS / Windows).
+- The Docker service hasn't been started (Linux: `dockerd`, `containerd`).
+- `DOCKER_HOST` points to a stale socket (e.g. left over from a previous Colima session).
+- Permissions issue — see [`MCPX_DOCKER_NO_PERMISSION`](MCPX_DOCKER_NO_PERMISSION.md)
+  for that variant.
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+```bash
+docker info               # works → daemon is up
+docker context ls         # which context (rootful, rootless, colima, …) is active
+echo "$DOCKER_HOST"       # should be empty or point at a real socket
+```
+
+### macOS / Windows — start Docker Desktop or Colima
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_DOCKER_DAEMON_DOWN --server <name>    # dry-run by default for destructive fixes
+open -a Docker            # macOS Docker Desktop
+colima start              # macOS / Linux Colima
 ```
+
+### Linux — start the daemon
+
+```bash
+sudo systemctl start docker
+sudo systemctl enable docker     # auto-start on boot
+```
+
+### Disable isolation for one server
+
+If you don't need isolation for a particular server, turn it off:
+
+```json
+{ "isolation": { "enabled": false } }
+```
+
+Note this means the upstream runs directly on the host with the host's
+`PATH` / network — only do it for servers you trust.
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [Docker Isolation](../features/docker-isolation.md)
+- [`MCPX_DOCKER_NO_PERMISSION`](MCPX_DOCKER_NO_PERMISSION.md)
+- [`MCPX_DOCKER_SNAP_APPARMOR`](MCPX_DOCKER_SNAP_APPARMOR.md)

--- a/docs/errors/MCPX_DOCKER_IMAGE_PULL_FAILED.md
+++ b/docs/errors/MCPX_DOCKER_IMAGE_PULL_FAILED.md
@@ -1,23 +1,68 @@
-# MCPX_DOCKER_IMAGE_PULL_FAILED
+---
+id: MCPX_DOCKER_IMAGE_PULL_FAILED
+title: MCPX_DOCKER_IMAGE_PULL_FAILED
+sidebar_label: IMAGE_PULL_FAILED
+description: Docker failed to pull the isolation image used by an upstream server.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_DOCKER_IMAGE_PULL_FAILED`
+
+**Severity:** error
+**Domain:** Docker
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_DOCKER_IMAGE_PULL_FAILED`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+Before starting an isolated upstream, mcpproxy needs the runtime image (e.g.
+`python:3.12-slim` for `uvx`, `node:20-alpine` for `npx`). Pulling failed.
+
+## Common causes
+
+- No internet connectivity at the moment.
+- Registry rate-limit (Docker Hub anonymous limit is 100 pulls / 6h per IP).
+- The image name in `isolation.image` is wrong.
+- A corporate registry mirror is required and isn't configured.
+- Disk full — pull aborted mid-stream.
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+### Pull manually to see the underlying error
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_DOCKER_IMAGE_PULL_FAILED --server <name>    # dry-run by default for destructive fixes
+docker pull <image>
+```
+
+Docker's own error is more specific than the wrapped one mcpproxy surfaces.
+
+### Authenticate against Docker Hub
+
+If you're hitting rate-limits:
+
+```bash
+docker login
+```
+
+A free Docker Hub account doubles the limit and gives you predictable resets.
+
+### Configure a registry mirror
+
+Many corporate networks require a private mirror. Configure it once in
+`~/.docker/daemon.json` (or per-platform equivalent):
+
+```json
+{ "registry-mirrors": ["https://registry.example.com"] }
+```
+
+Restart Docker after editing.
+
+### Free up disk
+
+```bash
+docker system df          # see what's using space
+docker system prune -a    # nuke unused images/containers (destructive — review first)
 ```
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [Docker Isolation](../features/docker-isolation.md)
+- [`MCPX_DOCKER_DAEMON_DOWN`](MCPX_DOCKER_DAEMON_DOWN.md)
+- [`MCPX_NETWORK_OFFLINE`](MCPX_NETWORK_OFFLINE.md)

--- a/docs/errors/MCPX_DOCKER_NO_PERMISSION.md
+++ b/docs/errors/MCPX_DOCKER_NO_PERMISSION.md
@@ -1,23 +1,59 @@
-# MCPX_DOCKER_NO_PERMISSION
+---
+id: MCPX_DOCKER_NO_PERMISSION
+title: MCPX_DOCKER_NO_PERMISSION
+sidebar_label: NO_PERMISSION
+description: The current user can't talk to the Docker socket.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_DOCKER_NO_PERMISSION`
+
+**Severity:** error
+**Domain:** Docker
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_DOCKER_NO_PERMISSION`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+The Docker daemon is up, but the user mcpproxy is running as does not have
+permission to connect to the Docker socket
+(`/var/run/docker.sock` on Linux/macOS).
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+### Linux — add the user to the `docker` group
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_DOCKER_NO_PERMISSION --server <name>    # dry-run by default for destructive fixes
+sudo usermod -aG docker "$USER"
+newgrp docker          # apply in the current shell without logging out
+docker info            # verify
 ```
+
+You may need to log out and back in for GUI apps (the tray) to pick up the new
+group.
+
+### macOS — check Docker Desktop permissions
+
+Docker Desktop usually grants access automatically. If not:
+
+- Reinstall Docker Desktop (it re-creates the socket symlink with the right perms).
+- Or use Colima, which runs as the current user without socket-permission issues.
+
+### Rootless Docker
+
+If you're using rootless Docker, make sure `DOCKER_HOST` points at the rootless
+socket and the systemd user service is running:
+
+```bash
+systemctl --user status docker
+echo "$DOCKER_HOST"     # typically unix:///run/user/<uid>/docker.sock
+```
+
+### Avoid setuid hacks
+
+Don't `chmod 666 /var/run/docker.sock` — that gives every local process root
+escalation via Docker. Adding the user to the `docker` group is the safe,
+canonical fix (and is documented to grant root-equivalent privileges).
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [`MCPX_DOCKER_DAEMON_DOWN`](MCPX_DOCKER_DAEMON_DOWN.md)
+- [`MCPX_DOCKER_SNAP_APPARMOR`](MCPX_DOCKER_SNAP_APPARMOR.md)
+- [Docker Isolation](../features/docker-isolation.md)

--- a/docs/errors/MCPX_DOCKER_SNAP_APPARMOR.md
+++ b/docs/errors/MCPX_DOCKER_SNAP_APPARMOR.md
@@ -1,23 +1,65 @@
-# MCPX_DOCKER_SNAP_APPARMOR
+---
+id: MCPX_DOCKER_SNAP_APPARMOR
+title: MCPX_DOCKER_SNAP_APPARMOR
+sidebar_label: SNAP_APPARMOR
+description: Snap-installed Docker on Ubuntu blocks mcpproxy's security scanner via AppArmor.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_DOCKER_SNAP_APPARMOR`
+
+**Severity:** warn
+**Domain:** Docker
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_DOCKER_SNAP_APPARMOR`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+mcpproxy's security scanner sandbox launches the upstream stdio server inside
+a Docker container with `--security-opt no-new-privileges` and a pinned
+AppArmor profile. On Ubuntu's snap-installed Docker, AppArmor's profile
+transition combined with `no-new-privileges` causes every command in the
+container to fail with *operation not permitted* — the scanner can't run.
+
+This is a known incompatibility between snap Docker's AppArmor confinement
+and the security flags mcpproxy needs for the scanner. Other (non-scanner)
+Docker isolation works fine.
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+You have three options:
+
+### 1. Switch to non-snap Docker (recommended)
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_DOCKER_SNAP_APPARMOR --server <name>    # dry-run by default for destructive fixes
+sudo snap remove docker
+# Then install Docker Desktop, Colima, or rootless Docker
+# https://docs.docker.com/engine/install/ubuntu/
 ```
+
+### 2. Disable the scanner for this server (dry-run shown by default)
+
+The error panel includes a **Disable scanner for this server** fix-step. The
+CLI equivalent:
+
+```bash
+mcpproxy upstream patch <server-name> --no-scanner --dry-run
+```
+
+Drop `--dry-run` to apply. The server will still run with isolation, but
+without TPA pre-flight scanning.
+
+### 3. Run mcpproxy without isolation for that server
+
+If you trust the upstream and don't need isolation:
+
+```json
+{ "isolation": { "enabled": false } }
+```
+
+## Background
+
+See [scanner snap-docker AppArmor incompatibility](https://github.com/smart-mcp-proxy/mcpproxy-go/issues?q=snap+apparmor)
+for the upstream tracking issue.
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [Docker Isolation](../features/docker-isolation.md)
+- [Security Quarantine](../features/security-quarantine.md)

--- a/docs/errors/MCPX_HTTP_401.md
+++ b/docs/errors/MCPX_HTTP_401.md
@@ -1,23 +1,59 @@
-# MCPX_HTTP_401
+---
+id: MCPX_HTTP_401
+title: MCPX_HTTP_401
+sidebar_label: HTTP 401
+description: The MCP server responded 401 Unauthorized.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_HTTP_401`
+
+**Severity:** error
+**Domain:** HTTP
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_HTTP_401`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+The upstream MCP server returned `401 Unauthorized`. mcpproxy either had no
+credentials, or the credentials it presented were rejected.
+
+## Common causes
+
+- No OAuth token has been obtained yet for this server.
+- The OAuth access token expired and the refresh path also failed (see
+  [`MCPX_OAUTH_REFRESH_EXPIRED`](MCPX_OAUTH_REFRESH_EXPIRED.md) /
+  [`MCPX_OAUTH_REFRESH_403`](MCPX_OAUTH_REFRESH_403.md)).
+- A static bearer token in `headers` was rotated server-side.
+- The `Authorization` header is being stripped by an intermediary proxy.
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+### Re-authenticate via OAuth
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_HTTP_401 --server <name>    # dry-run by default for destructive fixes
+mcpproxy upstream login <server-name>
 ```
+
+Or click **Log in again** on the server's web UI page.
+
+### Refresh static credentials
+
+If the server uses a static API token (e.g. `headers.Authorization: Bearer …`),
+generate a new token in that vendor's console and update the upstream config:
+
+```json
+{ "headers": { "Authorization": "Bearer <new-token>" } }
+```
+
+Then restart that single server: `mcpproxy upstream restart <server-name>`.
+
+### Confirm the token is sent
+
+```bash
+mcpproxy activity list --request-id <id>          # locate the failing call
+```
+
+The activity record includes the request ID and (redacted) headers.
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [OAuth Authentication](../features/oauth-authentication.md)
+- [`MCPX_HTTP_403`](MCPX_HTTP_403.md) — authenticated but lacks permission

--- a/docs/errors/MCPX_HTTP_403.md
+++ b/docs/errors/MCPX_HTTP_403.md
@@ -1,23 +1,57 @@
-# MCPX_HTTP_403
+---
+id: MCPX_HTTP_403
+title: MCPX_HTTP_403
+sidebar_label: HTTP 403
+description: The MCP server responded 403 Forbidden — credentials valid but lack permission.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_HTTP_403`
+
+**Severity:** error
+**Domain:** HTTP
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_HTTP_403`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+The upstream MCP server accepted mcpproxy's credentials but rejected the
+request: 403 Forbidden. Unlike 401, the identity is recognised — it just isn't
+authorised for what was attempted.
+
+## Common causes
+
+- The OAuth scopes granted at login don't include the scopes required for this
+  endpoint.
+- The user / API token has been moved to a less-privileged role.
+- The MCP server enforces resource-level ACLs (e.g. workspace, team).
+- Conditional-access policy (Microsoft, Okta) blocks this network/device.
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+### Re-authorise with broader scopes
+
+If the upstream advertises additional scopes you didn't accept, re-run login
+and accept them on the consent screen:
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_HTTP_403 --server <name>    # dry-run by default for destructive fixes
+mcpproxy upstream login <server-name>
+```
+
+Some upstreams let you pass scopes explicitly via `oauth.scopes` in the upstream
+config. Add the missing scope and log in again.
+
+### Ask an admin
+
+For role-based access, the fix is on the upstream side: an admin needs to grant
+the user / token the missing role.
+
+### Check the response body
+
+The response body usually says exactly which scope or role is missing:
+
+```bash
+mcpproxy activity show <id>
 ```
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [`MCPX_HTTP_401`](MCPX_HTTP_401.md) — credentials missing or invalid
+- [OAuth Authentication](../features/oauth-authentication.md)

--- a/docs/errors/MCPX_HTTP_404.md
+++ b/docs/errors/MCPX_HTTP_404.md
@@ -1,23 +1,54 @@
-# MCPX_HTTP_404
+---
+id: MCPX_HTTP_404
+title: MCPX_HTTP_404
+sidebar_label: HTTP 404
+description: The configured MCP endpoint URL returned 404 Not Found.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_HTTP_404`
+
+**Severity:** error
+**Domain:** HTTP
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_HTTP_404`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+The hostname resolved and TLS succeeded, but the configured URL path returned
+404 Not Found.
+
+## Common causes
+
+- The URL points at the server's homepage (`/`) instead of the MCP endpoint
+  (often `/mcp` or `/sse`).
+- The vendor moved the MCP endpoint between versions.
+- The URL has a trailing-slash mismatch the upstream is strict about.
+- The upstream removed the MCP integration.
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+### Verify the path
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_HTTP_404 --server <name>    # dry-run by default for destructive fixes
+curl -sS -i -H 'Accept: text/event-stream' '<server-url>'
+```
+
+A working MCP HTTP/SSE endpoint replies with `200` and a content-type containing
+`text/event-stream` (SSE) or `application/json` (HTTP transport).
+
+### Check vendor docs
+
+Most vendors document the canonical MCP path. Common shapes:
+
+- `https://api.example.com/mcp`
+- `https://example.com/sse`
+- `https://example.com/v1/mcp`
+
+Update the `url` field in your upstream entry and restart that server:
+
+```bash
+mcpproxy upstream restart <server-name>
 ```
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [`MCPX_HTTP_CONN_REFUSED`](MCPX_HTTP_CONN_REFUSED.md)
+- [Configuration → upstream servers](../configuration/upstream-servers.md)

--- a/docs/errors/MCPX_HTTP_5XX.md
+++ b/docs/errors/MCPX_HTTP_5XX.md
@@ -1,23 +1,54 @@
-# MCPX_HTTP_5XX
+---
+id: MCPX_HTTP_5XX
+title: MCPX_HTTP_5XX
+sidebar_label: HTTP 5xx
+description: The MCP server responded with an HTTP 5xx status — upstream-side failure.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_HTTP_5XX`
+
+**Severity:** warn
+**Domain:** HTTP
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_HTTP_5XX`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+The upstream MCP server returned a 5xx status. mcpproxy classifies this as a
+server-side problem rather than a misconfiguration. Common subcategories:
+
+- `500 Internal Server Error` — uncaught exception in the upstream.
+- `502 Bad Gateway` / `504 Gateway Timeout` — load balancer in front of the
+  MCP server lost the backend.
+- `503 Service Unavailable` — the upstream is rate-limiting or under
+  maintenance.
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+### 1. Check the upstream's status page
+
+If the vendor publishes a status page, that's the fastest signal. Try again
+when they report the incident as resolved.
+
+### 2. Retry with backoff
+
+mcpproxy applies exponential backoff to upstream connections automatically. If
+the failure is transient you'll see the server flip back to *Ready* without
+intervention.
+
+### 3. Look at the response body
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_HTTP_5XX --server <name>    # dry-run by default for destructive fixes
+mcpproxy activity show <id>
 ```
+
+Many upstreams put a useful diagnostic in the body even on 5xx (request id,
+correlation id) — quote that to upstream support.
+
+### 4. Persistent 5xx on a self-hosted upstream
+
+Check the server's own logs. The fix is on the upstream side; mcpproxy is just
+a faithful messenger.
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [`MCPX_HTTP_CONN_REFUSED`](MCPX_HTTP_CONN_REFUSED.md) — connection rejected before HTTP
+- [Activity Log](../features/activity-log.md)

--- a/docs/errors/MCPX_HTTP_CONN_REFUSED.md
+++ b/docs/errors/MCPX_HTTP_CONN_REFUSED.md
@@ -1,23 +1,55 @@
-# MCPX_HTTP_CONN_REFUSED
+---
+id: MCPX_HTTP_CONN_REFUSED
+title: MCPX_HTTP_CONN_REFUSED
+sidebar_label: CONN_REFUSED
+description: TCP connection to the MCP server was refused.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_HTTP_CONN_REFUSED`
+
+**Severity:** error
+**Domain:** HTTP
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_HTTP_CONN_REFUSED`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+DNS resolved the upstream hostname, but the TCP connection to the resolved
+address+port was refused (`ECONNREFUSED`). Nothing is listening, or a firewall
+rejected the SYN.
+
+## Common causes
+
+- The upstream MCP server is not running.
+- Wrong port in the URL (e.g. `https://localhost/mcp` without `:8080`).
+- The upstream is bound to a different interface (e.g. `127.0.0.1` only, but
+  mcpproxy connects from another network namespace).
+- Local firewall (`pf`, `ufw`, `iptables`, Windows Defender Firewall).
+- Docker container exposing the port wasn't started.
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+### Verify the port is open
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_HTTP_CONN_REFUSED --server <name>    # dry-run by default for destructive fixes
+nc -vz <host> <port>
+curl -v <server-url>
 ```
+
+If `nc` reports "Connection refused", nothing is listening. Start the upstream.
+
+### For self-hosted upstreams
+
+```bash
+docker ps                 # is the container running?
+ss -tlnp | grep <port>    # who's bound to that port?
+systemctl status <unit>   # is the service up?
+```
+
+### Switch to localhost-aware binding
+
+If the upstream binds only to `0.0.0.0` but you're connecting via `localhost`,
+make sure the URL uses an address that's actually listening.
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [`MCPX_HTTP_DNS_FAILED`](MCPX_HTTP_DNS_FAILED.md)
+- [`MCPX_NETWORK_OFFLINE`](MCPX_NETWORK_OFFLINE.md)

--- a/docs/errors/MCPX_HTTP_DNS_FAILED.md
+++ b/docs/errors/MCPX_HTTP_DNS_FAILED.md
@@ -1,23 +1,61 @@
-# MCPX_HTTP_DNS_FAILED
+---
+id: MCPX_HTTP_DNS_FAILED
+title: MCPX_HTTP_DNS_FAILED
+sidebar_label: DNS_FAILED
+description: DNS lookup for the configured MCP server hostname failed.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_HTTP_DNS_FAILED`
+
+**Severity:** error
+**Domain:** HTTP
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_HTTP_DNS_FAILED`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+mcpproxy could not resolve the hostname in the upstream server URL. The
+underlying error is from the OS resolver (`getaddrinfo`).
+
+## Common causes
+
+- Typo in the hostname.
+- VPN / corporate split-DNS not connected.
+- The hostname only resolves inside a private network and the host is offline
+  from that network.
+- DNS over HTTPS / DoH proxy is misconfigured.
+- `/etc/hosts` overrides interfering.
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
-
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_HTTP_DNS_FAILED --server <name>    # dry-run by default for destructive fixes
+# Verify the hostname:
+dig <hostname>            # should print A/AAAA records
+host <hostname>
+nslookup <hostname>
 ```
+
+If `dig` works but mcpproxy doesn't, the difference is usually:
+
+- A VPN that's only active in the launching shell.
+- A `HOSTALIASES` or `/etc/hosts` override visible in the shell but not the GUI.
+
+### VPN / split DNS
+
+Make sure your VPN client is started before mcpproxy if the MCP server lives
+inside the corporate network. Tray apps inherit the GUI environment, not the
+shell environment.
+
+### Override hostname in config
+
+If the hostname is unstable but the IP is known:
+
+```json
+{ "url": "https://203.0.113.10/mcp", "tls_server_name": "internal.example.com" }
+```
+
+Use `tls_server_name` to keep TLS verification working.
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [`MCPX_HTTP_CONN_REFUSED`](MCPX_HTTP_CONN_REFUSED.md)
+- [`MCPX_NETWORK_OFFLINE`](MCPX_NETWORK_OFFLINE.md)
+- [`MCPX_NETWORK_PROXY_MISCONFIG`](MCPX_NETWORK_PROXY_MISCONFIG.md)

--- a/docs/errors/MCPX_HTTP_TLS_FAILED.md
+++ b/docs/errors/MCPX_HTTP_TLS_FAILED.md
@@ -1,23 +1,69 @@
-# MCPX_HTTP_TLS_FAILED
+---
+id: MCPX_HTTP_TLS_FAILED
+title: MCPX_HTTP_TLS_FAILED
+sidebar_label: TLS_FAILED
+description: TLS verification of the upstream server failed.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_HTTP_TLS_FAILED`
+
+**Severity:** error
+**Domain:** HTTP
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_HTTP_TLS_FAILED`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+mcpproxy successfully resolved the hostname and opened a TCP connection, but the
+TLS handshake failed (certificate verification, hostname mismatch, expired
+certificate, or unsupported cipher).
+
+## Common causes
+
+- Self-signed certificate not trusted by the system store.
+- Certificate expired or hasn't started yet (clock skew).
+- Hostname doesn't match SAN entries on the certificate.
+- Corporate MITM proxy with its own root not installed in the system store.
+- Server only supports TLS 1.0/1.1 (mcpproxy requires 1.2+).
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+### Inspect the certificate
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_HTTP_TLS_FAILED --server <name>    # dry-run by default for destructive fixes
+openssl s_client -connect <host>:443 -servername <host> -showcerts </dev/null
+```
+
+Look for `Verify return code:` and the certificate validity dates.
+
+### Trust an internal CA
+
+- **macOS:** open the `.crt` in Keychain Access → System keychain → set to
+  *Always Trust*, or `sudo security add-trusted-cert -d -r trustRoot \
+  -k /Library/Keychains/System.keychain ca.crt`.
+- **Linux:** copy to `/usr/local/share/ca-certificates/` and run
+  `sudo update-ca-certificates`.
+- **Windows:** import via `certmgr.msc` to *Trusted Root Certification Authorities*.
+
+mcpproxy uses the OS trust store by default.
+
+### Fix clock skew
+
+```bash
+# macOS
+sudo sntp -sS time.apple.com
+# Linux
+sudo timedatectl set-ntp true
+```
+
+### Last-resort: skip verification (not recommended)
+
+For a server you fully control, you can disable verification per-server. Do not
+use this against the public internet.
+
+```json
+{ "tls_insecure_skip_verify": true }
 ```
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [`MCPX_HTTP_DNS_FAILED`](MCPX_HTTP_DNS_FAILED.md)
+- [`MCPX_NETWORK_PROXY_MISCONFIG`](MCPX_NETWORK_PROXY_MISCONFIG.md)

--- a/docs/errors/MCPX_NETWORK_OFFLINE.md
+++ b/docs/errors/MCPX_NETWORK_OFFLINE.md
@@ -1,23 +1,51 @@
-# MCPX_NETWORK_OFFLINE
+---
+id: MCPX_NETWORK_OFFLINE
+title: MCPX_NETWORK_OFFLINE
+sidebar_label: OFFLINE
+description: The host appears to have no network connectivity.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_NETWORK_OFFLINE`
+
+**Severity:** error
+**Domain:** Network
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_NETWORK_OFFLINE`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+mcpproxy classified a connection failure as "host appears offline" — typically
+DNS resolution failed for a stable, well-known host *and* TCP probes all
+errored with "no route" / "network unreachable".
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+### Confirm
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_NETWORK_OFFLINE --server <name>    # dry-run by default for destructive fixes
+ping -c 2 1.1.1.1
+ping -c 2 8.8.8.8
+dig +short cloudflare.com
 ```
+
+If all three fail, you really are offline.
+
+### Reconnect
+
+- Wi-Fi: forget + rejoin, or toggle airplane mode.
+- VPN: reconnect (or disconnect, if the VPN itself is the cause).
+- Cellular hotspot: usually a quick toggle.
+
+### Check captive portals
+
+Public Wi-Fi often hijacks DNS until you accept a portal. Open
+`http://neverssl.com` in a browser to be redirected to the portal.
+
+### Mobile / low-bandwidth
+
+If the network is reachable but very slow, mcpproxy may classify slow operations
+as offline because of strict timeouts. Increase per-server timeouts as needed.
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [`MCPX_HTTP_DNS_FAILED`](MCPX_HTTP_DNS_FAILED.md)
+- [`MCPX_HTTP_CONN_REFUSED`](MCPX_HTTP_CONN_REFUSED.md)
+- [`MCPX_NETWORK_PROXY_MISCONFIG`](MCPX_NETWORK_PROXY_MISCONFIG.md)

--- a/docs/errors/MCPX_NETWORK_PROXY_MISCONFIG.md
+++ b/docs/errors/MCPX_NETWORK_PROXY_MISCONFIG.md
@@ -1,23 +1,62 @@
-# MCPX_NETWORK_PROXY_MISCONFIG
+---
+id: MCPX_NETWORK_PROXY_MISCONFIG
+title: MCPX_NETWORK_PROXY_MISCONFIG
+sidebar_label: PROXY_MISCONFIG
+description: The system HTTP_PROXY / HTTPS_PROXY variables look misconfigured.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_NETWORK_PROXY_MISCONFIG`
+
+**Severity:** warn
+**Domain:** Network
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_NETWORK_PROXY_MISCONFIG`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+mcpproxy detected `HTTP_PROXY`, `HTTPS_PROXY`, or `ALL_PROXY` in its environment
+but they don't appear to be reachable, are missing a scheme, or look syntactically
+broken. Outbound connections will likely fail.
+
+## Common causes
+
+- Stale variables left over from a corporate VPN that's now disconnected.
+- Missing scheme: `proxy.example.com:8080` instead of `http://proxy.example.com:8080`.
+- `NO_PROXY` doesn't include the upstream MCP server's hostname.
+- A `.pac` file URL was set instead of a direct proxy.
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+### Inspect the current environment
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_NETWORK_PROXY_MISCONFIG --server <name>    # dry-run by default for destructive fixes
+env | grep -iE 'proxy|no_proxy'
+```
+
+### Fix the syntax
+
+```bash
+export HTTPS_PROXY=http://proxy.example.com:8080
+export HTTP_PROXY=http://proxy.example.com:8080
+export NO_PROXY="localhost,127.0.0.1,.example.com"
+```
+
+The proxy URL **must** include the scheme.
+
+### Set the environment for the tray
+
+Tray apps don't inherit shell `~/.zshrc` exports. On macOS, set them in
+`~/Library/LaunchAgents/com.mcpproxy.tray.plist` (the bundle includes a
+template) or use `launchctl setenv`.
+
+### Disable proxy when not needed
+
+If you no longer need the proxy:
+
+```bash
+unset HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY
 ```
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [`MCPX_HTTP_DNS_FAILED`](MCPX_HTTP_DNS_FAILED.md)
+- [`MCPX_HTTP_TLS_FAILED`](MCPX_HTTP_TLS_FAILED.md)
+- [`MCPX_NETWORK_OFFLINE`](MCPX_NETWORK_OFFLINE.md)

--- a/docs/errors/MCPX_OAUTH_CALLBACK_MISMATCH.md
+++ b/docs/errors/MCPX_OAUTH_CALLBACK_MISMATCH.md
@@ -1,23 +1,68 @@
-# MCPX_OAUTH_CALLBACK_MISMATCH
+---
+id: MCPX_OAUTH_CALLBACK_MISMATCH
+title: MCPX_OAUTH_CALLBACK_MISMATCH
+sidebar_label: CALLBACK_MISMATCH
+description: The OAuth redirect URI used in the callback didn't match the one mcpproxy registered.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_OAUTH_CALLBACK_MISMATCH`
+
+**Severity:** error
+**Domain:** OAuth
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_OAUTH_CALLBACK_MISMATCH`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+mcpproxy received an OAuth redirect, but the `redirect_uri` parameter in the
+authorisation response differs from the one mcpproxy persisted for this server.
+Returning a token in this state would violate RFC 8252 / PKCE binding, so the
+flow is aborted.
+
+## Common causes
+
+- The OAuth client registered with the provider lists a different redirect URI
+  than the one mcpproxy uses.
+- The provider was reconfigured between the start of the login and the
+  callback (rare).
+- mcpproxy's persisted port changed because the saved port was already in use.
+- A reverse proxy in front of mcpproxy rewrote the `redirect_uri`.
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+### Update the provider configuration
 
-```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_OAUTH_CALLBACK_MISMATCH --server <name>    # dry-run by default for destructive fixes
+mcpproxy uses `http://127.0.0.1:<port>/oauth/callback` (with a per-server
+persisted port). Add that exact URI to your OAuth client's allowed redirect
+URIs in the provider's developer console.
+
+For most providers wildcards aren't allowed; you'll need to register the exact
+port. mcpproxy persists the port in the upstream config — see
+[`oauth_redirect_port`](../configuration/upstream-servers.md) — so you can
+register a stable URI.
+
+### Re-pin the redirect port
+
+If you previously used a different port and want to restore it, set
+`oauth_redirect_port` explicitly:
+
+```json
+{
+  "name": "my-server",
+  "oauth": {
+    "client_id": "...",
+    "redirect_port": 53412
+  }
+}
 ```
+
+Then re-register that exact URI on the provider side.
+
+### If a reverse proxy is in front
+
+Make the proxy preserve the original `redirect_uri` query parameter and avoid
+host rewriting on `/oauth/callback`. mcpproxy ships a self-hosted callback —
+it doesn't need to be exposed publicly, only locally.
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [Spec 023 — OAuth state persistence](https://github.com/smart-mcp-proxy/mcpproxy-go/blob/main/specs/023-oauth-state-persistence/spec.md)
+- [OAuth Authentication](../features/oauth-authentication.md)

--- a/docs/errors/MCPX_OAUTH_CALLBACK_TIMEOUT.md
+++ b/docs/errors/MCPX_OAUTH_CALLBACK_TIMEOUT.md
@@ -1,23 +1,61 @@
-# MCPX_OAUTH_CALLBACK_TIMEOUT
+---
+id: MCPX_OAUTH_CALLBACK_TIMEOUT
+title: MCPX_OAUTH_CALLBACK_TIMEOUT
+sidebar_label: CALLBACK_TIMEOUT
+description: The OAuth browser callback did not arrive in time.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_OAUTH_CALLBACK_TIMEOUT`
+
+**Severity:** warn
+**Domain:** OAuth
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_OAUTH_CALLBACK_TIMEOUT`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+mcpproxy opened the OAuth authorisation URL in the user's browser and started a
+local listener on `127.0.0.1:<random-port>` to receive the callback. No callback
+arrived before the wait window elapsed, so mcpproxy gave up.
+
+## Common causes
+
+- The user closed the browser tab without completing the consent screen.
+- The provider redirected to a different host (e.g. set up to use the public
+  domain instead of `localhost`).
+- A browser extension or popup blocker swallowed the redirect.
+- The provider's consent UI is taking longer than the configured timeout (e.g.
+  step-up MFA, password reset, device approval).
+- The local loopback port is being filtered by a firewall (rare but possible
+  on locked-down corporate machines).
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+### Retry the login
+
+The fix step **Retry log in** in the error panel restarts the flow. On the CLI:
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_OAUTH_CALLBACK_TIMEOUT --server <name>    # dry-run by default for destructive fixes
+mcpproxy upstream login <server-name>
 ```
+
+Complete the consent screen quickly — most providers have a 5-10 minute
+authorisation-code lifetime that mcpproxy mirrors.
+
+### Verify the redirect URI
+
+mcpproxy persists a callback URI per server. If the provider has a different
+URI registered, the redirect won't reach mcpproxy. See
+[`MCPX_OAUTH_CALLBACK_MISMATCH`](MCPX_OAUTH_CALLBACK_MISMATCH.md) for the fix.
+
+### Check loopback reachability
+
+```bash
+# While the login flow is running:
+curl -v http://127.0.0.1:<port>/oauth/callback
+```
+
+If this fails locally, a firewall is blocking the loopback bind.
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [`MCPX_OAUTH_CALLBACK_MISMATCH`](MCPX_OAUTH_CALLBACK_MISMATCH.md)
+- [OAuth Authentication](../features/oauth-authentication.md)

--- a/docs/errors/MCPX_OAUTH_DISCOVERY_FAILED.md
+++ b/docs/errors/MCPX_OAUTH_DISCOVERY_FAILED.md
@@ -1,23 +1,77 @@
-# MCPX_OAUTH_DISCOVERY_FAILED
+---
+id: MCPX_OAUTH_DISCOVERY_FAILED
+title: MCPX_OAUTH_DISCOVERY_FAILED
+sidebar_label: DISCOVERY_FAILED
+description: mcpproxy could not fetch the OAuth metadata document from the upstream server.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_OAUTH_DISCOVERY_FAILED`
+
+**Severity:** error
+**Domain:** OAuth
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_OAUTH_DISCOVERY_FAILED`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+When connecting to an HTTP MCP server that requires OAuth, mcpproxy first
+discovers the authorisation endpoint by fetching one of:
+
+- `<server>/.well-known/oauth-authorization-server`
+- `<server>/.well-known/openid-configuration`
+
+The fetch failed (network error, 404, malformed JSON, missing required fields,
+or no advertised auth metadata at all).
+
+## Common causes
+
+- The MCP server doesn't actually require OAuth (mcpproxy auto-detected wrongly).
+- The server requires OAuth but doesn't expose `.well-known` discovery.
+- The discovery document is behind a corporate proxy / VPN that mcpproxy can't reach.
+- The discovery URL responded with an HTML login page instead of JSON.
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+### Test discovery manually
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_OAUTH_DISCOVERY_FAILED --server <name>    # dry-run by default for destructive fixes
+curl -sS <server-url>/.well-known/oauth-authorization-server | jq .
+curl -sS <server-url>/.well-known/openid-configuration       | jq .
 ```
+
+If both return non-JSON or 404, the server doesn't publish auto-discoverable
+metadata.
+
+### Configure OAuth manually
+
+Set the OAuth fields explicitly in the upstream config so mcpproxy doesn't have
+to discover them:
+
+```json
+{
+  "name": "my-server",
+  "url": "https://example.com/mcp",
+  "oauth": {
+    "authorization_endpoint": "https://example.com/oauth/authorize",
+    "token_endpoint": "https://example.com/oauth/token",
+    "client_id": "...",
+    "scopes": ["openid", "profile"]
+  }
+}
+```
+
+### Network reachability
+
+If discovery is blocked at the network layer:
+
+```bash
+curl -v <server-url>/.well-known/oauth-authorization-server
+env | grep -i proxy
+```
+
+See [`MCPX_NETWORK_PROXY_MISCONFIG`](MCPX_NETWORK_PROXY_MISCONFIG.md) if your
+proxy variables are wrong.
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [OAuth Authentication](../features/oauth-authentication.md)
+- [`MCPX_HTTP_DNS_FAILED`](MCPX_HTTP_DNS_FAILED.md)
+- [`MCPX_HTTP_TLS_FAILED`](MCPX_HTTP_TLS_FAILED.md)

--- a/docs/errors/MCPX_OAUTH_REFRESH_403.md
+++ b/docs/errors/MCPX_OAUTH_REFRESH_403.md
@@ -1,23 +1,58 @@
-# MCPX_OAUTH_REFRESH_403
+---
+id: MCPX_OAUTH_REFRESH_403
+title: MCPX_OAUTH_REFRESH_403
+sidebar_label: REFRESH_403
+description: The OAuth provider rejected the refresh token with HTTP 403.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_OAUTH_REFRESH_403`
+
+**Severity:** error
+**Domain:** OAuth
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_OAUTH_REFRESH_403`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+mcpproxy presented a refresh token to the provider's token endpoint and got an
+HTTP 403 (or `invalid_grant`) back. The token was technically still in our
+store, but the provider considers it unusable.
+
+## Common causes
+
+- The user revoked the OAuth grant from their account settings.
+- The OAuth client (client_id) was deleted or rotated provider-side.
+- Refresh-token rotation: the provider already issued a successor and now
+  refuses the older one.
+- The redirect URI / scopes registered for the client changed.
+- Conditional-access / device-trust policy (Microsoft Entra) revoked the session.
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+### 1. Re-authenticate
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_OAUTH_REFRESH_403 --server <name>    # dry-run by default for destructive fixes
+mcpproxy upstream login <server-name>
 ```
+
+Or click **Log in again** on the server's web UI page. This is the only
+deterministic recovery — silent retry will keep failing.
+
+### 2. Verify the client is still valid
+
+If re-login still 403s, the OAuth client itself may be misconfigured:
+
+- Confirm `client_id` / `client_secret` in the upstream config still exist on
+  the provider side.
+- Verify the redirect URI matches exactly what the provider has registered
+  (mcpproxy persists a per-server callback — see
+  [`MCPX_OAUTH_CALLBACK_MISMATCH`](MCPX_OAUTH_CALLBACK_MISMATCH.md)).
+
+### 3. Check provider-side audit log
+
+Many providers expose a sign-in / token audit log that says exactly why the
+refresh was denied (revoked, scope changed, conditional access, etc.).
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [`MCPX_OAUTH_REFRESH_EXPIRED`](MCPX_OAUTH_REFRESH_EXPIRED.md) — natural expiry
+- [`MCPX_OAUTH_CALLBACK_MISMATCH`](MCPX_OAUTH_CALLBACK_MISMATCH.md) — wrong redirect URI
+- [OAuth Authentication](../features/oauth-authentication.md)

--- a/docs/errors/MCPX_OAUTH_REFRESH_EXPIRED.md
+++ b/docs/errors/MCPX_OAUTH_REFRESH_EXPIRED.md
@@ -1,23 +1,50 @@
-# MCPX_OAUTH_REFRESH_EXPIRED
+---
+id: MCPX_OAUTH_REFRESH_EXPIRED
+title: MCPX_OAUTH_REFRESH_EXPIRED
+sidebar_label: REFRESH_EXPIRED
+description: The stored OAuth refresh token has expired and cannot be silently renewed.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_OAUTH_REFRESH_EXPIRED`
+
+**Severity:** error
+**Domain:** OAuth
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_OAUTH_REFRESH_EXPIRED`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+mcpproxy attempted to refresh an OAuth access token in the background, but the
+identity provider reported that the **refresh token itself** has expired. There
+is no way to silently recover — the user has to re-authenticate.
+
+## Common causes
+
+- The provider sets a finite lifetime on refresh tokens (Google: ~6 months
+  inactivity; some providers: 30 days; some: rotates on every refresh).
+- The user revoked the application from their account dashboard.
+- The mcpproxy host was offline for longer than the provider allows.
+- Time skew on the local machine made the refresh request look replayed.
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+### Re-authenticate
+
+In the web UI, open the server's detail page and click **Log in again**.
+On the CLI:
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_OAUTH_REFRESH_EXPIRED --server <name>    # dry-run by default for destructive fixes
+mcpproxy upstream login <server-name>
 ```
+
+This re-runs the OAuth 2.1 + PKCE flow in your default browser and persists
+fresh tokens to the local store.
+
+### Reduce future expirations
+
+- Keep mcpproxy running (or auto-start it) so the refresh window doesn't lapse.
+- Verify your system clock is correct (`timedatectl` on Linux,
+  `sntp -sS time.apple.com` on macOS).
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [`MCPX_OAUTH_REFRESH_403`](MCPX_OAUTH_REFRESH_403.md) — provider rejected even an unexpired refresh
+- [OAuth Authentication](../features/oauth-authentication.md)

--- a/docs/errors/MCPX_QUARANTINE_PENDING_APPROVAL.md
+++ b/docs/errors/MCPX_QUARANTINE_PENDING_APPROVAL.md
@@ -1,23 +1,56 @@
-# MCPX_QUARANTINE_PENDING_APPROVAL
+---
+id: MCPX_QUARANTINE_PENDING_APPROVAL
+title: MCPX_QUARANTINE_PENDING_APPROVAL
+sidebar_label: PENDING_APPROVAL
+description: This server has tools awaiting security approval; they will not run until approved.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_QUARANTINE_PENDING_APPROVAL`
+
+**Severity:** warn
+**Domain:** Quarantine
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_QUARANTINE_PENDING_APPROVAL`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+mcpproxy quarantines newly added MCP servers (and newly added tools on existing
+servers) by default. The quarantine is mcpproxy's defense against Tool Poisoning
+Attacks (TPA) — the user must review tool descriptions and JSON schemas before
+they're routed to AI clients.
+
+This warning means the server connected and reported its tools, but at least
+one tool is pending your approval.
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+### Approve via the web UI
+
+Open the server's detail page → **Quarantine** panel → review the tool
+descriptions / schemas → click **Approve all** or per-tool **Approve**.
+
+### Approve via the CLI
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_QUARANTINE_PENDING_APPROVAL --server <name>    # dry-run by default for destructive fixes
+mcpproxy upstream inspect <server-name>          # see what's pending
+mcpproxy upstream approve <server-name>          # approve all pending tools
+mcpproxy upstream approve <server-name> --tool foo  # approve a single tool
+```
+
+### Skip quarantine for trusted servers
+
+For servers you fully trust (e.g. self-written, or vendor-signed) you can opt
+out of quarantine on a per-server basis:
+
+```json
+{ "skip_quarantine": true }
+```
+
+Or globally (not recommended on shared dev machines):
+
+```json
+{ "quarantine_enabled": false }
 ```
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [Security Quarantine](../features/security-quarantine.md)
+- [`MCPX_QUARANTINE_TOOL_CHANGED`](MCPX_QUARANTINE_TOOL_CHANGED.md) — rug-pull detection

--- a/docs/errors/MCPX_QUARANTINE_TOOL_CHANGED.md
+++ b/docs/errors/MCPX_QUARANTINE_TOOL_CHANGED.md
@@ -1,23 +1,58 @@
-# MCPX_QUARANTINE_TOOL_CHANGED
+---
+id: MCPX_QUARANTINE_TOOL_CHANGED
+title: MCPX_QUARANTINE_TOOL_CHANGED
+sidebar_label: TOOL_CHANGED
+description: A previously approved tool changed its description or schema; re-approval is required.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_QUARANTINE_TOOL_CHANGED`
+
+**Severity:** warn
+**Domain:** Quarantine
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_QUARANTINE_TOOL_CHANGED`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+mcpproxy hashes the description and JSON schema of every tool at approval time.
+On every reconnect / poll, it re-hashes and compares. A tool whose hash changed
+is **rug-pull-protected**: it will not run until you re-approve it.
+
+This catches the case where a previously-trusted MCP server silently swaps a
+tool's instructions to inject malicious behaviour into AI agents.
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+### Review the diff
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_QUARANTINE_TOOL_CHANGED --server <name>    # dry-run by default for destructive fixes
+mcpproxy upstream inspect <server-name>             # marks tools as "changed"
+curl -H "X-API-Key: $KEY" \
+  "http://127.0.0.1:8080/api/v1/servers/<id>/tools/<tool>/diff"
 ```
+
+The web UI's Quarantine panel renders the diff side-by-side.
+
+### Re-approve
+
+If the change is legitimate (vendor updated the docstring, added a new
+parameter, etc.):
+
+```bash
+mcpproxy upstream approve <server-name> --tool <tool-name>
+mcpproxy upstream approve <server-name>             # approves all changed/pending
+```
+
+### If the change is not legitimate
+
+Disable or quarantine the server entirely until you understand what changed:
+
+```bash
+mcpproxy upstream disable <server-name>
+mcpproxy upstream quarantine <server-name>
+```
+
+Then file an issue with the upstream maintainer.
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [Security Quarantine — rug-pull detection](../features/security-quarantine.md)
+- [`MCPX_QUARANTINE_PENDING_APPROVAL`](MCPX_QUARANTINE_PENDING_APPROVAL.md)

--- a/docs/errors/MCPX_STDIO_EXIT_NONZERO.md
+++ b/docs/errors/MCPX_STDIO_EXIT_NONZERO.md
@@ -1,23 +1,70 @@
-# MCPX_STDIO_EXIT_NONZERO
+---
+id: MCPX_STDIO_EXIT_NONZERO
+title: MCPX_STDIO_EXIT_NONZERO
+sidebar_label: EXIT_NONZERO
+description: The stdio MCP server process exited with a non-zero status before completing the handshake.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_STDIO_EXIT_NONZERO`
+
+**Severity:** error
+**Domain:** STDIO
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_STDIO_EXIT_NONZERO`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+mcpproxy spawned the stdio server, but the process exited with a non-zero exit
+code before the MCP `initialize` handshake completed. Whatever crashed it usually
+printed something useful to **stderr**.
+
+## Common causes
+
+- Missing language runtime dependency (e.g. Python 3.10+ required, but only 3.9 available).
+- Missing required environment variable / API key.
+- Bad CLI flags or arguments passed via `args`.
+- Upstream package not installed in the resolved environment (`uvx`/`pipx`/`npx`).
+- Crash on startup due to incompatible OS or arch.
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+### 1. Read the last stderr lines
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_STDIO_EXIT_NONZERO --server <name>    # dry-run by default for destructive fixes
+mcpproxy upstream logs <server-name> --tail 100
+```
+
+The exit was synchronous: the very last lines almost always contain the real
+error (a Python traceback, a Node error, "module not found", etc.).
+
+### 2. Run the command manually
+
+Reproduce in a normal shell with the exact same `command`, `args`, and `env`
+from your config:
+
+```bash
+ENV_KEY=value /full/path/to/cmd --flag1 --flag2
+```
+
+If it fails the same way, fix the underlying tool before retrying through mcpproxy.
+
+### 3. Check required environment
+
+Many MCP servers require API keys via environment:
+
+```bash
+mcpproxy upstream inspect <server-name>   # shows resolved env (secrets redacted)
+```
+
+Add missing keys to the upstream `env` field or to a referenced secret.
+
+### 4. Check Python/Node version
+
+```bash
+python3 --version    # the server may require >=3.10
+node --version       # some packages drop support for old Node majors
 ```
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [`MCPX_STDIO_HANDSHAKE_TIMEOUT`](MCPX_STDIO_HANDSHAKE_TIMEOUT.md) — process started but never replied
+- [`MCPX_CONFIG_MISSING_SECRET`](MCPX_CONFIG_MISSING_SECRET.md) — secret references don't resolve
+- [Docker Isolation](../features/docker-isolation.md) — sandbox runtimes per server

--- a/docs/errors/MCPX_STDIO_HANDSHAKE_INVALID.md
+++ b/docs/errors/MCPX_STDIO_HANDSHAKE_INVALID.md
@@ -1,23 +1,65 @@
-# MCPX_STDIO_HANDSHAKE_INVALID
+---
+id: MCPX_STDIO_HANDSHAKE_INVALID
+title: MCPX_STDIO_HANDSHAKE_INVALID
+sidebar_label: HANDSHAKE_INVALID
+description: The stdio server replied, but the MCP handshake frame was malformed.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_STDIO_HANDSHAKE_INVALID`
+
+**Severity:** error
+**Domain:** STDIO
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_STDIO_HANDSHAKE_INVALID`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+The stdio server emitted bytes on stdout in response to `initialize`, but
+mcpproxy could not parse them as a valid MCP / JSON-RPC frame. Common shapes:
+HTML, a stack trace, ANSI-coloured logs, partial JSON, or an MCP frame for an
+unsupported protocol version.
+
+## Common causes
+
+- The server logs to stdout in addition to JSON-RPC frames.
+- The server speaks an older / newer MCP protocol version that mcpproxy can't negotiate.
+- An npm/pip wrapper script printed a deprecation warning before the real
+  process took over.
+- A shell wrapper added stdout content (e.g. `set -x`, `echo "starting…"`).
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+### Read the captured frame
+
+`upstream logs` records the raw stdout stream — find the offending payload:
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_STDIO_HANDSHAKE_INVALID --server <name>    # dry-run by default for destructive fixes
+mcpproxy upstream logs <server-name> --tail 200
+```
+
+### Silence non-JSON output
+
+- Redirect informational output to stderr in your wrapper script:
+  `echo "starting" >&2`.
+- Disable colour: `NO_COLOR=1`, `TERM=dumb`.
+- Remove `set -x` or `set -v` from start-up scripts.
+
+### Negotiate a compatible protocol
+
+mcpproxy currently advertises a recent protocol version. If the upstream server
+only supports an old one, update the server. Project maintainers should target
+the [MCP protocol versions](../api/mcp-protocol.md) that mcpproxy understands.
+
+### Try Docker isolation
+
+Running the server inside a clean container removes most sources of
+contamination from your shell profile and runtime:
+
+```json
+{
+  "isolation": { "enabled": true }
+}
 ```
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [`MCPX_STDIO_HANDSHAKE_TIMEOUT`](MCPX_STDIO_HANDSHAKE_TIMEOUT.md) — server didn't reply at all
+- [MCP Protocol](../api/mcp-protocol.md)

--- a/docs/errors/MCPX_STDIO_HANDSHAKE_TIMEOUT.md
+++ b/docs/errors/MCPX_STDIO_HANDSHAKE_TIMEOUT.md
@@ -1,23 +1,71 @@
-# MCPX_STDIO_HANDSHAKE_TIMEOUT
+---
+id: MCPX_STDIO_HANDSHAKE_TIMEOUT
+title: MCPX_STDIO_HANDSHAKE_TIMEOUT
+sidebar_label: HANDSHAKE_TIMEOUT
+description: The stdio server did not reply to the MCP initialize request in time.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_STDIO_HANDSHAKE_TIMEOUT`
+
+**Severity:** error
+**Domain:** STDIO
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_STDIO_HANDSHAKE_TIMEOUT`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+mcpproxy spawned the server and sent `initialize`, but the server did not reply
+within 30 seconds. The process is still alive (otherwise we'd see
+[`MCPX_STDIO_EXIT_NONZERO`](MCPX_STDIO_EXIT_NONZERO.md)), but it is not speaking
+the MCP protocol on stdout.
+
+## Common causes
+
+- The server prints log lines / banners to **stdout** instead of stderr,
+  corrupting the JSON-RPC channel.
+- The first call out of the server (auth handshake, model download, npm/pip
+  install on first run) is slower than 30s.
+- Wrong protocol — a CLI tool that doesn't actually implement MCP was configured
+  as an MCP server.
+- The runtime is buffering stdout (Python without `-u`, Node without
+  `process.stdout.write` flush) so frames never reach mcpproxy.
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+### 1. Inspect both streams
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_STDIO_HANDSHAKE_TIMEOUT --server <name>    # dry-run by default for destructive fixes
+mcpproxy upstream logs <server-name> --tail 100
 ```
+
+If you see human-readable banners or `pip install` output, the server is
+contaminating stdout. Either fix the server to log to stderr, or wrap it.
+
+### 2. Pre-warm slow first runs
+
+If the underlying tool is downloading a model or installing dependencies on
+first start, run it once manually to populate caches:
+
+```bash
+uvx some-mcp-server --help
+npx -y some-mcp-server --version
+```
+
+### 3. Force unbuffered stdout
+
+For Python servers, add `-u` to args or set `PYTHONUNBUFFERED=1` in env. For
+Node, ensure `process.stdout.write` calls aren't held in a TTY-detection branch.
+
+### 4. Verify it's actually an MCP server
+
+Test directly via stdio:
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"probe","version":"0"}}}' \
+  | <command> <args>
+```
+
+You should get a JSON-RPC reply within a few seconds.
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [`MCPX_STDIO_HANDSHAKE_INVALID`](MCPX_STDIO_HANDSHAKE_INVALID.md) — server replied but malformed
+- [`MCPX_STDIO_EXIT_NONZERO`](MCPX_STDIO_EXIT_NONZERO.md) — server crashed instead of stalling

--- a/docs/errors/MCPX_STDIO_SPAWN_EACCES.md
+++ b/docs/errors/MCPX_STDIO_SPAWN_EACCES.md
@@ -1,23 +1,68 @@
-# MCPX_STDIO_SPAWN_EACCES
+---
+id: MCPX_STDIO_SPAWN_EACCES
+title: MCPX_STDIO_SPAWN_EACCES
+sidebar_label: SPAWN_EACCES
+description: The OS denied permission to execute the stdio MCP server command.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_STDIO_SPAWN_EACCES`
+
+**Severity:** error
+**Domain:** STDIO
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_STDIO_SPAWN_EACCES`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+The configured command exists on `PATH`, but the OS refused to execute it
+(`EACCES`). The subprocess never started.
+
+## Common causes
+
+- The file is missing the executable bit (`chmod +x`).
+- The file is on a noexec-mounted volume (e.g. some `/tmp` or NFS mounts).
+- macOS Gatekeeper / quarantine flagged a downloaded binary.
+- AppArmor / SELinux denied the exec syscall.
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+### Restore the executable bit
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_STDIO_SPAWN_EACCES --server <name>    # dry-run by default for destructive fixes
+ls -l "$(which <command>)"        # check current mode
+chmod +x "$(which <command>)"     # add execute permission
 ```
+
+### macOS quarantine
+
+If the binary was downloaded outside the App Store / Homebrew, macOS may have
+quarantined it:
+
+```bash
+xattr -d com.apple.quarantine "$(which <command>)"
+```
+
+For pre-built tray bundles, prefer the signed/notarised DMG — see
+[Installation](../getting-started/installation.md).
+
+### Move off a noexec volume
+
+```bash
+mount | grep noexec
+# Reinstall the tool to ~/.local/bin or /usr/local/bin instead of /tmp
+```
+
+### AppArmor / SELinux
+
+Check the audit log for `DENIED exec`:
+
+```bash
+sudo dmesg | grep -i denied
+sudo journalctl -t audit | grep DENIED
+```
+
+Adjust the policy or run the upstream server in [Docker isolation](../features/docker-isolation.md)
+to sidestep host policy.
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [`MCPX_STDIO_SPAWN_ENOENT`](MCPX_STDIO_SPAWN_ENOENT.md) — file does not exist
+- [Docker Isolation](../features/docker-isolation.md)

--- a/docs/errors/MCPX_STDIO_SPAWN_ENOENT.md
+++ b/docs/errors/MCPX_STDIO_SPAWN_ENOENT.md
@@ -1,23 +1,93 @@
-# MCPX_STDIO_SPAWN_ENOENT
+---
+id: MCPX_STDIO_SPAWN_ENOENT
+title: MCPX_STDIO_SPAWN_ENOENT
+sidebar_label: SPAWN_ENOENT
+description: The configured command for a stdio MCP server was not found on PATH.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_STDIO_SPAWN_ENOENT`
+
+**Severity:** error
+**Domain:** STDIO
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_STDIO_SPAWN_ENOENT`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+mcpproxy tried to spawn a stdio MCP server, but the operating system reported
+`ENOENT` — the configured command does not exist on the user's `PATH`. The
+subprocess never started, so the MCP `initialize` handshake timed out.
+
+A typical error chain looks like:
+
+```
+failed to connect: stdio transport (command="uvx", docker_isolation=false):
+  server did not respond to MCP initialize within 30s
+  recent stderr: zsh:1: command not found: uvx
+```
+
+## Common causes
+
+- **Tool not installed** — `uvx`, `npx`, `python3`, `bunx`, etc. are missing from the host.
+- **Wrong `PATH`** — the GUI launcher (Finder, systemd, launchd) doesn't see the
+  shell-only `PATH` that includes `~/.local/bin`, `/opt/homebrew/bin`, NodeSource paths, etc.
+- **Wrong working directory** — the command exists at a relative path that's only
+  valid inside the server's `working_dir`.
+- **Typo** in the `command` field of the upstream entry.
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+### 1. Check what mcpproxy's environment sees
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_STDIO_SPAWN_ENOENT --server <name>    # dry-run by default for destructive fixes
+which npx && which uvx && which python3
+echo "$PATH"
 ```
+
+If the command is missing, install the runtime:
+
+```bash
+# uvx (Python tools) — recommended
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# npx (Node tools)
+brew install node            # macOS
+sudo apt install nodejs npm  # Debian/Ubuntu
+```
+
+### 2. Make the GUI inherit the shell PATH (macOS)
+
+The macOS tray launches mcpproxy with the user's login `PATH`, which is shorter
+than your interactive shell `PATH`. Either:
+
+- Move the binary to a system directory: `sudo ln -s "$(which uvx)" /usr/local/bin/uvx`, or
+- Set an absolute path in the upstream config: `"command": "/Users/you/.local/bin/uvx"`.
+
+### 3. Use Docker isolation
+
+If you don't want to install language runtimes on the host, enable Docker
+isolation for the server. mcpproxy will run the command inside a container
+that already has `uvx` / `npx` available.
+
+```json
+{
+  "name": "my-server",
+  "command": "uvx",
+  "args": ["some-mcp-server"],
+  "isolation": { "enabled": true }
+}
+```
+
+See [Docker Isolation](../features/docker-isolation.md).
+
+### 4. Inspect recent server logs
+
+```bash
+mcpproxy upstream logs <server-name> --tail 50
+```
+
+The last lines of stderr usually identify exactly which executable was missing.
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [Docker Isolation](../features/docker-isolation.md)
+- [Configuration → upstream servers](../configuration/upstream-servers.md)
+- `mcpproxy doctor --server <name>` for an interactive walk-through

--- a/docs/errors/MCPX_UNKNOWN_UNCLASSIFIED.md
+++ b/docs/errors/MCPX_UNKNOWN_UNCLASSIFIED.md
@@ -1,23 +1,50 @@
-# MCPX_UNKNOWN_UNCLASSIFIED
+---
+id: MCPX_UNKNOWN_UNCLASSIFIED
+title: MCPX_UNKNOWN_UNCLASSIFIED
+sidebar_label: UNCLASSIFIED
+description: mcpproxy could not classify this failure into a specific error code.
+---
 
-**Severity**: see `internal/diagnostics/registry.go` for the authoritative severity.
-**Registered in**: [`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go)
+# `MCPX_UNKNOWN_UNCLASSIFIED`
+
+**Severity:** error
+**Domain:** Unknown
 
 ## What happened
 
-mcpproxy classified a terminal failure as `MCPX_UNKNOWN_UNCLASSIFIED`. This page is a stub
-and will be expanded with cause, symptoms, and remediation guidance.
+mcpproxy's error classifier didn't recognise the underlying failure. This is a
+fallback code: every failure gets *some* code, but for novel error shapes the
+catalog doesn't have a specific one yet.
+
+When you see this code, it usually means **mcpproxy needs a new specific code**
+for the situation — please file a bug so we can add it.
 
 ## How to fix
 
-See the fix steps emitted by the CLI and web UI:
+### File a bug report
+
+The error panel includes a **Report a bug** fix-step that pre-fills the issue
+template. Or:
 
 ```bash
-mcpproxy doctor --server <name>
-mcpproxy doctor fix MCPX_UNKNOWN_UNCLASSIFIED --server <name>    # dry-run by default for destructive fixes
+mcpproxy feedback "MCPX_UNKNOWN_UNCLASSIFIED for <server-name>: <one-line summary>"
 ```
+
+Please include:
+
+- The full error text shown in the panel.
+- The output of `mcpproxy upstream logs <server-name> --tail 100`.
+- Your platform and mcpproxy version (`mcpproxy version`).
+- Whether the upstream is HTTP, stdio, isolated, etc.
+
+### Workarounds
+
+- Restart the affected server: `mcpproxy upstream restart <server-name>`.
+- Try Docker isolation, or temporarily disable it.
+- Use `mcpproxy doctor --server <name>` for an interactive walk-through —
+  it sometimes catches issues the runtime classifier misses.
 
 ## Related
 
-- [Spec 044 — Diagnostics & Error Taxonomy](../../specs/044-diagnostics-taxonomy/spec.md)
-- [Design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
+- [Filing a bug](../contributing.md)
+- [Diagnostics overview](README.md)

--- a/docs/errors/README.md
+++ b/docs/errors/README.md
@@ -1,36 +1,89 @@
-# Error Code Catalog (spec 044)
+---
+id: README
+title: Error Code Catalog
+sidebar_label: Overview
+description: Stable error codes emitted by mcpproxy with cause, symptoms, and remediation steps.
+---
 
-This directory is the user-facing documentation for every stable mcpproxy
-error code. Each code is identified by a name of the form
-`MCPX_<DOMAIN>_<SPECIFIC>` and has a dedicated page that explains the
-cause, the typical symptoms, and the remediation steps.
+# Error Code Catalog
 
-Codes are **stable**: once shipped, a code name is never renamed. A
-deprecated code points to its replacement.
+mcpproxy emits a stable error code with every classified failure. Codes follow the
+form `MCPX_<DOMAIN>_<SPECIFIC>` and are surfaced in the web UI error panel, the
+tray, the CLI (`mcpproxy doctor`, `mcpproxy upstream logs`) and the activity log.
 
-The authoritative in-code registry lives in
-[`internal/diagnostics/registry.go`](../../internal/diagnostics/registry.go).
-Run `mcpproxy doctor list-codes` for the machine-readable list.
+Each code has a dedicated page below explaining the cause, the typical symptoms,
+and the remediation steps. Links from the product point at this site
+(`https://docs.mcpproxy.app/errors/<CODE>`).
 
 ## Domains
 
 | Domain | Prefix | Covers |
 |---|---|---|
-| STDIO | `MCPX_STDIO_*` | stdio-transport MCP servers — spawn, handshake, exit |
-| OAUTH | `MCPX_OAUTH_*` | OAuth 2.1 / PKCE flows — discovery, refresh, callback |
-| HTTP  | `MCPX_HTTP_*`  | HTTP/SSE transports — DNS, TLS, auth, status |
-| DOCKER | `MCPX_DOCKER_*` | Docker isolation subsystem |
-| CONFIG | `MCPX_CONFIG_*` | Config parsing and secret resolution |
-| QUARANTINE | `MCPX_QUARANTINE_*` | Security quarantine state |
-| NETWORK | `MCPX_NETWORK_*` | Host network environment |
-| UNKNOWN | `MCPX_UNKNOWN_*` | Fallback when classification fails |
+| [STDIO](#stdio) | `MCPX_STDIO_*` | stdio-transport MCP servers — spawn, handshake, exit |
+| [OAuth](#oauth) | `MCPX_OAUTH_*` | OAuth 2.1 / PKCE flows — discovery, refresh, callback |
+| [HTTP](#http)  | `MCPX_HTTP_*`  | HTTP/SSE transports — DNS, TLS, auth, status |
+| [Docker](#docker) | `MCPX_DOCKER_*` | Docker isolation subsystem |
+| [Config](#config) | `MCPX_CONFIG_*` | Config parsing and secret resolution |
+| [Quarantine](#quarantine) | `MCPX_QUARANTINE_*` | Security quarantine state |
+| [Network](#network) | `MCPX_NETWORK_*` | Host network environment |
+| [Unknown](#unknown) | `MCPX_UNKNOWN_*` | Fallback when classification fails |
 
-## Pages
+## Stability guarantee
 
-Each registered code has a `docs/errors/<CODE>.md` page. The index is
-verified by `scripts/check-errors-docs-links.sh`; a missing page fails
-CI.
+Codes are stable: once shipped, a code name is never renamed. A deprecated code
+points to its replacement. The authoritative in-code registry lives in
+[`internal/diagnostics/registry.go`](https://github.com/smart-mcp-proxy/mcpproxy-go/blob/main/internal/diagnostics/registry.go).
+Run `mcpproxy doctor list-codes` for the machine-readable list.
 
-See the [diagnostics design doc](../superpowers/specs/2026-04-24-diagnostics-error-taxonomy-design.md)
-and [spec 044](../../specs/044-diagnostics-taxonomy/spec.md) for the
-design intent.
+## STDIO
+
+- [`MCPX_STDIO_SPAWN_ENOENT`](MCPX_STDIO_SPAWN_ENOENT.md) — command not found on PATH
+- [`MCPX_STDIO_SPAWN_EACCES`](MCPX_STDIO_SPAWN_EACCES.md) — permission denied executing command
+- [`MCPX_STDIO_EXIT_NONZERO`](MCPX_STDIO_EXIT_NONZERO.md) — server exited before handshake
+- [`MCPX_STDIO_HANDSHAKE_TIMEOUT`](MCPX_STDIO_HANDSHAKE_TIMEOUT.md) — no `initialize` reply within 30s
+- [`MCPX_STDIO_HANDSHAKE_INVALID`](MCPX_STDIO_HANDSHAKE_INVALID.md) — malformed MCP frame
+
+## OAuth
+
+- [`MCPX_OAUTH_REFRESH_EXPIRED`](MCPX_OAUTH_REFRESH_EXPIRED.md) — refresh token expired
+- [`MCPX_OAUTH_REFRESH_403`](MCPX_OAUTH_REFRESH_403.md) — provider rejected refresh
+- [`MCPX_OAUTH_DISCOVERY_FAILED`](MCPX_OAUTH_DISCOVERY_FAILED.md) — `.well-known` discovery failed
+- [`MCPX_OAUTH_CALLBACK_TIMEOUT`](MCPX_OAUTH_CALLBACK_TIMEOUT.md) — browser callback timed out
+- [`MCPX_OAUTH_CALLBACK_MISMATCH`](MCPX_OAUTH_CALLBACK_MISMATCH.md) — redirect URI mismatch
+
+## HTTP
+
+- [`MCPX_HTTP_DNS_FAILED`](MCPX_HTTP_DNS_FAILED.md) — DNS lookup failed
+- [`MCPX_HTTP_TLS_FAILED`](MCPX_HTTP_TLS_FAILED.md) — TLS handshake failed
+- [`MCPX_HTTP_401`](MCPX_HTTP_401.md) — Unauthorized
+- [`MCPX_HTTP_403`](MCPX_HTTP_403.md) — Forbidden
+- [`MCPX_HTTP_404`](MCPX_HTTP_404.md) — Not Found
+- [`MCPX_HTTP_5XX`](MCPX_HTTP_5XX.md) — Server error
+- [`MCPX_HTTP_CONN_REFUSED`](MCPX_HTTP_CONN_REFUSED.md) — Connection refused
+
+## Docker
+
+- [`MCPX_DOCKER_DAEMON_DOWN`](MCPX_DOCKER_DAEMON_DOWN.md) — daemon unreachable
+- [`MCPX_DOCKER_IMAGE_PULL_FAILED`](MCPX_DOCKER_IMAGE_PULL_FAILED.md) — pull failed
+- [`MCPX_DOCKER_NO_PERMISSION`](MCPX_DOCKER_NO_PERMISSION.md) — socket permission denied
+- [`MCPX_DOCKER_SNAP_APPARMOR`](MCPX_DOCKER_SNAP_APPARMOR.md) — snap Docker AppArmor block
+
+## Config
+
+- [`MCPX_CONFIG_DEPRECATED_FIELD`](MCPX_CONFIG_DEPRECATED_FIELD.md) — deprecated field used
+- [`MCPX_CONFIG_PARSE_ERROR`](MCPX_CONFIG_PARSE_ERROR.md) — invalid JSON
+- [`MCPX_CONFIG_MISSING_SECRET`](MCPX_CONFIG_MISSING_SECRET.md) — secret reference unresolved
+
+## Quarantine
+
+- [`MCPX_QUARANTINE_PENDING_APPROVAL`](MCPX_QUARANTINE_PENDING_APPROVAL.md) — tools awaiting approval
+- [`MCPX_QUARANTINE_TOOL_CHANGED`](MCPX_QUARANTINE_TOOL_CHANGED.md) — rug-pull detected
+
+## Network
+
+- [`MCPX_NETWORK_PROXY_MISCONFIG`](MCPX_NETWORK_PROXY_MISCONFIG.md) — proxy env broken
+- [`MCPX_NETWORK_OFFLINE`](MCPX_NETWORK_OFFLINE.md) — no network connectivity
+
+## Unknown
+
+- [`MCPX_UNKNOWN_UNCLASSIFIED`](MCPX_UNKNOWN_UNCLASSIFIED.md) — please file a bug

--- a/frontend/tests/unit/error-panel.spec.ts
+++ b/frontend/tests/unit/error-panel.spec.ts
@@ -39,7 +39,7 @@ describe('ErrorPanel (spec 044)', () => {
           fixer_key: 'stdio_show_last_logs',
         },
       ],
-      docs_url: 'docs/errors/MCPX_STDIO_SPAWN_ENOENT.md',
+      docs_url: 'https://docs.mcpproxy.app/errors/MCPX_STDIO_SPAWN_ENOENT',
       ...overrides,
     }
   }

--- a/internal/diagnostics/catalog_test.go
+++ b/internal/diagnostics/catalog_test.go
@@ -110,16 +110,17 @@ func TestCatalog_All_Stable(t *testing.T) {
 	}
 }
 
-// TestCatalog_DocsURL_MatchesCode — when DocsURL is relative, it must follow
-// the docs/errors/<CODE>.md convention.
+// TestCatalog_DocsURL_MatchesCode — DocsURL is published on docs.mcpproxy.app.
+// Each code must point to https://docs.mcpproxy.app/errors/<CODE>. Bug-report
+// pages and other absolute https:// URLs are also allowed for special cases
+// (e.g. UnknownUnclassified links to the issue tracker as a fix step, but its
+// own DocsURL still resolves to the catalog page).
 func TestCatalog_DocsURL_MatchesCode(t *testing.T) {
+	const prefix = "https://docs.mcpproxy.app/errors/"
 	for code, entry := range registry {
-		if strings.HasPrefix(entry.DocsURL, "http://") || strings.HasPrefix(entry.DocsURL, "https://") {
-			continue
-		}
-		expected := "docs/errors/" + string(code) + ".md"
+		expected := prefix + string(code)
 		if entry.DocsURL != expected {
-			t.Errorf("code %q has DocsURL %q, expected %q (or an absolute https:// URL)", code, entry.DocsURL, expected)
+			t.Errorf("code %q has DocsURL %q, expected %q", code, entry.DocsURL, expected)
 		}
 	}
 }

--- a/internal/diagnostics/registry.go
+++ b/internal/diagnostics/registry.go
@@ -15,8 +15,12 @@ func init() {
 	seedUNKNOWN()
 }
 
+// docsURL returns the absolute URL of the error documentation page on
+// docs.mcpproxy.app. We emit absolute URLs (rather than repo-relative paths)
+// because the docs are not shipped with the binary — fix-step links must be
+// click-through openable from the web UI, tray, and CLI.
 func docsURL(c Code) string {
-	return "docs/errors/" + string(c) + ".md"
+	return "https://docs.mcpproxy.app/errors/" + string(c)
 }
 
 func register(e CatalogEntry) {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -49,6 +49,7 @@ const config = {
             'web-ui/**/*.{md,mdx}',
             'features/**/*.{md,mdx}',
             'operations/**/*.{md,mdx}',
+            'errors/**/*.{md,mdx}',
             'development/**/*.{md,mdx}',
             'contributing.md',
           ],

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -84,6 +84,84 @@ const sidebars = {
     },
     {
       type: 'category',
+      label: 'Errors',
+      link: { type: 'doc', id: 'errors/README' },
+      items: [
+        {
+          type: 'category',
+          label: 'STDIO',
+          items: [
+            'errors/MCPX_STDIO_SPAWN_ENOENT',
+            'errors/MCPX_STDIO_SPAWN_EACCES',
+            'errors/MCPX_STDIO_EXIT_NONZERO',
+            'errors/MCPX_STDIO_HANDSHAKE_TIMEOUT',
+            'errors/MCPX_STDIO_HANDSHAKE_INVALID',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'OAuth',
+          items: [
+            'errors/MCPX_OAUTH_REFRESH_EXPIRED',
+            'errors/MCPX_OAUTH_REFRESH_403',
+            'errors/MCPX_OAUTH_DISCOVERY_FAILED',
+            'errors/MCPX_OAUTH_CALLBACK_TIMEOUT',
+            'errors/MCPX_OAUTH_CALLBACK_MISMATCH',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'HTTP',
+          items: [
+            'errors/MCPX_HTTP_DNS_FAILED',
+            'errors/MCPX_HTTP_TLS_FAILED',
+            'errors/MCPX_HTTP_401',
+            'errors/MCPX_HTTP_403',
+            'errors/MCPX_HTTP_404',
+            'errors/MCPX_HTTP_5XX',
+            'errors/MCPX_HTTP_CONN_REFUSED',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Docker',
+          items: [
+            'errors/MCPX_DOCKER_DAEMON_DOWN',
+            'errors/MCPX_DOCKER_IMAGE_PULL_FAILED',
+            'errors/MCPX_DOCKER_NO_PERMISSION',
+            'errors/MCPX_DOCKER_SNAP_APPARMOR',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Config',
+          items: [
+            'errors/MCPX_CONFIG_DEPRECATED_FIELD',
+            'errors/MCPX_CONFIG_PARSE_ERROR',
+            'errors/MCPX_CONFIG_MISSING_SECRET',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Quarantine',
+          items: [
+            'errors/MCPX_QUARANTINE_PENDING_APPROVAL',
+            'errors/MCPX_QUARANTINE_TOOL_CHANGED',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Network',
+          items: [
+            'errors/MCPX_NETWORK_PROXY_MISCONFIG',
+            'errors/MCPX_NETWORK_OFFLINE',
+          ],
+        },
+        'errors/MCPX_UNKNOWN_UNCLASSIFIED',
+      ],
+    },
+    {
+      type: 'category',
       label: 'Development',
       collapsed: true,
       items: [


### PR DESCRIPTION
## Summary

The web UI / tray / CLI error panel emitted `docs/errors/<CODE>.md` as the *Documentation* link. That path doesn't resolve anywhere — docs aren't shipped with the installer and the website only publishes a curated set of pages, so users see a dead link (see screenshot in #issue):

> Install the missing tool → `docs/errors/MCPX_STDIO_SPAWN_ENOENT.md` ❌

This PR makes the link point at `https://docs.mcpproxy.app/errors/<CODE>` and **publishes those pages with real content**.

## Changes

- **`internal/diagnostics/registry.go`** — `docsURL()` now returns the absolute `https://docs.mcpproxy.app/errors/<CODE>` URL. Tests updated to enforce the new shape.
- **`website/docusaurus.config.js`** — added `errors/**/*.{md,mdx}` to the docs `include` whitelist so the catalog is built.
- **`website/sidebars.js`** — new "Errors" category (with sub-categories per domain: STDIO, OAuth, HTTP, Docker, Config, Quarantine, Network, Unknown). The category overview links to `errors/README`.
- **`docs/errors/*.md` (29 files)** — replaced 23-line stubs with real content: cause / common causes / how-to-fix (commands) / related codes. Added Docusaurus frontmatter (`id` / `title` / `sidebar_label` / `description`) so each page renders cleanly and is searchable.
- **`docs/errors/README.md`** — proper overview with grouped catalog.
- **`frontend/tests/unit/error-panel.spec.ts`** — fixture URL updated.

## Test plan

- [x] `go test -race ./internal/diagnostics/...` — pass
- [x] `npx vitest run tests/unit/error-panel.spec.ts` — pass
- [x] `./scripts/run-linter.sh` — 0 issues
- [x] `cd website && bash prepare-docs.sh && npx docusaurus build` — pass; `onBrokenLinks: 'throw'` is on, so this proves the catalog is link-clean. 29 pages emitted under `build/errors/MCPX_*/`.
- [ ] After merge: deploy docs.mcpproxy.app and click the *Documentation* link from the error panel for at least one server failure to confirm end-to-end (the URL produced by the binary will resolve once docs are deployed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)