### PR TITLE
fix(upstream): docker recovery survives launchd minimal PATH + stale state

### DIFF
--- a/internal/upstream/manager.go
+++ b/internal/upstream/manager.go
@@ -15,12 +15,29 @@ import (
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/oauth"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/secret"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/shellwrap"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/transport"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/upstream/core"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/upstream/managed"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/upstream/types"
 )
+
+// dockerResolverFn returns the absolute path to the docker binary, or "" with
+// an error if it cannot be resolved. Overridable in tests.
+//
+// The default implementation delegates to shellwrap.ResolveDockerPath which
+// (a) tries exec.LookPath, (b) probes well-known install locations
+// (/Applications/Docker.app/..., /usr/local/bin/docker, /opt/homebrew/bin/docker,
+// ~/.docker/bin, ~/.orbstack/bin, /opt/podman/bin, …), and (c) finally asks the
+// user's login shell `command -v docker` for non-standard installs (mise, asdf,
+// Colima). This matters when mcpproxy boots from a macOS .app bundle / LoginItem
+// where launchd hands the parent process a minimal PATH=/usr/bin:/bin:/usr/sbin:/sbin
+// — bare exec.Command("docker") fails with `executable file not found in $PATH`
+// even though docker is installed at a standard location.
+var dockerResolverFn = func(logger *zap.Logger) (string, error) {
+	return shellwrap.ResolveDockerPath(logger)
+}
 
 // Docker recovery constants - internal implementation defaults
 const (
@@ -33,6 +50,21 @@ const (
 	dockerRetryInterval5     = 60 * time.Second // Fifth+ retry (max backoff)
 	dockerHealthCheckTimeout = 3 * time.Second  // Timeout for docker info command
 )
+
+// freshenLoadedDockerRecoveryState clears per-process retry counters from a
+// recovery state loaded from persistent storage at process startup. The
+// persisted FailureCount / AttemptsSinceUp / RecoveryMode describe the previous
+// process's situation; the new process must not inherit them as a depleted
+// retry budget. Telemetry fields (LastSuccessfulAt, LastError, LastAttempt,
+// DockerAvailable) are preserved so operators can still see the prior state.
+func freshenLoadedDockerRecoveryState(state *storage.DockerRecoveryState) {
+	if state == nil {
+		return
+	}
+	state.FailureCount = 0
+	state.AttemptsSinceUp = 0
+	state.RecoveryMode = false
+}
 
 // getDockerRetryInterval returns the retry interval for a given attempt number (exponential backoff)
 func getDockerRetryInterval(attempt int) time.Duration {
@@ -2041,13 +2073,22 @@ func (m *Manager) startDockerRecoveryMonitor(ctx context.Context) {
 	defer m.shutdownWg.Done()
 	m.logger.Info("Starting Docker recovery monitor")
 
-	// Load existing recovery state (always persist for reliability)
+	// Load existing recovery state (always persist for reliability) but reset
+	// per-process retry counters. The persisted FailureCount belongs to the
+	// previous process — if it bled out at the retry limit, the new process
+	// would otherwise hit `attempt >= maxRetries` on its very first probe and
+	// give up without ever sleeping, producing the "10 attempts in 5ms" log
+	// pattern. A fresh boot deserves a fresh retry budget; the loaded state
+	// is kept only for telemetry (LastSuccessfulAt, LastError).
 	if m.storageMgr != nil {
 		if state, err := m.storageMgr.LoadDockerRecoveryState(); err == nil && state != nil {
+			previousFailureCount := state.FailureCount
+			freshenLoadedDockerRecoveryState(state)
 			m.dockerRecoveryMu.Lock()
 			m.dockerRecoveryState = state
 			m.dockerRecoveryMu.Unlock()
 			m.logger.Info("Loaded existing Docker recovery state",
+				zap.Int("previous_failure_count", previousFailureCount),
 				zap.Int("failure_count", state.FailureCount),
 				zap.Bool("docker_available", state.DockerAvailable),
 				zap.Time("last_attempt", state.LastAttempt))
@@ -2090,12 +2131,27 @@ func (m *Manager) startDockerRecoveryMonitor(ctx context.Context) {
 	}
 }
 
-// checkDockerAvailability checks if Docker daemon is running and responsive
+// checkDockerAvailability checks if Docker daemon is running and responsive.
+//
+// Resolves the docker binary via dockerResolverFn (shellwrap-backed by default)
+// rather than relying on the parent process's $PATH. This is essential when
+// mcpproxy is launched from a macOS .app bundle / LoginItem: launchd hands the
+// process PATH=/usr/bin:/bin:/usr/sbin:/sbin and a bare exec.Command("docker")
+// would fail with `executable file not found in $PATH` even though docker is
+// installed at /Applications/Docker.app/... or /usr/local/bin/docker.
 func (m *Manager) checkDockerAvailability(ctx context.Context) error {
 	checkCtx, cancel := context.WithTimeout(ctx, dockerHealthCheckTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(checkCtx, "docker", "info", "--format", "{{json .ServerVersion}}")
+	dockerBin, resolveErr := dockerResolverFn(m.logger)
+	if resolveErr != nil || dockerBin == "" {
+		// Fall back to bare "docker" — exec will surface the same lookup error
+		// the previous code path would have produced, preserving error behaviour
+		// when shellwrap also cannot find a docker binary anywhere.
+		dockerBin = "docker"
+	}
+
+	cmd := exec.CommandContext(checkCtx, dockerBin, "info", "--format", "{{json .ServerVersion}}")
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("docker unavailable: %w", err)
 	}

--- a/internal/upstream/manager_docker_recovery_test.go
+++ b/internal/upstream/manager_docker_recovery_test.go
@@ -1,0 +1,154 @@
+package upstream
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
+)
+
+// TestCheckDockerAvailability_UsesShellwrapResolver verifies that a launchd-style
+// minimal PATH (the situation when mcpproxy is launched from /Applications/...app
+// or a LoginItem) does not break docker lookup, because checkDockerAvailability
+// now goes through dockerResolverFn (shellwrap-backed) instead of relying on
+// $PATH for the bare "docker" binary.
+//
+// We exercise the real resolver indirectly: the test installs a fake docker
+// shim into a temp dir, points dockerResolverFn at it, drops $PATH to the
+// launchd minimum, and asserts that checkDockerAvailability still succeeds.
+// Without the fix, exec.Command("docker") would error with `executable file
+// not found in $PATH` regardless of how the resolver was wired.
+func TestCheckDockerAvailability_UsesShellwrapResolver(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("launchd PATH scenario is macOS/Linux only")
+	}
+
+	tmpDir := t.TempDir()
+	dockerPath := filepath.Join(tmpDir, "docker")
+
+	// Fake docker that prints a server version when invoked with `info`.
+	// Anything else exits non-zero so we know the call shape was correct.
+	script := `#!/bin/sh
+case "$1" in
+  info) printf '"24.0.0"\n'; exit 0 ;;
+  *)    exit 99 ;;
+esac
+`
+	if err := os.WriteFile(dockerPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake docker: %v", err)
+	}
+
+	// Simulate launchd's minimal PATH — fake docker is NOT on it. If the
+	// production code resolved via os.Getenv("PATH") we would fail here.
+	t.Setenv("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+
+	original := dockerResolverFn
+	t.Cleanup(func() { dockerResolverFn = original })
+	dockerResolverFn = func(*zap.Logger) (string, error) {
+		return dockerPath, nil
+	}
+
+	m := &Manager{logger: zap.NewNop()}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := m.checkDockerAvailability(ctx); err != nil {
+		t.Fatalf("expected docker to be reachable via resolver, got: %v", err)
+	}
+}
+
+// TestCheckDockerAvailability_FallbackOnResolverFailure ensures that even when
+// the resolver itself errors out we still attempt a bare-name exec — preserving
+// the original behaviour for hosts where the shellwrap probes legitimately
+// cannot find docker but it IS on the parent's PATH.
+func TestCheckDockerAvailability_FallbackOnResolverFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("/bin/sh-style fake docker is POSIX only")
+	}
+
+	tmpDir := t.TempDir()
+	dockerPath := filepath.Join(tmpDir, "docker")
+	script := `#!/bin/sh
+exit 0
+`
+	if err := os.WriteFile(dockerPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake docker: %v", err)
+	}
+
+	// Resolver fails — the fallback should still exec via bare PATH.
+	t.Setenv("PATH", tmpDir)
+
+	original := dockerResolverFn
+	t.Cleanup(func() { dockerResolverFn = original })
+	dockerResolverFn = func(*zap.Logger) (string, error) {
+		return "", errors.New("simulated resolver failure")
+	}
+
+	m := &Manager{logger: zap.NewNop()}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := m.checkDockerAvailability(ctx); err != nil {
+		t.Fatalf("expected fallback bare-name exec to succeed, got: %v", err)
+	}
+}
+
+// TestFreshenLoadedDockerRecoveryState verifies that a state loaded from the
+// previous process gets its per-process retry counters reset to zero so the
+// new process has a fresh retry budget.
+func TestFreshenLoadedDockerRecoveryState(t *testing.T) {
+	now := time.Now()
+	staleErr := "previous process error"
+	state := &storage.DockerRecoveryState{
+		LastAttempt:      now.Add(-5 * time.Minute),
+		FailureCount:     10, // exhausted previous budget
+		DockerAvailable:  false,
+		RecoveryMode:     true,
+		LastError:        staleErr,
+		AttemptsSinceUp:  17,
+		LastSuccessfulAt: now.Add(-1 * time.Hour),
+	}
+
+	freshenLoadedDockerRecoveryState(state)
+
+	// Per-process counters cleared.
+	if state.FailureCount != 0 {
+		t.Errorf("FailureCount: want 0, got %d", state.FailureCount)
+	}
+	if state.AttemptsSinceUp != 0 {
+		t.Errorf("AttemptsSinceUp: want 0, got %d", state.AttemptsSinceUp)
+	}
+	if state.RecoveryMode {
+		t.Error("RecoveryMode: want false, got true")
+	}
+
+	// Telemetry fields preserved.
+	if state.LastError != staleErr {
+		t.Errorf("LastError should be preserved: got %q", state.LastError)
+	}
+	if state.LastSuccessfulAt.IsZero() {
+		t.Error("LastSuccessfulAt should be preserved")
+	}
+	if state.LastAttempt.IsZero() {
+		t.Error("LastAttempt should be preserved")
+	}
+}
+
+// TestFreshenLoadedDockerRecoveryState_NilSafe verifies that the helper is a
+// no-op on nil input — the production code path uses it inside an `if state != nil`
+// guard, but defensive coverage prevents future regressions.
+func TestFreshenLoadedDockerRecoveryState_NilSafe(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("freshenLoadedDockerRecoveryState panicked on nil: %v", r)
+		}
+	}()
+	freshenLoadedDockerRecoveryState(nil)
+}


