### PR TITLE
ci(053): commitlint — enforce Conventional Commit PR titles (WP-C5)

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,39 @@
+name: Commitlint
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+  statuses: write
+
+jobs:
+  validate-pr-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title follows Conventional Commits
+        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017  # v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Allowed Conventional Commit types for this repo.
+          # Keep in sync with the types used in squash-merge commit messages.
+          types: |
+            feat
+            fix
+            docs
+            chore
+            ci
+            refactor
+            test
+            perf
+            build
+            style
+            revert
+          # Scope is optional; allow any scope string when present.
+          requireScope: false


### PR DESCRIPTION
## What

Adds `.github/workflows/commitlint.yml` that validates the **PR title** against the [Conventional Commits](https://www.conventionalcommits.org/) spec.

## Why

This repo uses squash-merge, so the PR title becomes the commit message on `main`. Enforcing a valid Conventional Commit title at PR time means the `main` history stays clean without requiring contributors to rebase or amend local commits.

## How

- Triggers on `pull_request` events: `opened`, `edited`, `synchronize`
- Uses `amannn/action-semantic-pull-request` pinned to commit SHA `0723387faaf9b38adef4775cd42cfd5155ed6017` (v5.5.3), following the WP-B5 SHA-pinning convention
- Allowed types: `feat`, `fix`, `docs`, `chore`, `ci`, `refactor`, `test`, `perf`, `build`, `style`, `revert`
- Scope is optional (`requireScope: false`)
- Permissions: `pull-requests: read`, `statuses: write`
- Local commits are **not** affected — only the PR title is checked