### PR TITLE
fix(049): classifyServerToolStatus runtime config authority

### DIFF
--- a/internal/runtime/tool_disabled_classify_test.go
+++ b/internal/runtime/tool_disabled_classify_test.go
@@ -79,3 +79,20 @@ func BenchmarkClassifyDisabledTool(b *testing.B) {
 		_ = rt.ClassifyDisabledTool("github", "delete_repo")
 	}
 }
+
+// Regression for the #476 follow-up: config-file disabled_tools live ONLY in
+// the runtime config, not always in the storage copy. ClassifyDisabledTool
+// must read the live config (r.Config()) so disabled_by_config is correct for
+// config-file stdio servers — the server-layer classifier delegates its
+// config-denied leg to this authority.
+func TestClassifyDisabledTool_ConfigFromLiveConfig(t *testing.T) {
+	rt := setupConfigFilterRuntime(t, []*config.ServerConfig{
+		{Name: "cfgsrv", Enabled: true, DisabledTools: []string{"locked"}},
+	})
+	// No storage approval record and no storage.SaveUpstreamServer call:
+	// disabled_tools exists only in the live config here.
+	assert.Equal(t, contracts.DisabledStatusByConfig,
+		rt.ClassifyDisabledTool("cfgsrv", "locked"))
+	assert.Equal(t, contracts.DisabledStatusUnknown,
+		rt.ClassifyDisabledTool("cfgsrv", "allowed")) // callable → not a disable reason
+}

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -4665,8 +4665,11 @@ func (p *MCPProxyServer) serverToolCounts(serverName string, toolNames []string)
 }
 
 // classifyServerToolStatus returns "" when the tool is callable, otherwise the
-// disable reason. Storage-sourced, runtime-independent, mirrors
-// classifyDisabledTool's precedence so the two never drift.
+// disable reason. Mirrors classifyDisabledTool's precedence so the two never
+// drift. The config-denied leg prefers the live runtime signal (the same
+// authority isToolCallable/blockedToolMessage use — config-file disabled_tools
+// only lives in the live config, not always in the storage copy); it falls
+// back to the storage ServerConfig when no runtime is wired (unit tests).
 func (p *MCPProxyServer) classifyServerToolStatus(serverName, toolName string) contracts.DisabledToolStatus {
 	if strings.Contains(toolName, ":") {
 		if parts := strings.SplitN(toolName, ":", 2); len(parts) == 2 {
@@ -4683,7 +4686,13 @@ func (p *MCPProxyServer) classifyServerToolStatus(serverName, toolName string) c
 	if !sc.Enabled {
 		return contracts.DisabledStatusServerDisabled
 	}
-	if !sc.IsToolAllowedByConfig(toolName) {
+	configDenied := false
+	if p.mainServer != nil && p.mainServer.runtime != nil {
+		configDenied = p.mainServer.runtime.IsToolConfigDenied(serverName, toolName)
+	} else {
+		configDenied = !sc.IsToolAllowedByConfig(toolName)
+	}
+	if configDenied {
 		return contracts.DisabledStatusByConfig
 	}
 	if approval, aerr := p.storage.GetToolApproval(serverName, toolName); aerr == nil && approval != nil {


### PR DESCRIPTION
Follow-up correctness fix to #476 (spec 049).

#476's `classifyServerToolStatus` derived config-denial only from the storage `ServerConfig` copy. For config-file `disabled_tools` on **stdio** servers, that value lives in the live runtime config and is not always mirrored into storage — so `disabled_by_config` classification and `upstream_servers` tool counts were wrong at runtime for that case. (Unit tests passed because the no-runtime test harness exercises the storage fallback path; the gap was found during live curl/MCP verification and documented in `specs/049-…/quickstart.md`.)

## Fix
- `classifyServerToolStatus` now prefers `runtime.IsToolConfigDenied` (the same authority `isToolCallable`/`blockedToolMessage` use); falls back to storage `IsToolAllowedByConfig` only when no runtime is wired (unit tests).
- Adds `TestClassifyDisabledTool_ConfigFromLiveConfig` pinning that the runtime classifier reads live config (the authority the server layer delegates to).

No behavior change on the default path; no storage/enforcement change.

Related #468