### PR TITLE
feat(doctor): surface snap-docker override hint when host needs it

### DIFF
--- a/cmd/mcpproxy/doctor_cmd.go
+++ b/cmd/mcpproxy/doctor_cmd.go
@@ -118,6 +118,26 @@ func runDoctorClientMode(ctx context.Context, dataDir string, logger *zap.Logger
 	// Collect quarantine stats from servers
 	quarantineStats := collectQuarantineStats(ctx, client, logger)
 
+	// Host-environment hint (issue #457). Cheap probe — runs locally because
+	// doctor is socket-bound, i.e. same host as the daemon. Skip on a single-
+	// server filter since the hint is host-global, not server-scoped.
+	var envHint string
+	if doctorServerFilter == "" {
+		servers, err := client.GetServers(ctx)
+		if err != nil {
+			logger.Debug("Failed to get servers for env hint", zap.Error(err))
+		} else {
+			inputs := snapDockerEnvInputs{
+				SnapDockerPresent:      detectSnapDockerPresent(ctx),
+				ServiceHomeOutsideHome: homeOutsideHome(detectServiceHome(ctx)),
+				HasDockerUpstream:      hasDockerUpstream(servers),
+			}
+			if inputs.ShouldWarn() {
+				envHint = snapDockerHint()
+			}
+		}
+	}
+
 	// Spec 044 — optionally narrow to a single server. Applied after
 	// collection so the backend diagnostic shape is unchanged.
 	if doctorServerFilter != "" {
@@ -125,7 +145,7 @@ func runDoctorClientMode(ctx context.Context, dataDir string, logger *zap.Logger
 		quarantineStats = filterQuarantineStatsByServer(quarantineStats, doctorServerFilter)
 	}
 
-	return outputDiagnostics(diag, info, quarantineStats)
+	return outputDiagnostics(diag, info, quarantineStats, envHint)
 }
 
 // filterDiagnosticsByServer returns a shallow copy of the diagnostics
@@ -238,7 +258,7 @@ func collectQuarantineStats(ctx context.Context, client *cliclient.Client, logge
 	return stats
 }
 
-func outputDiagnostics(diag map[string]interface{}, info map[string]interface{}, quarantineStats []quarantineServerStats) error {
+func outputDiagnostics(diag map[string]interface{}, info map[string]interface{}, quarantineStats []quarantineServerStats, envHint string) error {
 	switch doctorOutput {
 	case "json":
 		// Combine diagnostics with info for JSON output
@@ -250,6 +270,9 @@ func outputDiagnostics(diag map[string]interface{}, info map[string]interface{},
 		}
 		if len(quarantineStats) > 0 {
 			combined["quarantine"] = quarantineStats
+		}
+		if envHint != "" {
+			combined["environment_warnings"] = []string{envHint}
 		}
 		output, err := json.MarshalIndent(combined, "", "  ")
 		if err != nil {
@@ -298,6 +321,11 @@ func outputDiagnostics(diag map[string]interface{}, info map[string]interface{},
 
 			// Show deprecated config warnings even when no issues
 			displayDeprecatedConfigs(diag)
+
+			// Host-environment hint (snap-docker, issue #457). Surfaced even
+			// when no per-server diagnostics fired because the upstreams may
+			// still be in retry — the hint preempts the next failure.
+			displayEnvironmentHint(envHint)
 
 			// Display security features status even when no issues
 			fmt.Println("🔒 Security Features")
@@ -461,6 +489,9 @@ func outputDiagnostics(diag map[string]interface{}, info map[string]interface{},
 
 		// Deprecated Configuration warnings
 		displayDeprecatedConfigs(diag)
+
+		// Host-environment hint (snap-docker, issue #457).
+		displayEnvironmentHint(envHint)
 
 		fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 		fmt.Println()

--- a/cmd/mcpproxy/doctor_cmd_test.go
+++ b/cmd/mcpproxy/doctor_cmd_test.go
@@ -30,7 +30,7 @@ func TestOutputDiagnostics_JSONFormat(t *testing.T) {
 	defer func() { os.Stdout = oldStdout }()
 
 	doctorOutput = "json"
-	err := outputDiagnostics(diag, nil, nil)
+	err := outputDiagnostics(diag, nil, nil, "")
 
 	w.Close()
 	var buf bytes.Buffer
@@ -69,7 +69,7 @@ func TestOutputDiagnostics_PrettyFormat_NoIssues(t *testing.T) {
 	defer func() { os.Stdout = oldStdout }()
 
 	doctorOutput = "pretty"
-	err := outputDiagnostics(diag, nil, nil)
+	err := outputDiagnostics(diag, nil, nil, "")
 
 	w.Close()
 	var buf bytes.Buffer
@@ -111,7 +111,7 @@ func TestOutputDiagnostics_PrettyFormat_WithUpstreamErrors(t *testing.T) {
 	defer func() { os.Stdout = oldStdout }()
 
 	doctorOutput = "pretty"
-	err := outputDiagnostics(diag, nil, nil)
+	err := outputDiagnostics(diag, nil, nil, "")
 
 	w.Close()
 	var buf bytes.Buffer
@@ -167,7 +167,7 @@ func TestOutputDiagnostics_PrettyFormat_WithOAuthRequired(t *testing.T) {
 	defer func() { os.Stdout = oldStdout }()
 
 	doctorOutput = "pretty"
-	err := outputDiagnostics(diag, nil, nil)
+	err := outputDiagnostics(diag, nil, nil, "")
 
 	w.Close()
 	var buf bytes.Buffer
@@ -213,7 +213,7 @@ func TestOutputDiagnostics_PrettyFormat_WithMissingSecrets(t *testing.T) {
 	defer func() { os.Stdout = oldStdout }()
 
 	doctorOutput = "pretty"
-	err := outputDiagnostics(diag, nil, nil)
+	err := outputDiagnostics(diag, nil, nil, "")
 
 	w.Close()
 	var buf bytes.Buffer
@@ -255,7 +255,7 @@ func TestOutputDiagnostics_PrettyFormat_WithRuntimeWarnings(t *testing.T) {
 	defer func() { os.Stdout = oldStdout }()
 
 	doctorOutput = "pretty"
-	err := outputDiagnostics(diag, nil, nil)
+	err := outputDiagnostics(diag, nil, nil, "")
 
 	w.Close()
 	var buf bytes.Buffer
@@ -309,7 +309,7 @@ func TestOutputDiagnostics_PrettyFormat_MultipleIssueTypes(t *testing.T) {
 	defer func() { os.Stdout = oldStdout }()
 
 	doctorOutput = "pretty"
-	err := outputDiagnostics(diag, nil, nil)
+	err := outputDiagnostics(diag, nil, nil, "")
 
 	w.Close()
 	var buf bytes.Buffer
@@ -356,7 +356,7 @@ func TestOutputDiagnostics_PrettyFormat_SingleIssue(t *testing.T) {
 	defer func() { os.Stdout = oldStdout }()
 
 	doctorOutput = "pretty"
-	err := outputDiagnostics(diag, nil, nil)
+	err := outputDiagnostics(diag, nil, nil, "")
 
 	w.Close()
 	var buf bytes.Buffer
@@ -386,7 +386,7 @@ func TestOutputDiagnostics_EmptyFormat(t *testing.T) {
 
 	// Empty string should default to pretty format
 	doctorOutput = ""
-	err := outputDiagnostics(diag, nil, nil)
+	err := outputDiagnostics(diag, nil, nil, "")
 
 	w.Close()
 	var buf bytes.Buffer
@@ -551,7 +551,7 @@ func TestOutputDiagnostics_WarningWithoutTitle(t *testing.T) {
 	defer func() { os.Stdout = oldStdout }()
 
 	doctorOutput = "pretty"
-	err := outputDiagnostics(diag, nil, nil)
+	err := outputDiagnostics(diag, nil, nil, "")
 
 	w.Close()
 	var buf bytes.Buffer
@@ -586,7 +586,7 @@ func TestOutputDiagnostics_HighSeverityWarning(t *testing.T) {
 	defer func() { os.Stdout = oldStdout }()
 
 	doctorOutput = "pretty"
-	err := outputDiagnostics(diag, nil, nil)
+	err := outputDiagnostics(diag, nil, nil, "")
 
 	w.Close()
 	var buf bytes.Buffer
@@ -624,7 +624,7 @@ func TestOutputDiagnostics_SecretWithoutOptionalFields(t *testing.T) {
 	defer func() { os.Stdout = oldStdout }()
 
 	doctorOutput = "pretty"
-	err := outputDiagnostics(diag, nil, nil)
+	err := outputDiagnostics(diag, nil, nil, "")
 
 	w.Close()
 	var buf bytes.Buffer
@@ -665,7 +665,7 @@ func TestOutputDiagnostics_MissingSecretsRealJSON(t *testing.T) {
 	defer func() { os.Stdout = oldStdout }()
 
 	doctorOutput = "pretty"
-	err := outputDiagnostics(diag, nil, nil)
+	err := outputDiagnostics(diag, nil, nil, "")
 
 	w.Close()
 	var buf bytes.Buffer

--- a/cmd/mcpproxy/doctor_env_snapdocker.go
+++ b/cmd/mcpproxy/doctor_env_snapdocker.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// Host-environment hint surfaced by `mcpproxy doctor` when the combination
+// "snap-installed Docker" + "service runs as a system user with HOME outside
+// /home" + "at least one configured upstream uses docker" is detected.
+//
+// On such hosts, the deb's packaged systemd hardening fights snap-confine on
+// four orthogonal axes (HOME location, ProtectHome=true masking /run/user/<uid>,
+// CapabilityBoundingSet too narrow, NoNewPrivileges blocking the SUID hop into
+// snap-confine). Without an override drop-in, every docker-based upstream
+// produces a several-paragraph stderr blob that's hard to map back to a fix.
+//
+// See https://github.com/smart-mcp-proxy/mcpproxy-go/issues/457 for the trace.
+
+// snapDockerEnvInputs is the set of observations the warning decision is
+// computed from. Keeping it a plain struct makes the decision testable without
+// running on a real host.
+type snapDockerEnvInputs struct {
+	SnapDockerPresent      bool
+	ServiceHomeOutsideHome bool
+	HasDockerUpstream      bool
+}
+
+// ShouldWarn reports whether the doctor output should include the override
+// hint. All three signals must be true — any one missing means the user is
+// not affected by this specific incompatibility.
+func (i snapDockerEnvInputs) ShouldWarn() bool {
+	return i.SnapDockerPresent && i.ServiceHomeOutsideHome && i.HasDockerUpstream
+}
+
+// homeOutsideHome decides whether a given HOME path triggers snap-confine's
+// "home directories outside of /home" rejection. Empty HOME is treated as
+// "inside" so we don't false-positive on hosts where we couldn't read the
+// service's environment.
+func homeOutsideHome(home string) bool {
+	if home == "" {
+		return false
+	}
+	return !strings.HasPrefix(home, "/home/")
+}
+
+// hasDockerUpstream inspects the daemon's server list (the shape returned by
+// GET /api/v1/servers, decoded as []map[string]interface{}) and reports
+// whether any configured upstream would invoke `docker`.
+//
+// Three patterns count:
+//
+//  1. command == "docker" (direct stdio docker)
+//  2. command == "/bin/bash" (or similar shell) whose args contain "docker"
+//     — the kubic linkedin-direct pattern that sources an env file then execs
+//     docker run.
+//  3. docker_isolation == true regardless of command — the Spec-027 Docker
+//     isolation flag spawns docker run on any upstream.
+//
+// Disabled servers still count because re-enabling them in the UI shouldn't
+// surprise the user with a fresh stderr storm.
+func hasDockerUpstream(servers []map[string]interface{}) bool {
+	for _, s := range servers {
+		if iso, ok := s["docker_isolation"].(bool); ok && iso {
+			return true
+		}
+		cmd, _ := s["command"].(string)
+		if cmd == "docker" {
+			return true
+		}
+		// Shell wrappers — check args for `docker`.
+		if cmd == "/bin/bash" || cmd == "/bin/sh" || cmd == "bash" || cmd == "sh" {
+			args, _ := s["args"].([]interface{})
+			for _, a := range args {
+				if str, ok := a.(string); ok && strings.Contains(str, "docker") {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// detectSnapDockerPresent returns true if snap-installed docker is on the
+// host. Cheap stat — no exec needed. Falls back to `docker version` parse
+// only when the canonical /snap/bin/docker is absent (some installs symlink
+// from /usr/local/bin or vary by snap version).
+func detectSnapDockerPresent(ctx context.Context) bool {
+	if runtime.GOOS != "linux" {
+		return false
+	}
+	if _, err := os.Stat("/snap/bin/docker"); err == nil {
+		return true
+	}
+	cctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(cctx, "docker", "version", "--format", "{{.Server.Platform.Name}}").Output()
+	if err != nil {
+		return false
+	}
+	return bytes.Contains(bytes.ToLower(out), []byte("snap"))
+}
+
+// detectServiceHome returns the effective HOME of the mcpproxy systemd
+// service ("" if it cannot be read, e.g. service not under systemd or we
+// aren't on Linux). Uses `systemctl show` because it's the only way to
+// observe the unit's resolved env without running anything as the service
+// user. Non-root reads are fine — show is a read-only introspection call.
+func detectServiceHome(ctx context.Context) string {
+	if runtime.GOOS != "linux" {
+		return ""
+	}
+	cctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(cctx, "systemctl", "show", "mcpproxy.service", "--property=Environment").Output()
+	if err != nil {
+		return ""
+	}
+	// Output format: "Environment=HEADLESS=1 HOME=/var/lib/mcpproxy ..."
+	line := strings.TrimSpace(strings.TrimPrefix(string(out), "Environment="))
+	for _, kv := range strings.Fields(line) {
+		if rest, found := strings.CutPrefix(kv, "HOME="); found {
+			return rest
+		}
+	}
+	return ""
+}
+
+// displayEnvironmentHint prints the host-environment hint in pretty doctor
+// output. No-op when hint is empty so the caller doesn't need to gate it.
+func displayEnvironmentHint(hint string) {
+	if hint == "" {
+		return
+	}
+	fmt.Println("🌐 Environment")
+	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	fmt.Println(hint)
+	fmt.Println()
+}
+
+// snapDockerHint returns the canonical override snippet, ready for the user
+// to copy-paste verbatim. Asserted token-by-token in tests so wording can
+// drift but the operationally-critical lines can't.
+func snapDockerHint() string {
+	return `⚠️  Snap-docker incompatibility detected
+
+This host has Docker installed via snap, and the mcpproxy service is running
+under a system user whose HOME sits outside /home/. One or more of your
+upstream MCP servers shells out to "docker run", which will fail under the
+deb's default hardening with stderr like:
+
+    snap-confine ... required permitted capability cap_dac_override not found
+    cannot create XDG_RUNTIME_DIR folder "/run/user/<uid>/snap.docker"
+
+Fix (one-time host setup):
+
+    sudo loginctl enable-linger mcpproxy
+    sudo snap set system homedirs=/var/lib
+    sudo systemctl restart snapd
+    sudo snap restart docker
+
+Then drop /etc/systemd/system/mcpproxy.service.d/snap-docker.conf with:
+
+    [Service]
+    NoNewPrivileges=false
+    RestrictSUIDSGID=false
+    LockPersonality=false
+    ProtectHome=false
+    CapabilityBoundingSet=~
+    AmbientCapabilities=
+    RuntimeDirectory=mcpproxy
+    RuntimeDirectoryMode=0700
+
+…and: sudo systemctl daemon-reload && sudo systemctl restart mcpproxy
+
+Why each line is needed: see docs/getting-started/installation.md
+(section: Migrating from a manually-installed mcpproxy) or the project's
+issue tracker for the full root-cause breakdown.`
+}

--- a/cmd/mcpproxy/doctor_env_snapdocker_test.go
+++ b/cmd/mcpproxy/doctor_env_snapdocker_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Pure-logic unit tests for the snap-docker environment hint. The detection
+// itself runs against the live host (proc, /snap/bin/docker, the daemon's
+// server list) — the part exercised here is only the decision: given a set
+// of observations, should `mcpproxy doctor` print the override snippet?
+//
+// Keeping detection inputs separate from the decision lets us add new probes
+// (e.g. checking AppArmor profile state) without churning the test matrix.
+
+func TestSnapDockerEnvInputs_ShouldWarn(t *testing.T) {
+	cases := []struct {
+		name string
+		in   snapDockerEnvInputs
+		want bool
+	}{
+		{
+			name: "all signals present — warn",
+			in:   snapDockerEnvInputs{SnapDockerPresent: true, ServiceHomeOutsideHome: true, HasDockerUpstream: true},
+			want: true,
+		},
+		{
+			name: "no snap docker on host — no warn (apt docker handles HOME fine)",
+			in:   snapDockerEnvInputs{SnapDockerPresent: false, ServiceHomeOutsideHome: true, HasDockerUpstream: true},
+			want: false,
+		},
+		{
+			name: "service runs under /home — no warn (manual install pattern)",
+			in:   snapDockerEnvInputs{SnapDockerPresent: true, ServiceHomeOutsideHome: false, HasDockerUpstream: true},
+			want: false,
+		},
+		{
+			name: "no docker upstreams configured — no warn (snap docker never invoked)",
+			in:   snapDockerEnvInputs{SnapDockerPresent: true, ServiceHomeOutsideHome: true, HasDockerUpstream: false},
+			want: false,
+		},
+		{
+			name: "zero signals — no warn",
+			in:   snapDockerEnvInputs{},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.in.ShouldWarn(); got != tc.want {
+				t.Errorf("ShouldWarn()=%v, want %v (inputs=%+v)", got, tc.want, tc.in)
+			}
+		})
+	}
+}
+
+func TestHomeOutsideHome(t *testing.T) {
+	cases := []struct {
+		name     string
+		home     string
+		expected bool
+	}{
+		{"deb's system user", "/var/lib/mcpproxy", true},
+		{"alt sysuser dir", "/var/lib/something", true},
+		{"empty HOME treated as inside (don't false-positive)", "", false},
+		{"human user under /home", "/home/alice", false},
+		{"root", "/root", true},
+		{"trailing slash on /home prefix counted as inside", "/home/", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := homeOutsideHome(tc.home); got != tc.expected {
+				t.Errorf("homeOutsideHome(%q)=%v, want %v", tc.home, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestHasDockerUpstreamFromServers(t *testing.T) {
+	cases := []struct {
+		name    string
+		servers []map[string]interface{}
+		want    bool
+	}{
+		{
+			name: "direct command: docker",
+			servers: []map[string]interface{}{
+				{"name": "duckduckgo", "command": "docker", "enabled": true},
+			},
+			want: true,
+		},
+		{
+			name: "bash wrapper that execs docker run",
+			servers: []map[string]interface{}{
+				{"name": "linkedin", "command": "/bin/bash", "args": []interface{}{"-c", "set -a; source /etc/x.env; exec docker run -i --rm img"}, "enabled": true},
+			},
+			want: true,
+		},
+		{
+			name: "stdio server with no docker — irrelevant",
+			servers: []map[string]interface{}{
+				{"name": "tavily", "command": "uvx", "args": []interface{}{"tavily-mcp"}, "enabled": true},
+			},
+			want: false,
+		},
+		{
+			name: "docker upstream but disabled — still relevant (will reconnect when enabled)",
+			servers: []map[string]interface{}{
+				{"name": "duckduckgo", "command": "docker", "enabled": false},
+			},
+			want: true,
+		},
+		{
+			name: "docker_isolation true on otherwise-non-docker server (Spec docker-isolation flag)",
+			servers: []map[string]interface{}{
+				{"name": "x", "command": "uvx", "args": []interface{}{"y"}, "docker_isolation": true, "enabled": true},
+			},
+			want: true,
+		},
+		{
+			name:    "no servers at all",
+			servers: nil,
+			want:    false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasDockerUpstream(tc.servers); got != tc.want {
+				t.Errorf("hasDockerUpstream()=%v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSnapDockerHintContent(t *testing.T) {
+	hint := snapDockerHint()
+	// Just sanity — make sure the rendered hint contains the critical commands
+	// users need to copy-paste. The exact wording is intentionally not asserted
+	// to keep wordsmith edits cheap.
+	required := []string{
+		"loginctl enable-linger mcpproxy",
+		"snap set system homedirs=/var/lib",
+		"systemctl restart snapd",
+		"/etc/systemd/system/mcpproxy.service.d/snap-docker.conf",
+		"ProtectHome=false",
+		"NoNewPrivileges=false",
+		"CapabilityBoundingSet=~",
+	}
+	for _, want := range required {
+		if !strings.Contains(hint, want) {
+			t.Errorf("snapDockerHint() missing required token %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `mcpproxy doctor` gains a host-environment check that detects the snap-docker × deb-hardened-unit incompatibility (issue #457)
- When all three signals fire (snap docker present, systemd service HOME outside `/home/`, at least one upstream uses docker), pretty output prints a new `🌐 Environment` section with the exact override drop-in plus one-time host commands
- JSON output (`--output=json`) gains an `environment_warnings` array — consistent with the existing `runtime_warnings` shape

## Why

Migrating to the deb on an Ubuntu host with snap docker produces stderr like:

```
snap-confine ... required permitted capability cap_dac_override not found
cannot create XDG_RUNTIME_DIR folder "/run/user/996/snap.docker"
```

…which is hard to map back to "you need a ~10-line systemd drop-in". This makes `mcpproxy doctor` print the snippet directly so the user can copy-paste it. Same class of help as the existing `ClassifyScannerExecFailure` for scanner containers.

## Design

Pure decision (`snapDockerEnvInputs.ShouldWarn`) is split from the host probes so the test matrix doesn't depend on running on a real snap-docker host:

- `hasDockerUpstream(servers)` — matches `command: docker`, shell wrappers whose args contain `docker`, and `docker_isolation: true`
- `homeOutsideHome(path)` — treats empty HOME as "inside" so we don't false-positive when we can't read service env
- `detectSnapDockerPresent(ctx)` — `/snap/bin/docker` stat, falls back to `docker version --format` parse
- `detectServiceHome(ctx)` — `systemctl show mcpproxy.service --property=Environment`, parses `HOME=...`
- Both host probes no-op on non-Linux

## Test plan

- [x] `go test ./cmd/mcpproxy/` passes (16 new sub-tests across 4 functions)
- [x] `go test -race ./cmd/mcpproxy/` clean
- [x] `go vet ./cmd/mcpproxy/` clean
- [x] Existing doctor tests updated to the new `outputDiagnostics` signature
- [ ] Reviewer: try `./mcpproxy doctor` on a snap-docker host with a docker-based upstream and confirm the Environment block renders. Also try on macOS / non-snap-docker Linux and confirm it's silent (no false positives).

Closes #457.

🤖 Generated with [Claude Code](https://claude.com/claude-code)