### PR TITLE
fix(secureenv): inherit user's interactive PATH so stdio servers find uvx/npx (closes #439)

### DIFF
--- a/internal/secureenv/docker_path_test.go
+++ b/internal/secureenv/docker_path_test.go
@@ -79,11 +79,19 @@ func TestDockerPathEnhancement(t *testing.T) {
 		assert.Contains(t, enhancedPath, "/usr/bin", "Enhanced PATH should preserve original /usr/bin")
 		assert.Contains(t, enhancedPath, "/bin", "Enhanced PATH should preserve original /bin")
 
-		// Should prioritize discovered paths (they should come first)
+		// Should add at least one entry beyond the original two-element PATH.
 		pathParts := strings.Split(enhancedPath, ":")
 		assert.True(t, len(pathParts) > 2, "Enhanced PATH should have more entries than original")
 
-		// /usr/local/bin should come before the original paths for priority
+		// /usr/local/bin must end up in the result. Position relative to
+		// /usr/bin is intentionally not asserted: post-#439 the compose
+		// order is `login-shell PATH → discovered → existing`, so the
+		// final position depends on what the user's login shell exposes.
+		// On a host where login-shell capture doesn't enrich the ambient
+		// PATH (e.g. CI runners where bash -l -c does not pull in
+		// /etc/environment), /usr/local/bin is still added (via
+		// discovery) but ranks after /usr/bin — that is fine for tool
+		// resolution.
 		localBinIndex := -1
 		usrBinIndex := -1
 		for i, part := range pathParts {
@@ -97,7 +105,6 @@ func TestDockerPathEnhancement(t *testing.T) {
 
 		assert.True(t, localBinIndex >= 0, "/usr/local/bin should be in the PATH")
 		assert.True(t, usrBinIndex >= 0, "/usr/bin should be in the PATH")
-		assert.True(t, localBinIndex < usrBinIndex, "/usr/local/bin should come before /usr/bin for priority")
 	})
 
 	t.Run("PATH enhancement skipped for comprehensive paths", func(t *testing.T) {

--- a/internal/secureenv/launchd_path_test.go
+++ b/internal/secureenv/launchd_path_test.go
@@ -1,0 +1,244 @@
+package secureenv
+
+import (
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLaunchdMinimalPath_Enhancement reproduces issue #439: when MCPProxy is
+// launched from Finder / Dock / a LoginItem, launchd hands the process a
+// 4-element PATH ("/usr/bin:/bin:/usr/sbin:/sbin"). Pre-fix, the
+// `len(pathParts) <= 2` gate in buildEnhancedPath blocked enhancement, so
+// stdio servers couldn't find tools like uvx/npx in /usr/local/bin or
+// /opt/homebrew/bin.
+func TestLaunchdMinimalPath_Enhancement(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("launchd PATH semantics are macOS/Linux-only")
+	}
+
+	originalEnv := os.Environ()
+	defer func() {
+		os.Clearenv()
+		for _, env := range originalEnv {
+			parts := strings.SplitN(env, "=", 2)
+			if len(parts) == 2 {
+				os.Setenv(parts[0], parts[1])
+			}
+		}
+	}()
+
+	// Override loginShellPATHFn so the test does not actually fork a shell
+	// and the captured value is deterministic.
+	t.Cleanup(withFakeLoginShellPath(""))
+
+	// Exact PATH that launchd hands a GUI-launched app on macOS — 4 entries,
+	// none of which contain uvx/npx/brew binaries.
+	os.Clearenv()
+	os.Setenv("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+	os.Setenv("HOME", "/tmp/test-home")
+
+	manager := NewManager(&EnvConfig{
+		InheritSystemSafe: true,
+		AllowedSystemVars: []string{"PATH", "HOME"},
+		EnhancePath:       true,
+	})
+
+	envVars := manager.BuildSecureEnvironment()
+	pathVal := getPATH(envVars)
+	require.NotEmpty(t, pathVal, "PATH must be present in built environment")
+
+	parts := strings.Split(pathVal, ":")
+	assert.Greater(t, len(parts), 4, "launchd 4-element PATH must be enhanced — gate was blocking enhancement before the fix")
+
+	// At least one of /usr/local/bin or /opt/homebrew/bin should be in the
+	// result on a normal dev machine. We accept either to keep the test
+	// portable across Intel and Apple Silicon hosts (and CI).
+	hasHomebrew := false
+	for _, dir := range []string{"/usr/local/bin", "/opt/homebrew/bin"} {
+		if _, err := os.Stat(dir); err == nil {
+			assert.Contains(t, pathVal, dir,
+				"existing tool directory %s must be added to enhanced PATH", dir)
+			hasHomebrew = true
+		}
+	}
+	if !hasHomebrew {
+		t.Skip("no /usr/local/bin or /opt/homebrew/bin on this system; cannot assert tool-dir presence")
+	}
+
+	// Original launchd entries must be preserved.
+	assert.Contains(t, pathVal, "/usr/bin")
+	assert.Contains(t, pathVal, "/bin")
+}
+
+// TestLaunchdMinimalPath_LoginShellPathPriority verifies that user-specific
+// tool paths (Colima / mise / asdf / pyenv shims / custom installs) captured
+// from the user's interactive login shell get merged into the enhanced PATH
+// and rank ahead of the launchd-minimal entries.
+func TestLaunchdMinimalPath_LoginShellPathPriority(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("launchd PATH semantics are macOS/Linux-only")
+	}
+
+	originalEnv := os.Environ()
+	defer func() {
+		os.Clearenv()
+		for _, env := range originalEnv {
+			parts := strings.SplitN(env, "=", 2)
+			if len(parts) == 2 {
+				os.Setenv(parts[0], parts[1])
+			}
+		}
+	}()
+
+	// Pretend the user's login shell exposes mise + a custom dir that no
+	// static-discovery list would ever guess.
+	loginShellPATH := "/Users/test/.local/share/mise/shims:/Users/test/.colima/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+	t.Cleanup(withFakeLoginShellPath(loginShellPATH))
+
+	os.Clearenv()
+	os.Setenv("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+	os.Setenv("HOME", "/tmp/test-home")
+
+	manager := NewManager(&EnvConfig{
+		InheritSystemSafe: true,
+		AllowedSystemVars: []string{"PATH", "HOME"},
+		EnhancePath:       true,
+	})
+
+	pathVal := getPATH(manager.BuildSecureEnvironment())
+	require.NotEmpty(t, pathVal)
+
+	// The mise shim path must be in the result — only the login-shell
+	// capture would have surfaced it.
+	assert.Contains(t, pathVal, "/Users/test/.local/share/mise/shims",
+		"login-shell PATH entries must be merged into the enhanced PATH (issue #439)")
+	assert.Contains(t, pathVal, "/Users/test/.colima/bin",
+		"login-shell PATH entries must be merged into the enhanced PATH (issue #439)")
+
+	// Login-shell entries must rank ahead of launchd-minimal entries so
+	// `which uvx` resolves the user's preferred toolchain version.
+	parts := strings.Split(pathVal, ":")
+	idxMise := indexOf(parts, "/Users/test/.local/share/mise/shims")
+	idxBin := indexOf(parts, "/bin")
+	require.GreaterOrEqual(t, idxMise, 0, "mise shim must be present")
+	require.GreaterOrEqual(t, idxBin, 0, "/bin must be present")
+	assert.Less(t, idxMise, idxBin, "login-shell entries must come before launchd-minimal entries")
+
+	// No duplicates.
+	seen := make(map[string]bool)
+	for _, p := range parts {
+		assert.False(t, seen[p], "duplicate PATH segment %q in %q", p, pathVal)
+		seen[p] = true
+	}
+}
+
+// TestLaunchdMinimalPath_NoLoginShellAvailable covers the "fresh macOS
+// account, no rc files" case — login-shell capture returns "" so we must
+// still produce a usable PATH from static discovery alone.
+func TestLaunchdMinimalPath_NoLoginShellAvailable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("launchd PATH semantics are macOS/Linux-only")
+	}
+
+	originalEnv := os.Environ()
+	defer func() {
+		os.Clearenv()
+		for _, env := range originalEnv {
+			parts := strings.SplitN(env, "=", 2)
+			if len(parts) == 2 {
+				os.Setenv(parts[0], parts[1])
+			}
+		}
+	}()
+
+	t.Cleanup(withFakeLoginShellPath(""))
+
+	os.Clearenv()
+	os.Setenv("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+	os.Setenv("HOME", "/tmp/test-home")
+
+	manager := NewManager(&EnvConfig{
+		InheritSystemSafe: true,
+		AllowedSystemVars: []string{"PATH", "HOME"},
+		EnhancePath:       true,
+	})
+
+	pathVal := getPATH(manager.BuildSecureEnvironment())
+	require.NotEmpty(t, pathVal)
+	parts := strings.Split(pathVal, ":")
+	assert.Greater(t, len(parts), 4, "even without login-shell capture, static discovery must enhance the launchd-minimal PATH")
+}
+
+// TestLaunchdMinimalPath_AlreadyComprehensive verifies the existing
+// behaviour: when PATH is already comprehensive (contains /usr/local/bin or
+// /opt/homebrew/bin), do not touch it. Same as the existing
+// "PATH enhancement skipped for comprehensive paths" test, restated for
+// clarity in the launchd context.
+func TestLaunchdMinimalPath_AlreadyComprehensive(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("launchd PATH semantics are macOS/Linux-only")
+	}
+
+	originalEnv := os.Environ()
+	defer func() {
+		os.Clearenv()
+		for _, env := range originalEnv {
+			parts := strings.SplitN(env, "=", 2)
+			if len(parts) == 2 {
+				os.Setenv(parts[0], parts[1])
+			}
+		}
+	}()
+
+	// Even if the user has a rich login-shell PATH, a process started from a
+	// terminal (with /usr/local/bin already on PATH) should be left alone.
+	t.Cleanup(withFakeLoginShellPath("/Users/test/.local/share/mise/shims:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"))
+
+	comprehensivePath := "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+	os.Clearenv()
+	os.Setenv("PATH", comprehensivePath)
+	os.Setenv("HOME", "/tmp/test-home")
+
+	manager := NewManager(&EnvConfig{
+		InheritSystemSafe: true,
+		AllowedSystemVars: []string{"PATH", "HOME"},
+		EnhancePath:       true,
+	})
+
+	pathVal := getPATH(manager.BuildSecureEnvironment())
+	assert.Equal(t, comprehensivePath, pathVal,
+		"comprehensive PATH must be returned unchanged — terminal-launched processes should not be polluted by login-shell capture")
+}
+
+// --- test helpers --------------------------------------------------------
+
+// withFakeLoginShellPath swaps loginShellPATHFn for a stub returning `path`.
+// Returns a cleanup function suitable for t.Cleanup.
+func withFakeLoginShellPath(path string) func() {
+	prev := loginShellPATHFn
+	loginShellPATHFn = func() string { return path }
+	return func() { loginShellPATHFn = prev }
+}
+
+func getPATH(envVars []string) string {
+	for _, kv := range envVars {
+		if strings.HasPrefix(kv, "PATH=") {
+			return strings.TrimPrefix(kv, "PATH=")
+		}
+	}
+	return ""
+}
+
+func indexOf(parts []string, target string) int {
+	for i, p := range parts {
+		if p == target {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/secureenv/manager.go
+++ b/internal/secureenv/manager.go
@@ -4,7 +4,14 @@ import (
 	"os"
 	"runtime"
 	"strings"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/shellwrap"
 )
+
+// loginShellPATHFn captures the user's interactive login-shell $PATH.
+// Overridable in tests. Default delegates to shellwrap.LoginShellPATH which
+// caches the result for the process lifetime via sync.Once.
+var loginShellPATHFn = func() string { return shellwrap.LoginShellPATH(nil) }
 
 const (
 	osWindows = "windows"
@@ -195,11 +202,11 @@ func (m *Manager) discoverWindowsPaths() []string {
 
 	if homeDir != "" {
 		commonPaths = append(commonPaths,
-			homeDir+`\.cargo\bin`,                                    // Rust tools (cargo, uv)
-			homeDir+`\.local\bin`,                                    // Python user scripts
-			homeDir+`\go\bin`,                                        // Go binaries
-			homeDir+`\AppData\Roaming\npm`,                           // npm globals
-			homeDir+`\scoop\shims`,                                   // Scoop packages
+			homeDir+`\.cargo\bin`,          // Rust tools (cargo, uv)
+			homeDir+`\.local\bin`,          // Python user scripts
+			homeDir+`\go\bin`,              // Go binaries
+			homeDir+`\AppData\Roaming\npm`, // npm globals
+			homeDir+`\scoop\shims`,         // Scoop packages
 			homeDir+`\AppData\Local\Programs\Python\Python313\Scripts`, // Python 3.13
 			homeDir+`\AppData\Local\Programs\Python\Python312\Scripts`, // Python 3.12
 			homeDir+`\AppData\Local\Programs\Python\Python311\Scripts`, // Python 3.11
@@ -268,70 +275,78 @@ func (m *Manager) ensureComprehensivePath(envVars []string) []string {
 	return envVars
 }
 
-// buildEnhancedPath builds a comprehensive PATH by combining existing path with discovered paths
+// buildEnhancedPath builds a comprehensive PATH by combining (in priority
+// order) the user's interactive login-shell PATH, statically-discovered
+// well-known tool directories, and the existing PATH inherited from the
+// parent process.
+//
+// Enhancement is gated on EnvConfig.EnhancePath being explicitly opted in
+// (true today only for stdio upstream servers — see core/client.go) and on
+// the existing PATH NOT already containing a comprehensive tool directory.
+// Issue #439: the previous gate `len(pathParts) <= 2` blocked enhancement
+// for the launchd-handed `/usr/bin:/bin:/usr/sbin:/sbin` (4 entries), which
+// is exactly the bad PATH that triggers the bug. We drop that gate and
+// instead rely on login-shell capture + static discovery to enrich PATH
+// whenever it lacks /usr/local/bin or /opt/homebrew/bin.
 func (m *Manager) buildEnhancedPath(existingPath string) string {
-	// If existing path is empty, use discovered paths
+	sep := string(os.PathListSeparator)
+
 	if existingPath == "" {
-		return strings.Join(m.pathDiscovery.DiscoveredPaths, string(os.PathListSeparator))
+		return strings.Join(m.pathDiscovery.DiscoveredPaths, sep)
 	}
 
-	// Check if the existing PATH is missing common tool directories
-	// This indicates a Launchd-style minimal environment
-	pathParts := strings.Split(existingPath, string(os.PathListSeparator))
+	pathParts := strings.Split(existingPath, sep)
 
-	// Look for common tool directories that should contain Docker, etc.
+	// If PATH already contains a common tool directory the user is fine —
+	// don't pollute their carefully-set PATH with login-shell capture.
 	commonToolDirs := []string{"/usr/local/bin", "/opt/homebrew/bin"}
 	if runtime.GOOS == osWindows {
 		commonToolDirs = []string{`C:\Program Files\Docker\Docker\resources\bin`}
 	}
-
-	hasCommonToolDirs := false
 	for _, toolDir := range commonToolDirs {
 		for _, pathPart := range pathParts {
 			if pathPart == toolDir {
-				hasCommonToolDirs = true
-				break
+				return existingPath
 			}
-		}
-		if hasCommonToolDirs {
-			break
 		}
 	}
 
-	// Only enhance if explicitly enabled AND we're missing common tool directories AND the path is minimal
-	// This specifically targets Launchd scenarios while preserving normal behavior by default
-	shouldEnhance := m.config.EnhancePath && !hasCommonToolDirs && len(pathParts) <= 2
-	if shouldEnhance {
-		// Start with discovered paths for better tool discovery
-		enhancedParts := make([]string, 0, len(m.pathDiscovery.DiscoveredPaths)+len(pathParts))
-
-		// Add discovered paths first (prioritize them)
-		for _, discoveredPath := range m.pathDiscovery.DiscoveredPaths {
-			// Avoid duplicates
-			found := false
-			for _, existingPart := range pathParts {
-				if existingPart == discoveredPath {
-					found = true
-					break
-				}
-			}
-			if !found {
-				enhancedParts = append(enhancedParts, discoveredPath)
-			}
-		}
-
-		// Add existing path parts
-		for _, part := range pathParts {
-			if part != "" {
-				enhancedParts = append(enhancedParts, part)
-			}
-		}
-
-		return strings.Join(enhancedParts, string(os.PathListSeparator))
+	if !m.config.EnhancePath {
+		return existingPath
 	}
 
-	// For paths that already have common tool directories or are comprehensive, use as-is
-	return existingPath
+	// Compose: login-shell PATH first (highest priority — captures the
+	// user's actual interactive PATH including mise/asdf/Colima/custom
+	// shims), then statically-discovered well-known directories (deterministic
+	// floor when login-shell capture is empty / contaminated / unavailable),
+	// then the existing PATH (preserves anything the operator deliberately
+	// set on the daemon).
+	enhancedParts := make([]string, 0, len(m.pathDiscovery.DiscoveredPaths)+len(pathParts)+8)
+	seen := make(map[string]struct{}, len(enhancedParts))
+	add := func(p string) {
+		if p == "" {
+			return
+		}
+		if _, ok := seen[p]; ok {
+			return
+		}
+		seen[p] = struct{}{}
+		enhancedParts = append(enhancedParts, p)
+	}
+
+	if loginShellPATHFn != nil {
+		for _, p := range strings.Split(loginShellPATHFn(), sep) {
+			add(p)
+		}
+	}
+	for _, p := range m.pathDiscovery.DiscoveredPaths {
+		add(p)
+	}
+	for _, p := range pathParts {
+		add(p)
+	}
+
+	return strings.Join(enhancedParts, sep)
 }
 
 // getFilteredSystemEnv retrieves allowed environment variables from the system

--- a/internal/shellwrap/shellwrap.go
+++ b/internal/shellwrap/shellwrap.go
@@ -322,6 +322,31 @@ var (
 //
 // Callers should treat an empty return value as "no override available"
 // and fall back to os.Getenv("PATH").
+// loginShellPATHMarkerBegin / loginShellPATHMarkerEnd bracket the captured
+// PATH inside the shell's stdout. The markers let us pluck the real PATH
+// out of arbitrary banner / motd / oh-my-zsh / direnv output that login-rc
+// files routinely emit on stdout. See issue #439.
+//
+// The strings are deliberately unlikely to appear in any rc-file banner.
+const (
+	loginShellPATHMarkerBegin = "__MCPPROXY_LOGIN_PATH_BEGIN__"
+	loginShellPATHMarkerEnd   = "__MCPPROXY_LOGIN_PATH_END__"
+)
+
+// extractLoginShellPATH parses the stdout of the login-shell capture command
+// and returns the PATH between the begin/end markers. If the markers are
+// absent (e.g. test fakes that ignore `-c`), it falls back to the trimmed
+// stdout for backward compatibility. Returns "" if no usable value is found.
+func extractLoginShellPATH(stdout string) string {
+	if i := strings.Index(stdout, loginShellPATHMarkerBegin); i >= 0 {
+		rest := stdout[i+len(loginShellPATHMarkerBegin):]
+		if j := strings.Index(rest, loginShellPATHMarkerEnd); j >= 0 {
+			return rest[:j]
+		}
+	}
+	return strings.TrimSpace(stdout)
+}
+
 func LoginShellPATH(logger *zap.Logger) string {
 	loginShellPathOnce.Do(func() {
 		if runtime.GOOS == osWindows {
@@ -330,11 +355,18 @@ func LoginShellPATH(logger *zap.Logger) string {
 		shell := resolveLoginShell()
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		// `-l -c 'printf %s "$PATH"'` works on bash, zsh, dash, sh.
+		// Bracket the captured PATH with unique markers so banner output
+		// emitted by rc files (welcome messages, oh-my-zsh updates,
+		// direnv hooks, motd, etc.) does NOT leak into the value we
+		// hand back to callers. Without markers the captured stdout
+		// becomes "Welcome banner/usr/local/bin:…" — exec.LookPath then
+		// can't resolve anything.
+		//
 		// We deliberately build the argv ourselves rather than going
 		// through WrapWithUserShell because shellescape would quote
 		// the `$PATH` and suppress expansion.
-		cmd := exec.CommandContext(ctx, shell, "-l", "-c", `printf %s "$PATH"`)
+		script := `printf '` + loginShellPATHMarkerBegin + `%s` + loginShellPATHMarkerEnd + `' "$PATH"`
+		cmd := exec.CommandContext(ctx, shell, "-l", "-c", script)
 		out, err := cmd.Output()
 		if err != nil {
 			if logger != nil {
@@ -344,7 +376,7 @@ func LoginShellPATH(logger *zap.Logger) string {
 			}
 			return
 		}
-		captured := strings.TrimSpace(string(out))
+		captured := extractLoginShellPATH(string(out))
 		if captured == "" {
 			return
 		}

--- a/internal/shellwrap/shellwrap_test.go
+++ b/internal/shellwrap/shellwrap_test.go
@@ -315,6 +315,57 @@ func writeFakeShell(t *testing.T, dir, wantPath string) string {
 	return p
 }
 
+// writeFakeRealShell writes a POSIX shell script that simulates a real login
+// shell: it prints `bannerOutput` on stdout (mimicking rc-file welcome
+// banners, oh-my-zsh updates, etc.) and then evaluates whatever command
+// follows `-c` so the caller's `printf …` actually runs in a context where
+// PATH is whatever the parent process set.
+func writeFakeRealShell(t *testing.T, dir, bannerOutput string) string {
+	t.Helper()
+	// Use a heredoc-ish embedding so the banner can contain arbitrary text.
+	// The script prints the banner verbatim, then walks its arg list looking
+	// for `-c <cmd>` and evaluates <cmd>.
+	script := `#!/bin/sh
+printf '%s' "$BANNER"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -l|--login) shift ;;
+    -c) shift; eval "$1"; shift ;;
+    *) shift ;;
+  esac
+done
+`
+	p := filepath.Join(dir, "fake-real-shell")
+	require.NoError(t, os.WriteFile(p, []byte(script), 0o755))
+	t.Setenv("BANNER", bannerOutput)
+	return p
+}
+
+func TestLoginShellPATH_StripsBannerContamination(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-only")
+	}
+	resetLoginShellPathCacheForTest()
+	t.Cleanup(resetLoginShellPathCacheForTest)
+
+	// Simulate an rc file that prints noisy banner output before our
+	// printf marker — real-world examples: oh-my-zsh "auto-update" line,
+	// motd, fortune, direnv hook, "Loading nvm…" messages.
+	banner := "Last login: Wed Apr 30 12:34 on ttys000\noh-my-zsh: Updating…\n"
+	dir := t.TempDir()
+	fake := writeFakeRealShell(t, dir, banner)
+	t.Setenv("SHELL", fake)
+	// Set the PATH the fake shell will see — this is what our printf must
+	// emit, untouched by the banner.
+	t.Setenv("PATH", "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin")
+
+	got := LoginShellPATH(nil)
+	assert.Equal(t, "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin", got,
+		"LoginShellPATH must strip rc-file banner output and return only $PATH")
+	assert.NotContains(t, got, "oh-my-zsh", "banner content must not leak into PATH")
+	assert.NotContains(t, got, "Last login", "banner content must not leak into PATH")
+}
+
 func TestLoginShellPATH_CapturesFromShell(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("login-shell PATH capture is Unix-only")


### PR DESCRIPTION
## Summary
Closes #439. When MCPProxy launches from a macOS `.app` bundle (Finder, Dock, Login Item), launchd hands the process `PATH=/usr/bin:/bin:/usr/sbin:/sbin` (4 entries). Stdio MCP servers then can't resolve `uvx`, `npx`, `node`, `brew`, etc., because none of those live on the system-bin set.

The existing PATH-enhancement gate `len(pathParts) <= 2` (in `internal/secureenv/manager.go`) blocked enhancement for that 4-entry launchd PATH, so enhancement never triggered for the headline scenario in the issue. PR #420 was a related fix but only covered the PKG postinstall launch path.

## What this PR changes

- **Drop the `len(pathParts) <= 2` gate.** `EnhancePath` is already an explicit opt-in (set only for stdio upstreams in `internal/upstream/core/client.go:155`); the additional path-length condition was redundant and turned out to be the bug.
- **Merge in the user's interactive login-shell PATH** via `shellwrap.LoginShellPATH` so non-standard installs (mise/asdf/Colima/custom shims) get picked up — not just `/usr/local/bin` and `/opt/homebrew/bin`. The login-shell capture is already cached process-wide via `sync.Once`.
- **Harden `shellwrap.LoginShellPATH` against rc-file banner contamination.** Bracket the captured `$PATH` with unique markers so welcome messages / oh-my-zsh updates / motd lines on stdout don't get prepended onto the value. Previously, banner output mixed with PATH made `exec.LookPath` fail to resolve anything.

The new compose order in `buildEnhancedPath`: login-shell PATH → static-discovery → existing PATH. Static discovery acts as a deterministic floor when login-shell capture is unavailable / contaminated / shell-less. PATHs already containing `/usr/local/bin` or `/opt/homebrew/bin` are returned untouched (terminal launches stay clean).

## Test plan
- [x] `go test ./internal/secureenv/... ./internal/shellwrap/... -count=1 -race` — all green, including new tests
- [x] `go test ./internal/upstream/...` — green
- [x] `go build ./cmd/mcpproxy` (personal) and `go build -tags server ./cmd/mcpproxy` (server) — both clean
- [x] `./scripts/run-linter.sh` — 0 issues
- [x] **Local repro on macOS:** `env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin HOME=$HOME ./mcpproxy serve …` with a `npx`-based stdio server connects + initializes. A focused demo program shows `BuildSecureEnvironment()` returns 14 PATH entries (resolving `uvx`/`npx`/`node`/`brew`) under launchd-minimal input; on `main` the same scenario yields the unchanged 4-entry PATH and all four tools fail to resolve.

## New tests
- `internal/secureenv/launchd_path_test.go` — launchd 4-entry PATH must be enhanced; login-shell entries rank ahead of launchd-minimal ones; static discovery still works when login-shell capture is empty; comprehensive PATH is left untouched.
- `internal/shellwrap/shellwrap_test.go` (`TestLoginShellPATH_StripsBannerContamination`) — banner stdout from rc files is rejected by the marker parser; only the bracketed `$PATH` value is returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)