### PR TITLE
fix(runtime): emit servers.changed after tool approval (#438)

### DIFF
--- a/internal/runtime/tool_approval_event_test.go
+++ b/internal/runtime/tool_approval_event_test.go
@@ -1,0 +1,86 @@
+package runtime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
+)
+
+// TestApproveTools_EmitsServersChanged verifies that ApproveTools publishes a
+// servers.changed runtime event after successfully updating tool approval
+// records. Without this, a Servers/overview page open in another browser tab
+// has no way to know it should re-fetch — see issue #438. Subscribed via the
+// same mechanism the SSE handler uses, so this test exercises the end-to-end
+// publish path.
+func TestApproveTools_EmitsServersChanged(t *testing.T) {
+	rt := setupQuarantineRuntime(t, boolP(true), []*config.ServerConfig{
+		{Name: "github", Enabled: true, Quarantined: false},
+	})
+
+	// Pre-seed an approval record in the "pending" state so ApproveTools has
+	// real work to do.
+	require.NoError(t, rt.storageManager.SaveToolApproval(&storage.ToolApprovalRecord{
+		ServerName:         "github",
+		ToolName:           "create_issue",
+		Status:             storage.ToolApprovalStatusPending,
+		CurrentHash:        "h1",
+		CurrentDescription: "Creates a GitHub issue",
+		CurrentSchema:      `{"type":"object"}`,
+	}))
+
+	events := rt.SubscribeEvents()
+	defer rt.UnsubscribeEvents(events)
+
+	require.NoError(t, rt.ApproveTools("github", []string{"create_issue"}, "test-user"))
+
+	// We expect at least one EventTypeServersChanged with reason=tools_approved
+	// to land within a reasonable window. The event-bus uses a non-blocking
+	// publish, so a generous timeout shouldn't slow CI in practice.
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case evt := <-events:
+			if evt.Type != EventTypeServersChanged {
+				continue
+			}
+			assert.Equal(t, "tools_approved", evt.Payload["reason"])
+			assert.Equal(t, "github", evt.Payload["server"])
+			assert.Equal(t, 1, evt.Payload["approved_count"])
+			assert.Equal(t, "test-user", evt.Payload["approved_by"])
+			return
+		case <-deadline:
+			t.Fatalf("expected servers.changed (tools_approved) event, none received within 2s")
+		}
+	}
+}
+
+// TestApproveTools_NoEventOnNoOp verifies that when ApproveTools is called for
+// a tool that has no approval record (already approved / never seen), it does
+// NOT emit a stray servers.changed event. The bus is shared with other
+// subscribers so we shouldn't publish when nothing changed.
+func TestApproveTools_NoEventOnNoOp(t *testing.T) {
+	rt := setupQuarantineRuntime(t, boolP(true), []*config.ServerConfig{
+		{Name: "github", Enabled: true, Quarantined: false},
+	})
+
+	events := rt.SubscribeEvents()
+	defer rt.UnsubscribeEvents(events)
+
+	// No pre-seeded record — ApproveTools should log a warning and continue
+	// without saving anything, which means approved=0 and no event.
+	require.NoError(t, rt.ApproveTools("github", []string{"nonexistent"}, "test-user"))
+
+	select {
+	case evt := <-events:
+		if evt.Type == EventTypeServersChanged {
+			t.Fatalf("did not expect servers.changed when no approvals were applied; got %+v", evt)
+		}
+	case <-time.After(150 * time.Millisecond):
+		// expected: no event delivered
+	}
+}

--- a/internal/runtime/tool_quarantine.go
+++ b/internal/runtime/tool_quarantine.go
@@ -567,6 +567,7 @@ func (r *Runtime) ApproveTools(serverName string, toolNames []string, approvedBy
 		return nil
 	}
 
