### PR TITLE
fix(ui/store): clear missing server fields on merge (#438)

### DIFF
--- a/frontend/src/stores/servers.ts
+++ b/frontend/src/stores/servers.ts
@@ -47,23 +47,26 @@ export const useServersStore = defineStore('servers', () => {
       const existingServer = existingMap.get(incomingServer.name)
 
       if (existingServer) {
-        // Update existing server in-place (preserves object reference)
-        // Only update properties that have changed
-        let hasChanges = false
-
-        // IMPORTANT: Clear last_error if not present in incoming server
-        // Object.assign won't clear properties that are missing from source
-        if (!('last_error' in incomingServer) && existingServer.last_error) {
-          delete existingServer.last_error
-          hasChanges = true
+        // Update existing server in-place (preserves object reference so
+        // ServerCard's v-memo / consumers' computeds keep their identity).
+        //
+        // CRITICAL: the API response is authoritative — any field absent on
+        // the incoming server has been cleared on the backend and must be
+        // dropped from the existing reactive object. Object.assign alone
+        // would leak a stale `quarantine: { pending_count: 5 }` (and other
+        // conditionally-emitted fields) after the user approves all tools,
+        // because the backend stops emitting the field when its count hits
+        // zero (see internal/httpapi/server.go enrichServersWithQuarantineStats).
+        // This was the root cause of issue #438.
+        const existingKeys = Object.keys(existingServer) as (keyof Server)[]
+        const incomingKeys = new Set(Object.keys(incomingServer))
+        for (const key of existingKeys) {
+          if (!incomingKeys.has(key)) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            delete (existingServer as any)[key]
+          }
         }
-
         Object.assign(existingServer, incomingServer)
-        hasChanges = true
-
-        if (hasChanges) {
-          console.log(`Server ${existingServer.name} updated with changes`)
-        }
 
         result.push(existingServer)
       } else {

--- a/frontend/tests/unit/servers-store.spec.ts
+++ b/frontend/tests/unit/servers-store.spec.ts
@@ -11,6 +11,135 @@ vi.mock('@/services/api', () => ({
   },
 }))
 
+describe('useServersStore — mergeServers field-clearing (issue #438)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  function mkServer(overrides: Record<string, unknown> = {}) {
+    return {
+      name: 'srv',
+      protocol: 'http' as const,
+      enabled: true,
+      quarantined: false,
+      connected: true,
+      connecting: false,
+      tool_count: 4,
+      ...overrides,
+    }
+  }
+
+  it('drops the stale `quarantine` field when the backend stops emitting it', async () => {
+    // The backend's enrichServersWithQuarantineStats sets `Quarantine` only
+    // when pending > 0 || changed > 0. After "Approve all tools" the field
+    // disappears from the JSON entirely; without a clear-on-merge path the
+    // old `pending_count: 5` would survive on the in-place reactive object
+    // and ServerCard would keep rendering the "5 pending approval" badge.
+    ;(api.getServers as any).mockResolvedValueOnce({
+      success: true,
+      data: { servers: [mkServer({ quarantine: { pending_count: 5, changed_count: 0 } })] },
+    })
+
+    const store = useServersStore()
+    await store.fetchServers()
+    expect(store.servers[0].quarantine).toEqual({ pending_count: 5, changed_count: 0 })
+
+    ;(api.getServers as any).mockResolvedValueOnce({
+      success: true,
+      data: { servers: [mkServer()] }, // no quarantine field at all
+    })
+
+    await store.fetchServers()
+    expect(store.servers[0].quarantine).toBeUndefined()
+  })
+
+  it('drops `last_error` on recovery (regression coverage for the original special case)', async () => {
+    ;(api.getServers as any).mockResolvedValueOnce({
+      success: true,
+      data: { servers: [mkServer({ last_error: 'connection refused' })] },
+    })
+
+    const store = useServersStore()
+    await store.fetchServers()
+    expect(store.servers[0].last_error).toBe('connection refused')
+
+    ;(api.getServers as any).mockResolvedValueOnce({
+      success: true,
+      data: { servers: [mkServer()] },
+    })
+
+    await store.fetchServers()
+    expect(store.servers[0].last_error).toBeUndefined()
+  })
+
+  it('drops `oauth_status`, `token_expires_at`, and `user_logged_out` when no longer present', async () => {
+    ;(api.getServers as any).mockResolvedValueOnce({
+      success: true,
+      data: {
+        servers: [
+          mkServer({
+            oauth_status: 'expired',
+            token_expires_at: '2026-04-30T00:00:00Z',
+            user_logged_out: true,
+          }),
+        ],
+      },
+    })
+    const store = useServersStore()
+    await store.fetchServers()
+
+    ;(api.getServers as any).mockResolvedValueOnce({
+      success: true,
+      data: { servers: [mkServer()] },
+    })
+    await store.fetchServers()
+
+    expect(store.servers[0].oauth_status).toBeUndefined()
+    expect(store.servers[0].token_expires_at).toBeUndefined()
+    expect(store.servers[0].user_logged_out).toBeUndefined()
+  })
+
+  it('preserves the existing object reference across merges (identity stability for v-memo)', async () => {
+    ;(api.getServers as any).mockResolvedValueOnce({
+      success: true,
+      data: { servers: [mkServer({ quarantine: { pending_count: 2, changed_count: 0 } })] },
+    })
+    const store = useServersStore()
+    await store.fetchServers()
+    const ref1 = store.servers[0]
+
+    ;(api.getServers as any).mockResolvedValueOnce({
+      success: true,
+      data: { servers: [mkServer()] },
+    })
+    await store.fetchServers()
+    const ref2 = store.servers[0]
+
+    // Same reactive object — v-memo on ServerCard still sees stable identity.
+    expect(ref2).toBe(ref1)
+    expect(ref2.quarantine).toBeUndefined()
+  })
+
+  it('still updates and adds present fields (sanity: the clear logic does not break normal merges)', async () => {
+    ;(api.getServers as any).mockResolvedValueOnce({
+      success: true,
+      data: { servers: [mkServer({ tool_count: 1 })] },
+    })
+    const store = useServersStore()
+    await store.fetchServers()
+
+    ;(api.getServers as any).mockResolvedValueOnce({
+      success: true,
+      data: { servers: [mkServer({ tool_count: 9, last_error: 'oops' })] },
+    })
+    await store.fetchServers()
+
+    expect(store.servers[0].tool_count).toBe(9)
+    expect(store.servers[0].last_error).toBe('oops')
+  })
+})
+
 describe('useServersStore — securityApproveServer (F-04)', () => {
   beforeEach(() => {
     setActivePinia(createPinia())


### PR DESCRIPTION
Closes #438. Generalises the previously-special-cased `last_error` clear in the Pinia `mergeServers` helper to handle every conditionally-emitted optional field on `Server`.

## The bug Jason hit

After clicking *Approve all tools* on the Server Detail page, navigating to the **Servers overview** kept showing the "5 pending approval" quarantine badge. A hard browser refresh fixed it. He also flagged seeing similar stale-state in several other places.

## Root cause

`frontend/src/stores/servers.ts::mergeServers` updates each existing server in place via `Object.assign(existing, incoming)`. The backend's `enrichServersWithQuarantineStats` (`internal/httpapi/server.go:1143-1148`) only sets `Quarantine` when `pending > 0 || changed > 0`:

\`\`\`go
if pending > 0 || changed > 0 {
    servers[i].Quarantine = &contracts.QuarantineStats{
        PendingCount: pending,
        ChangedCount: changed,
    }
}
\`\`\`

After the user approves everything the field disappears from the JSON entirely. `Object.assign` adds and overwrites — **it never deletes**. The stale `quarantine: { pending_count: 5 }` therefore survives on the reactive object and `ServerCard`'s `server.quarantine?.pending_count` keeps rendering the badge.

The author of this code already noticed the pattern for `last_error` and special-cased it. The same trap exists for every other optional field the backend conditionally emits:

| Field | Emitted only when |
|---|---|
| `quarantine` | `pending > 0 \|\| changed > 0` |
| `last_error` | non-empty (already handled) |
| `oauth_status`, `token_expires_at` | OAuth in use |
| `user_logged_out` | true |
| `health`, `diagnostic`, `error_code` | conditional |
| `security_scan` | scan exists |
| `connected_at`, `last_reconnect_at`, `reconnect_count` | conditional |

## Fix

Replace the one-field special case with a general key-sync: for each key on the existing server that is absent on the incoming server, `delete` it **before** `Object.assign`. The API response is authoritative; this treats it that way. The existing object reference is still preserved so `ServerCard`'s `v-memo` keeps stable identity and the list does not visually re-render.

## Tests (`frontend/tests/unit/servers-store.spec.ts`)

5 new + 3 existing = 8 passing:

- drops the stale `quarantine` field when the backend stops emitting it
- drops `last_error` on recovery (regression coverage for the previous special case)
- drops `oauth_status` / `token_expires_at` / `user_logged_out` together
- preserves the existing object reference across merges (identity stability for `v-memo`)
- sanity: still updates and adds present fields

## Test plan

- [x] \`npx vitest run tests/unit/servers-store.spec.ts\` — 8/8 pass
- [x] \`npm run build\` clean
- [ ] Will verify end-to-end via Chrome MCP after CI is green (reproduce: server with pending tools → Approve All → navigate to /ui/servers → assert no badge)

## Note on cross-tab updates

A complementary backend change — emit \`servers.changed\` SSE after \`ApproveTools\` — will land in a **separate PR** so a Servers/overview tab open elsewhere also reactively updates without depending on the Approve flow's explicit \`fetchServers()\` call. This PR is the primary fix Jason saw; the SSE one is the cross-tab improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)