### PR TITLE
Add OpenCode AI client connect support and fix missing favicon

### DIFF
--- a/cmd/mcpproxy/connect_cmd.go
+++ b/cmd/mcpproxy/connect_cmd.go
@@ -27,7 +27,7 @@ func GetConnectCommand() *cobra.Command {
 AI coding clients. This modifies the client's config file to add an HTTP/SSE
 entry pointing to the running MCPProxy instance.
 
-Supported clients: claude-code, cursor, windsurf, vscode, codex, gemini
+Supported clients: claude-code, cursor, windsurf, vscode, codex, gemini, opencode
 
 A backup of the original config file is created before any modification.
 
@@ -36,6 +36,7 @@ Examples:
   mcpproxy connect claude-code               # Register in Claude Code
   mcpproxy connect cursor --force            # Overwrite existing entry
   mcpproxy connect codex --name my-proxy     # Custom server name
+  mcpproxy connect opencode                  # Register in OpenCode
   mcpproxy connect --all                     # Register in all supported clients`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: runConnect,

--- a/cmd/mcpproxy/connect_cmd_test.go
+++ b/cmd/mcpproxy/connect_cmd_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/connect"
+)
+
+func TestConnectClientRegistry_IncludesOpenCode(t *testing.T) {
+	clients := connect.GetAllClients()
+	found := false
+	for _, c := range clients {
+		if c.ID == "opencode" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected opencode in client registry")
+	}
+}

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -216,6 +216,20 @@ Create `.vscode/mcp.json` in your workspace:
 
 ---
 
+### 🧩 OpenCode
+
+OpenCode can be connected through MCPProxy's Connect Clients flow.
+
+- Client ID: `opencode`
+- Config section: `mcp`
+- macOS/Linux global config path: `~/.config/opencode/opencode.json`
+- Windows global config path: `%LOCALAPPDATA%\opencode\opencode.json`
+- OpenCode config must already exist; MCPProxy does not create it for you.
+- On connect, MCPProxy writes or updates only the OpenCode `mcp` subtree and preserves unrelated root config.
+- MCPProxy treats endpoint-equivalent existing entries as already connected, even if they use a non-canonical server name.
+
+---
+
 ### 🤖 Claude Desktop
 
 Claude Desktop supports two different approaches depending on your plan:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MCPProxy Control Panel</title>
   </head>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 120 120"
+   version="1.1"
+   id="svg5"
+   sodipodi:docname="logo.svg"
+   inkscape:version="1.4.2 (ebf0e940, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs5">
+    <linearGradient
+       id="linearGradient16"
+       inkscape:collect="always">
+      <stop
+         style="stop-color:#ccffdd;stop-opacity:1;"
+         offset="0"
+         id="stop16" />
+      <stop
+         style="stop-color:#006644;stop-opacity:1;"
+         offset="1"
+         id="stop17" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient16"
+       id="radialGradient17"
+       cx="28.966673"
+       cy="23.640537"
+       fx="28.966673"
+       fy="23.640537"
+       r="31.901502"
+       gradientTransform="matrix(1.556145,2.4018829,-1.531152,0.99201115,13.533268,-94.722392)"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="namedview5"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:zoom="6.2985159"
+     inkscape:cx="60.569824"
+     inkscape:cy="57.553241"
+     inkscape:window-width="1488"
+     inkscape:window-height="956"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg5" />
+  <title
+     id="title1">mcpproxy shield logo</title>
+  <desc
+     id="desc1">Blue shield with MCP circles beneath</desc>
+  <path
+     d="M 61.076795,-0.12020106 25.669448,12.823274 V 38.71023 c 0,22.651084 14.64979,46.337652 35.407347,51.773913 C 81.834351,85.047882 96.484141,61.361314 96.484141,38.71023 V 12.823274 Z"
+     fill="#007bff"
+     id="path1"
+     style="fill:url(#radialGradient17);fill-rule:nonzero;stroke-width:4.3702;stroke-dasharray:none"
+     inkscape:transform-center-x="-3.6060105"
+     inkscape:transform-center-y="4.6076795" />
+  <ellipse
+     cx="27.218142"
+     cy="99.239571"
+     fill="#007bff"
+     id="circle1"
+     rx="16.648861"
+     ry="17.65192"
+     style="stroke-width:1.71431;fill:#005533;fill-opacity:1" />
+  <ellipse
+     cx="60.515858"
+     cy="99.239571"
+     fill="#007bff"
+     id="circle2"
+     rx="16.648861"
+     ry="17.65192"
+     style="stroke-width:1.71431;fill:#005533;fill-opacity:1" />
+  <ellipse
+     cx="93.813583"
+     cy="99.239571"
+     fill="#007bff"
+     id="circle3"
+     rx="16.648861"
+     ry="17.65192"
+     style="stroke-width:1.71431;fill:#005533;fill-opacity:1" />
+  <text
+     x="28.02607"
+     y="103.23593"
+     text-anchor="middle"
+     font-family="Arial"
+     font-size="17.1431px"
+     fill="#ffffff"
+     font-weight="bold"
+     id="text3"
+     transform="scale(0.97117223,1.0296835)"
+     style="stroke-width:1.71431">M</text>
+  <text
+     x="62.31218"
+     y="103.23593"
+     text-anchor="middle"
+     font-family="Arial"
+     font-size="17.1431px"
+     fill="#ffffff"
+     font-weight="bold"
+     id="text4"
+     transform="scale(0.97117223,1.0296835)"
+     style="stroke-width:1.71431">C</text>
+  <text
+     x="96.598289"
+     y="103.23593"
+     text-anchor="middle"
+     font-family="Arial"
+     font-size="17.1431px"
+     fill="#ffffff"
+     font-weight="bold"
+     id="text5"
+     transform="scale(0.97117223,1.0296835)"
+     style="stroke-width:1.71431">P</text>
+</svg>

