### PR TITLE
chore(ci): align workflow frontend-copy with Makefile frontend-build

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -176,8 +176,11 @@ jobs:
         shell: bash
         run: |
           rm -rf web/frontend
-          mkdir -p web/frontend
-          cp -r frontend/dist web/frontend/
+          mkdir -p web/frontend/dist
+          cp -r frontend/dist/. web/frontend/dist/
+          # Recreate the tracked .gitkeep so //go:embed all:frontend/dist
+          # always has something to embed (matches the Makefile frontend-build target).
+          touch web/frontend/dist/.gitkeep
 
       - name: Run tests (skip binary E2E tests - not compatible with cross-compilation)
         # Skip tests for Windows ARM64 (cross-compilation - can't run ARM64 binaries on AMD64 runner)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -294,8 +294,11 @@ jobs:
         shell: bash
         run: |
           rm -rf web/frontend
-          mkdir -p web/frontend
-          cp -r frontend/dist web/frontend/
+          mkdir -p web/frontend/dist
+          cp -r frontend/dist/. web/frontend/dist/
+          # Recreate the tracked .gitkeep so //go:embed all:frontend/dist
+          # always has something to embed (matches the Makefile frontend-build target).
+          touch web/frontend/dist/.gitkeep
 
       - name: Import Code-Signing Certificates (macOS)
         if: matrix.goos == 'darwin'


### PR DESCRIPTION
## Summary

Follow-up to #473. That PR changed the Makefile `frontend-build` target to:

```sh
mkdir -p web/frontend/dist
cp -r frontend/dist/. web/frontend/dist/
touch web/frontend/dist/.gitkeep
```

but left the `Copy frontend dist` steps in `release.yml` and `pr-build.yml` on the older form:

```sh
mkdir -p web/frontend
cp -r frontend/dist web/frontend/
```

Both forms place a real `index.html` under `web/frontend/dist/`, so **release artifacts (Homebrew, Docker, .deb, DMG, etc.) were never broken** — the divergence was purely a maintenance/consistency hazard, and the workflows did not recreate the tracked `.gitkeep`. This change makes the two CI workflows use the exact same canonical form as the Makefile.

## Changes

- `.github/workflows/release.yml` — copy step now `cp -r frontend/dist/. web/frontend/dist/` + `touch web/frontend/dist/.gitkeep`
- `.github/workflows/pr-build.yml` — same

## Risk

None functional. The embed input is identical (real Vite bundle under `web/frontend/dist/`); only the copy form and an extra harmless `.gitkeep` touch change. YAML validated.

## Merge order

Best merged **after #473** (the `.gitkeep` is meaningless until #473 tracks it), but functionally safe in either order since `web/frontend/` is gitignored on `main` today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)