### PR TITLE
fix(homebrew): one-line install in docs + guard tap job against pre-release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1256,7 +1256,9 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     environment: production
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Stable channel only: skip pre-release tags (v*-rc1, v*-beta, etc.) so an
+    # RC tag never overwrites the stable formula/cask in the tap.
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') && github.repository == 'smart-mcp-proxy/mcpproxy-go'
 
     steps:
       - name: Checkout tap repository

--- a/AUTOUPDATE.md
+++ b/AUTOUPDATE.md
@@ -64,8 +64,11 @@ echo 'export MCPPROXY_ALLOW_PRERELEASE_UPDATES=true' >> ~/.zshrc
 Auto-update is **automatically disabled** when installed via Homebrew to prevent conflicts:
 
 ```bash
-# Homebrew installation - auto-update disabled automatically
-brew install smart-mcp-proxy/tap/mcpproxy
+# Homebrew installation - auto-update disabled automatically.
+# The fully-qualified name auto-taps smart-mcp-proxy/mcpproxy, so no
+# separate `brew tap` step is needed.
+brew install smart-mcp-proxy/mcpproxy/mcpproxy          # CLI
+brew install --cask smart-mcp-proxy/mcpproxy/mcpproxy   # tray app
 
 # Use Homebrew for updates
 brew upgrade mcpproxy
@@ -93,7 +96,7 @@ The system detects common package manager paths and disables auto-update accordi
 ### File Format Support
 
 - **Windows**: `.zip` archives
-- **macOS**: `.tar.gz` archives  
+- **macOS**: `.tar.gz` archives
 - **Linux**: `.tar.gz` archives
 
 ### Asset Detection Priority
@@ -125,7 +128,7 @@ mcpproxy
 ├── Status: Running (localhost:8080)
 ├── ─────────────────────────────
 ├── Start/Stop Server
-├── ─────────────────────────────  
+├── ─────────────────────────────
 ├── Check for Updates...          ← Manual update check
 │   ├── Auto-update: Enabled      ← Shows current mode
 │   └── [Disabled for Homebrew]   ← If package manager detected
@@ -207,4 +210,4 @@ Each release includes:
 - `mcpproxy-latest-linux-amd64.tar.gz` (latest)
 - Similar files for all supported platforms
 
-The auto-updater prioritizes "latest" assets for consistency with website download links. 
+The auto-updater prioritizes "latest" assets for consistency with website download links.


### PR DESCRIPTION
## Summary

Two small Homebrew-tap correctness fixes. The official tap (`smart-mcp-proxy/homebrew-mcpproxy`) already ships a working formula + cask, auto-bumped by the `update-homebrew` job on every `v*` tag — this just cleans up a stale doc and closes a latent CI hole.

### 1. `AUTOUPDATE.md` — fix the install command
- Old: `brew install smart-mcp-proxy/tap/mcpproxy` — the `/tap/` segment resolves to a **nonexistent** `homebrew-tap` repo (Homebrew maps `org/NAME` → `github.com/org/homebrew-NAME`). Anyone copying it gets an error.
- New: `brew install smart-mcp-proxy/mcpproxy/mcpproxy`. The fully-qualified `org/tap/formula` form **auto-taps**, so no separate `brew tap` step is needed. Added the `--cask` line for the tray app.

### 2. `release.yml` — guard `update-homebrew` against pre-release tags
- The job triggered on any `v*` tag, including `v1.2.3-rc1`/`-beta`, which would push the pre-release version into the **stable** formula/cask in the tap.
- Added `!contains(github.ref_name, '-')` + the repo-owner guard, mirroring the existing `publish-linux-repos` job condition.

## Verification
- Confirmed the live tap's formula + cask are at v0.33.1 and their declared SHA-256s match the actual release artifacts; the arm64 DMG is notarized + stapled (`spctl` → "accepted, Notarized Developer ID"). So `brew install smart-mcp-proxy/mcpproxy/mcpproxy` (and `--cask`) work today.
- `release.yml` re-validated as well-formed YAML.

## Follow-up (separate, different repo)
The cask's `uninstall pkgutil:` identifier is `com.smartmcpproxy.mcpproxy` but `scripts/create-pkg.sh` builds the component pkg with `--identifier "$BUNDLE_ID.pkg"`, so `brew uninstall --cask` leaves the receipt behind. That fix lives in the `homebrew-mcpproxy` tap repo (release.yml only sed-patches version/sha256, not the pkgutil line) and will be handled there.