--- a/frontend/src/components/ConnectModal.vue
+++ b/frontend/src/components/ConnectModal.vue
@@ -129,6 +129,9 @@ function clientIcon(client: ClientStatus): string {
     'cursor': '\u{1F4DD}',
     'vscode': '\u{1F4D0}',
     'windsurf': '\u{1F3C4}',
+    'opencode': '\u{1F9E0}',
+    'gemini': '\u264A',
+    'codex': '\u2318',
     'zed': '\u26A1',
     'cline': '\u{1F916}',
     'continue': '\u27A1\uFE0F',
@@ -163,9 +166,7 @@ async function connect(clientId: string) {
     if (response.success && response.data) {
       resultMessage.value = response.data.message || `Connected to ${clientId}`
       resultSuccess.value = true
-      // Update local state
-      const client = clients.value.find(c => c.id === clientId)
-      if (client) client.connected = true
+      await fetchClients()
       systemStore.addToast({
         type: 'success',
         title: 'Client Connected',
@@ -188,13 +189,12 @@ async function disconnect(clientId: string) {
   resultMessage.value = ''
 
   try {
-    const response = await api.disconnectClient(clientId)
+    const client = clients.value.find(c => c.id === clientId)
+    const response = await api.disconnectClient(clientId, client?.server_name || 'mcpproxy')
     if (response.success && response.data) {
       resultMessage.value = response.data.message || `Disconnected from ${clientId}`
       resultSuccess.value = true
-      // Update local state
-      const client = clients.value.find(c => c.id === clientId)
-      if (client) client.connected = false
+      await fetchClients()
       systemStore.addToast({
         type: 'info',
         title: 'Client Disconnected',

--- a/frontend/src/components/ConnectModal.vue
+++ b/frontend/src/components/ConnectModal.vue
@@ -129,7 +129,7 @@ function clientIcon(client: ClientStatus): string {
     'cursor': '\u{1F4DD}',
     'vscode': '\u{1F4D0}',
     'windsurf': '\u{1F3C4}',
-    'opencode': '\u{1F9E0}',
+    'opencode': '\u26A1',
     'gemini': '\u264A',
     'codex': '\u2318',
     'zed': '\u26A1',

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -805,9 +805,10 @@ class APIService {
     })
   }
 
-  async disconnectClient(clientId: string): Promise<APIResponse<ConnectResult>> {
+  async disconnectClient(clientId: string, serverName = 'mcpproxy'): Promise<APIResponse<ConnectResult>> {
     return this.request<ConnectResult>(`/api/v1/connect/${encodeURIComponent(clientId)}`, {
       method: 'DELETE',
+      body: JSON.stringify({ server_name: serverName }),
     })
   }
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -661,6 +661,7 @@ export interface ClientStatus {
   supported: boolean
   reason?: string
   icon: string
+  server_name?: string
 }
 
 export interface ConnectResult {

--- a/frontend/tests/unit/connect-modal.spec.ts
+++ b/frontend/tests/unit/connect-modal.spec.ts
@@ -49,7 +49,7 @@ describe('ConnectModal', () => {
     expect(wrapper.text()).toContain('/Users/test/.config/opencode/opencode.json')
   })
 
-  it('renders icons for OpenCode, Gemini, and Codex', async () => {
+  it('renders emoji icons for OpenCode, Gemini, and Codex', async () => {
     ;(api.getConnectStatus as any).mockResolvedValue({
       success: true,
       data: [
@@ -91,7 +91,7 @@ describe('ConnectModal', () => {
     await wrapper.setProps({ show: true })
     await flushPromises()
 
-    expect(wrapper.text()).toContain('🧠')
+    expect(wrapper.text()).toContain('⚡')
     expect(wrapper.text()).toContain('♊')
     expect(wrapper.text()).toContain('⌘')
   })

--- a/frontend/tests/unit/connect-modal.spec.ts
+++ b/frontend/tests/unit/connect-modal.spec.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import ConnectModal from '@/components/ConnectModal.vue'
+import api from '@/services/api'
+
+vi.mock('@/services/api', () => ({
+  default: {
+    getConnectStatus: vi.fn(),
+    connectClient: vi.fn(),
+    disconnectClient: vi.fn(),
+  },
+}))
+
+describe('ConnectModal', () => {
+  let pinia: any
+
+  beforeEach(() => {
+    pinia = createPinia()
+    setActivePinia(pinia)
+    ;(api.getConnectStatus as any).mockReset()
+    ;(api.connectClient as any).mockReset()
+    ;(api.disconnectClient as any).mockReset()
+  })
+
+  it('renders an OpenCode row', async () => {
+    ;(api.getConnectStatus as any).mockResolvedValue({
+      success: true,
+      data: [{
+        id: 'opencode',
+        name: 'OpenCode',
+        config_path: '/Users/test/.config/opencode/opencode.json',
+        exists: true,
+        connected: false,
+        supported: true,
+        icon: 'opencode',
+      }],
+    })
+
+    const wrapper = mount(ConnectModal, {
+      props: { show: false },
+      global: { plugins: [pinia] },
+    })
+
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('OpenCode')
+    expect(wrapper.text()).toContain('/Users/test/.config/opencode/opencode.json')
+  })
+
+  it('renders icons for OpenCode, Gemini, and Codex', async () => {
+    ;(api.getConnectStatus as any).mockResolvedValue({
+      success: true,
+      data: [
+        {
+          id: 'opencode',
+          name: 'OpenCode',
+          config_path: '/Users/test/.config/opencode/opencode.json',
+          exists: true,
+          connected: false,
+          supported: true,
+          icon: 'opencode',
+        },
+        {
+          id: 'gemini',
+          name: 'Gemini CLI',
+          config_path: '/Users/test/.gemini/settings.json',
+          exists: true,
+          connected: false,
+          supported: true,
+          icon: 'gemini',
+        },
+        {
+          id: 'codex',
+          name: 'Codex CLI',
+          config_path: '/Users/test/.codex/config.toml',
+          exists: true,
+          connected: false,
+          supported: true,
+          icon: 'codex',
+        },
+      ],
+    })
+
+    const wrapper = mount(ConnectModal, {
+      props: { show: false },
+      global: { plugins: [pinia] },
+    })
+
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('🧠')
+    expect(wrapper.text()).toContain('♊')
+    expect(wrapper.text()).toContain('⌘')
+  })
+
+  it('disconnect uses server_name alias when OpenCode status is adopted', async () => {
+    ;(api.getConnectStatus as any).mockResolvedValue({
+      success: true,
+      data: [{
+        id: 'opencode',
+        name: 'OpenCode',
+        config_path: '/Users/test/.config/opencode/opencode.json',
+        exists: true,
+        connected: true,
+        supported: true,
+        icon: 'opencode',
+        server_name: 'proxy-alt',
+      }],
+    })
+    const disconnectSpy = vi.spyOn(api, 'disconnectClient').mockResolvedValue({
+      success: true,
+      data: {
+        success: true,
+        client: 'opencode',
+        config_path: '',
+        server_name: 'proxy-alt',
+        action: 'removed',
+        message: 'ok',
+      },
+    } as any)
+
+    const wrapper = mount(ConnectModal, {
+      props: { show: false },
+      global: { plugins: [pinia] },
+    })
+
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    const button = wrapper.find('button.btn-ghost')
+    expect(button.exists()).toBe(true)
+    await button.trigger('click')
+    await flushPromises()
+
+    expect(disconnectSpy).toHaveBeenCalledWith('opencode', 'proxy-alt')
+  })
+})

--- a/internal/connect/clients.go
+++ b/internal/connect/clients.go
@@ -78,6 +78,14 @@ var allClients = []ClientDef{
 		Supported: true,
 		Icon:      "gemini",
 	},
+	{
+		ID:        "opencode",
+		Name:      "OpenCode",
+		Format:    "json",
+		ServerKey: "mcp",
+		Supported: true,
+		Icon:      "opencode",
+	},
 }
 
 // GetAllClients returns the definitions of all known clients.
@@ -154,6 +162,16 @@ func ConfigPath(clientID, homeDir string) string {
 	case "gemini":
 		return filepath.Join(homeDir, ".gemini", "settings.json")
 
+	case "opencode":
+		if runtime.GOOS == "windows" {
+			localAppData := os.Getenv("LOCALAPPDATA")
+			if localAppData == "" {
+				localAppData = filepath.Join(homeDir, "AppData", "Local")
+			}
+			return filepath.Join(localAppData, "opencode", "opencode.json")
+		}
+		return filepath.Join(homeDir, ".config", "opencode", "opencode.json")
+
 	default:
 		return ""
 	}
@@ -186,6 +204,11 @@ func buildServerEntry(clientID, mcpURL string) map[string]interface{} {
 	case "gemini":
 		return map[string]interface{}{
 			"httpUrl": mcpURL,
+		}
+	case "opencode":
+		return map[string]interface{}{
+			"type": "remote",
+			"url":  mcpURL,
 		}
 	default:
 		// Fallback: generic HTTP entry

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -132,6 +133,11 @@ func (s *Service) Connect(clientID, serverName string, force bool) (*ConnectResu
 	if cfgPath == "" {
 		return nil, fmt.Errorf("cannot determine config path for %s", clientID)
 	}
+	if client.ID == "opencode" {
+		if _, err := os.Stat(cfgPath); os.IsNotExist(err) {
+			return nil, fmt.Errorf("OpenCode config file %s does not exist", cfgPath)
+		}
+	}
 
 	mcpURL := s.mcpURL()
 
@@ -198,6 +204,23 @@ func (s *Service) connectJSON(client *ClientDef, cfgPath, serverName, mcpURL str
 		action = "updated"
 	}
 
+	if client.ID == "opencode" {
+		if adoptedName, found := findEquivalentJSONServerName(serversMap, mcpURL, serverName); found && adoptedName != serverName {
+			if !force {
+				return &ConnectResult{
+					Success:    true,
+					Client:     client.ID,
+					ConfigPath: cfgPath,
+					ServerName: adoptedName,
+					Action:     "already_exists",
+					Message:    fmt.Sprintf("%s already connected as %q", client.Name, adoptedName),
+				}, nil
+			}
+			delete(serversMap, adoptedName)
+			action = "updated"
+		}
+	}
+
 	// Create backup before modifying
 	backupPath, err := backupFile(cfgPath)
 	if err != nil {
@@ -253,7 +276,7 @@ func (s *Service) disconnectJSON(client *ClientDef, cfgPath, serverName string) 
 	}
 
 	var data map[string]interface{}
-	if err := json.Unmarshal(raw, &data); err != nil {
+	if err := unmarshalLenientJSON(raw, &data); err != nil {
 		return nil, fmt.Errorf("parse config: %w", err)
 	}
 
@@ -491,7 +514,7 @@ func readOrCreateJSON(path string) (map[string]interface{}, os.FileMode, error) 
 	}
 
 	var data map[string]interface{}
-	if err := json.Unmarshal(raw, &data); err != nil {
+	if err := unmarshalLenientJSON(raw, &data); err != nil {
 		return nil, perm, fmt.Errorf("parse JSON in %s: %w", path, err)
 	}
 
@@ -540,7 +563,7 @@ func verifyJSONEntry(path, serversKey, serverName string) error {
 		return fmt.Errorf("re-read %s: %w", path, err)
 	}
 	var data map[string]interface{}
-	if err := json.Unmarshal(raw, &data); err != nil {
+	if err := unmarshalLenientJSON(raw, &data); err != nil {
 		return fmt.Errorf("re-parse %s: %w", path, err)
 	}
 	serversMap, ok := data[serversKey].(map[string]interface{})
@@ -551,6 +574,29 @@ func verifyJSONEntry(path, serversKey, serverName string) error {
 		return fmt.Errorf("entry %q missing after write", serverName)
 	}
 	return nil
+}
+
+func findEquivalentJSONServerName(serversMap map[string]interface{}, mcpURL, requestedServerName string) (string, bool) {
+	baseURL := strings.SplitN(mcpURL, "?", 2)[0]
+	for name, rawEntry := range serversMap {
+		entry, ok := rawEntry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, field := range []string{"url", "serverUrl", "httpUrl"} {
+			entryURL, ok := entry[field].(string)
+			if !ok {
+				continue
+			}
+			if entryURL == mcpURL || entryURL == baseURL || strings.HasPrefix(entryURL, baseURL+"?") {
+				return name, true
+			}
+		}
+		if name == requestedServerName {
+			return name, true
+		}
+	}
+	return "", false
 }
 
 // findEntry checks whether a config file contains an mcpproxy-like entry.
@@ -570,7 +616,7 @@ func (s *Service) findEntryJSON(client ClientDef, cfgPath string) (string, bool)
 	}
 
 	var data map[string]interface{}
-	if err := json.Unmarshal(raw, &data); err != nil {
+	if err := unmarshalLenientJSON(raw, &data); err != nil {
 		return "", false
 	}
 
@@ -604,6 +650,16 @@ func (s *Service) findEntryJSON(client ClientDef, cfgPath string) (string, bool)
 	}
 
 	return "", false
+}
+
+var trailingCommaPattern = regexp.MustCompile(`,\s*([}\]])`)
+
+func unmarshalLenientJSON(raw []byte, out interface{}) error {
+	if err := json.Unmarshal(raw, out); err == nil {
+		return nil
+	}
+	cleaned := trailingCommaPattern.ReplaceAll(raw, []byte(`$1`))
+	return json.Unmarshal(cleaned, out)
 }
 
 // findEntryTOML looks for an entry in a TOML config that points to our MCP URL.

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -11,6 +11,48 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
+func TestConnect_OpenCode_AllowsTrailingCommaJSON(t *testing.T) {
+	svc, home := testService(t)
+	cfgPath := ConfigPath("opencode", home)
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cfgPath, []byte(`{
+	  "theme": "dark",
+	  "mcp": {
+	  },
+	}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := svc.Connect("opencode", "mcpproxy", false)
+	if err != nil {
+		t.Fatalf("expected OpenCode JSONC-style config to parse, got %v", err)
+	}
+	if !res.Success {
+		t.Fatalf("expected success, got %+v", res)
+	}
+
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var data map[string]interface{}
+	if err := json.Unmarshal(raw, &data); err != nil {
+		t.Fatalf("expected normalized strict JSON output, got %v", err)
+	}
+	if data["theme"] != "dark" {
+		t.Fatalf("expected theme preserved, got %v", data["theme"])
+	}
+	servers, ok := data["mcp"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected mcp object")
+	}
+	if _, ok := servers["mcpproxy"]; !ok {
+		t.Fatal("expected mcpproxy entry")
+	}
+}
+
 // helper to create a service pointing at a temp home directory
 func testService(t *testing.T) (*Service, string) {
 	t.Helper()
@@ -24,6 +66,161 @@ func testServiceWithKey(t *testing.T) (*Service, string) {
 	homeDir := t.TempDir()
 	svc := NewServiceWithHome("127.0.0.1:8080", "test-key-123", homeDir)
 	return svc, homeDir
+}
+
+func TestFindClient_OpenCode(t *testing.T) {
+	client := FindClient("opencode")
+	if client == nil {
+		t.Fatal("expected opencode client definition")
+	}
+	if client.Format != "json" {
+		t.Fatalf("expected json format, got %s", client.Format)
+	}
+	if client.ServerKey != "mcp" {
+		t.Fatalf("expected mcp key, got %s", client.ServerKey)
+	}
+}
+
+func TestConfigPath_OpenCode_GlobalConfigPath(t *testing.T) {
+	home := "/tmp/home"
+	path := ConfigPath("opencode", home)
+	if runtime.GOOS == "windows" {
+		expected := filepath.Join(home, "AppData", "Local", "opencode", "opencode.json")
+		if os.Getenv("LOCALAPPDATA") != "" {
+			expected = filepath.Join(os.Getenv("LOCALAPPDATA"), "opencode", "opencode.json")
+		}
+		if path != expected {
+			t.Fatalf("expected %s, got %s", expected, path)
+		}
+		return
+	}
+	expected := filepath.Join(home, ".config", "opencode", "opencode.json")
+	if path != expected {
+		t.Fatalf("expected %s, got %s", expected, path)
+	}
+}
+
+func TestConnect_OpenCode_RequiresExistingConfigFile(t *testing.T) {
+	svc, _ := testService(t)
+
+	_, err := svc.Connect("opencode", "", false)
+	if err == nil {
+		t.Fatal("expected missing-config error for OpenCode")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "does not exist") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestConnect_OpenCode_PreservesNonMCPRootKeys(t *testing.T) {
+	svc, home := testService(t)
+	cfgPath := ConfigPath("opencode", home)
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cfgPath, []byte(`{"theme":"dark","mcp":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := svc.Connect("opencode", "mcpproxy", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var data map[string]interface{}
+	if err := json.Unmarshal(raw, &data); err != nil {
+		t.Fatal(err)
+	}
+	if data["theme"] != "dark" {
+		t.Fatalf("expected theme preserved, got %v", data["theme"])
+	}
+}
+
+func TestConnect_OpenCode_AdoptsEquivalentEntryWithoutForce(t *testing.T) {
+	svc, home := testService(t)
+	cfgPath := ConfigPath("opencode", home)
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cfgPath, []byte(`{
+	  "mcp": {
+	    "proxy-alt": {"type":"remote","url":"http://127.0.0.1:8080/mcp"}
+	  }
+	}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := svc.Connect("opencode", "mcpproxy", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Success || res.Action != "already_exists" {
+		t.Fatalf("expected idempotent already_exists success, got %+v", res)
+	}
+	if res.ServerName != "proxy-alt" {
+		t.Fatalf("expected adopted name proxy-alt, got %s", res.ServerName)
+	}
+}
+
+func TestConnect_OpenCode_ForceNormalizesAdoptedName(t *testing.T) {
+	svc, home := testService(t)
+	cfgPath := ConfigPath("opencode", home)
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cfgPath, []byte(`{
+	  "mcp": {
+	    "proxy-alt": {"type":"remote","url":"http://127.0.0.1:8080/mcp"}
+	  }
+	}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := svc.Connect("opencode", "mcpproxy", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Success || res.Action != "updated" {
+		t.Fatalf("expected updated success, got %+v", res)
+	}
+
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "proxy-alt") {
+		t.Fatal("expected alias removed after normalization")
+	}
+	if !strings.Contains(string(raw), "mcpproxy") {
+		t.Fatal("expected canonical entry written after normalization")
+	}
+}
+
+func TestDisconnect_OpenCode_RemovesAdoptedAliasWhenSpecified(t *testing.T) {
+	svc, home := testService(t)
+	cfgPath := ConfigPath("opencode", home)
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cfgPath, []byte(`{
+	  "mcp": {
+	    "proxy-alt": {"type":"remote","url":"http://127.0.0.1:8080/mcp"}
+	  }
+	}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := svc.Disconnect("opencode", "proxy-alt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Success {
+		t.Fatalf("expected success, got %+v", res)
+	}
 }
 
 // ---------- JSON client tests ----------
@@ -760,8 +957,8 @@ func TestFindClient(t *testing.T) {
 
 func TestGetAllClients(t *testing.T) {
 	clients := GetAllClients()
-	if len(clients) != 7 {
-		t.Errorf("Expected 7 clients, got %d", len(clients))
+	if len(clients) != 8 {
+		t.Errorf("Expected 8 clients, got %d", len(clients))
 	}
 
 	// Verify all have non-empty IDs and names

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -57,6 +57,11 @@ func TestConnect_OpenCode_AllowsTrailingCommaJSON(t *testing.T) {
 func testService(t *testing.T) (*Service, string) {
 	t.Helper()
 	homeDir := t.TempDir()
+	// On Windows, ConfigPath("opencode", homeDir) reads %LOCALAPPDATA% from
+	// the real environment and only falls back to homeDir when the env is
+	// unset. Pin it under the test temp dir so the fallback path is the one
+	// that fires regardless of CI runner state. No-op on macOS/Linux.
+	t.Setenv("LOCALAPPDATA", filepath.Join(homeDir, "AppData", "Local"))
 	svc := NewServiceWithHome("127.0.0.1:8080", "", homeDir)
 	return svc, homeDir
 }
@@ -64,6 +69,7 @@ func testService(t *testing.T) (*Service, string) {
 func testServiceWithKey(t *testing.T) (*Service, string) {
 	t.Helper()
 	homeDir := t.TempDir()
+	t.Setenv("LOCALAPPDATA", filepath.Join(homeDir, "AppData", "Local"))
 	svc := NewServiceWithHome("127.0.0.1:8080", "test-key-123", homeDir)
 	return svc, homeDir
 }

--- a/internal/httpapi/connect_test.go
+++ b/internal/httpapi/connect_test.go
@@ -1,0 +1,105 @@
+package httpapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestHandleConnectClient_OpenCodeAdoptedAlreadyExistsReturns200(t *testing.T) {
+	logger := zap.NewNop().Sugar()
+	mockCtrl := &mockRoutingController{apiKey: "test-key", routingMode: "retrieve_tools"}
+	srv := NewServer(mockCtrl, logger, nil)
+	home := t.TempDir()
+	svc := connect.NewServiceWithHome("127.0.0.1:8080", "", home)
+	srv.SetConnectService(svc)
+
+	cfgPath := connect.ConfigPath("opencode", home)
+	require.NoError(t, os.MkdirAll(filepath.Dir(cfgPath), 0o755))
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`{"mcp":{"proxy-alt":{"type":"remote","url":"http://127.0.0.1:8080/mcp"}}}`), 0o644))
+
+	body, _ := json.Marshal(ConnectRequest{ServerName: "mcpproxy", Force: false})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/connect/opencode", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", "test-key")
+	w := httptest.NewRecorder()
+
+	srv.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Success bool                   `json:"success"`
+		Data    connect.ConnectResult  `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.True(t, resp.Success)
+	assert.Equal(t, "already_exists", resp.Data.Action)
+	assert.Equal(t, "proxy-alt", resp.Data.ServerName)
+}
+
+func TestHandleConnectClient_OpenCodeMissingConfigReturns400(t *testing.T) {
+	logger := zap.NewNop().Sugar()
+	mockCtrl := &mockRoutingController{apiKey: "test-key", routingMode: "retrieve_tools"}
+	srv := NewServer(mockCtrl, logger, nil)
+	srv.SetConnectService(connect.NewServiceWithHome("127.0.0.1:8080", "", t.TempDir()))
+
+	body, _ := json.Marshal(ConnectRequest{ServerName: "mcpproxy", Force: false})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/connect/opencode", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", "test-key")
+	w := httptest.NewRecorder()
+
+	srv.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var resp struct {
+		Success bool   `json:"success"`
+		Error   string `json:"error"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.False(t, resp.Success)
+	assert.Contains(t, resp.Error, "does not exist")
+}
+
+func TestHandleConnectClient_TrueConflictStillReturns409(t *testing.T) {
+	logger := zap.NewNop().Sugar()
+	mockCtrl := &mockRoutingController{apiKey: "test-key", routingMode: "retrieve_tools"}
+	srv := NewServer(mockCtrl, logger, nil)
+	home := t.TempDir()
+	svc := connect.NewServiceWithHome("127.0.0.1:8080", "", home)
+	srv.SetConnectService(svc)
+
+	_, err := svc.Connect("claude-code", "mcpproxy", false)
+	require.NoError(t, err)
+
+	body, _ := json.Marshal(ConnectRequest{ServerName: "mcpproxy", Force: false})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/connect/claude-code", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", "test-key")
+	w := httptest.NewRecorder()
+
+	srv.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusConflict, w.Code)
+
+	var resp struct {
+		Success bool                  `json:"success"`
+		Data    connect.ConnectResult `json:"data"`
+		Error   string                `json:"error"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.False(t, resp.Success)
+	assert.Equal(t, "already_exists", resp.Data.Action)
+	assert.NotEmpty(t, resp.Error)
+}

--- a/internal/httpapi/connect_test.go
+++ b/internal/httpapi/connect_test.go
@@ -20,6 +20,9 @@ func TestHandleConnectClient_OpenCodeAdoptedAlreadyExistsReturns200(t *testing.T
 	mockCtrl := &mockRoutingController{apiKey: "test-key", routingMode: "retrieve_tools"}
 	srv := NewServer(mockCtrl, logger, nil)
 	home := t.TempDir()
+	// Pin %LOCALAPPDATA% under the test temp dir so OpenCode's Windows
+	// config-path lookup uses the same root as homeDir. No-op on macOS/Linux.
+	t.Setenv("LOCALAPPDATA", filepath.Join(home, "AppData", "Local"))
 	svc := connect.NewServiceWithHome("127.0.0.1:8080", "", home)
 	srv.SetConnectService(svc)
 
@@ -38,8 +41,8 @@ func TestHandleConnectClient_OpenCodeAdoptedAlreadyExistsReturns200(t *testing.T
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var resp struct {
-		Success bool                   `json:"success"`
-		Data    connect.ConnectResult  `json:"data"`
+		Success bool                  `json:"success"`
+		Data    connect.ConnectResult `json:"data"`
 	}
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
 	assert.True(t, resp.Success)
@@ -51,7 +54,11 @@ func TestHandleConnectClient_OpenCodeMissingConfigReturns400(t *testing.T) {
 	logger := zap.NewNop().Sugar()
 	mockCtrl := &mockRoutingController{apiKey: "test-key", routingMode: "retrieve_tools"}
 	srv := NewServer(mockCtrl, logger, nil)
-	srv.SetConnectService(connect.NewServiceWithHome("127.0.0.1:8080", "", t.TempDir()))
+	home := t.TempDir()
+	// Pin %LOCALAPPDATA% under the test temp dir so OpenCode's Windows
+	// config-path lookup uses the same root as homeDir. No-op on macOS/Linux.
+	t.Setenv("LOCALAPPDATA", filepath.Join(home, "AppData", "Local"))
+	srv.SetConnectService(connect.NewServiceWithHome("127.0.0.1:8080", "", home))
 
 	body, _ := json.Marshal(ConnectRequest{ServerName: "mcpproxy", Force: false})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/connect/opencode", bytes.NewReader(body))


### PR DESCRIPTION
**Description**  
This PR adds OpenCode as a first-class connect/disconnect client across backend, CLI, and web UI, and tightens related client UX.

### What changed

<img width="1965" height="1684" alt="image" src="https://github.com/user-attachments/assets/ba5b3380-0b37-43ec-934c-fff3a91a7893" />

<img width="970" height="441" alt="image" src="https://github.com/user-attachments/assets/fde8507c-88bb-4a0a-b526-7e0e63c1671a" />

<img width="549" height="145" alt="image" src="https://github.com/user-attachments/assets/1b8fe1d2-c466-4032-9949-22d86c278d24" />

#### Backend
- Added `opencode` to the connect client registry
- Mapped OpenCode config to:
  - config path: `~/.config/opencode/opencode.json` on macOS/Linux
  - config section: `mcp`
- Enforced existing-file policy for OpenCode config
- Restricted OpenCode edits to the `mcp` subtree only
- Added endpoint-equivalent adoption logic for OpenCode entries
- Added alias-aware disconnect support via `server_name`
- Added lenient parsing for OpenCode-style trailing-comma JSON configs

#### API
- Added/covered connect handler behavior for:
  - adopted OpenCode entries returning idempotent success
  - missing OpenCode config returning `400`
  - true conflicts still returning `409`

#### CLI
- Included OpenCode in connect command help/registry coverage
- Added CLI test coverage for registry inclusion

#### Frontend
- Added `server_name?: string` to connect status typing
- Updated disconnect API calls to send optional alias `server_name`
- Updated Connect modal to:
  - support alias-aware disconnect
  - refresh status after connect/disconnect
  - render OpenCode with a lightning icon
- Added unit coverage for:
  - OpenCode row rendering
  - icon rendering
  - alias-aware disconnect

#### Favicon / browser tab icon
- Replaced default Vite favicon usage with project favicon setup
- Added `frontend/public/favicon.svg` based on `assets/logo.svg`
- Updated `frontend/index.html` to use the normal Vite public-asset favicon path

#### Docs
- Added OpenCode setup/connect documentation

---

### Verification
Ran and tested locally
