### PR TITLE
feat(ui): clickable KPI cards on Activity / Servers / Agent Tokens (#436)

### DIFF
--- a/frontend/src/views/Activity.vue
+++ b/frontend/src/views/Activity.vue
@@ -30,24 +30,48 @@
       </div>
     </div>
 
-    <!-- Summary Stats -->
+    <!-- Summary Stats — clickable, drive the Status filter (issue #436) -->
     <div v-if="summary" class="stats shadow bg-base-100 w-full">
-      <div class="stat">
+      <button
+        type="button"
+        data-test="kpi-card-total"
+        :class="['stat text-left transition-colors cursor-pointer hover:bg-base-200/60', filterStatus === '' ? 'bg-base-200 ring-2 ring-inset ring-primary/40' : '']"
+        :aria-pressed="filterStatus === ''"
+        @click="filterStatus = ''"
+      >
         <div class="stat-title">Total (24h)</div>
         <div class="stat-value text-2xl">{{ summary.total_count }}</div>
-      </div>
-      <div class="stat">
+      </button>
+      <button
+        type="button"
+        data-test="kpi-card-success"
+        :class="['stat text-left transition-colors cursor-pointer hover:bg-base-200/60', filterStatus === 'success' ? 'bg-base-200 ring-2 ring-inset ring-primary/40' : '']"
+        :aria-pressed="filterStatus === 'success'"
+        @click="filterStatus = filterStatus === 'success' ? '' : 'success'"
+      >
         <div class="stat-title">Success</div>
         <div class="stat-value text-2xl text-success">{{ summary.success_count }}</div>
-      </div>
-      <div class="stat">
+      </button>
+      <button
+        type="button"
+        data-test="kpi-card-errors"
+        :class="['stat text-left transition-colors cursor-pointer hover:bg-base-200/60', filterStatus === 'error' ? 'bg-base-200 ring-2 ring-inset ring-primary/40' : '']"
+        :aria-pressed="filterStatus === 'error'"
+        @click="filterStatus = filterStatus === 'error' ? '' : 'error'"
+      >
         <div class="stat-title">Errors</div>
         <div class="stat-value text-2xl text-error">{{ summary.error_count }}</div>
-      </div>
-      <div class="stat">
+      </button>
+      <button
+        type="button"
+        data-test="kpi-card-blocked"
+        :class="['stat text-left transition-colors cursor-pointer hover:bg-base-200/60', filterStatus === 'blocked' ? 'bg-base-200 ring-2 ring-inset ring-primary/40' : '']"
+        :aria-pressed="filterStatus === 'blocked'"
+        @click="filterStatus = filterStatus === 'blocked' ? '' : 'blocked'"
+      >
         <div class="stat-title">Blocked</div>
         <div class="stat-value text-2xl text-warning">{{ summary.blocked_count }}</div>
-      </div>
+      </button>
     </div>
 
     <!-- Filters -->

--- a/frontend/src/views/AgentTokens.vue
+++ b/frontend/src/views/AgentTokens.vue
@@ -30,23 +30,41 @@
       </div>
     </div>
 
-    <!-- Summary Stats -->
+    <!-- Summary Stats — clickable cards drive the token filter (issue #436) -->
     <div class="stats shadow bg-base-100 w-full">
-      <div class="stat">
+      <button
+        type="button"
+        data-test="kpi-card-total"
+        :class="['stat text-left transition-colors cursor-pointer hover:bg-base-200/60', tokenFilter === 'all' ? 'bg-base-200 ring-2 ring-inset ring-primary/40' : '']"
+        :aria-pressed="tokenFilter === 'all'"
+        @click="tokenFilter = 'all'"
+      >
         <div class="stat-title">Total Tokens</div>
         <div class="stat-value">{{ tokens.length }}</div>
         <div class="stat-desc">All agent tokens</div>
-      </div>
-      <div class="stat">
+      </button>
+      <button
+        type="button"
+        data-test="kpi-card-active"
+        :class="['stat text-left transition-colors cursor-pointer hover:bg-base-200/60', tokenFilter === 'active' ? 'bg-base-200 ring-2 ring-inset ring-primary/40' : '']"
+        :aria-pressed="tokenFilter === 'active'"
+        @click="tokenFilter = tokenFilter === 'active' ? 'all' : 'active'"
+      >
         <div class="stat-title">Active</div>
         <div class="stat-value text-success">{{ activeCount }}</div>
         <div class="stat-desc">Currently valid</div>
-      </div>
-      <div class="stat">
+      </button>
+      <button
+        type="button"
+        data-test="kpi-card-expired"
+        :class="['stat text-left transition-colors cursor-pointer hover:bg-base-200/60', tokenFilter === 'expired' ? 'bg-base-200 ring-2 ring-inset ring-primary/40' : '']"
+        :aria-pressed="tokenFilter === 'expired'"
+        @click="tokenFilter = tokenFilter === 'expired' ? 'all' : 'expired'"
+      >
         <div class="stat-title">Expired / Revoked</div>
         <div class="stat-value text-warning">{{ expiredOrRevokedCount }}</div>
         <div class="stat-desc">No longer usable</div>
-      </div>
+      </button>
     </div>
 
     <!-- Loading State -->
@@ -86,6 +104,16 @@
       </button>
     </div>
 
+    <!-- Filter empty state: tokens exist but none match the active filter -->
+    <div v-else-if="filteredTokens.length === 0" class="text-center py-12" data-test="tokens-filter-empty">
+      <p class="text-base-content/70 mb-4">
+        No tokens match the <span class="font-semibold">{{ tokenFilter }}</span> filter.
+      </p>
+      <button @click="tokenFilter = 'all'" class="btn btn-sm btn-outline">
+        Show all
+      </button>
+    </div>
+
     <!-- Token List Table -->
     <div v-else class="overflow-x-auto">
       <table class="table table-zebra w-full">
@@ -102,7 +130,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr v-for="token in tokens" :key="token.name">
+          <tr v-for="token in filteredTokens" :key="token.name">
             <td class="font-medium">{{ token.name }}</td>
             <td>
               <code class="text-sm bg-base-200 px-2 py-1 rounded">{{ token.token_prefix }}</code>
@@ -390,6 +418,19 @@ const activeCount = computed(() => {
 
 const expiredOrRevokedCount = computed(() => {
   return tokens.value.filter(t => t.revoked || isExpired(t)).length
+})
+
+// KPI-card-driven filter (issue #436): 'all' | 'active' | 'expired'
+const tokenFilter = ref<'all' | 'active' | 'expired'>('all')
+
+const filteredTokens = computed(() => {
+  if (tokenFilter.value === 'active') {
+    return tokens.value.filter(t => !t.revoked && !isExpired(t))
+  }
+  if (tokenFilter.value === 'expired') {
+    return tokens.value.filter(t => t.revoked || isExpired(t))
+  }
+  return tokens.value
 })
 
 // Helper functions

--- a/frontend/src/views/Servers.vue
+++ b/frontend/src/views/Servers.vue
@@ -33,27 +33,45 @@
       </div>
     </div>
 
-    <!-- Summary Stats -->
+    <!-- Summary Stats — clickable cards drive the filter row (issue #436) -->
     <div class="stats shadow bg-base-100 w-full">
-      <div class="stat">
+      <button
+        type="button"
+        data-test="kpi-card-total"
+        :class="['stat text-left transition-colors cursor-pointer hover:bg-base-200/60', filter === 'all' ? 'bg-base-200 ring-2 ring-inset ring-primary/40' : '']"
+        :aria-pressed="filter === 'all'"
+        @click="filter = 'all'"
+      >
         <div class="stat-title">Total Servers</div>
         <div class="stat-value">{{ serversStore.serverCount.total }}</div>
         <div class="stat-desc">{{ serversStore.serverCount.enabled }} enabled</div>
-      </div>
+      </button>
 
-      <div class="stat">
+      <button
+        type="button"
+        data-test="kpi-card-connected"
+        :class="['stat text-left transition-colors cursor-pointer hover:bg-base-200/60', filter === 'connected' ? 'bg-base-200 ring-2 ring-inset ring-primary/40' : '']"
+        :aria-pressed="filter === 'connected'"
+        @click="filter = filter === 'connected' ? 'all' : 'connected'"
+      >
         <div class="stat-title">Connected</div>
         <div class="stat-value text-success">{{ serversStore.serverCount.connected }}</div>
         <div class="stat-desc">{{ Math.round((serversStore.serverCount.connected / serversStore.serverCount.total) * 100) || 0 }}% online</div>
-      </div>
+      </button>
 
-      <div class="stat">
+      <button
+        type="button"
+        data-test="kpi-card-quarantined"
+        :class="['stat text-left transition-colors cursor-pointer hover:bg-base-200/60', filter === 'quarantined' ? 'bg-base-200 ring-2 ring-inset ring-primary/40' : '']"
+        :aria-pressed="filter === 'quarantined'"
+        @click="filter = filter === 'quarantined' ? 'all' : 'quarantined'"
+      >
         <div class="stat-title">Quarantined</div>
         <div class="stat-value text-warning">{{ serversStore.serverCount.quarantined }}</div>
         <div class="stat-desc">Need security review</div>
-      </div>
+      </button>
 
-      <div class="stat">
+      <div class="stat" data-test="kpi-card-total-tools">
         <div class="stat-title">Total Tools</div>
         <div class="stat-value text-info">{{ serversStore.totalTools }}</div>
         <div class="stat-desc">Available across all servers</div>


### PR DESCRIPTION
## Summary

Closes #436. KPI cards on three pages were passive — the count would change but you couldn't click them. Jason filed the issue saying "It was the first thing I tried but nothing happened." Bundling all three (and matching the same affordance) is more consistent than fixing one and leaving the others awkward.

Each card now drives the matching filter:

| Page | Card | Filter |
|---|---|---|
| **Activity** | Total (24h) | `filterStatus = ''` |
| | Success | `'success'` |
| | Errors | `'error'` |
| | Blocked | `'blocked'` |
| **Servers** | Total Servers | `filter = 'all'` |
| | Connected | `'connected'` |
| | Quarantined | `'quarantined'` |
| | Total Tools | — (no matching list-state, intentionally non-clickable) |
| **Agent Tokens** | Total Tokens | `tokenFilter = 'all'` |
| | Active | `'active'` |
| | Expired / Revoked | `'expired'` |

Clicking an already-active non-Total card toggles the filter off; **Total** always resets to `all`. Active card has `bg-base-200 + ring-2 ring-inset ring-primary/40`; all clickable cards have `cursor-pointer + hover:bg-base-200/60`.

Each card carries a stable `data-test="kpi-card-<state>"` and proper `aria-pressed` for accessibility / future Playwright tests.

## Notes

- **Servers + Activity** drive existing filter state (no behaviour change for users who use the filter row / dropdown directly).
- **Agent Tokens** had no filter at all; adds a `tokenFilter` ref + `filteredTokens` computed, plus a "no tokens match this filter — Show all" empty state.
- **Secrets** was deferred (its KPIs aren't mutually-exclusive states of one list — see brainstorm in #436 follow-up).
- Generated `frontend/src/types/contracts.ts` regen from `make frontend-build` was reverted (unrelated `IsolationDefaults` regression — not part of this PR).

## Test plan

End-to-end verified via the Chrome extension MCP against a live mcpproxy serve on port 18083:

- [x] **Servers** (3 servers, 1 quarantined): clicking Quarantined toggles the existing `Quarantined (1)` filter button to `btn-primary`; clicking Connected highlights kpi-connected; clicking Connected again resets to Total.
- [x] **Agent Tokens** (2 active + 1 revoked): baseline 3 rows → click Active → 2 rows (2 Active badges, 0 Revoked) → click Expired → 1 row (1 Revoked, 0 Active) → click Total → 3 rows.
- [x] **Activity** (1 system_start success): click Success → status select="success", "Status: success" badge appears; click Errors → "Status: error"; click Errors again → toggles off.
- [x] `vue-tsc --noEmit` clean.
- [x] `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)