### PR TITLE
fix(release-notes): stop inventing edition scoping in generated notes

### DIFF
--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -128,7 +128,7 @@ build_prompt() {
     cat << EOF
 Generate concise release notes for version ${version} of MCPProxy (Smart MCP Proxy).
 
-MCPProxy is a desktop application that acts as a smart proxy for AI agents using the Model Context Protocol (MCP). It provides intelligent tool discovery, token savings, and security quarantine for MCP servers.
+MCPProxy is built in two editions from the same codebase: a default Personal edition (desktop app, distributed as DMG / Windows installer / Linux tar.gz / .deb / .rpm) and a Server edition built with the \`server\` Go build tag (Docker image + multi-user OAuth, code under \`internal/teams/\`). Most changes ship in BOTH editions because shared code (\`internal/runtime/\`, \`internal/server/\`, \`internal/upstream/\`, \`frontend/\`, etc.) is compiled into both binaries.
 
 Commits since last release:
 ${commits}
@@ -146,6 +146,12 @@ Requirements:
 - Use bullet points for each change
 - Be specific but brief - describe the user benefit, not implementation details
 - If there are no meaningful changes, say "Minor internal improvements and maintenance updates."
+
+Edition scoping rules — read carefully:
+- DO NOT add notes like "applies to the Personal edition only" or "applies to the Teams/Server edition only" unless a commit subject EXPLICITLY says so (e.g. contains \`(server)\`, \`(teams)\`, \`server-only\`, or \`personal-only\`).
+- DO NOT speculate about which edition a change targets based on subject keywords (\`ui\`, \`runtime\`, \`oauth\`, \`teams\`, \`dashboard\`, \`KPI\`, etc.). Shared code lands in both editions.
+- DO NOT call this "the Teams edition" — the server edition is named "Server edition" (built with the \`server\` build tag). "Teams" is an internal package name, not a product name.
+- If you are unsure which edition a change applies to, omit edition labels entirely. The default assumption is BOTH editions.
 EOF
 }
 


### PR DESCRIPTION
## Summary

The release-notes generator (`scripts/generate-release-notes.sh`) feeds commit subjects to Claude with no edition context, and Claude has been inventing edition annotations on its own. The most recent miss is v0.29.2:

> *Note: All changes in this release apply to the Teams edition only.*

— wrong. All three PRs in v0.29.2 (#442, #443, #444) modify shared code (`internal/runtime/tool_quarantine.go`, `frontend/src/stores/servers.ts`, `frontend/src/views/{Activity,AgentTokens,Servers}.vue`). None of those files have `//go:build server` and none live under `internal/teams/`, so the fixes ship in **both** editions.

This isn't a one-off — same pattern in v0.29.0 ("*primarily affect the Personal Edition*") and v0.29.1 (a "Personal Edition (macOS)" header). The model is filling in plausible-sounding edition framing because the prompt never tells it not to.

## Fix

`scripts/generate-release-notes.sh` — extend the prompt with:

1. A one-paragraph explanation of the two-edition build model (Personal default vs Server build tag, shared code in `internal/runtime/`, `internal/server/`, `frontend/`, etc.) so the model doesn't have to guess from training data.
2. Explicit "Edition scoping rules":
   - **Don't** add edition-only notes unless a commit subject explicitly says so (`(server)`, `(teams)`, `server-only`, `personal-only`).
   - **Don't** speculate from subject keywords (`ui`, `runtime`, `oauth`, `dashboard`, etc.) — shared code lands in both.
   - Use **"Server edition"**, not "Teams edition" (Teams is an internal package name).
   - When unsure, omit edition labels — default assumption is BOTH editions.

No script logic changed; only the heredoc inside `build_prompt()`.

## Out of scope

The v0.29.2 release body has already been hand-corrected (`gh release edit`); this PR only prevents the next release from making the same mistake.

## Test plan

- [x] `bash -n scripts/generate-release-notes.sh` — syntax clean
- [ ] Smoke-run before next tag: `ANTHROPIC_API_KEY=... ./scripts/generate-release-notes.sh v0.29.2` (or whichever tag is being prepped) and confirm no spurious edition annotations slip in. If a commit explicitly does target one edition, confirm the label still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)