### PR TITLE
fix: filter direct-mode tools by agent token scope

### DIFF
--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -108,6 +109,13 @@ type MCPProxyServer struct {
 
 	// Hooks shared across all routing mode servers
 	hooks *mcpserver.Hooks
+
+	// directToolPerms maps direct-mode tool names (server__tool) to the
+	// operation permission required to call them. It is populated with the
+	// direct-mode registry and used only to filter tools/list for scoped agent
+	// tokens; execution-time authorization remains authoritative.
+	directToolPermsMu sync.RWMutex
+	directToolPerms   map[string]string
 
 	// Spec 049: in-memory only counter of retrieve_tools calls that opted into
 	// include_disabled. Never persisted (privacy, consistent with Spec 042).

--- a/internal/server/mcp_direct_scope.go
+++ b/internal/server/mcp_direct_scope.go
@@ -1,0 +1,88 @@
+package server
+
+import (
+	"context"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/contracts"
+)
+
+// requiredPermissionForDirectTool derives the agent-token permission a direct
+// tool requires from its annotations. It reuses the same variant->operation-type
+// mapping that call-time authorization uses (see handleDirectToolCall in
+// mcp_routing.go) so discovery filtering can never diverge from execution
+// enforcement.
+func requiredPermissionForDirectTool(annotations *config.ToolAnnotations) string {
+	return contracts.ToolVariantToOperationType[contracts.DeriveCallWith(annotations)]
+}
+
+func (p *MCPProxyServer) setDirectToolPermissions(perms map[string]string) {
+	p.directToolPermsMu.Lock()
+	defer p.directToolPermsMu.Unlock()
+
+	if len(perms) == 0 {
+		p.directToolPerms = nil
+		return
+	}
+
+	copied := make(map[string]string, len(perms))
+	for name, perm := range perms {
+		copied[name] = perm
+	}
+	p.directToolPerms = copied
+}
+
+func (p *MCPProxyServer) lookupDirectToolPermission(directName string) (string, bool) {
+	p.directToolPermsMu.RLock()
+	defer p.directToolPermsMu.RUnlock()
+
+	perm, ok := p.directToolPerms[directName]
+	return perm, ok
+}
+
+// filterDirectModeToolsForAuth filters tools/list for scoped agent tokens.
+//
+// Direct mode registers upstream tools globally as server__tool. Without this
+// filter, scoped agent tokens prevent execution but still disclose tool names,
+// descriptions, and schemas for servers outside their scope. Call-time auth is
+// still authoritative; this filter only removes tools that the current token
+// could not call from discovery responses.
+func (p *MCPProxyServer) filterDirectModeToolsForAuth(ctx context.Context, tools []mcp.Tool) []mcp.Tool {
+	if len(tools) == 0 {
+		return tools
+	}
+
+	authCtx := auth.AuthContextFromContext(ctx)
+	if authCtx == nil || authCtx.Type != auth.AuthTypeAgent {
+		return tools
+	}
+
+	filtered := make([]mcp.Tool, 0, len(tools))
+	for _, tool := range tools {
+		serverName, _, ok := ParseDirectToolName(tool.Name)
+		if !ok {
+			filtered = append(filtered, tool)
+			continue
+		}
+
+		if !authCtx.CanAccessServer(serverName) {
+			continue
+		}
+
+		requiredPerm, ok := p.lookupDirectToolPermission(tool.Name)
+		if !ok {
+			continue
+		}
+
+		if requiredPerm != "" && !authCtx.HasPermission(requiredPerm) {
+			continue
+		}
+
+		filtered = append(filtered, tool)
+	}
+
+	return filtered
+}

--- a/internal/server/mcp_routing.go
+++ b/internal/server/mcp_routing.go
@@ -48,13 +48,16 @@ func (p *MCPProxyServer) buildDirectModeTools() []mcpserver.ServerTool {
 	// Use DiscoverTools which already filters for connected, enabled, non-quarantined servers
 	tools, err := p.upstreamManager.DiscoverTools(ctx)
 	if err != nil {
+		p.setDirectToolPermissions(nil)
 		p.logger.Error("failed to discover tools for direct mode", zap.Error(err))
 		return nil
 	}
 
 	serverTools := make([]mcpserver.ServerTool, 0, len(tools))
+	directToolPerms := make(map[string]string, len(tools))
 	for _, tool := range tools {
 		directName := FormatDirectToolName(tool.ServerName, tool.Name)
+		directToolPerms[directName] = requiredPermissionForDirectTool(tool.Annotations)
 
 		// Build MCP tool options
 		opts := []mcp.ToolOption{
@@ -113,6 +116,8 @@ func (p *MCPProxyServer) buildDirectModeTools() []mcpserver.ServerTool {
 			Handler: p.makeDirectModeHandler(tool.ServerName, tool.Name, tool.Annotations),
 		})
 	}
+
+	p.setDirectToolPermissions(directToolPerms)
 
 	p.logger.Info("built direct mode tools",
 		zap.Int("tool_count", len(serverTools)))
@@ -500,9 +505,16 @@ func (p *MCPProxyServer) initRoutingModeServers() {
 		opts = append(opts, mcpserver.WithHooks(p.hooks))
 	}
 
-	// Create direct mode server
+	// Create direct mode server. Both direct-mode tool filters are agent-scoped
+	// discovery filters and belong only on the direct server (not the shared
+	// code-exec / call-tool servers): filterDirectModeToolsForAuth enforces
+	// agent-token server/permission scope, filterDirectToolsForAgentCallability
+	// hides tools the agent could not actually invoke.
 	directOpts := append([]mcpserver.ServerOption{}, opts...)
-	directOpts = append(directOpts, mcpserver.WithToolFilter(p.filterDirectToolsForAgentCallability))
+	directOpts = append(directOpts,
+		mcpserver.WithToolFilter(p.filterDirectModeToolsForAuth),
+		mcpserver.WithToolFilter(p.filterDirectToolsForAgentCallability),
+	)
 	p.directServer = mcpserver.NewMCPServer(
 		"mcpproxy-go",
 		mcpServerVersion(),

--- a/internal/server/mcp_routing_test.go
+++ b/internal/server/mcp_routing_test.go
@@ -366,6 +366,204 @@ func TestDirectModeHandler_DestructiveToolNeedsDestructivePermission(t *testing.
 	assert.Contains(t, result.Content[0].(mcp.TextContent).Text, "destructive")
 }
 
+func TestRequiredPermissionForDirectTool_MapsAnnotationsToAuthPermissions(t *testing.T) {
+	readOnly := true
+	write := false
+	destructive := true
+
+	tests := []struct {
+		name        string
+		annotations *config.ToolAnnotations
+		want        string
+	}{
+		{
+			name: "nil annotations default to read",
+			want: auth.PermRead,
+		},
+		{
+			name: "read only hint maps to read",
+			annotations: &config.ToolAnnotations{
+				ReadOnlyHint: &readOnly,
+			},
+			want: auth.PermRead,
+		},
+		{
+			name: "read only false maps to write",
+			annotations: &config.ToolAnnotations{
+				ReadOnlyHint: &write,
+			},
+			want: auth.PermWrite,
+		},
+		{
+			name: "destructive hint maps to destructive",
+			annotations: &config.ToolAnnotations{
+				DestructiveHint: &destructive,
+			},
+			want: auth.PermDestructive,
+		},
+		{
+			name: "destructive hint takes precedence over read only hint",
+			annotations: &config.ToolAnnotations{
+				ReadOnlyHint:    &readOnly,
+				DestructiveHint: &destructive,
+			},
+			want: auth.PermDestructive,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, requiredPermissionForDirectTool(tt.annotations))
+		})
+	}
+}
+
+func TestSetDirectToolPermissions_DefensivelyCopiesMap(t *testing.T) {
+	proxy := &MCPProxyServer{}
+	toolName := FormatDirectToolName("github", "get_issue")
+	perms := map[string]string{
+		toolName: auth.PermRead,
+	}
+
+	proxy.setDirectToolPermissions(perms)
+	perms[toolName] = auth.PermDestructive
+
+	got, ok := proxy.lookupDirectToolPermission(toolName)
+	require.True(t, ok)
+	assert.Equal(t, auth.PermRead, got)
+}
+
+func TestFilterDirectModeToolsForAuth_DoesNotMutateInputSlice(t *testing.T) {
+	proxy := &MCPProxyServer{}
+	allowed := FormatDirectToolName("github", "get_issue")
+	denied := FormatDirectToolName("gitlab", "get_issue")
+	tools := []mcp.Tool{
+		{Name: allowed},
+		{Name: denied},
+	}
+	original := append([]mcp.Tool(nil), tools...)
+
+	proxy.setDirectToolPermissions(map[string]string{
+		allowed: auth.PermRead,
+		denied:  auth.PermRead,
+	})
+
+	ctx := auth.WithAuthContext(context.Background(), &auth.AuthContext{
+		Type:           auth.AuthTypeAgent,
+		AgentName:      "test-agent",
+		AllowedServers: []string{"github"},
+		Permissions:    []string{auth.PermRead},
+	})
+
+	filtered := proxy.filterDirectModeToolsForAuth(ctx, tools)
+
+	assert.Equal(t, []string{allowed}, directToolNamesForTest(filtered))
+	assert.Equal(t, original, tools)
+}
+
+func TestFilterDirectModeToolsForAuth_AgentServerAndPermissionScope(t *testing.T) {
+	proxy := &MCPProxyServer{}
+
+	githubRead := FormatDirectToolName("github", "get_issue")
+	githubWrite := FormatDirectToolName("github", "create_issue")
+	githubDestroy := FormatDirectToolName("github", "delete_repo")
+	gitlabRead := FormatDirectToolName("gitlab", "get_issue")
+
+	proxy.setDirectToolPermissions(map[string]string{
+		githubRead:    auth.PermRead,
+		githubWrite:   auth.PermWrite,
+		githubDestroy: auth.PermDestructive,
+		gitlabRead:    auth.PermRead,
+	})
+
+	tools := []mcp.Tool{
+		{Name: githubRead},
+		{Name: githubWrite},
+		{Name: githubDestroy},
+		{Name: gitlabRead},
+	}
+
+	agentCtx := auth.WithAuthContext(context.Background(), &auth.AuthContext{
+		Type:           auth.AuthTypeAgent,
+		AgentName:      "test-agent",
+		AllowedServers: []string{"github"},
+		Permissions:    []string{auth.PermRead, auth.PermWrite},
+	})
+
+	filtered := proxy.filterDirectModeToolsForAuth(agentCtx, tools)
+
+	assert.Equal(t, []string{githubRead, githubWrite}, directToolNamesForTest(filtered))
+}
+
+func TestFilterDirectModeToolsForAuth_NonAgentUnchanged(t *testing.T) {
+	proxy := &MCPProxyServer{}
+	tools := []mcp.Tool{
+		{Name: FormatDirectToolName("github", "get_issue")},
+		{Name: FormatDirectToolName("gitlab", "get_issue")},
+	}
+
+	assert.Equal(t, tools, proxy.filterDirectModeToolsForAuth(context.Background(), tools))
+
+	adminCtx := auth.WithAuthContext(context.Background(), auth.AdminContext())
+	assert.Equal(t, tools, proxy.filterDirectModeToolsForAuth(adminCtx, tools))
+}
+
+func TestFilterDirectModeToolsForAuth_FailsClosedOnMissingPermissionMetadata(t *testing.T) {
+	proxy := &MCPProxyServer{}
+
+	visible := FormatDirectToolName("github", "get_issue")
+	missing := FormatDirectToolName("github", "unknown")
+	proxy.setDirectToolPermissions(map[string]string{
+		visible: auth.PermRead,
+	})
+
+	ctx := auth.WithAuthContext(context.Background(), &auth.AuthContext{
+		Type:           auth.AuthTypeAgent,
+		AgentName:      "test-agent",
+		AllowedServers: []string{"github"},
+		Permissions:    []string{auth.PermRead},
+	})
+
+	filtered := proxy.filterDirectModeToolsForAuth(ctx, []mcp.Tool{
+		{Name: visible},
+		{Name: missing},
+	})
+
+	assert.Equal(t, []string{visible}, directToolNamesForTest(filtered))
+}
+
+func TestFilterDirectModeToolsForAuth_KeepsNonDirectTools(t *testing.T) {
+	proxy := &MCPProxyServer{}
+
+	direct := FormatDirectToolName("github", "get_issue")
+	nonDirect := "retrieve_tools"
+	proxy.setDirectToolPermissions(map[string]string{
+		direct: auth.PermRead,
+	})
+
+	ctx := auth.WithAuthContext(context.Background(), &auth.AuthContext{
+		Type:           auth.AuthTypeAgent,
+		AgentName:      "test-agent",
+		AllowedServers: []string{"github"},
+		Permissions:    []string{auth.PermRead},
+	})
+
+	filtered := proxy.filterDirectModeToolsForAuth(ctx, []mcp.Tool{
+		{Name: direct},
+		{Name: nonDirect},
+	})
+
+	assert.Equal(t, []string{direct, nonDirect}, directToolNamesForTest(filtered))
+}
+
+func directToolNamesForTest(tools []mcp.Tool) []string {
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		names = append(names, tool.Name)
+	}
+	return names
+}
+
 func TestDirectModeHandler_NoAuthContext(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	proxy := &MCPProxyServer{


### PR DESCRIPTION
## Summary

Direct mode already enforces agent-token scope at tool call time, but tools/list still exposed every direct-mode upstream tool definition. This meant scoped agent tokens blocked execution, but still disclosed tool names, descriptions, and schemas for servers outside the token scope.

This PR filters direct-mode tools/list responses for agent tokens using the same server and permission semantics already used by direct-mode execution.

## Changes

- Track direct-mode tool permission metadata while rebuilding the direct-mode tool registry.
- Add a tools/list filter for auth.AuthTypeAgent contexts.
- Hide tools from servers outside the agent token's AllowedServers scope.
- Hide tools requiring permissions not present on the agent token.
- Preserve existing behavior for admin, OAuth user, and unauthenticated/back-compat contexts.
- Keep call-time authorization unchanged and authoritative.
- Add focused unit tests for server scope, permission scope, fail-closed missing metadata, and non-agent compatibility.

## Verification

- go test ./internal/server -run TestFilterDirectModeToolsForAuth -count=1 -v
- go test ./internal/server -run TestDirectModeHandler_PermissionDenied -count=1 -v
- go test ./internal/auth ./internal/contracts -count=1
- go build ./cmd/mcpproxy
- IntelliJ build_project: passed
- Smoke run on 127.0.0.1:18080 with isolated data dir: /health returned 200 {"status":"ok"}

Note: broader go test ./internal/server and go test ./internal/... attempts exceeded the IDE tool timeout in this local environment before producing Go failures.