### PR TITLE
fix(webui): surface tool-level quarantine on the Servers list

### DIFF
--- a/frontend/src/components/ServerCard.vue
+++ b/frontend/src/components/ServerCard.vue
@@ -35,13 +35,13 @@
             </svg>
             {{ blockedToolCount }} disabled
           </div>
-          <div v-else-if="quarantineToolCount > 0" class="stat-desc text-xs text-warning flex items-center gap-1">
+          <div v-if="quarantineToolCount > 0" class="stat-desc text-xs text-warning flex items-center gap-1">
             <svg class="w-3 h-3 inline-block flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
             </svg>
             {{ quarantineToolCount }} pending approval
           </div>
-          <div v-else-if="server.tool_list_token_size" class="stat-desc text-xs">
+          <div v-if="blockedToolCount === 0 && quarantineToolCount === 0 && server.tool_list_token_size" class="stat-desc text-xs">
             {{ server.tool_list_token_size.toLocaleString() }} tokens
           </div>
         </div>
@@ -106,12 +106,33 @@
         <span class="text-xs">{{ server.last_error }}</span>
       </div>
 
-      <!-- Quarantine warning -->
+      <!-- Server-level quarantine warning. Server is held back entirely until
+           the user approves it. Drives the Approve button below via
+           health.action='approve'. -->
       <div v-if="server.quarantined" class="alert alert-warning alert-sm mb-4">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.732-.833-2.5 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z" />
         </svg>
         <span class="text-xs">Server is quarantined</span>
+      </div>
+
+      <!-- Tool-level quarantine warning (Spec 032). Independent of server
+           quarantine: when a server is trusted at the server level but ships
+           tools with descriptions/schemas that have not yet been approved
+           (or that changed since last approval — rug-pull guard), they are
+           silently blocked from agent use. Surface this on the list so users
+           don't have to open Details to discover it. -->
+      <div v-else-if="quarantineToolCount > 0" class="alert alert-warning alert-sm mb-4">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.732-.833-2.5 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z" />
+        </svg>
+        <span class="text-xs flex-1">{{ toolQuarantineSummary }}</span>
+        <router-link
+          :to="`/servers/${server.name}?tab=tools`"
+          class="btn btn-xs btn-warning"
+        >
+          Review
+        </router-link>
       </div>
 
       <!-- Actions - uses unified health.action when available -->
@@ -406,6 +427,34 @@ const blockedToolCount = computed(() => {
   const q = props.server.quarantine
   if (!q) return 0
   return q.blocked_count ?? 0
+})
+
+// Human-readable summary for the tool-quarantine banner. Differentiates
+// fully-quarantined (every tool needs approval) from partially-quarantined,
+// and surfaces "changed" tools separately because they indicate a rug-pull
+// rather than a first-time review.
+const toolQuarantineSummary = computed(() => {
+  const q = props.server.quarantine
+  if (!q) return ''
+  const pending = q.pending_count ?? 0
+  const changed = q.changed_count ?? 0
+  const total = pending + changed
+  if (total === 0) return ''
+  const toolCount = props.server.tool_count ?? 0
+  const noun = (n: number) => (n === 1 ? 'tool' : 'tools')
+  if (changed > 0 && pending > 0) {
+    return `${pending} ${noun(pending)} pending, ${changed} changed — approval needed`
+  }
+  if (changed > 0) {
+    return `${changed} ${noun(changed)} changed since approval — re-review needed`
+  }
+  if (toolCount > 0 && pending === toolCount) {
+    return `All ${pending} ${noun(pending)} pending security approval`
+  }
+  if (toolCount > 0) {
+    return `${pending} of ${toolCount} ${noun(toolCount)} pending security approval`
+  }
+  return `${pending} ${noun(pending)} pending security approval`
 })
 
 // Security scan badge (Spec 039)

--- a/frontend/src/components/__tests__/ServerCard.test.ts
+++ b/frontend/src/components/__tests__/ServerCard.test.ts
@@ -61,4 +61,106 @@ describe('ServerCard', () => {
     expect(wrapper.text()).toContain('disabled-server')
     expect(wrapper.text()).toContain('Disabled')
   })
