### PR TITLE
fix(wizard): record per-step completion/skip for Spec 046 funnel

### DIFF
--- a/frontend/src/components/OnboardingWizard.vue
+++ b/frontend/src/components/OnboardingWizard.vue
@@ -936,6 +936,10 @@ async function onBulkImport(quarantine: boolean) {
       if (quarantine && totalImported > 0) msg += '. Approve from the Servers page.'
       selectionImportMessage.value = msg
       selection.value = new Set()
+      // Spec 046 — bulk-import counts as completing the server step.
+      if (totalImported > 0 && onboarding.state?.state.server_step_status !== 'completed') {
+        await onboarding.markServerCompleted()
+      }
       systemStore.addToast({
         type: 'success',
         title: 'Import complete',
@@ -1013,6 +1017,12 @@ async function connectOne(clientId: string) {
       connectMessageOk.value = true
       connectMessage.value = res.data.message || `Connected ${clientId}`
       await fetchClients()
+      // Spec 046 — record connect-step completion for telemetry funnel.
+      // Only the first successful connect transitions the status; subsequent
+      // calls are no-ops on the backend.
+      if (onboarding.state?.state.connect_step_status !== 'completed') {
+        await onboarding.markConnectCompleted()
+      }
       await onboarding.fetchState()
       systemStore.addToast({
         type: 'success',
@@ -1038,6 +1048,10 @@ function openAddServer() {
 async function onServerAdded() {
   addServerOpen.value = false
   serverAddedJustNow.value = true
+  // Spec 046 — record server-step completion for telemetry funnel.
+  if (onboarding.state?.state.server_step_status !== 'completed') {
+    await onboarding.markServerCompleted()
+  }
   await Promise.all([
     serversStore.fetchServers(),
     onboarding.fetchState(),
@@ -1054,6 +1068,16 @@ async function dismiss() {
   // we don't auto-popup again. The sidebar Setup entry remains visible so
   // the user can return.
   if (!onboarding.isEngaged) {
+    // Spec 046 — any step the user never advanced through counts as "skipped"
+    // so the funnel (engaged - completed - skipped) reconciles to engaged
+    // total. Per-step calls are no-ops if a status is already recorded.
+    const stepState = onboarding.state?.state
+    if (stepState && !stepState.connect_step_status) {
+      await onboarding.markConnectSkipped()
+    }
+    if (stepState && !stepState.server_step_status) {
+      await onboarding.markServerSkipped()
+    }
     await onboarding.markEngaged()
   }
   emit('close')


### PR DESCRIPTION
## Summary

The first-run onboarding wizard only ever called `markEngaged()` on dismiss — it never invoked `markConnect*` or `markServer*`. Production telemetry on `telemetry.mcpproxy.app` confirmed the gap: every install that engaged the wizard reported `wizard_engaged=true` with `wizard_connect_step` / `wizard_server_step` still `NULL`, so the funnel queries documented in **Spec 046 SC-012/SC-013** were dead on arrival.

Backend (`internal/httpapi/onboarding.go`), `OnboardingState` storage, telemetry payload (`internal/telemetry/telemetry.go`), and the Cloudflare Worker schema were already correct. The bug was purely a frontend wiring gap in `OnboardingWizard.vue`.

## Fix

Wired four call sites in `frontend/src/components/OnboardingWizard.vue`:

| Trigger | Call added |
|---|---|
| `connectOne()` success | `markConnectCompleted()` |
| `onServerAdded()` (single server) | `markServerCompleted()` |
| `onBulkImport()` with `totalImported > 0` | `markServerCompleted()` |
| `dismiss()` (per step still empty) | `markConnectSkipped()` / `markServerSkipped()` before `markEngaged()` |

Each guarded so it only fires once per install (no re-firing if a status is already `'completed'` / `'skipped'`).

## Evidence the data was broken

After applying migration `0005_add_onboarding_funnel.sql` to the prod D1 and backfilling existing rows from `payload_json`:

```
{wizard_engaged: None, connect_step: None, server_step: None, installs: 10}
{wizard_engaged: 1,    connect_step: None, server_step: None, installs: 5}
```

Every engaged install had both step columns NULL — no install ever made it past step 0 in our funnel reporting, even though the data shows users were clearly using the wizard.

## Test plan

- [x] `npx vue-tsc --noEmit` passes
- [x] `npm run build` succeeds
- [ ] Manual: open wizard, click Connect on a client → verify `connect_step_status='completed'` via `GET /api/v1/onboarding/state`
- [ ] Manual: open wizard, add a server via the modal → verify `server_step_status='completed'`
- [ ] Manual: open wizard, click "Close for now" without acting → verify both step statuses become `'skipped'` and `engaged=true`
- [ ] Manual: re-open wizard after a completed step, dismiss again → verify already-recorded step status is preserved (not overwritten to `'skipped'`)

## Related

- Spec 046: local-first onboarding (`specs/046-local-first-onboarding/`)
- Telemetry worker prod deploy with v4 INSERT path: smart-mcp-proxy/mcpproxy-telemetry@a0f69ac

🤖 Generated with [Claude Code](https://claude.com/claude-code)