### PR TITLE
fix(ci): pin unit/e2e Go matrix to 1.25 (go.mod now requires go 1.25.5)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -45,10 +45,12 @@ jobs:
 
     strategy:
       matrix:
-        # On PRs: test only latest Go on ubuntu-latest
-        # On main/push: test full matrix
+        # On PRs: test only ubuntu-latest. On main/push: test all OSes.
+        # Go is pinned to "1.25" because go.mod requires go 1.25.5 — older
+        # toolchains can't build the module, and auto-downloading 1.25.x under
+        # setup-go's module cache collides ("tar: ... File exists").
         os: ${{ github.event_name == 'pull_request' && fromJSON('["ubuntu-latest"]') || fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') }}
-        go-version: ${{ github.event_name == 'pull_request' && fromJSON('["1.25"]') || fromJSON('["1.23.10", "1.24.5", "1.25"]') }}
+        go-version: ["1.25"]
 
     steps:
       - name: Checkout code
@@ -155,13 +157,13 @@ jobs:
           GO_TEST_TIMEOUT: 300s
 
       - name: Run E2E tests with race detector
-        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.23.10'
+        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.25'
         run: go test -v -race -timeout 10m ./internal/server -run TestE2E
         env:
           GO_TEST_TIMEOUT: 600s
 
       - name: Run Logging E2E tests with race detector
-        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.23.10'
+        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.25'
         run: go test -v -race -timeout 10m ./internal/logs -run TestE2E
         env:
           GO_TEST_TIMEOUT: 600s

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -63,10 +63,12 @@ jobs:
 
     strategy:
       matrix:
-        # On PRs: test only latest Go on ubuntu-latest
-        # On main/push: test full matrix
+        # On PRs: test only ubuntu-latest. On main/push: test all OSes.
+        # Go is pinned to "1.25" because go.mod requires go 1.25.5 — older
+        # toolchains can't build the module, and auto-downloading 1.25.x under
+        # setup-go's module cache collides ("tar: ... File exists").
         os: ${{ github.event_name == 'pull_request' && fromJSON('["ubuntu-latest"]') || fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') }}
-        go-version: ${{ github.event_name == 'pull_request' && fromJSON('["1.25"]') || fromJSON('["1.23.10", "1.24.5", "1.25"]') }}
+        go-version: ["1.25"]
 
     steps:
       - name: Checkout code
@@ -124,7 +126,7 @@ jobs:
         run: go tool cover -html=coverage.out -o coverage.html
 
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.23.10'
+        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.25'
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238  # v4.6.0
         with:
           file: ./coverage.out
@@ -133,7 +135,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload coverage artifacts
-        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.23.10'
+        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.25'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: coverage-report


### PR DESCRIPTION
## Problem
`Unit Tests` (and `E2E Tests`) went **red on `main`** right after the merges. Root cause: the **go-dependencies bump (#496)** raised `go.mod` from `go 1.24.2` → **`go 1.25.5`**, but the *push-event* test matrices in `unit-tests.yml` and `e2e-tests.yml` still listed `1.23.10` and `1.24.5`.

Those older toolchains can't build a `go 1.25.5` module, so `go` auto-downloads the 1.25.5 toolchain — and under `actions/setup-go`'s module cache that extraction collides:
```
/usr/bin/tar: .../toolchain@v0.0.1-go1.25.5...: Cannot open: File exists
```
The native `1.25` jobs pass; the `1.23.10`/`1.24.5` jobs fail (fail-fast then cancels the rest). PRs were unaffected because PRs only test `["1.25"]`.

## Fix
Pin both matrices' `go-version` to `["1.25"]` (still testing all three OSes on push) and move the coverage/race-detector step guards from `matrix.go-version == '1.23.10'` → `'1.25'`. No stale `1.23.10`/`1.24.5` references remain in any workflow.

> Note: keeping `go 1.25.5` (what #496 landed and what builds/lints/tests green); this just aligns CI with it. If you'd rather not be on 1.25.5 yet, that's a separate go.mod decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)