+
+  it('shows tool-quarantine banner with Review link when tools are pending and server is not quarantined', () => {
+    const server = {
+      name: 'partial-server',
+      protocol: 'stdio' as const,
+      enabled: true,
+      connected: true,
+      quarantined: false,
+      tool_count: 10,
+      quarantine: { pending_count: 3, changed_count: 0, blocked_count: 0 }
+    }
+
+    const wrapper = mount(ServerCard, {
+      props: { server },
+      global: { plugins: [pinia, router] }
+    })
+
+    expect(wrapper.text()).toContain('3 of 10 tools pending security approval')
+    const review = wrapper.find('a.btn-warning')
+    expect(review.exists()).toBe(true)
+    expect(review.attributes('href')).toBe('/servers/partial-server?tab=tools')
+    // The server-level "Server is quarantined" banner must NOT render here
+    expect(wrapper.text()).not.toContain('Server is quarantined')
+  })
+
+  it('says "All N pending" when every tool is pending', () => {
+    const server = {
+      name: 'fully-pending',
+      protocol: 'stdio' as const,
+      enabled: true,
+      connected: true,
+      quarantined: false,
+      tool_count: 4,
+      quarantine: { pending_count: 4, changed_count: 0, blocked_count: 0 }
+    }
+
+    const wrapper = mount(ServerCard, {
+      props: { server },
+      global: { plugins: [pinia, router] }
+    })
+
+    expect(wrapper.text()).toContain('All 4 tools pending security approval')
+  })
+
+  it('flags rug-pull-style changed tools separately', () => {
+    const server = {
+      name: 'rugpull',
+      protocol: 'stdio' as const,
+      enabled: true,
+      connected: true,
+      quarantined: false,
+      tool_count: 5,
+      quarantine: { pending_count: 0, changed_count: 2, blocked_count: 0 }
+    }
+
+    const wrapper = mount(ServerCard, {
+      props: { server },
+      global: { plugins: [pinia, router] }
+    })
+
+    expect(wrapper.text()).toContain('2 tools changed since approval')
+  })
+
+  it('does not double up: server-level banner wins over tool-level banner', () => {
+    const server = {
+      name: 'srv-quarantined',
+      protocol: 'stdio' as const,
+      enabled: true,
+      connected: false,
+      quarantined: true,
+      tool_count: 4,
+      quarantine: { pending_count: 4, changed_count: 0, blocked_count: 0 }
+    }
+
+    const wrapper = mount(ServerCard, {
+      props: { server },
+      global: { plugins: [pinia, router] }
+    })
+
+    expect(wrapper.text()).toContain('Server is quarantined')
+    expect(wrapper.text()).not.toContain('pending security approval')
+  })
+
+  it('shows both disabled and pending counts when both apply', () => {
+    const server = {
+      name: 'mixed',
+      protocol: 'stdio' as const,
+      enabled: true,
+      connected: true,
+      quarantined: false,
+      tool_count: 10,
+      quarantine: { pending_count: 2, changed_count: 0, blocked_count: 3 }
+    }
+
+    const wrapper = mount(ServerCard, {
+      props: { server },
+      global: { plugins: [pinia, router] }
+    })
+
+    expect(wrapper.text()).toContain('3 disabled')
+    expect(wrapper.text()).toContain('2 pending approval')
+  })
 })


### PR DESCRIPTION
## Problem

The Servers grid in the Web UI renders the big orange **Server is quarantined** banner + **Approve** button **only when `server.quarantined === true`**. Servers that are trusted at the server level but ship tools blocked by Spec 032 tool-level quarantine (`pending` / `changed`) get only a tiny `stat-desc` line under the tool count — easy to miss, and shadowed entirely by the `X disabled` line whenever any tool is also disabled, because both lines share a `v-if / v-else-if` chain at `ServerCard.vue:32–46`.

The detail page **does** escalate tool-level quarantine to its own yellow alert with an Approve-All button (`ServerDetail.vue:325`). So users who hit the daemon's `quarantine pending approval` error find clear remediation on Details, but nothing actionable on the list view — and they report the list as broken or inconsistent.

A common path into this state is `setup.sh`-style provisioning that registers servers with `--no-quarantine` but doesn't catch every tool in the post-add auto-approve pass (OAuth servers like Atlassian, lazy-spawn servers, or anything exceeding the approval-poll timeout). Those servers end up `quarantined=false` + `quarantine.pending_count > 0` — exactly the gap this PR closes.

## Change

- Adds a second `alert-warning` banner in `ServerCard.vue` for tool-level quarantine, with a `Review` link to `/servers/<name>?tab=tools`. Mutually exclusive with the server-level banner via `v-else-if` — when the server itself is quarantined the existing banner already implies the tools won't run.
- Splits the stat-desc `v-if / v-else-if` chain so `X disabled` and `N pending approval` can render side-by-side instead of one masking the other. The `<token-size>` hint stays the "nothing wrong" fallback.
- Adds a `toolQuarantineSummary` computed that picks one of:
  - `All N tools pending security approval` (every tool pending)
  - `N of M tools pending security approval` (partial)
  - `N tools changed since approval — re-review needed` (rug-pull guard)
  - mixed `pending, changed` form when both apply

No backend change. The `quarantine.{pending_count,changed_count,blocked_count}` block is already populated by `enrichServersWithQuarantineStats` in both REST list (`internal/httpapi/server.go:1140`) and SSE paths (`internal/runtime/event_bus.go:270`). The `v-memo` deps on `Servers.vue:165–175` already include both `pending_count` and `changed_count`, so the new banner re-renders reactively.

## Tests

Extends `frontend/src/components/__tests__/ServerCard.test.ts` with five new cases:

- partial: `3 of 10 tools pending` + Review link present + no server-level banner
- full: `All 4 tools pending`
- changed-only (rug pull): `2 tools changed since approval`
- precedence: server-level banner wins when `server.quarantined === true`
- mixed disabled+pending: both stat-desc lines render together

## Test plan

- [ ] CI runs `frontend` tests with the new cases (could not exercise locally — sandboxed environment couldn't reach `@guolao/vue-monaco-editor` to reinstall node modules).
- [ ] Manual: add a server with `--no-quarantine` and tools that aren't auto-approved → list now shows yellow banner + Review link.
- [ ] Manual: quarantine a server manually → only the existing **Server is quarantined** banner shows (no double warning).
- [ ] Manual: server with some tools disabled and some pending → both stat-desc lines render.