### PR TITLE
Fix intermittent missing enabled servers in tool retrieval

### DIFF
--- a/internal/runtime/lifecycle.go
+++ b/internal/runtime/lifecycle.go
@@ -302,13 +302,54 @@ func (r *Runtime) DiscoverAndIndexTools(ctx context.Context) error {
 		toolsByServer[tool.ServerName] = append(toolsByServer[tool.ServerName], tool)
 	}
 
-	// Apply differential update for each server
+	// Persist fresh snapshots for discovered servers
+	r.lastGoodToolsMu.Lock()
 	for serverName, serverTools := range toolsByServer {
+		cp := make([]*config.ToolMetadata, len(serverTools))
+		copy(cp, serverTools)
+		r.lastGoodTools[serverName] = cp
+	}
+	r.lastGoodToolsMu.Unlock()
+
+	// Apply differential update for each server with fallback to last-good snapshots
+	processedServers := make(map[string]struct{}, len(toolsByServer))
+	for serverName, serverTools := range toolsByServer {
+		processedServers[serverName] = struct{}{}
 		if err := r.applyDifferentialToolUpdate(ctx, serverName, serverTools); err != nil {
 			r.logger.Error("Failed to apply differential update for server",
 				zap.String("server", serverName),
 				zap.Error(err))
 			// Continue with other servers instead of failing completely
+		}
+	}
+
+	// For connected servers that were temporarily missing from discovery results,
+	// re-apply last-good snapshot to avoid transient index shrink.
+	for _, serverName := range r.upstreamManager.GetAllServerNames() {
+		if _, ok := processedServers[serverName]; ok {
+			continue
+		}
+
+		client, ok := r.upstreamManager.GetClient(serverName)
+		if !ok || client == nil || !client.IsConnected() {
+			continue
+		}
+
+		r.lastGoodToolsMu.RLock()
+		snapshot, hasSnapshot := r.lastGoodTools[serverName]
+		r.lastGoodToolsMu.RUnlock()
+		if !hasSnapshot || len(snapshot) == 0 {
+			continue
+		}
+
+		r.logger.Warn("Server missing from discovery result; reusing last-good tool snapshot",
+			zap.String("server", serverName),
+			zap.Int("snapshot_tools", len(snapshot)))
+
+		if err := r.applyDifferentialToolUpdate(ctx, serverName, snapshot); err != nil {
+			r.logger.Error("Failed to apply last-good snapshot for server",
+				zap.String("server", serverName),
+				zap.Error(err))
 		}
 	}
 

--- a/internal/runtime/lifecycle.go
+++ b/internal/runtime/lifecycle.go
@@ -302,12 +302,27 @@ func (r *Runtime) DiscoverAndIndexTools(ctx context.Context) error {
 		toolsByServer[tool.ServerName] = append(toolsByServer[tool.ServerName], tool)
 	}
 
-	// Persist fresh snapshots for discovered servers
+	// Snapshot the set of currently-known servers so we can prune entries for
+	// servers that have been removed from config and avoid an unbounded map.
+	knownServers := r.upstreamManager.GetAllServerNames()
+	knownServerSet := make(map[string]struct{}, len(knownServers))
+	for _, name := range knownServers {
+		knownServerSet[name] = struct{}{}
+	}
+
+	// Persist fresh snapshots for discovered servers and prune stale entries.
+	// ToolMetadata values are treated as immutable post-discovery; if that ever
+	// changes, switch to a deep copy here.
 	r.lastGoodToolsMu.Lock()
 	for serverName, serverTools := range toolsByServer {
 		cp := make([]*config.ToolMetadata, len(serverTools))
 		copy(cp, serverTools)
 		r.lastGoodTools[serverName] = cp
+	}
+	for serverName := range r.lastGoodTools {
+		if _, ok := knownServerSet[serverName]; !ok {
+			delete(r.lastGoodTools, serverName)
+		}
 	}
 	r.lastGoodToolsMu.Unlock()
 
