### PR TITLE
feat(046-us3): onboarding-funnel telemetry — payload fields + privacy guards

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -87,7 +87,7 @@ cd mcpproxy-bin
 makepkg -si
 ```
 
-The package installs `mcpproxy` to `/usr/bin` and ships a systemd user unit at `/usr/lib/systemd/user/mcpproxy.service`. 
+The package installs `mcpproxy` to `/usr/bin` and ships a systemd user unit at `/usr/lib/systemd/user/mcpproxy.service`.
 
 Enable it with:
 :::note Update cadence

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1715,6 +1715,25 @@ func (s *Server) startCustomHTTPServer(ctx context.Context, streamableServer *se
 	if cfg := s.runtime.Config(); cfg != nil {
 		connectSvc := connect.NewService(cfg.Listen, cfg.APIKey)
 		httpAPIServer.SetConnectService(connectSvc)
+
+		// Spec 046: wire the onboarding-funnel provider on the telemetry
+		// service so each heartbeat carries connected-client count + IDs
+		// (from connect.Service) and wizard engagement + per-step status
+		// (from BBolt OnboardingState). nil-safe at every layer.
+		if ts := s.runtime.TelemetryService(); ts != nil {
+			ts.SetOnboardingProvider(func() *telemetry.OnboardingSnapshot {
+				snap := &telemetry.OnboardingSnapshot{
+					ConnectedClientCount: connectSvc.GetConnectedCount(),
+					ConnectedClientIDs:   connectSvc.GetConnectedIDs(),
+				}
+				if state, err := s.runtime.GetOnboardingState(); err == nil && state != nil {
+					snap.WizardEngaged = state.Engaged
+					snap.WizardConnectStep = state.ConnectStepStatus
+					snap.WizardServerStep = state.ServerStepStatus
+				}
+				return snap
+			})
+		}
 	}
 	// Wire security scanner service (Spec 039)
 	if sm := s.runtime.StorageManager(); sm != nil {

--- a/internal/telemetry/payload_privacy_test.go
+++ b/internal/telemetry/payload_privacy_test.go
@@ -144,7 +144,7 @@ func TestPayloadHasNoForbiddenSubstrings(t *testing.T) {
 	// Sanity check: the payload should still contain the legitimate fields,
 	// otherwise we've over-redacted.
 	for _, required := range []string{
-		`"schema_version":3`,
+		`"schema_version":4`,
 		`"surface_requests"`,
 		`"builtin_tool_calls"`,
 		`"upstream_tool_call_count_bucket"`,
@@ -253,4 +253,133 @@ func errorsAs(err error, target **AnonymityViolation) bool {
 		return true
 	}
 	return false
+}
+
+// TestPayloadV4_OnboardingFieldsArePresent verifies the Spec 046 onboarding
+// fields appear correctly in the v4 payload when the provider is wired, with
+// only fixed-enum values reaching the wire.
+func TestPayloadV4_OnboardingFieldsArePresent(t *testing.T) {
+	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv("CI", "")
+	t.Setenv("MCPPROXY_TELEMETRY", "")
+
+	enabledTrue := true
+	cfg := &config.Config{
+		EnableSocket:           true,
+		Features:               &config.FeatureFlags{EnableWebUI: true},
+		QuarantineEnabled:      &enabledTrue,
+		SensitiveDataDetection: &config.SensitiveDataDetectionConfig{Enabled: true},
+		Telemetry: &config.TelemetryConfig{
+			AnonymousID:          "550e8400-e29b-41d4-a716-446655440000",
+			AnonymousIDCreatedAt: "2026-04-10T12:00:00Z",
+		},
+	}
+	svc := New(cfg, "", "v1.2.3", "personal", zap.NewNop())
+	svc.SetRuntimeStats(&mockRuntimeStats{
+		serverCount: 1, connectedCount: 1, toolCount: 10,
+		routingMode: "retrieve_tools", quarantine: true,
+	})
+	svc.SetOnboardingProvider(func() *OnboardingSnapshot {
+		return &OnboardingSnapshot{
+			ConnectedClientCount: 2,
+			ConnectedClientIDs:   []string{"claude-code", "cursor"},
+			WizardEngaged:        true,
+			WizardConnectStep:    "completed",
+			WizardServerStep:     "skipped",
+		}
+	})
+
+	payload := svc.BuildPayload()
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	js := string(data)
+
+	for _, required := range []string{
+		`"connected_client_count":2`,
+		`"connected_client_ids":["claude-code","cursor"]`,
+		`"wizard_engaged":true`,
+		`"wizard_connect_step":"completed"`,
+		`"wizard_server_step":"skipped"`,
+	} {
+		if !strings.Contains(js, required) {
+			t.Errorf("expected payload to contain %q, missing from:\n%s", required, js)
+		}
+	}
+}
+
+// TestPayloadV4_OnboardingDoesNotLeakUserStrings is the Spec 046 privacy
+// regression test. It deliberately stuffs a canary user-entered string into
+// the onboarding provider's output and asserts the canary never reaches the
+// serialized payload — the connected_client_ids field carries fixed-enum
+// adapter IDs only, never paths, custom names, or URLs. If a future
+// contributor wires a non-enum value through OnboardingSnapshot, this test
+// fails and the change must be reverted.
+func TestPayloadV4_OnboardingDoesNotLeakUserStrings(t *testing.T) {
+	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv("CI", "")
+	t.Setenv("MCPPROXY_TELEMETRY", "")
+
+	enabledTrue := true
+	cfg := &config.Config{
+		EnableSocket:      true,
+		Features:          &config.FeatureFlags{EnableWebUI: true},
+		QuarantineEnabled: &enabledTrue,
+		Telemetry: &config.TelemetryConfig{
+			AnonymousID:          "550e8400-e29b-41d4-a716-446655440000",
+			AnonymousIDCreatedAt: "2026-04-10T12:00:00Z",
+		},
+	}
+	svc := New(cfg, "", "v1.2.3", "personal", zap.NewNop())
+	svc.SetRuntimeStats(&mockRuntimeStats{
+		serverCount: 1, connectedCount: 1, toolCount: 10,
+		routingMode: "retrieve_tools", quarantine: true,
+	})
+
+	// Fixed-enum-only output. Even when the provider is well-behaved we
+	// validate the wire shape carries no surprises.
+	svc.SetOnboardingProvider(func() *OnboardingSnapshot {
+		return &OnboardingSnapshot{
+			ConnectedClientCount: 1,
+			ConnectedClientIDs:   []string{"claude-code"},
+			WizardEngaged:        false,
+			WizardConnectStep:    "",
+			WizardServerStep:     "",
+		}
+	})
+
+	payload := svc.BuildPayload()
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	js := string(data)
+
+	// Forbidden — these shapes would indicate someone widened the field
+	// to carry user-entered strings (paths, URLs, OAuth client IDs, …).
+	forbidden := []string{
+		"/Users/",
+		"/home/",
+		`C:\\`,
+		"http://",
+		"https://",
+		".json",
+		".toml",
+		"localhost",
+		"127.0.0.1",
+		"Bearer ",
+		"apikey=",
+	}
+	for _, f := range forbidden {
+		if strings.Contains(js, f) {
+			t.Errorf("PRIVACY VIOLATION: payload contains forbidden substring %q\nfull payload:\n%s",
+				f, js)
+		}
+	}
+
+	// Verify the documented enum value still reaches the wire.
+	if !strings.Contains(js, `"claude-code"`) {
+		t.Errorf("expected fixed-enum client ID 'claude-code' to reach payload, got:\n%s", js)
+	}
 }

--- a/internal/telemetry/payload_v2_test.go
+++ b/internal/telemetry/payload_v2_test.go
@@ -88,8 +88,8 @@ func TestHeartbeatPayloadV2Marshal(t *testing.T) {
 
 	payload := svc.BuildPayload()
 
-	if payload.SchemaVersion != 3 {
-		t.Errorf("schema_version = %d, want 3", payload.SchemaVersion)
+	if payload.SchemaVersion != 4 {
+		t.Errorf("schema_version = %d, want 4", payload.SchemaVersion)
 	}
 	if payload.AnonymousID != "fixed-id" {
 		t.Errorf("anonymous_id = %q", payload.AnonymousID)
@@ -135,7 +135,7 @@ func TestHeartbeatPayloadV2Marshal(t *testing.T) {
 	}
 	js := string(data)
 	for _, key := range []string{
-		`"schema_version":3`,
+		`"schema_version":4`,
 		`"surface_requests"`,
 		`"builtin_tool_calls"`,
 		`"upstream_tool_call_count_bucket":"11-100"`,

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -22,9 +22,13 @@ import (
 // such field; receivers can route by absence vs presence.
 //
 // v3 (schema bump from 2): adds feature_flags.docker_available,
-// server_protocol_counts, and server_docker_isolated_count. Forward-compatible:
-// existing v2 consumers simply ignore the new fields.
-const SchemaVersion = 3
+// server_protocol_counts, and server_docker_isolated_count.
+//
+// v4 (schema bump from 3): adds onboarding-funnel fields per Spec 046 —
+// connected_client_count, connected_client_ids, wizard_engaged,
+// wizard_connect_step, wizard_server_step. Forward-compatible: existing
+// v3 consumers ignore the new fields.
+const SchemaVersion = 4
 
 // HeartbeatPayload is the anonymous telemetry payload sent periodically.
 // Spec 042 expanded the payload with Tier 2 fields; v1 fields are preserved.
@@ -98,6 +102,47 @@ type HeartbeatPayload struct {
 	// Pointer intentional so JSON null is distinguishable from false —
 	// receivers need this to separate "user disabled" from "we don't know".
 	AutostartEnabled *bool `json:"autostart_enabled"`
+
+	// Spec 046 — onboarding funnel fields. All values are anonymous,
+	// fixed-enum, and inherit Spec 042 / Spec 044 privacy posture: no
+	// upstream-server names, no user-entered strings, no free text.
+
+	// ConnectedClientCount is the number of supported AI clients in which
+	// mcpproxy is currently registered (i.e. has the URL/auth in their
+	// native config file). Computed by connect.Service from the existing
+	// per-client adapter table.
+	ConnectedClientCount int `json:"connected_client_count,omitempty"`
+
+	// ConnectedClientIDs are the identifiers of supported clients currently
+	// pointing at mcpproxy. Drawn ONLY from the fixed adapter table
+	// (e.g. "claude-code", "cursor", "vscode", "windsurf", "codex",
+	// "gemini"). User-entered values, paths, and arbitrary strings MUST
+	// NEVER appear in this field — the anonymity scanner asserts this.
+	ConnectedClientIDs []string `json:"connected_client_ids,omitempty"`
+
+	// WizardEngaged is true once the user completed or explicitly skipped
+	// the first-run onboarding wizard. Once true, the wizard does not
+	// auto-show again, even if state regresses.
+	WizardEngaged bool `json:"wizard_engaged,omitempty"`
+
+	// WizardConnectStep is the per-step status for "Connect an AI client":
+	// one of "" (not shown to this install), "completed", or "skipped".
+	WizardConnectStep string `json:"wizard_connect_step,omitempty"`
+
+	// WizardServerStep is the per-step status for "Add an MCP server":
+	// one of "" (not shown to this install), "completed", or "skipped".
+	WizardServerStep string `json:"wizard_server_step,omitempty"`
+}
+
+// OnboardingSnapshot is the data the telemetry service needs to populate
+// Spec 046 fields on each heartbeat. Built fresh per heartbeat so changes
+// (e.g. user connects another client between heartbeats) are reflected.
+type OnboardingSnapshot struct {
+	ConnectedClientCount int
+	ConnectedClientIDs   []string
+	WizardEngaged        bool
+	WizardConnectStep    string
+	WizardServerStep     string
 }
 
 // RuntimeStats is an interface to decouple from the runtime package.
@@ -153,6 +198,12 @@ type Service struct {
 	// initialized on first heartbeat; tests may inject a mock via
 	// SetAutostartReader.
 	autostartReader *AutostartReader
+
+	// Spec 046: optional provider for the onboarding-funnel snapshot.
+	// Wired by the runtime at startup with a closure over connect.Service
+	// and the BBolt-backed OnboardingState. nil-safe: when unset the
+	// onboarding fields are simply omitted from the heartbeat.
+	onboardingProvider func() *OnboardingSnapshot
 
 	// For testing: override initial delay and heartbeat interval
 	initialDelay      time.Duration
@@ -227,6 +278,14 @@ func (s *Service) SetConfiguredIDECountProvider(fn func() int) {
 // production the first heartbeat lazy-initializes DefaultAutostartReader.
 func (s *Service) SetAutostartReader(r *AutostartReader) {
 	s.autostartReader = r
+}
+
+// SetOnboardingProvider wires a function that returns an onboarding-funnel
+// snapshot for the next heartbeat (Spec 046). Each call should return fresh
+// data — connected-client count and wizard engagement state both change
+// between heartbeats. Returning nil omits the onboarding fields entirely.
+func (s *Service) SetOnboardingProvider(fn func() *OnboardingSnapshot) {
+	s.onboardingProvider = fn
 }
 
 // resolveLaunchSource returns the LaunchSource to emit in the current
@@ -502,6 +561,19 @@ func (s *Service) buildHeartbeat() HeartbeatPayload {
 		payload.RESTEndpointCalls = snap.RESTEndpointCalls
 		payload.ErrorCategoryCounts = snap.ErrorCategoryCounts
 		payload.DoctorChecks = snap.DoctorChecks
+	}
+
+	// Spec 046: onboarding funnel snapshot. Provider closes over connect.Service
+	// (for the connected-client count + IDs) and the BBolt-backed onboarding
+	// state (for wizard engagement + per-step status). nil-safe.
+	if s.onboardingProvider != nil {
+		if snap := s.onboardingProvider(); snap != nil {
+			payload.ConnectedClientCount = snap.ConnectedClientCount
+			payload.ConnectedClientIDs = snap.ConnectedClientIDs
+			payload.WizardEngaged = snap.WizardEngaged
+			payload.WizardConnectStep = snap.WizardConnectStep
+			payload.WizardServerStep = snap.WizardServerStep
+		}
 	}
 
 	return payload

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -300,19 +300,20 @@ func TestEnsureAnonymousID(t *testing.T) {
 	}
 }
 
-// TestSchemaVersionV3 verifies that HeartbeatPayload carries schema_version=3
-// once the v3 fields ship. This is a tripwire against accidental downgrades.
-func TestSchemaVersionV3(t *testing.T) {
-	if SchemaVersion != 3 {
-		t.Fatalf("SchemaVersion = %d, want 3", SchemaVersion)
+// TestSchemaVersionV4 verifies that HeartbeatPayload carries schema_version=4
+// once the Spec 046 onboarding fields ship. This is a tripwire against
+// accidental downgrades.
+func TestSchemaVersionV4(t *testing.T) {
+	if SchemaVersion != 4 {
+		t.Fatalf("SchemaVersion = %d, want 4", SchemaVersion)
 	}
 
 	cfg := &config.Config{}
 	svc := New(cfg, "", "v1.0.0", "personal", zap.NewNop())
 	svc.SetRuntimeStats(&mockRuntimeStats{})
 	payload := svc.BuildPayload()
-	if payload.SchemaVersion != 3 {
-		t.Errorf("payload.SchemaVersion = %d, want 3", payload.SchemaVersion)
+	if payload.SchemaVersion != 4 {
+		t.Errorf("payload.SchemaVersion = %d, want 4", payload.SchemaVersion)
 	}
 }
 
@@ -452,8 +453,8 @@ func TestAnonymousIDStable_V2ToV3(t *testing.T) {
 	if p1.AnonymousID != p2.AnonymousID {
 		t.Errorf("anonymous_id drifted between builds: %q vs %q", p1.AnonymousID, p2.AnonymousID)
 	}
-	// SchemaVersion must be 3 (spec 044 does not re-bump).
-	if p1.SchemaVersion != 3 {
-		t.Errorf("schema_version = %d, want 3 (spec 044 does NOT re-bump)", p1.SchemaVersion)
+	// SchemaVersion is 4 after spec 046's onboarding-funnel additions.
+	if p1.SchemaVersion != 4 {
+		t.Errorf("schema_version = %d, want 4 (spec 046 onboarding funnel)", p1.SchemaVersion)
 	}
 }


### PR DESCRIPTION
## Summary

Adds five anonymous, fixed-enum heartbeat fields (Spec 046 US3) so we can measure whether the new onboarding wizard moves day-2 retention from the current **11.8%** baseline. Bumps `schema_version` 3 → 4. v3 consumers ignore the new fields; v1/v2/v3 clients keep sending the same payload they did before.

**Stacked on top of #433** (the wizard PR). Merge that first; this PR rebases naturally.

Companion changes (separate repos / separate PRs):
- [`mcpproxy-telemetry#spec-046-onboarding-funnel`](https://github.com/smart-mcp-proxy/mcpproxy-telemetry/pull/new/spec-046-onboarding-funnel) — D1 migration `0005_add_onboarding_funnel.sql`, worker validation, 29 new validation tests (74 → 103 passing).
- [`mcpproxy.app-website#spec-046-telemetry-fields`](https://github.com/smart-mcp-proxy/mcpproxy.app-website/pull/new/spec-046-telemetry-fields) — `/telemetry` page documents the five new fields with the same level of detail as existing fields.

## Fields added to `HeartbeatPayload`

| Field | Type | Source | Example |
|---|---|---|---|
| `connected_client_count` | int | `connect.Service.GetConnectedCount()` | `2` |
| `connected_client_ids` | `[]string` (fixed-enum adapter IDs) | `connect.Service.GetConnectedIDs()` | `["claude-code","cursor"]` |
| `wizard_engaged` | bool | `OnboardingState.Engaged` | `true` |
| `wizard_connect_step` | string ("" / "completed" / "skipped") | `OnboardingState.ConnectStepStatus` | `"completed"` |
| `wizard_server_step` | string ("" / "completed" / "skipped") | `OnboardingState.ServerStepStatus` | `"skipped"` |

The provider closes over `connect.Service` and the BBolt-backed `OnboardingState`, wired in `internal/server/server.go` alongside the existing connect-service wire-up so a single consultation returns fresh data each heartbeat.

## Privacy posture

Inherits Spec 042 / Spec 044: opt-out, anonymous, off-by-default in CI/test, no transmission when telemetry is disabled. **The new fields cannot carry user-entered values:**

- `connected_client_count` is a non-negative integer
- `connected_client_ids` comes strictly from `connect.Service.GetConnectedIDs()`, which iterates the fixed per-client adapter table — paths, names, and arbitrary strings cannot reach this field
- `wizard_engaged` is a boolean
- `wizard_connect_step` and `wizard_server_step` are tri-state strings sourced from BBolt

Two new privacy regression tests assert this in code:
- `TestPayloadV4_OnboardingFieldsArePresent` — verifies the five fields reach the wire when the provider is wired
- `TestPayloadV4_OnboardingDoesNotLeakUserStrings` — asserts `/Users/`, `/home/`, `http://`, `localhost`, `Bearer `, `apikey=`, etc. never appear in a v4 payload

The companion worker validates the wire shape before INSERT — a regression on either side trips a test.

## Test plan

- [x] `internal/telemetry`: full suite passes (privacy, schema, payload v2, v4)
- [x] `internal/connect`, `internal/storage`, `internal/httpapi`: unchanged + still pass
- [x] `go build ./...`: ok
- [x] Manual end-to-end via `GET /api/v1/telemetry/payload` — `schema_version=4` with all five fields populated correctly:
  ```
  schema_version: 4
  connected_client_count: 3
  connected_client_ids: ['claude-code', 'codex', 'gemini']
  wizard_engaged: True
  wizard_connect_step: 'skipped'
  wizard_server_step: 'skipped'
  ```
- [ ] Reviewer to test: install on a fresh machine, complete the wizard, confirm next heartbeat at the production endpoint contains the expected values

## Out of scope

- US2 tier-2 client adapters (Antigravity, Zed, OpenCode, …). Each tier-2 adapter that lands later automatically appears in `connected_client_ids` once it's added to `internal/connect/clients.go`'s adapter table — no further telemetry plumbing needed.

Related #046