### PR TITLE
fix(ui): respect engaged flag in sidebar Setup pulse

### DIFF
--- a/frontend/src/components/SidebarNav.vue
+++ b/frontend/src/components/SidebarNav.vue
@@ -402,8 +402,17 @@ const onboardingStore = useOnboardingStore()
 
 // Spec 046 v2: badge count drives the sidebar Setup entry's pulse + count.
 // Refetched on mount; the wizard itself drives subsequent updates while open.
+//
+// Pulse is also gated on `!isEngaged` so that headless / LAN-server installs
+// (where HasConnectedClient and FirstMCPClientEver are structurally false —
+// there's no local AI client and no GUI to install one) can quiet the badge
+// by clicking "Close for now". The Setup entry itself remains in the sidebar
+// so the user can re-open the wizard, but it no longer pulses or shows a
+// count after engagement.
 const setupCount = computed(() => onboardingStore.incompleteTabCount)
-const setupIncomplete = computed(() => setupCount.value > 0)
+const setupIncomplete = computed(
+  () => setupCount.value > 0 && !onboardingStore.isEngaged
+)
 const setupTitleAttr = computed(() =>
   setupIncomplete.value
     ? `Setup (${setupCount.value} step${setupCount.value === 1 ? '' : 's'} remaining)`


### PR DESCRIPTION
## Summary

One-line fix in `frontend/src/components/SidebarNav.vue`: the sidebar Setup item's pulse + badge now respect `onboardingStore.isEngaged`, not just the live `incompleteTabCount`.

```diff
-const setupIncomplete = computed(() => setupCount.value > 0)
+const setupIncomplete = computed(
+  () => setupCount.value > 0 && !onboardingStore.isEngaged
+)
```

## Why

On a remote/LAN mcpproxy install, `HasConnectedClient` and `FirstMCPClientEver` are structurally false (no local AI client, no GUI to install one). `incompleteTabCount` stayed ≥ 1 forever, so the Setup item pulsed indefinitely — even after the user clicked the wizard's "Close for now" multiple times. The dismiss action correctly persisted `engaged: true` server-side via `markEngaged()`, but the sidebar wasn't reading it back. Half a feature.

The Setup entry itself remains in the sidebar so users can reopen the wizard whenever they want; only the `animate-ping` halo and the count badge are gated.

## Test plan

- [x] `npm run type-check` clean
- [ ] Manual verification: open the web UI on a headless mcpproxy, confirm Setup pulses, click "Close for now", confirm pulse + badge disappear but Setup item is still clickable
- [ ] Reviewer: visual check that the existing "all green" path (count == 0) still shows the quiet checkmark — the change is `count > 0 && !engaged`, so when count is 0 the branch is the same as before

Closes #461.

🤖 Generated with [Claude Code](https://claude.com/claude-code)