@@ -325,7 +340,7 @@ func (r *Runtime) DiscoverAndIndexTools(ctx context.Context) error {
 
 	// For connected servers that were temporarily missing from discovery results,
 	// re-apply last-good snapshot to avoid transient index shrink.
-	for _, serverName := range r.upstreamManager.GetAllServerNames() {
+	for _, serverName := range knownServers {
 		if _, ok := processedServers[serverName]; ok {
 			continue
 		}
@@ -342,7 +357,9 @@ func (r *Runtime) DiscoverAndIndexTools(ctx context.Context) error {
 			continue
 		}
 
-		r.logger.Warn("Server missing from discovery result; reusing last-good tool snapshot",
+		// Logged at Info: this can fire repeatedly during reconnect storms and
+		// is benign self-healing, not a warning condition.
+		r.logger.Info("Server missing from discovery result; reusing last-good tool snapshot",
 			zap.String("server", serverName),
 			zap.Int("snapshot_tools", len(snapshot)))
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -91,6 +91,11 @@ type Runtime struct {
 	// Key: serverName, Value: struct{} (presence indicates discovery in progress)
 	discoveryInProgress sync.Map
 
+	// Last-good tool snapshots per server used to avoid transient tool loss during
+	// global discovery races/restarts.
+	lastGoodToolsMu sync.RWMutex
+	lastGoodTools   map[string][]*config.ToolMetadata
+
 	// Schema v3 (telemetry): time-cached Docker daemon availability. The
 	// probe has a 2s `docker info` cost, so we don't want to run it on every
 	// heartbeat — but we also can't memoize it for the whole process lifetime:
@@ -244,9 +249,10 @@ func New(cfg *config.Config, cfgPath string, logger *zap.Logger) (*Runtime, erro
 			Message:     "Runtime is initializing...",
 			LastUpdated: time.Now(),
 		},
-		statusCh:     make(chan Status, 10),
-		eventSubs:    make(map[chan Event]struct{}),
-		phaseMachine: newPhaseMachine(PhaseInitializing),
+		statusCh:      make(chan Status, 10),
+		eventSubs:     make(map[chan Event]struct{}),
+		phaseMachine:  newPhaseMachine(PhaseInitializing),
+		lastGoodTools: make(map[string][]*config.ToolMetadata),
 	}
 
 	return rt, nil

--- a/internal/upstream/managed/client.go
+++ b/internal/upstream/managed/client.go
@@ -38,6 +38,9 @@ type Client struct {
 	listToolsMu         sync.Mutex
 	listToolsInProgress bool
 	listToolsCancel     context.CancelFunc
+	listToolsWaitCh     chan struct{}
+	listToolsLastResult []*config.ToolMetadata
+	listToolsLastErr    error
 
 	// Connect cancellation - allows Disconnect() to cancel an in-flight Connect()
 	// without waiting for mc.mu (which Connect holds during the entire OAuth flow)
@@ -442,7 +445,7 @@ func (mc *Client) acquireListToolsContext(ctx context.Context, timeout time.Dura
 	return listCtx, release, true
 }
 
-// ListTools retrieves tools with concurrency control
+// ListTools retrieves tools with concurrency control and coalesces concurrent calls.
 func (mc *Client) ListTools(ctx context.Context) ([]*config.ToolMetadata, error) {
 	mc.logger.Debug("🔍 ListTools called",
 		zap.String("server", mc.Config.Name),
@@ -456,31 +459,60 @@ func (mc *Client) ListTools(ctx context.Context) ([]*config.ToolMetadata, error)
 		return nil, fmt.Errorf("client not connected (state: %s)", mc.StateManager.GetState().String())
 	}
 
-	listCtx, release, ok := mc.acquireListToolsContext(ctx, 30*time.Second)
-	if !ok {
-		mc.logger.Debug("🔍 ListTools already in progress, rejecting",
+	// Coalesce concurrent ListTools calls: one caller fetches, others wait for shared result.
+	mc.listToolsMu.Lock()
+	if mc.listToolsInProgress {
+		waitCh := mc.listToolsWaitCh
+		mc.listToolsMu.Unlock()
+
+		mc.logger.Debug("🔍 ListTools already in progress, waiting for shared result",
 			zap.String("server", mc.Config.Name))
-		return nil, fmt.Errorf("ListTools operation already in progress for server %s", mc.Config.Name)
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-waitCh:
+			mc.listToolsMu.Lock()
+			res := mc.listToolsLastResult
+			err := mc.listToolsLastErr
+			mc.listToolsMu.Unlock()
+			if err != nil {
+				return nil, fmt.Errorf("ListTools failed: %w", err)
+			}
+			return res, nil
+		}
 	}
 
+	mc.listToolsInProgress = true
+	mc.listToolsWaitCh = make(chan struct{})
+	listCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	mc.listToolsCancel = cancel
+	mc.listToolsMu.Unlock()
+
 	defer func() {
-		if release() {
-			mc.logger.Debug("🔍 ListTools operation completed, flag reset",
-				zap.String("server", mc.Config.Name))
-		} else {
-			mc.logger.Debug("🔍 ListTools operation completed while disconnected",
-				zap.String("server", mc.Config.Name))
+		cancel()
+		mc.listToolsMu.Lock()
+		mc.listToolsCancel = nil
+		mc.listToolsInProgress = false
+		if mc.listToolsWaitCh != nil {
+			close(mc.listToolsWaitCh)
+			mc.listToolsWaitCh = nil
 		}
+		mc.listToolsMu.Unlock()
 	}()
 
 	tools, err := mc.coreClient.ListTools(listCtx)
+
+	mc.listToolsMu.Lock()
+	mc.listToolsLastResult = tools
+	mc.listToolsLastErr = err
+	mc.listToolsMu.Unlock()
+
 	if err != nil {
-		// Log the error immediately for better debugging
 		mc.logger.Error("ListTools operation failed",
 			zap.String("server", mc.Config.Name),
 			zap.Error(err))
 
-		// Check if it's a connection error and update state
 		if mc.isConnectionError(err) {
 			mc.logger.Warn("Connection error detected during ListTools, updating server state",
 				zap.String("server", mc.Config.Name),

--- a/internal/upstream/managed/client.go
+++ b/internal/upstream/managed/client.go
@@ -421,6 +421,13 @@ func (mc *Client) SetToolDiscoveryCallback(callback func(ctx context.Context, se
 	mc.toolDiscoveryCallback = callback
 }
 
+// acquireListToolsContext claims the in-progress flag for an upstream ListTools
+// call. When successful it also allocates listToolsWaitCh and resets the cached
+// last-result, so any concurrent ListTools waiter can safely block on the
+// channel and read the published result regardless of which caller is the
+// leader. release() must be called exactly once; it cancels the timeout,
+// publishes any result via publishListToolsResult (if the caller wrote one),
+// and closes the wait channel so coalesced waiters wake up.
 func (mc *Client) acquireListToolsContext(ctx context.Context, timeout time.Duration) (context.Context, func() bool, bool) {
 	mc.listToolsMu.Lock()
 	if mc.listToolsInProgress {
@@ -429,6 +436,9 @@ func (mc *Client) acquireListToolsContext(ctx context.Context, timeout time.Dura
 	}
 
 	mc.listToolsInProgress = true
+	mc.listToolsWaitCh = make(chan struct{})
+	mc.listToolsLastResult = nil
+	mc.listToolsLastErr = nil
 	listCtx, cancel := context.WithTimeout(ctx, timeout)
 	mc.listToolsCancel = cancel
 	mc.listToolsMu.Unlock()
@@ -438,6 +448,10 @@ func (mc *Client) acquireListToolsContext(ctx context.Context, timeout time.Dura
 		mc.listToolsMu.Lock()
 		mc.listToolsCancel = nil
 		mc.listToolsInProgress = false
+		if mc.listToolsWaitCh != nil {
+			close(mc.listToolsWaitCh)
+			mc.listToolsWaitCh = nil
+		}
 		mc.listToolsMu.Unlock()
 		return mc.IsConnected()
 	}
@@ -445,7 +459,20 @@ func (mc *Client) acquireListToolsContext(ctx context.Context, timeout time.Dura
 	return listCtx, release, true
 }
 
-// ListTools retrieves tools with concurrency control and coalesces concurrent calls.
+// publishListToolsResult records the outcome of an upstream ListTools call so
+// that coalesced waiters in ListTools() can read it once the wait channel is
+// closed. All call sites that go through acquireListToolsContext (ListTools,
+// the health check, and the tool-count refresh) must publish their result so
+// that an arriving ListTools waiter never reads stale or zero data.
+func (mc *Client) publishListToolsResult(tools []*config.ToolMetadata, err error) {
+	mc.listToolsMu.Lock()
+	mc.listToolsLastResult = tools
+	mc.listToolsLastErr = err
+	mc.listToolsMu.Unlock()
+}
+
+// ListTools retrieves tools with concurrency control and coalesces concurrent
+// callers onto a single in-flight upstream call.
 func (mc *Client) ListTools(ctx context.Context) ([]*config.ToolMetadata, error) {
 	mc.logger.Debug("🔍 ListTools called",
 		zap.String("server", mc.Config.Name),
@@ -459,11 +486,28 @@ func (mc *Client) ListTools(ctx context.Context) ([]*config.ToolMetadata, error)
 		return nil, fmt.Errorf("client not connected (state: %s)", mc.StateManager.GetState().String())
 	}
 
-	// Coalesce concurrent ListTools calls: one caller fetches, others wait for shared result.
-	mc.listToolsMu.Lock()
-	if mc.listToolsInProgress {
+	for {
+		listCtx, release, ok := mc.acquireListToolsContext(ctx, 30*time.Second)
+		if ok {
+			return mc.runListToolsAsLeader(listCtx, release)
+		}
+
+		mc.listToolsMu.Lock()
 		waitCh := mc.listToolsWaitCh
+		inProgress := mc.listToolsInProgress
 		mc.listToolsMu.Unlock()
+
+		if !inProgress {
+			// Race: holder released between the failed acquire and our re-check.
+			// Try to become the leader again.
+			continue
+		}
+		if waitCh == nil {
+			// Defensive fallback: every leader path is supposed to allocate a
+			// wait channel via acquireListToolsContext, so this should be
+			// unreachable. Fail fast rather than block forever on a nil channel.
+			return nil, fmt.Errorf("ListTools operation already in progress for server %s", mc.Config.Name)
+		}
 
 		mc.logger.Debug("🔍 ListTools already in progress, waiting for shared result",
 			zap.String("server", mc.Config.Name))
@@ -482,31 +526,24 @@ func (mc *Client) ListTools(ctx context.Context) ([]*config.ToolMetadata, error)
 			return res, nil
 		}
 	}
+}
 
-	mc.listToolsInProgress = true
-	mc.listToolsWaitCh = make(chan struct{})
-	listCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	mc.listToolsCancel = cancel
-	mc.listToolsMu.Unlock()
-
+// runListToolsAsLeader performs the upstream ListTools call as the elected
+// leader and publishes the result before release() closes the wait channel,
+// so coalesced waiters always see a consistent result.
+func (mc *Client) runListToolsAsLeader(listCtx context.Context, release func() bool) ([]*config.ToolMetadata, error) {
 	defer func() {
-		cancel()
-		mc.listToolsMu.Lock()
-		mc.listToolsCancel = nil
-		mc.listToolsInProgress = false
-		if mc.listToolsWaitCh != nil {
-			close(mc.listToolsWaitCh)
-			mc.listToolsWaitCh = nil
+		if release() {
+			mc.logger.Debug("🔍 ListTools operation completed, flag reset",
+				zap.String("server", mc.Config.Name))
+		} else {
+			mc.logger.Debug("🔍 ListTools operation completed while disconnected",
+				zap.String("server", mc.Config.Name))
 		}
-		mc.listToolsMu.Unlock()
 	}()
 
 	tools, err := mc.coreClient.ListTools(listCtx)
-
-	mc.listToolsMu.Lock()
-	mc.listToolsLastResult = tools
-	mc.listToolsLastErr = err
-	mc.listToolsMu.Unlock()
+	mc.publishListToolsResult(tools, err)
 
 	if err != nil {
 		mc.logger.Error("ListTools operation failed",
@@ -522,9 +559,7 @@ func (mc *Client) ListTools(ctx context.Context) ([]*config.ToolMetadata, error)
 		return nil, fmt.Errorf("ListTools failed: %w", err)
 	}
 
-	// Cache the latest tool count for non-blocking stats consumers
 	mc.setToolCountCache(len(tools))
-
 	return tools, nil
 }
 
@@ -788,7 +823,10 @@ func (mc *Client) performHealthCheck() {
 
 	defer release()
 
-	_, err := mc.coreClient.ListTools(listCtx)
+	// Capture and publish the full result so any concurrent ListTools waiter
+	// (coalesced via the wait channel) receives a real list rather than nil.
+	tools, err := mc.coreClient.ListTools(listCtx)
+	mc.publishListToolsResult(tools, err)
 
 	if err != nil {
 		// Only mark as error if it's a real connection issue, not timeout during high activity
@@ -1267,8 +1305,10 @@ func (mc *Client) GetCachedToolCount(ctx context.Context) (int, error) {
 		zap.Bool("cache_expired", !cachedTime.IsZero()),
 		zap.Duration("cache_age", time.Since(cachedTime)))
 
-	// Fetch fresh tool count with timeout
+	// Fetch fresh tool count with timeout. Publish the result so any concurrent
+	// ListTools waiter coalesced behind us receives the real tools list.
 	tools, err := mc.coreClient.ListTools(listCtx)
+	mc.publishListToolsResult(tools, err)
 	if err != nil {
 		mc.logger.Debug("Tool count fetch failed, returning cached value",
 			zap.String("server", mc.Config.Name),

--- a/internal/upstream/managed/listtools_coalescing_test.go
+++ b/internal/upstream/managed/listtools_coalescing_test.go
@@ -2,7 +2,10 @@ package managed
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,18 +15,23 @@ import (
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/upstream/types"
 )
 
-// TestListTools_CoalescesWaiters verifies that when a ListTools operation is already
-// in progress, additional callers wait for and receive the shared result instead of
-// failing with an in-progress error.
-func TestListTools_CoalescesWaiters(t *testing.T) {
+func newTestReadyClient(t *testing.T) *Client {
+	t.Helper()
 	mc := &Client{
 		Config: &config.ServerConfig{Name: "test-server"},
 		logger: zap.NewNop(),
 	}
-
 	mc.StateManager = types.NewStateManager()
 	mc.StateManager.TransitionTo(types.StateConnecting)
 	mc.StateManager.TransitionTo(types.StateReady)
+	return mc
+}
+
+// TestListTools_CoalescesWaiters verifies that when a ListTools operation is already
+// in progress, additional callers wait for and receive the shared result instead of
+// failing with an in-progress error.
+func TestListTools_CoalescesWaiters(t *testing.T) {
+	mc := newTestReadyClient(t)
 
 	shared := []*config.ToolMetadata{
 		{ServerName: "test-server", Name: "tool_a"},
@@ -45,14 +53,7 @@ func TestListTools_CoalescesWaiters(t *testing.T) {
 // TestListTools_CoalescesWaitersError verifies waiting callers get the same error
 // returned by the in-flight ListTools operation.
 func TestListTools_CoalescesWaitersError(t *testing.T) {
-	mc := &Client{
-		Config: &config.ServerConfig{Name: "test-server"},
-		logger: zap.NewNop(),
-	}
-
-	mc.StateManager = types.NewStateManager()
-	mc.StateManager.TransitionTo(types.StateConnecting)
-	mc.StateManager.TransitionTo(types.StateReady)
+	mc := newTestReadyClient(t)
 
 	mc.listToolsInProgress = true
 	mc.listToolsWaitCh = make(chan struct{})
@@ -64,4 +65,150 @@ func TestListTools_CoalescesWaitersError(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, tools)
 	assert.Contains(t, err.Error(), "ListTools failed")
+}
+
+// TestListTools_MultipleWaitersUnblockedByLeader simulates a real leader/waiter
+// interaction without going through coreClient: the test acquires the
+// in-progress flag (just like the health-check or tool-count paths do), spawns
+// N goroutines that should park in the wait branch, and verifies that
+// publishing a result + releasing wakes all of them with the same data.
+func TestListTools_MultipleWaitersUnblockedByLeader(t *testing.T) {
+	mc := newTestReadyClient(t)
+
+	_, release, ok := mc.acquireListToolsContext(context.Background(), 5*time.Second)
+	require.True(t, ok)
+
+	const waiters = 5
+	results := make([][]*config.ToolMetadata, waiters)
+	errs := make([]error, waiters)
+	var wg sync.WaitGroup
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	for i := 0; i < waiters; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			tools, err := mc.ListTools(ctx)
+			results[idx] = tools
+			errs[idx] = err
+		}(i)
+	}
+
+	// Give waiters a beat to enter the wait branch.
+	time.Sleep(50 * time.Millisecond)
+
+	shared := []*config.ToolMetadata{
+		{ServerName: "test-server", Name: "tool_x"},
+		{ServerName: "test-server", Name: "tool_y"},
+	}
+	mc.publishListToolsResult(shared, nil)
+	release()
+
+	wg.Wait()
+
+	for i := 0; i < waiters; i++ {
+		require.NoErrorf(t, errs[i], "waiter %d", i)
+		assert.Equalf(t, shared, results[i], "waiter %d", i)
+	}
+}
+
+// TestListTools_HealthCheckLeaderDoesNotDeadlockWaiters is the regression test
+// for the nil-channel bug: when a non-ListTools caller (here emulated as a
+// health-check style leader using acquireListToolsContext) holds the
+// in-progress flag, an arriving ListTools must not block on a nil channel.
+// Previously acquireListToolsContext did not allocate a wait channel, so
+// ListTools waiters hung until ctx.Done(). After the fix the channel is always
+// allocated and waiters wake up promptly.
+func TestListTools_HealthCheckLeaderDoesNotDeadlockWaiters(t *testing.T) {
+	mc := newTestReadyClient(t)
+
+	_, release, ok := mc.acquireListToolsContext(context.Background(), 5*time.Second)
+	require.True(t, ok)
+
+	mc.listToolsMu.Lock()
+	require.NotNil(t, mc.listToolsWaitCh, "acquireListToolsContext must allocate a wait channel")
+	mc.listToolsMu.Unlock()
+
+	done := make(chan struct{})
+	var (
+		gotTools []*config.ToolMetadata
+		gotErr   error
+	)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		gotTools, gotErr = mc.ListTools(ctx)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	expected := []*config.ToolMetadata{{ServerName: "test-server", Name: "ping"}}
+	mc.publishListToolsResult(expected, nil)
+	release()
+
+	select {
+	case <-done:
+		require.NoError(t, gotErr)
+		assert.Equal(t, expected, gotTools)
+	case <-time.After(3 * time.Second):
+		t.Fatal("ListTools waiter did not wake up after leader released; coalescing is broken")
+	}
+}
+
+// TestListTools_LeaderErrorPropagatedToWaiters verifies an error from the
+// upstream ListTools call performed by the leader is forwarded to all waiters.
+func TestListTools_LeaderErrorPropagatedToWaiters(t *testing.T) {
+	mc := newTestReadyClient(t)
+
+	_, release, ok := mc.acquireListToolsContext(context.Background(), 5*time.Second)
+	require.True(t, ok)
+
+	const waiters = 3
+	wErrs := make([]error, waiters)
+	var wg sync.WaitGroup
+	for i := 0; i < waiters; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			_, wErrs[idx] = mc.ListTools(ctx)
+		}(i)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	leaderErr := errors.New("upstream boom")
+	mc.publishListToolsResult(nil, leaderErr)
+	release()
+
+	wg.Wait()
+
+	for i := 0; i < waiters; i++ {
+		require.Errorf(t, wErrs[i], "waiter %d", i)
+		assert.Containsf(t, wErrs[i].Error(), "ListTools failed", "waiter %d", i)
+		assert.Containsf(t, wErrs[i].Error(), "upstream boom", "waiter %d", i)
+	}
+}
+
+// TestListTools_AcquireContextResetsCachedResult ensures stale results from a
+// previous call are cleared when a new leader is elected, so any waiter that
+// arrives can never observe a result from an earlier round.
+func TestListTools_AcquireContextResetsCachedResult(t *testing.T) {
+	mc := newTestReadyClient(t)
+
+	mc.listToolsLastResult = []*config.ToolMetadata{{ServerName: "test-server", Name: "stale"}}
+	mc.listToolsLastErr = errors.New("stale error")
+
+	_, release, ok := mc.acquireListToolsContext(context.Background(), time.Second)
+	require.True(t, ok)
+	defer release()
+
+	mc.listToolsMu.Lock()
+	defer mc.listToolsMu.Unlock()
+	assert.Nil(t, mc.listToolsLastResult, "leader acquisition must clear stale results")
+	assert.Nil(t, mc.listToolsLastErr, "leader acquisition must clear stale error")
 }

--- a/internal/upstream/managed/listtools_coalescing_test.go
+++ b/internal/upstream/managed/listtools_coalescing_test.go
@@ -1,0 +1,67 @@
+package managed
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/upstream/types"
+)
+
+// TestListTools_CoalescesWaiters verifies that when a ListTools operation is already
+// in progress, additional callers wait for and receive the shared result instead of
+// failing with an in-progress error.
+func TestListTools_CoalescesWaiters(t *testing.T) {
+	mc := &Client{
+		Config: &config.ServerConfig{Name: "test-server"},
+		logger: zap.NewNop(),
+	}
+
+	mc.StateManager = types.NewStateManager()
+	mc.StateManager.TransitionTo(types.StateConnecting)
+	mc.StateManager.TransitionTo(types.StateReady)
+
+	shared := []*config.ToolMetadata{
+		{ServerName: "test-server", Name: "tool_a"},
+		{ServerName: "test-server", Name: "tool_b"},
+	}
+
+	mc.listToolsInProgress = true
+	mc.listToolsWaitCh = make(chan struct{})
+	mc.listToolsLastResult = shared
+	mc.listToolsLastErr = nil
+
+	close(mc.listToolsWaitCh)
+
+	tools, err := mc.ListTools(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, shared, tools)
+}
+
+// TestListTools_CoalescesWaitersError verifies waiting callers get the same error
+// returned by the in-flight ListTools operation.
+func TestListTools_CoalescesWaitersError(t *testing.T) {
+	mc := &Client{
+		Config: &config.ServerConfig{Name: "test-server"},
+		logger: zap.NewNop(),
+	}
+
+	mc.StateManager = types.NewStateManager()
+	mc.StateManager.TransitionTo(types.StateConnecting)
+	mc.StateManager.TransitionTo(types.StateReady)
+
+	mc.listToolsInProgress = true
+	mc.listToolsWaitCh = make(chan struct{})
+	mc.listToolsLastErr = assert.AnError
+
+	close(mc.listToolsWaitCh)
+
+	tools, err := mc.ListTools(context.Background())
+	require.Error(t, err)
+	assert.Nil(t, tools)
+	assert.Contains(t, err.Error(), "ListTools failed")
+}


### PR DESCRIPTION
### Summary

This PR fixes an intermittent issue where tools from enabled/connected servers (notably `rider-official`) would sometimes not appear in `retrieve_tools` results, even though upstream `ListTools` calls succeeded.

The fix addresses two core causes:

1. **Concurrent `ListTools` contention** produced transient failures (`ListTools operation already in progress`) during discovery.
2. **Discovery race windows** could temporarily omit connected servers from global discovery output, causing visible tool-set shrink in search results.

---

## Root cause

During server churn (restart/reconnect, reactive discovery, background discovery), multiple discovery paths could call `ListTools` on the same managed client at the same time.

Previously:
- first call proceeded,
- second call failed fast with an “already in progress” error.

At the same time, global discovery accepted partial results from currently successful servers. If one connected server was omitted in that cycle, its tools were temporarily absent from indexed/searchable results.

This produced the observed “sometimes shows, sometimes missing” behavior.

---

## What changed

### 1) Coalesced concurrent `ListTools` calls
**File:** `internal/upstream/managed/client.go`

- Reworked managed client `ListTools` concurrency behavior:
  - one caller performs upstream `ListTools`,
  - concurrent callers wait for the same in-flight operation,
  - all waiters receive the shared result/error.
- Eliminates fail-fast path that previously returned:
  - `ListTools operation already in progress for server ...`

**Impact:** prevents transient per-server tool discovery drops caused by local concurrency collisions.

---

### 2) Added last-good per-server snapshot fallback in global discovery
**Files:** `internal/runtime/runtime.go`, `internal/runtime/lifecycle.go`

- Added runtime cache of last known good tool snapshots per server.
- During `DiscoverAndIndexTools`:
  - fresh per-server snapshots are updated from current discovery results,
  - standard differential updates are applied,
  - for connected servers missing from the current discovery pass, the last-good snapshot is reused and re-applied.

**Impact:** avoids temporary index shrink when a connected server is missed in one discovery cycle.

---

### 3) Regression tests for ListTools coalescing
**File:** `internal/upstream/managed/listtools_coalescing_test.go`

Added tests:
- `TestListTools_CoalescesWaiters`
- `TestListTools_CoalescesWaitersError`

These verify that waiters receive shared success/error instead of being rejected while a list operation is already in progress.

---

## Verification

- `go test ./internal/upstream/managed ./internal/runtime` passed.
- Build check passed (`build_project` success).

---

## Scope and non-goals

- This PR focuses on correctness/stability of discovery and visibility.
- Does **not** change retrieval ranking semantics or hard limits (e.g., `retrieve_tools.limit` max 100).
- Does **not** introduce debounce/metadata enhancements (can be follow-up).

---

## Expected behavior after fix

- Enabled/connected servers should no longer disappear from tool retrieval due to in-process `ListTools` races.
- Transient discovery omissions should be masked by last-good snapshots, reducing inconsistent tool visibility across adjacent queries.

---

## Follow-ups (optional)

- Add explicit discovery health metadata to `retrieve_tools` responses (`fresh/degraded`, missing/stale servers).
- Add event debounce for server churn bursts to reduce redundant discovery passes.
- Add broader integration test simulating reconnect storms with repeated retrieval queries.