### PR TITLE
fix(registry): Docker MCP Catalog → docker run install (closes #483)

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -642,9 +642,15 @@ class APIService {
       protocol: 'stdio'
     }
 
-    // Determine command and args from installCmd or connectUrl
-    if (server.installCmd) {
-      const parts = server.installCmd.split(' ')
+    // Determine command and args from install_cmd or connect_url.
+    // NB: backend contracts.RepositoryServer serialises these as snake_case
+    // (install_cmd, connect_url). Reading the wrong casing here is the
+    // second half of issue #483 — for a stdio entry the install command
+    // was silently undefined and the call fell through to "neither url nor
+    // command supplied", surfaced as "Either 'url' or 'command' parameter
+    // is required".
+    if (server.install_cmd) {
+      const parts = server.install_cmd.split(' ').filter(Boolean)
       args.command = parts[0]
       if (parts.length > 1) {
         args.args_json = JSON.stringify(parts.slice(1))
@@ -653,9 +659,9 @@ class APIService {
       // Remote server with HTTP protocol
       args.protocol = 'http'
       args.url = server.url
-    } else if (server.connectUrl) {
+    } else if (server.connect_url) {
       args.protocol = 'http'
-      args.url = server.connectUrl
+      args.url = server.connect_url
     }
 
     return this.callTool('upstream_servers', args)

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -531,8 +531,8 @@ export interface RepositoryServer {
   description: string
   url?: string  // MCP endpoint for remote servers only
   source_code_url?: string  // Source repository URL
-  installCmd?: string  // Installation command
-  connectUrl?: string  // Alternative connection URL
+  install_cmd?: string  // Installation command (matches backend contracts.RepositoryServer)
+  connect_url?: string  // Alternative connection URL (matches backend contracts.RepositoryServer)
   updatedAt?: string
   createdAt?: string
   registry?: string  // Which registry this came from

--- a/frontend/src/views/Repositories.vue
+++ b/frontend/src/views/Repositories.vue
@@ -131,11 +131,11 @@
             </div>
 
             <!-- Install Command -->
-            <div v-if="server.installCmd" class="mt-3">
+            <div v-if="server.install_cmd" class="mt-3">
               <div class="flex items-center justify-between bg-base-200 rounded px-2 py-1">
-                <code class="text-xs flex-1 overflow-x-auto">{{ server.installCmd }}</code>
+                <code class="text-xs flex-1 overflow-x-auto">{{ server.install_cmd }}</code>
                 <button
-                  @click="copyToClipboard(server.installCmd)"
+                  @click="copyToClipboard(server.install_cmd)"
                   class="btn btn-ghost btn-xs ml-2"
                   title="Copy install command"
                 >

--- a/internal/registries/search.go
+++ b/internal/registries/search.go
@@ -326,9 +326,17 @@ func parseDocker(rawData interface{}) []ServerEntry {
 			continue
 		}
 		if name, ok := itemMap["name"].(string); ok && name != "" {
+			// Docker Hub's mcp/ namespace returns image repo names (e.g. "sqlite",
+			// "git", "fetch"). The full reference is mcp/<name>. These images are
+			// stdio MCP servers, so the canonical launch is `docker run -i --rm`.
+			// We MUST set InstallCmd (not URL) — the URL field is reserved for HTTP/SSE
+			// remote endpoints. See issue #483: synthesising "docker://mcp/<name>" as a
+			// URL caused the frontend to register it as an http transport, leading to
+			// `Post "docker://mcp/sqlite": unsupported protocol scheme "docker"`.
 			server := ServerEntry{
-				ID:   name,
-				Name: name,
+				ID:         name,
+				Name:       name,
+				InstallCmd: fmt.Sprintf("docker run -i --rm mcp/%s", name),
 			}
 
 			// Try to get description from images array
@@ -563,9 +571,12 @@ func constructServerURL(server *ServerEntry, reg *RegistryEntry) string {
 			return fmt.Sprintf("https://api.mcpstore.co/servers/%s/mcp", server.ID)
 		}
 	case protocolDocker:
-		if server.ID != "" {
-			return fmt.Sprintf("docker://mcp/%s", server.ID)
-		}
+		// Docker MCP catalog entries are stdio servers launched via `docker run`
+		// (see parseDocker — InstallCmd is populated). Do NOT synthesise a URL:
+		// the URL field is for HTTP/SSE remote endpoints only, and any non-empty
+		// value here causes the frontend to register the server as an http
+		// transport (issue #483).
+		return ""
 	case protocolFleur:
 		if server.ID != "" {
 			return fmt.Sprintf("https://api.fleurmcp.com/apps/%s/mcp", server.ID)

--- a/internal/registries/search_test.go
+++ b/internal/registries/search_test.go
@@ -296,6 +296,16 @@ func TestParseDocker(t *testing.T) {
 	if servers[0].Description != "Weather MCP server" {
 		t.Errorf("expected description 'Weather MCP server', got '%s'", servers[0].Description)
 	}
+	// Regression for issue #483: Docker catalog entries must surface as a docker
+	// run install command, NOT a synthetic "docker://" URL (which the frontend
+	// would mis-classify as an http transport).
+	if servers[0].URL != "" {
+		t.Errorf("expected empty URL for Docker catalog entry, got '%s'", servers[0].URL)
+	}
+	wantCmd := "docker run -i --rm mcp/mcp-weather"
+	if servers[0].InstallCmd != wantCmd {
+		t.Errorf("expected InstallCmd %q, got %q", wantCmd, servers[0].InstallCmd)
+	}
 }
 
 func TestParseFleur(t *testing.T) {
@@ -769,10 +779,13 @@ func TestConstructServerURL(t *testing.T) {
 			"https://api.mcpstore.co/servers/news/mcp",
 		},
 		{
-			"docker protocol",
+			// Issue #483: Docker catalog must NOT synthesise a docker:// URL —
+			// the URL field is reserved for HTTP/SSE remote endpoints. The launch
+			// info travels via InstallCmd populated by parseDocker.
+			"docker protocol returns empty (install via docker run)",
 			ServerEntry{ID: "scraper", URL: ""},
 			RegistryEntry{Protocol: "custom/docker"},
-			"docker://mcp/scraper",
+			"",
 		},
 		{
 			"fleur protocol",


### PR DESCRIPTION
## Summary

Closes #483. Adding a server from the Docker MCP Catalog repository now produces a valid stdio config (`docker run -i --rm mcp/<name>`) instead of the synthetic `docker://mcp/<name>` URL that the frontend then mis-classified as an HTTP transport.

Two stacked bugs were both blocking the flow — fixing #1 alone surfaces #2.

### Bug 1 — backend: `parseDocker` produced a fake URL

`internal/registries/search.go` left `ServerEntry.URL` empty in `parseDocker` and then `constructServerURL` filled the gap with `docker://mcp/<name>`. The frontend treats any non-empty `server.url` as an HTTP endpoint, so the MCP client tried `POST docker://mcp/sqlite` → `unsupported protocol scheme: docker` (the exact error in #483).

**Fix:** `parseDocker` now emits `InstallCmd: "docker run -i --rm mcp/<name>"` (matching the OCI pattern that `parseFleur` was already using), and `constructServerURL` no longer fabricates URLs for `protocolDocker`. The `URL` field is reserved for HTTP/SSE endpoints.

### Bug 2 — frontend: snake_case vs camelCase mismatch

The backend contract (`contracts.RepositoryServer`) serialises `install_cmd` and `connect_url` in snake_case, but `frontend/src/{services/api.ts,types/api.ts,views/Repositories.vue}` were reading `server.installCmd` / `server.connectUrl` (camelCase). Always `undefined`. Pre-fix, Docker entries fell through to `server.url` (the fake `docker://` value), so this latent bug was hidden behind Bug 1.

**Fix:** read `install_cmd` / `connect_url` consistently, matching `source_code_url` etc. already used in the same file.

## Regression tests

- `TestParseDocker` asserts `InstallCmd` populated and `URL` empty.
- `TestConstructServerURL/docker_protocol_returns_empty` asserts no synthetic URL.

## Verification

End-to-end verified locally:

1. `curl /api/v1/registries/docker-mcp-catalog/servers?q=sqlite` returns `install_cmd: "docker run -i --rm mcp/sqlite"`, no `url`.
2. Calling `upstream_servers` via MCP with that command/args registers the server cleanly as `{protocol: stdio, command: docker, args: [run,-i,--rm,mcp/sqlite]}`.
3. Chrome flow on the Repositories page: pick Docker MCP Catalog → search "sqlite" → "Add to MCP" → server appears in Servers list as "sqlite — stdio • docker", auto-quarantined for review. No error banner.

## Follow-up

A larger registry modernisation is being drafted under `specs/051-registry-modernization/` — adopt the canonical `registry.modelcontextprotocol.io` v0 schema (`packages[]` / `remotes[]`), retire stale fallbacks (Smithery, Azure demo), and unify the parsed payload so the frontend doesn't have to guess transport from `installCmd` vs `url`. This PR is the narrow, ship-now half.

Refs: #483