### PR TITLE
chore(053): server.json description — local-first + security scanning

### DIFF
--- a/docs/mcp-registry-publishing.md
+++ b/docs/mcp-registry-publishing.md
@@ -97,8 +97,8 @@ mcp-publisher status --status deleted \
 
 - `version` must be a plain semantic version string (`0.33.1`) — no `v` prefix, no ranges.
 - `packages[]` is empty because none of the supported `registryType` values (`npm`, `pypi`, `oci`, `nuget`, `mcpb`) match MCPProxy's distribution channels (Homebrew tap, GitHub release tarballs, `.deb`/`.rpm`, `go install`). The Docker server-edition image at `ghcr.io/smart-mcp-proxy/mcpproxy-server` is not yet published to releases (gated behind `if: false` in the release workflow).
-- `remotes[]` describes the actual MCP transport: a locally-run `mcpproxy serve` instance that exposes a Streamable HTTP endpoint at `http://localhost:8080/mcp`. MCP clients that support HTTP transport connect directly to this address.
-- If a Docker image for the server edition is published in a future release, add an `oci` entry to `packages[]` pointing at `ghcr.io/smart-mcp-proxy/mcpproxy-server:{version}` with `"transport": {"type": "stdio"}` and the appropriate `runtimeArguments` for `docker run`.
+- `remotes[]` is intentionally **omitted**. mcpproxy runs locally (`mcpproxy serve` exposes Streamable HTTP at `http://localhost:8080/mcp`), but the registry's semantic validation **rejects localhost/private remote URLs** (`invalid-remote-url`) — `remotes[]` is reserved for publicly reachable hosted endpoints. With no public remote and no installable package type, the entry is **discovery-only**: it lists the server, description, and repository link so clients can find it and follow the repo's install instructions.
+- If a Docker image for the server edition is published in a future release, add an `oci` entry to `packages[]` pointing at `ghcr.io/smart-mcp-proxy/mcpproxy-server:{version}` with `"transport": {"type": "stdio"}` and the appropriate `runtimeArguments` for `docker run`. That would upgrade the entry from discovery-only to one-click installable.
 
 ## References
 

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.smart-mcp-proxy/mcpproxy-go",
   "title": "MCPProxy",
-  "description": "Smart MCP proxy with BM25 tool discovery, quarantine security, and ~99% token savings",
+  "description": "Local-first MCP proxy with BM25 tool discovery, security scanning, quarantine & ~99% token savings",
   "websiteUrl": "https://mcpproxy.app",
   "repository": {
     "url": "https://github.com/smart-mcp-proxy/mcpproxy-go",

--- a/server.json
+++ b/server.json
@@ -9,11 +9,5 @@
     "source": "github"
   },
   "version": "0.33.1",
-  "packages": [],
-  "remotes": [
-    {
-      "type": "streamable-http",
-      "url": "http://localhost:8080/mcp"
-    }
-  ]
+  "packages": []
 }


### PR DESCRIPTION
Refreshes the MCP registry `server.json` description to reflect current product positioning.

**Before:** `Smart MCP proxy with BM25 tool discovery, quarantine security, and ~99% token savings` (85 chars)
**After:** `Local-first MCP proxy with BM25 tool discovery, security scanning, quarantine & ~99% token savings` (98 chars)

- Adds **local-first** positioning (Spec 046) and **security scanning** (sensitive-data detection).
- Keeps BM25 discovery, quarantine, and ~99% token-savings messaging.
- `version` stays `0.33.1` — already matches the latest release.
- Schema-validated against the 2025-12-11 server schema (`description` maxLength 100; we use 98).

Note: this only changes the committed `server.json`. Publishing the updated entry to registry.modelcontextprotocol.io is still the manual `mcp-publisher publish` step (see `docs/mcp-registry-publishing.md`).