### PR DESCRIPTION
## Summary

Two bugs combined to make Docker recovery permanently dead when mcpproxy boots from a macOS `.app` bundle / LoginItem (launchd hands the parent `PATH=/usr/bin:/bin:/usr/sbin:/sbin`):

1. **`checkDockerAvailability` skipped shellwrap** — used a bare `exec.Command("docker", "info")` whose lookup goes through `os.Getenv("PATH")`. Every other docker call site in the codebase (`runtime.IsDockerAvailable`, `core/docker.go`, `management/diagnostics`, `security/scanner/docker`) already uses `shellwrap.ResolveDockerPath` (which probes `/Applications/Docker.app/...`, `/usr/local/bin/docker`, `/opt/homebrew/bin/docker`, login-shell PATH, etc.). The recovery monitor was missed during that migration.

2. **Persisted `FailureCount` was inherited verbatim** — `startDockerRecoveryMonitor` loaded prior state, including `FailureCount=10` from the previous process. The recovery loop's `attempt >= maxRetries` guard then fired on the very first probe and exited in milliseconds without ever sleeping. Logs showed:
   ```
   2026-04-30T19:39:01.303 WARN  Docker unavailable on startup, starting recovery
   2026-04-30T19:39:01.308 ERROR Docker recovery max retries exceeded {"attempts":10}
   ```
   Five milliseconds. No retry budget. Recovery was dead for the lifetime of that process.

