### PR TITLE
fix: enforce direct-mode tool callability

### DIFF
--- a/internal/server/mcp_direct_callability.go
+++ b/internal/server/mcp_direct_callability.go
@@ -97,6 +97,10 @@ func (p *MCPProxyServer) isDirectToolCallable(serverName, toolName string) bool 
 		return false
 	}
 
+	if !serverConfig.IsToolAllowedByConfig(toolName) {
+		return false
+	}
+
 	if p.config != nil && p.config.IsQuarantineEnabled() && !serverConfig.IsQuarantineSkipped() {
 		approval, approvalErr := p.storage.GetToolApproval(serverName, toolName)
 		if approvalErr == nil && approval != nil {

--- a/internal/server/mcp_direct_callability.go
+++ b/internal/server/mcp_direct_callability.go
@@ -3,13 +3,44 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/mark3labs/mcp-go/mcp"
 
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
 )
+
+type directCallabilityDecision struct {
+	callable       bool
+	serverName     string
+	toolName       string
+	serverConfig   *config.ServerConfig
+	approval       *storage.ToolApprovalRecord
+	approvalStatus string
+	configDenied   bool
+	storageErr     error
+}
+
+type directCallabilityEvaluator struct {
+	proxy         *MCPProxyServer
+	serverConfigs map[string]*config.ServerConfig
+	serverErrors  map[string]error
+	approvals     map[string]*storage.ToolApprovalRecord
+	approvalErrs  map[string]error
+}
+
+func newDirectCallabilityEvaluator(proxy *MCPProxyServer) *directCallabilityEvaluator {
+	return &directCallabilityEvaluator{
+		proxy:         proxy,
+		serverConfigs: make(map[string]*config.ServerConfig),
+		serverErrors:  make(map[string]error),
+		approvals:     make(map[string]*storage.ToolApprovalRecord),
+		approvalErrs:  make(map[string]error),
+	}
+}
 
 // filterDirectToolsForAgentCallability hides direct-mode tools that an agent
 // token cannot actually invoke because they are disabled, quarantined, pending
@@ -25,6 +56,7 @@ func (p *MCPProxyServer) filterDirectToolsForAgentCallability(ctx context.Contex
 		return tools
 	}
 
+	evaluator := newDirectCallabilityEvaluator(p)
 	filtered := make([]mcp.Tool, 0, len(tools))
 	for _, tool := range tools {
 		serverName, toolName, ok := ParseDirectToolName(tool.Name)
@@ -33,7 +65,7 @@ func (p *MCPProxyServer) filterDirectToolsForAgentCallability(ctx context.Contex
 			continue
 		}
 
-		if p.isDirectToolCallable(serverName, toolName) {
+		if evaluator.evaluate(serverName, toolName).callable {
 			filtered = append(filtered, tool)
 		}
 	}
@@ -52,64 +84,110 @@ func (p *MCPProxyServer) directToolCallabilityBlock(ctx context.Context, serverN
 		return nil
 	}
 
-	serverConfig, err := p.storage.GetUpstreamServer(serverName)
-	if err != nil || serverConfig == nil {
-		return mcp.NewToolResultError(p.blockedToolMessage(serverName, toolName))
+	decision := newDirectCallabilityEvaluator(p).evaluate(serverName, toolName)
+	if decision.callable {
+		return nil
 	}
 
-	if serverConfig.Quarantined {
-		return p.handleQuarantinedToolCall(ctx, serverName, toolName, args)
+	return p.directToolCallabilityResult(ctx, decision, args)
+}
+
+func (e *directCallabilityEvaluator) evaluate(serverName, toolName string) directCallabilityDecision {
+	decision := directCallabilityDecision{
+		serverName: serverName,
+		toolName:   toolName,
+	}
+
+	if e.proxy.storage == nil {
+		return decision
+	}
+
+	serverConfig, serverErr := e.getServerConfig(serverName)
+	if serverErr != nil || serverConfig == nil {
+		decision.storageErr = serverErr
+		return decision
+	}
+	decision.serverConfig = serverConfig
+
+	if !serverConfig.Enabled || serverConfig.Quarantined {
+		return decision
 	}
 
 	if !serverConfig.IsToolAllowedByConfig(toolName) {
+		decision.configDenied = true
+		return decision
+	}
+
+	approval, approvalErr := e.getToolApproval(serverName, toolName)
+	if approvalErr != nil && !errors.Is(approvalErr, storage.ErrToolApprovalNotFound) {
+		decision.storageErr = approvalErr
+		return decision
+	}
+	decision.approval = approval
+
+	if e.proxy.config != nil && e.proxy.config.IsQuarantineEnabled() && !serverConfig.IsQuarantineSkipped() && approval != nil {
+		switch approval.Status {
+		case storage.ToolApprovalStatusPending, storage.ToolApprovalStatusChanged:
+			decision.approvalStatus = approval.Status
+			return decision
+		}
+	}
+
+	if approval != nil && approval.Disabled {
+		return decision
+	}
+
+	decision.callable = true
+	return decision
+}
+
+func (e *directCallabilityEvaluator) getServerConfig(serverName string) (*config.ServerConfig, error) {
+	if serverConfig, ok := e.serverConfigs[serverName]; ok {
+		return serverConfig, e.serverErrors[serverName]
+	}
+
+	serverConfig, err := e.proxy.storage.GetUpstreamServer(serverName)
+	e.serverConfigs[serverName] = serverConfig
+	e.serverErrors[serverName] = err
+	return serverConfig, err
+}
+
+func (e *directCallabilityEvaluator) getToolApproval(serverName, toolName string) (*storage.ToolApprovalRecord, error) {
+	key := serverName + "\x00" + toolName
+	if approval, ok := e.approvals[key]; ok {
+		return approval, e.approvalErrs[key]
+	}
+	if err, ok := e.approvalErrs[key]; ok {
+		return nil, err
+	}
+
+	approval, err := e.proxy.storage.GetToolApproval(serverName, toolName)
+	if approval != nil {
+		e.approvals[key] = approval
+	}
+	e.approvalErrs[key] = err
+	return approval, err
+}
+
+func (p *MCPProxyServer) directToolCallabilityResult(ctx context.Context, decision directCallabilityDecision, args map[string]interface{}) *mcp.CallToolResult {
+	if decision.serverConfig != nil && decision.serverConfig.Quarantined {
+		return p.handleQuarantinedToolCall(ctx, decision.serverName, decision.toolName, args)
+	}
+
+	if decision.configDenied {
 		return mcp.NewToolResultError(blockedToolMessageFor(true))
 	}
 
-	if p.config != nil && p.config.IsQuarantineEnabled() && !serverConfig.IsQuarantineSkipped() {
-		approval, approvalErr := p.storage.GetToolApproval(serverName, toolName)
-		if approvalErr == nil && approval != nil {
-			switch approval.Status {
-			case storage.ToolApprovalStatusPending:
-				return directPendingApprovalResult(serverName, toolName, approval)
-			case storage.ToolApprovalStatusChanged:
-				return directChangedApprovalResult(serverName, toolName, approval)
-			}
+	if decision.approval != nil {
+		switch decision.approvalStatus {
+		case storage.ToolApprovalStatusPending:
+			return directPendingApprovalResult(decision.serverName, decision.toolName, decision.approval)
+		case storage.ToolApprovalStatusChanged:
+			return directChangedApprovalResult(decision.serverName, decision.toolName, decision.approval)
 		}
 	}
 
-	if !p.isToolCallable(serverName, toolName) {
-		return mcp.NewToolResultError(p.blockedToolMessage(serverName, toolName))
-	}
-
-	return nil
-}
-
-// isDirectToolCallable is the direct-mode discovery predicate. It includes the
-// generic callable check plus tool-level pending/changed quarantine, because
-// isToolCallable intentionally handles only disabled/config/server state.
-func (p *MCPProxyServer) isDirectToolCallable(serverName, toolName string) bool {
-	if p.storage == nil || !p.isToolCallable(serverName, toolName) {
-		return false
-	}
-
-	serverConfig, err := p.storage.GetUpstreamServer(serverName)
-	if err != nil || serverConfig == nil || serverConfig.Quarantined {
-		return false
-	}
-
-	if !serverConfig.IsToolAllowedByConfig(toolName) {
-		return false
-	}
-
-	if p.config != nil && p.config.IsQuarantineEnabled() && !serverConfig.IsQuarantineSkipped() {
-		approval, approvalErr := p.storage.GetToolApproval(serverName, toolName)
-		if approvalErr == nil && approval != nil {
-			return approval.Status != storage.ToolApprovalStatusPending &&
-				approval.Status != storage.ToolApprovalStatusChanged
-		}
-	}
-
-	return true
+	return mcp.NewToolResultError(p.blockedToolMessage(decision.serverName, decision.toolName))
 }
 
 func directPendingApprovalResult(serverName, toolName string, approval *storage.ToolApprovalRecord) *mcp.CallToolResult {
@@ -122,8 +200,7 @@ func directPendingApprovalResult(serverName, toolName string, approval *storage.
 		"current_description": approval.CurrentDescription,
 		"action":              fmt.Sprintf("Approve via: POST /api/v1/servers/%s/tools/approve or mcpproxy upstream inspect %s", serverName, serverName),
 	}
-	jsonResult, _ := json.Marshal(response)
-	return mcp.NewToolResultText(string(jsonResult))
+	return directPolicyJSONResult(response, "pending tool approval")
 }
 
 func directChangedApprovalResult(serverName, toolName string, approval *storage.ToolApprovalRecord) *mcp.CallToolResult {
@@ -137,6 +214,13 @@ func directChangedApprovalResult(serverName, toolName string, approval *storage.
 		"current_description":  approval.CurrentDescription,
 		"action":               fmt.Sprintf("Approve via: POST /api/v1/servers/%s/tools/approve or mcpproxy upstream inspect %s", serverName, serverName),
 	}
-	jsonResult, _ := json.Marshal(response)
+	return directPolicyJSONResult(response, "changed tool approval")
+}
+
+func directPolicyJSONResult(response map[string]interface{}, description string) *mcp.CallToolResult {
+	jsonResult, err := json.Marshal(response)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to serialize %s response: %v", description, err))
+	}
 	return mcp.NewToolResultText(string(jsonResult))
 }

--- a/internal/server/mcp_direct_callability.go
+++ b/internal/server/mcp_direct_callability.go
@@ -1,0 +1,138 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
+)
+
+// filterDirectToolsForAgentCallability hides direct-mode tools that an agent
+// token cannot actually invoke because they are disabled, quarantined, pending
+// approval, or changed since approval. Non-agent contexts keep the existing
+// operator-visible discovery behavior.
+func (p *MCPProxyServer) filterDirectToolsForAgentCallability(ctx context.Context, tools []mcp.Tool) []mcp.Tool {
+	if len(tools) == 0 {
+		return tools
+	}
+
+	authCtx := auth.AuthContextFromContext(ctx)
+	if authCtx == nil || authCtx.Type != auth.AuthTypeAgent {
+		return tools
+	}
+
+	filtered := make([]mcp.Tool, 0, len(tools))
+	for _, tool := range tools {
+		serverName, toolName, ok := ParseDirectToolName(tool.Name)
+		if !ok {
+			filtered = append(filtered, tool)
+			continue
+		}
+
+		if p.isDirectToolCallable(serverName, toolName) {
+			filtered = append(filtered, tool)
+		}
+	}
+
+	return filtered
+}
+
+// directToolCallabilityBlock returns a policy response when a direct-mode tool
+// is not callable. It mirrors the call_tool_* policy boundary so direct mode
+// cannot bypass disabled-tool, server-quarantine, or tool-approval controls.
+func (p *MCPProxyServer) directToolCallabilityBlock(ctx context.Context, serverName, toolName string, args map[string]interface{}) *mcp.CallToolResult {
+	// Unit tests historically construct a minimal MCPProxyServer with no
+	// storage. Preserve that narrow behavior; production servers always have
+	// storage and therefore enforce the policy below.
+	if p.storage == nil {
+		return nil
+	}
+
+	serverConfig, err := p.storage.GetUpstreamServer(serverName)
+	if err != nil || serverConfig == nil {
+		return mcp.NewToolResultError(p.blockedToolMessage(serverName, toolName))
+	}
+
+	if serverConfig.Quarantined {
+		return p.handleQuarantinedToolCall(ctx, serverName, toolName, args)
+	}
+
+	if !serverConfig.IsToolAllowedByConfig(toolName) {
+		return mcp.NewToolResultError(blockedToolMessageFor(true))
+	}
+
+	if p.config != nil && p.config.IsQuarantineEnabled() && !serverConfig.IsQuarantineSkipped() {
+		approval, approvalErr := p.storage.GetToolApproval(serverName, toolName)
+		if approvalErr == nil && approval != nil {
+			switch approval.Status {
+			case storage.ToolApprovalStatusPending:
+				return directPendingApprovalResult(serverName, toolName, approval)
+			case storage.ToolApprovalStatusChanged:
+				return directChangedApprovalResult(serverName, toolName, approval)
+			}
+		}
+	}
+
+	if !p.isToolCallable(serverName, toolName) {
+		return mcp.NewToolResultError(p.blockedToolMessage(serverName, toolName))
+	}
+
+	return nil
+}
+
+// isDirectToolCallable is the direct-mode discovery predicate. It includes the
+// generic callable check plus tool-level pending/changed quarantine, because
+// isToolCallable intentionally handles only disabled/config/server state.
+func (p *MCPProxyServer) isDirectToolCallable(serverName, toolName string) bool {
+	if p.storage == nil || !p.isToolCallable(serverName, toolName) {
+		return false
+	}
+
+	serverConfig, err := p.storage.GetUpstreamServer(serverName)
+	if err != nil || serverConfig == nil || serverConfig.Quarantined {
+		return false
+	}
+
+	if p.config != nil && p.config.IsQuarantineEnabled() && !serverConfig.IsQuarantineSkipped() {
+		approval, approvalErr := p.storage.GetToolApproval(serverName, toolName)
+		if approvalErr == nil && approval != nil {
+			return approval.Status != storage.ToolApprovalStatusPending &&
+				approval.Status != storage.ToolApprovalStatusChanged
+		}
+	}
+
+	return true
+}
+
+func directPendingApprovalResult(serverName, toolName string, approval *storage.ToolApprovalRecord) *mcp.CallToolResult {
+	response := map[string]interface{}{
+		"status":              "TOOL_QUARANTINED",
+		"server_name":         serverName,
+		"tool_name":           toolName,
+		"reason":              "new_unapproved_tool",
+		"message":             fmt.Sprintf("Tool '%s:%s' has not been approved yet. New tools must be inspected and approved before use.", serverName, toolName),
+		"current_description": approval.CurrentDescription,
+		"action":              fmt.Sprintf("Approve via: POST /api/v1/servers/%s/tools/approve or mcpproxy upstream inspect %s", serverName, serverName),
+	}
+	jsonResult, _ := json.Marshal(response)
+	return mcp.NewToolResultText(string(jsonResult))
+}
+
+func directChangedApprovalResult(serverName, toolName string, approval *storage.ToolApprovalRecord) *mcp.CallToolResult {
+	response := map[string]interface{}{
+		"status":               "TOOL_QUARANTINED",
+		"server_name":          serverName,
+		"tool_name":            toolName,
+		"reason":               "tool_description_changed",
+		"message":              fmt.Sprintf("Tool '%s:%s' description has changed since last approval. Inspect changes before using.", serverName, toolName),
+		"previous_description": approval.PreviousDescription,
+		"current_description":  approval.CurrentDescription,
+		"action":               fmt.Sprintf("Approve via: POST /api/v1/servers/%s/tools/approve or mcpproxy upstream inspect %s", serverName, serverName),
+	}
+	jsonResult, _ := json.Marshal(response)
+	return mcp.NewToolResultText(string(jsonResult))
+}

--- a/internal/server/mcp_direct_callability_test.go
+++ b/internal/server/mcp_direct_callability_test.go
@@ -180,12 +180,12 @@ func TestFilterDirectToolsForAgentCallability_AgentOnly(t *testing.T) {
 	})
 
 	filtered := proxy.filterDirectToolsForAgentCallability(agentCtx, tools)
-	assert.Equal(t, []string{FormatDirectToolName("github", "allowed")}, directToolNamesForTest(filtered))
+	assert.Equal(t, []string{FormatDirectToolName("github", "allowed")}, directCallabilityToolNamesForTest(filtered))
 
 	assert.Equal(t, tools, proxy.filterDirectToolsForAgentCallability(context.Background(), tools))
 }
 
-func directToolNamesForTest(tools []mcp.Tool) []string {
+func directCallabilityToolNamesForTest(tools []mcp.Tool) []string {
 	names := make([]string, 0, len(tools))
 	for _, tool := range tools {
 		names = append(names, tool.Name)

--- a/internal/server/mcp_direct_callability_test.go
+++ b/internal/server/mcp_direct_callability_test.go
@@ -92,7 +92,12 @@ func TestDirectToolCallabilityBlock_PendingApproval(t *testing.T) {
 	text := result.Content[0].(mcp.TextContent).Text
 	require.NoError(t, json.Unmarshal([]byte(text), &response))
 	assert.Equal(t, "TOOL_QUARANTINED", response["status"])
+	assert.Equal(t, "github", response["server_name"])
+	assert.Equal(t, "new_tool", response["tool_name"])
 	assert.Equal(t, "new_unapproved_tool", response["reason"])
+	assert.Contains(t, response["message"], "has not been approved")
+	assert.Equal(t, "new capability", response["current_description"])
+	assert.Contains(t, response["action"], "/api/v1/servers/github/tools/approve")
 }
 
 func TestDirectToolCallabilityBlock_ChangedApproval(t *testing.T) {
@@ -114,7 +119,13 @@ func TestDirectToolCallabilityBlock_ChangedApproval(t *testing.T) {
 	text := result.Content[0].(mcp.TextContent).Text
 	require.NoError(t, json.Unmarshal([]byte(text), &response))
 	assert.Equal(t, "TOOL_QUARANTINED", response["status"])
+	assert.Equal(t, "github", response["server_name"])
+	assert.Equal(t, "mutated_tool", response["tool_name"])
 	assert.Equal(t, "tool_description_changed", response["reason"])
+	assert.Contains(t, response["message"], "description has changed")
+	assert.Equal(t, "old", response["previous_description"])
+	assert.Equal(t, "new", response["current_description"])
+	assert.Contains(t, response["action"], "/api/v1/servers/github/tools/approve")
 }
 
 func TestDirectToolCallabilityBlock_ApprovedToolAllowed(t *testing.T) {

--- a/internal/server/mcp_direct_callability_test.go
+++ b/internal/server/mcp_direct_callability_test.go
@@ -56,7 +56,11 @@ func TestDirectToolCallabilityBlock_ConfigDeniedTool(t *testing.T) {
 
 func TestDirectToolCallabilityBlock_DisabledTool(t *testing.T) {
 	proxy := createTestMCPProxyServer(t)
-	require.NoError(t, proxy.storage.SaveUpstreamServer(&config.ServerConfig{Name: "github", Enabled: true}))
+	require.NoError(t, proxy.storage.SaveUpstreamServer(&config.ServerConfig{
+		Name:          "github",
+		Enabled:       true,
+		DisabledTools: []string{"config_disabled"},
+	}))
 	require.NoError(t, proxy.storage.SaveToolApproval(&storage.ToolApprovalRecord{
 		ServerName: "github",
 		ToolName:   "delete_repo",
@@ -128,7 +132,11 @@ func TestDirectToolCallabilityBlock_ApprovedToolAllowed(t *testing.T) {
 
 func TestFilterDirectToolsForAgentCallability_AgentOnly(t *testing.T) {
 	proxy := createTestMCPProxyServer(t)
-	require.NoError(t, proxy.storage.SaveUpstreamServer(&config.ServerConfig{Name: "github", Enabled: true}))
+	require.NoError(t, proxy.storage.SaveUpstreamServer(&config.ServerConfig{
+		Name:          "github",
+		Enabled:       true,
+		DisabledTools: []string{"config_disabled"},
+	}))
 	require.NoError(t, proxy.storage.SaveToolApproval(&storage.ToolApprovalRecord{
 		ServerName: "github",
 		ToolName:   "allowed",
@@ -150,6 +158,7 @@ func TestFilterDirectToolsForAgentCallability_AgentOnly(t *testing.T) {
 		{Name: FormatDirectToolName("github", "allowed")},
 		{Name: FormatDirectToolName("github", "disabled")},
 		{Name: FormatDirectToolName("github", "pending")},
+		{Name: FormatDirectToolName("github", "config_disabled")},
 	}
 
 	agentCtx := auth.WithAuthContext(context.Background(), &auth.AuthContext{

--- a/internal/server/mcp_direct_callability_test.go
+++ b/internal/server/mcp_direct_callability_test.go
@@ -1,0 +1,174 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
+)
+
+func TestDirectToolCallabilityBlock_ServerDisabled(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+	require.NoError(t, proxy.storage.SaveUpstreamServer(&config.ServerConfig{Name: "github", Enabled: false}))
+
+	result := proxy.directToolCallabilityBlock(context.Background(), "github", "list_repos", map[string]interface{}{})
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Content[0].(mcp.TextContent).Text, "Tool is disabled")
+}
+
+func TestDirectToolCallabilityBlock_ServerQuarantined(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+	require.NoError(t, proxy.storage.SaveUpstreamServer(&config.ServerConfig{Name: "github", Enabled: true, Quarantined: true}))
+
+	result := proxy.directToolCallabilityBlock(context.Background(), "github", "list_repos", map[string]interface{}{"q": "x"})
+	require.NotNil(t, result)
+	assert.False(t, result.IsError)
+
+	var response map[string]interface{}
+	text := result.Content[0].(mcp.TextContent).Text
+	require.NoError(t, json.Unmarshal([]byte(text), &response))
+	assert.Equal(t, "QUARANTINED_SERVER_BLOCKED", response["status"])
+	assert.Equal(t, "github", response["serverName"])
+	assert.Equal(t, "list_repos", response["toolName"])
+}
+
+func TestDirectToolCallabilityBlock_ConfigDeniedTool(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+	require.NoError(t, proxy.storage.SaveUpstreamServer(&config.ServerConfig{
+		Name:          "github",
+		Enabled:       true,
+		DisabledTools: []string{"delete_repo"},
+	}))
+
+	result := proxy.directToolCallabilityBlock(context.Background(), "github", "delete_repo", map[string]interface{}{})
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Content[0].(mcp.TextContent).Text, "NOT user-overridable")
+}
+
+func TestDirectToolCallabilityBlock_DisabledTool(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+	require.NoError(t, proxy.storage.SaveUpstreamServer(&config.ServerConfig{Name: "github", Enabled: true}))
+	require.NoError(t, proxy.storage.SaveToolApproval(&storage.ToolApprovalRecord{
+		ServerName: "github",
+		ToolName:   "delete_repo",
+		Status:     storage.ToolApprovalStatusApproved,
+		Disabled:   true,
+	}))
+
+	result := proxy.directToolCallabilityBlock(context.Background(), "github", "delete_repo", map[string]interface{}{})
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Content[0].(mcp.TextContent).Text, "Tool is disabled")
+}
+
+func TestDirectToolCallabilityBlock_PendingApproval(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+	require.NoError(t, proxy.storage.SaveUpstreamServer(&config.ServerConfig{Name: "github", Enabled: true}))
+	require.NoError(t, proxy.storage.SaveToolApproval(&storage.ToolApprovalRecord{
+		ServerName:         "github",
+		ToolName:           "new_tool",
+		Status:             storage.ToolApprovalStatusPending,
+		CurrentDescription: "new capability",
+	}))
+
+	result := proxy.directToolCallabilityBlock(context.Background(), "github", "new_tool", map[string]interface{}{})
+	require.NotNil(t, result)
+	assert.False(t, result.IsError)
+
+	var response map[string]interface{}
+	text := result.Content[0].(mcp.TextContent).Text
+	require.NoError(t, json.Unmarshal([]byte(text), &response))
+	assert.Equal(t, "TOOL_QUARANTINED", response["status"])
+	assert.Equal(t, "new_unapproved_tool", response["reason"])
+}
+
+func TestDirectToolCallabilityBlock_ChangedApproval(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+	require.NoError(t, proxy.storage.SaveUpstreamServer(&config.ServerConfig{Name: "github", Enabled: true}))
+	require.NoError(t, proxy.storage.SaveToolApproval(&storage.ToolApprovalRecord{
+		ServerName:          "github",
+		ToolName:            "mutated_tool",
+		Status:              storage.ToolApprovalStatusChanged,
+		PreviousDescription: "old",
+		CurrentDescription:  "new",
+	}))
+
+	result := proxy.directToolCallabilityBlock(context.Background(), "github", "mutated_tool", map[string]interface{}{})
+	require.NotNil(t, result)
+	assert.False(t, result.IsError)
+
+	var response map[string]interface{}
+	text := result.Content[0].(mcp.TextContent).Text
+	require.NoError(t, json.Unmarshal([]byte(text), &response))
+	assert.Equal(t, "TOOL_QUARANTINED", response["status"])
+	assert.Equal(t, "tool_description_changed", response["reason"])
+}
+
+func TestDirectToolCallabilityBlock_ApprovedToolAllowed(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+	require.NoError(t, proxy.storage.SaveUpstreamServer(&config.ServerConfig{Name: "github", Enabled: true}))
+	require.NoError(t, proxy.storage.SaveToolApproval(&storage.ToolApprovalRecord{
+		ServerName: "github",
+		ToolName:   "list_repos",
+		Status:     storage.ToolApprovalStatusApproved,
+	}))
+
+	result := proxy.directToolCallabilityBlock(context.Background(), "github", "list_repos", map[string]interface{}{})
+	assert.Nil(t, result)
+}
+
+func TestFilterDirectToolsForAgentCallability_AgentOnly(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+	require.NoError(t, proxy.storage.SaveUpstreamServer(&config.ServerConfig{Name: "github", Enabled: true}))
+	require.NoError(t, proxy.storage.SaveToolApproval(&storage.ToolApprovalRecord{
+		ServerName: "github",
+		ToolName:   "allowed",
+		Status:     storage.ToolApprovalStatusApproved,
+	}))
+	require.NoError(t, proxy.storage.SaveToolApproval(&storage.ToolApprovalRecord{
+		ServerName: "github",
+		ToolName:   "disabled",
+		Status:     storage.ToolApprovalStatusApproved,
+		Disabled:   true,
+	}))
+	require.NoError(t, proxy.storage.SaveToolApproval(&storage.ToolApprovalRecord{
+		ServerName: "github",
+		ToolName:   "pending",
+		Status:     storage.ToolApprovalStatusPending,
+	}))
+
+	tools := []mcp.Tool{
+		{Name: FormatDirectToolName("github", "allowed")},
+		{Name: FormatDirectToolName("github", "disabled")},
+		{Name: FormatDirectToolName("github", "pending")},
+	}
+
+	agentCtx := auth.WithAuthContext(context.Background(), &auth.AuthContext{
+		Type:           auth.AuthTypeAgent,
+		AgentName:      "agent",
+		AllowedServers: []string{"github"},
+		Permissions:    []string{auth.PermRead},
+	})
+
+	filtered := proxy.filterDirectToolsForAgentCallability(agentCtx, tools)
+	assert.Equal(t, []string{FormatDirectToolName("github", "allowed")}, directToolNamesForTest(filtered))
+
+	assert.Equal(t, tools, proxy.filterDirectToolsForAgentCallability(context.Background(), tools))
+}
+
+func directToolNamesForTest(tools []mcp.Tool) []string {
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		names = append(names, tool.Name)
+	}
+	return names
+}

--- a/internal/server/mcp_routing.go
+++ b/internal/server/mcp_routing.go
@@ -154,6 +154,14 @@ func (p *MCPProxyServer) makeDirectModeHandler(serverName, toolName string, anno
 		// Get arguments from the request
 		args := request.GetArguments()
 
+		// Enforce direct-mode callability before emitting a tool-started event or
+		// invoking upstream. Direct mode must not bypass disabled, quarantine, or
+		// approval controls enforced by call_tool_* variants.
+		if blocked := p.directToolCallabilityBlock(ctx, serverName, toolName, injectAuthMetadata(ctx, args)); blocked != nil {
+			p.emitActivityPolicyDecision(serverName, toolName, sessionID, "blocked", "direct tool is not callable")
+			return blocked, nil
+		}
+
 		// Emit activity event
 		enrichedArgs := injectAuthMetadata(ctx, args)
 		p.emitActivityToolCallStarted(serverName, toolName, sessionID, requestID, "mcp", enrichedArgs)
@@ -489,10 +497,12 @@ func (p *MCPProxyServer) initRoutingModeServers() {
 	}
 
 	// Create direct mode server
+	directOpts := append([]mcpserver.ServerOption{}, opts...)
+	directOpts = append(directOpts, mcpserver.WithToolFilter(p.filterDirectToolsForAgentCallability))
 	p.directServer = mcpserver.NewMCPServer(
 		"mcpproxy-go",
 		mcpServerVersion(),
-		opts...,
+		directOpts...,
 	)
 
 	// Create code execution mode server

--- a/internal/server/mcp_routing.go
+++ b/internal/server/mcp_routing.go
@@ -153,17 +153,17 @@ func (p *MCPProxyServer) makeDirectModeHandler(serverName, toolName string, anno
 
 		// Get arguments from the request
 		args := request.GetArguments()
+		enrichedArgs := injectAuthMetadata(ctx, args)
 
 		// Enforce direct-mode callability before emitting a tool-started event or
 		// invoking upstream. Direct mode must not bypass disabled, quarantine, or
 		// approval controls enforced by call_tool_* variants.
-		if blocked := p.directToolCallabilityBlock(ctx, serverName, toolName, injectAuthMetadata(ctx, args)); blocked != nil {
+		if blocked := p.directToolCallabilityBlock(ctx, serverName, toolName, enrichedArgs); blocked != nil {
 			p.emitActivityPolicyDecision(serverName, toolName, sessionID, "blocked", "direct tool is not callable")
 			return blocked, nil
 		}
 
 		// Emit activity event
-		enrichedArgs := injectAuthMetadata(ctx, args)
 		p.emitActivityToolCallStarted(serverName, toolName, sessionID, requestID, "mcp", enrichedArgs)
 
 		// Call upstream


### PR DESCRIPTION
## Summary

Enforces the existing callable-tool policy boundary in direct mode.

Direct mode previously checked agent-token server/permission scope, then invoked the upstream tool directly. That allowed direct-mode clients to bypass disabled-tool, server-quarantine, and tool-approval controls that are enforced by the `call_tool_*` paths.

This change blocks direct-mode calls before upstream invocation when the target tool is not callable, and filters direct-mode `tools/list` for agent-token contexts so agents do not discover tools they cannot invoke.

## Changes

- Blocks direct-mode calls to:
  - disabled servers
  - quarantined servers
  - tools denied by `enabled_tools` / `disabled_tools`
  - user-disabled tools
  - pending-approval tools
  - changed-since-approval tools
- Adds a direct-mode `WithToolFilter` for agent-token `tools/list`.
- Hides non-callable direct tools from agent discovery.
- Preserves existing admin/non-agent discovery behavior.
- Keeps existing direct-mode agent server/permission checks intact.

## Validation

Targeted tests only:

```bash
go test ./internal/server -run 'TestDirectToolCallabilityBlock|TestFilterDirectToolsForAgentCallability|TestDirectModeHandler|TestGetMCPServerForMode' -count=1