+	approved := 0
 	for _, toolName := range toolNames {
 		record, err := r.storageManager.GetToolApproval(serverName, toolName)
 		if err != nil {
@@ -591,6 +592,7 @@ func (r *Runtime) ApproveTools(serverName string, toolNames []string, approvedBy
 		if err := r.storageManager.SaveToolApproval(record); err != nil {
 			return err
 		}
+		approved++
 
 		r.logger.Info("Tool approved",
 			zap.String("server", serverName),
@@ -600,6 +602,19 @@ func (r *Runtime) ApproveTools(serverName string, toolNames []string, approvedBy
 		// Emit activity event
 		r.emitToolQuarantineEvent(serverName, toolName, "tool_approved",
 			"", record.ApprovedHash, "", record.CurrentDescription, "", record.CurrentSchema)
+	}
+
+	// Notify SSE subscribers that the server's tool-quarantine counts changed.
+	// Without this, a Servers/overview page open in another tab/window keeps
+	// showing the stale "N pending approval" badge until the user manually
+	// reloads — see issue #438. Emit once per call (not per tool) to keep
+	// the bus quiet on bulk approvals.
+	if approved > 0 {
+		r.emitServersChanged("tools_approved", map[string]any{
+			"server":         serverName,
+			"approved_count": approved,
+			"approved_by":    approvedBy,
+		})
 	}
 
 	return nil


### PR DESCRIPTION
Companion to #443 (frontend mergeServers stale-field clear). Together they close #438.

## Background

Issue #438 — when a user clicks **Approve all tools** on the Server Detail page, the Servers/overview page kept showing the "N pending approval" quarantine badge until a manual reload.

- **#443** fixes the case where the user navigates to Servers in the same tab/session — the click handler already calls \`serversStore.fetchServers()\`, but the merge logic didn't clear the now-missing \`quarantine\` field.
- **This PR** fixes the cross-tab / cross-session case: a Servers tab open in another window has no way to know it should re-fetch unless we tell it.

## Fix

\`Runtime.ApproveTools\` (\`internal/runtime/tool_quarantine.go\`) now publishes a \`servers.changed\` runtime event with \`reason="tools_approved"\` after successfully updating approval records. The event is already emitted for every other server-state mutation in this codebase (enable/disable, restart, quarantine toggle, sync, server connected/disconnected, tools indexed — see \`internal/runtime/lifecycle.go\`); this fills in the one missing call site.

Properties of the emit:

- **Once per call**, after the loop, gated on \`approved > 0\`. Bulk approval of 50 tools doesn't spam 50 events. A no-op call (tools without records) emits nothing.
- **Payload includes** \`server\`, \`approved_count\`, \`approved_by\` so consumers can render targeted toasts without a follow-up GET.

\`\`\`go
if approved > 0 {
    r.emitServersChanged("tools_approved", map[string]any{
        "server":         serverName,
        "approved_count": approved,
        "approved_by":    approvedBy,
    })
}
\`\`\`

## Tests (\`internal/runtime/tool_approval_event_test.go\`)

- **\`TestApproveTools_EmitsServersChanged\`** — pre-seed a pending record, subscribe via the same \`SubscribeEvents\` channel the SSE handler uses, call \`ApproveTools\`, assert one \`servers.changed\` (reason=tools_approved) within 2s with the expected payload.
- **\`TestApproveTools_NoEventOnNoOp\`** — call \`ApproveTools\` for a tool with no record (warn-and-continue path), assert no event is published.

## Test plan

- [x] \`go test -race -count=1 -run 'TestApproveTools_Emits|TestApproveTools_NoEvent' ./internal/runtime/\` — both pass
- [x] \`go test -race ./internal/runtime/...\` — full suite green
- [x] \`go build ./cmd/mcpproxy\` — clean

## Why split from #443

The frontend merge fix is necessary on its own (without it, even the same-tab Approve flow leaves a stale badge after \`fetchServers\`). The SSE emit is purely additive and could ship independently. Per project convention, keeping the surface of each PR small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)