### PR TITLE
fix(diagnostics): correct bug-report URL in Unknown failure catalog entry

### DIFF
--- a/internal/diagnostics/registry.go
+++ b/internal/diagnostics/registry.go
@@ -345,7 +345,7 @@ func seedUNKNOWN() {
 		Severity:    SeverityError,
 		UserMessage: "mcpproxy could not classify this failure. Please file a bug report so we can add a specific code.",
 		FixSteps: []FixStep{
-			{Type: FixStepLink, Label: "Report a bug", URL: "https://github.com/smartmcpproxy/mcpproxy-go/issues/new?template=bug_report.md"},
+			{Type: FixStepLink, Label: "Report a bug", URL: "https://github.com/smart-mcp-proxy/mcpproxy-go/issues/new"},
 		},
 		DocsURL: docsURL(UnknownUnclassified),
 	})


### PR DESCRIPTION
## Summary
Fix the "Report a bug" link shown for `UnknownUnclassified` diagnostic failures.

Old URL:
```
https://github.com/smartmcpproxy/mcpproxy-go/issues/new?template=bug_report.md
```

Two problems:
- **Wrong org**: real repo is `smart-mcp-proxy` (hyphenated). The unhyphenated form 404s.
- **Template doesn't exist**: the repo has no `.github/ISSUE_TEMPLATE/` directory, so `?template=bug_report.md` silently selects nothing even on the correct org.

New URL (matches the existing link in `frontend/src/views/Feedback.vue`):
```
https://github.com/smart-mcp-proxy/mcpproxy-go/issues/new
```

## Test plan
- [x] `go build ./...` — green.
- [x] `go vet ./internal/diagnostics/` — clean.
- [ ] Manual: trigger an `UnknownUnclassified` diagnostic and click the bug-report link — should land on the real issue-create page on `smart-mcp-proxy/mcpproxy-go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)