## Fix

- Route `checkDockerAvailability` through a package-level `dockerResolverFn` (default: `shellwrap.ResolveDockerPath`, fallback: bare `"docker"`). Test-overridable.
- Add `freshenLoadedDockerRecoveryState` helper that resets `FailureCount` / `AttemptsSinceUp` / `RecoveryMode` on the loaded state. Telemetry fields (`LastSuccessfulAt`, `LastError`, `LastAttempt`) are preserved so operators can still see prior context.

## Tests

- `TestCheckDockerAvailability_UsesShellwrapResolver` — fake docker in temp dir + launchd minimal PATH; would fail with bare exec.
- `TestCheckDockerAvailability_FallbackOnResolverFailure` — when resolver errors, bare-name exec via ambient PATH still works.
- `TestFreshenLoadedDockerRecoveryState` — counters reset, telemetry preserved.
- `TestFreshenLoadedDockerRecoveryState_NilSafe` — defensive nil guard.

## Test plan

- [x] `go test -race ./internal/upstream/...`
- [x] `go test -race ./internal/secureenv/... ./internal/shellwrap/... ./internal/runtime/... ./internal/storage/...`
- [x] `go build ./cmd/mcpproxy` and `go build -tags server ./cmd/mcpproxy`
- [x] Smoke test: `env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin mcpproxy serve` with a docker-isolated server. Container stays Up >2 min, zero recovery starts, zero `ForceReconnectAll` rebuilds, no max-retries log line. Without the fix the same env reproduces the original "stuck Loading" behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)