### PR TITLE
fix: include output schema in tool approval hash migration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -239,9 +239,9 @@ type ServerConfig struct {
 	// when the server is configured with both Command and an HTTP/SSE URL — i.e.,
 	// mcpproxy starts the process AND connects via network. Stdio servers ignore
 	// this field. Zero or unset → 30s default.
-	LauncherWaitTimeout Duration  `json:"launcher_wait_timeout,omitempty" mapstructure:"launcher_wait_timeout" swaggertype:"string"`
-	EnabledTools        []string  `json:"enabled_tools,omitempty" mapstructure:"enabled_tools"`   // Allowlist: only these tools are exposed; mutually exclusive with disabled_tools
-	DisabledTools       []string  `json:"disabled_tools,omitempty" mapstructure:"disabled_tools"` // Denylist: these tools are hidden; mutually exclusive with enabled_tools
+	LauncherWaitTimeout Duration `json:"launcher_wait_timeout,omitempty" mapstructure:"launcher_wait_timeout" swaggertype:"string"`
+	EnabledTools        []string `json:"enabled_tools,omitempty" mapstructure:"enabled_tools"`   // Allowlist: only these tools are exposed; mutually exclusive with disabled_tools
+	DisabledTools       []string `json:"disabled_tools,omitempty" mapstructure:"disabled_tools"` // Denylist: these tools are hidden; mutually exclusive with enabled_tools
 }
 
 // OAuthConfig represents OAuth configuration for a server
@@ -523,14 +523,15 @@ func ConvertFromCursorFormat(cursorConfig *CursorMCPConfig) []*ServerConfig {
 
 // ToolMetadata represents tool information stored in the index
 type ToolMetadata struct {
-	Name        string           `json:"name"`
-	ServerName  string           `json:"server_name"`
-	Description string           `json:"description"`
-	ParamsJSON  string           `json:"params_json"`
-	Hash        string           `json:"hash"`
-	Created     time.Time        `json:"created"`
-	Updated     time.Time        `json:"updated"`
-	Annotations *ToolAnnotations `json:"annotations,omitempty"`
+	Name             string           `json:"name"`
+	ServerName       string           `json:"server_name"`
+	Description      string           `json:"description"`
+	ParamsJSON       string           `json:"params_json"`
+	OutputSchemaJSON string           `json:"output_schema_json,omitempty"`
+	Hash             string           `json:"hash"`
+	Created          time.Time        `json:"created"`
+	Updated          time.Time        `json:"updated"`
+	Annotations      *ToolAnnotations `json:"annotations,omitempty"`
 }
 
 // ToolAnnotations represents MCP tool behavior hints

--- a/internal/hash/hash.go
+++ b/internal/hash/hash.go
@@ -7,9 +7,17 @@ import (
 	"fmt"
 )
 
-// ToolHash computes SHA-256 hash for tool change detection
+// ToolHash computes SHA-256 hash for tool change detection.
 // Format: sha256(serverName + toolName + description + parametersSchemaJSON)
 func ToolHash(serverName, toolName, description string, parametersSchema interface{}) (string, error) {
+	return ToolHashWithOutputSchema(serverName, toolName, description, parametersSchema, "")
+}
+
+// ToolHashWithOutputSchema computes SHA-256 hash for the full tool contract.
+// Output schema is included because it describes the data shape returned to the
+// agent and therefore belongs to the human-approved tool contract.
+// Format: sha256(serverName + toolName + description + parametersSchemaJSON + outputSchemaJSON)
+func ToolHashWithOutputSchema(serverName, toolName, description string, parametersSchema interface{}, outputSchemaJSON string) (string, error) {
 	// Serialize parameters schema to JSON for consistent hashing
 	var schemaBytes []byte
 	var err error
@@ -21,8 +29,8 @@ func ToolHash(serverName, toolName, description string, parametersSchema interfa
 		}
 	}
 
-	// Combine server name, tool name, description, and schema JSON
-	combined := serverName + toolName + description + string(schemaBytes)
+	// Combine server name, tool name, description, input schema JSON, and output schema JSON
+	combined := serverName + toolName + description + string(schemaBytes) + outputSchemaJSON
 
 	// Compute SHA-256 hash
 	hasher := sha256.New()
@@ -60,7 +68,12 @@ func VerifyToolHash(serverName, toolName, description string, parametersSchema i
 
 // ComputeToolHash computes a SHA256 hash for a tool (alias for ToolHash that doesn't return error)
 func ComputeToolHash(serverName, toolName, description string, inputSchema interface{}) string {
-	hash, err := ToolHash(serverName, toolName, description, inputSchema)
+	return ComputeToolHashWithOutputSchema(serverName, toolName, description, inputSchema, "")
+}
+
+// ComputeToolHashWithOutputSchema computes a SHA256 hash for a tool including output schema.
+func ComputeToolHashWithOutputSchema(serverName, toolName, description string, inputSchema interface{}, outputSchemaJSON string) string {
+	hash, err := ToolHashWithOutputSchema(serverName, toolName, description, inputSchema, outputSchemaJSON)
 	if err != nil {
 		// If hashing fails, return a default hash based on server and tool name
 		fallback := StringHash(fmt.Sprintf("%s:%s", serverName, toolName))

--- a/internal/hash/hash.go
+++ b/internal/hash/hash.go
@@ -7,8 +7,16 @@ import (
 	"fmt"
 )
 
+type toolHashContract struct {
+	ServerName       string          `json:"server_name"`
+	ToolName         string          `json:"tool_name"`
+	Description      string          `json:"description"`
+	InputSchema      json.RawMessage `json:"input_schema,omitempty"`
+	OutputSchemaJSON json.RawMessage `json:"output_schema,omitempty"`
+}
+
 // ToolHash computes SHA-256 hash for tool change detection.
-// Format: sha256(serverName + toolName + description + parametersSchemaJSON)
+// Format: sha256(canonical JSON of serverName, toolName, description, input schema)
 func ToolHash(serverName, toolName, description string, parametersSchema interface{}) (string, error) {
 	return ToolHashWithOutputSchema(serverName, toolName, description, parametersSchema, "")
 }
@@ -16,28 +24,84 @@ func ToolHash(serverName, toolName, description string, parametersSchema interfa
 // ToolHashWithOutputSchema computes SHA-256 hash for the full tool contract.
 // Output schema is included because it describes the data shape returned to the
 // agent and therefore belongs to the human-approved tool contract.
-// Format: sha256(serverName + toolName + description + parametersSchemaJSON + outputSchemaJSON)
+// Format: sha256(canonical JSON of serverName, toolName, description, input schema, output schema)
 func ToolHashWithOutputSchema(serverName, toolName, description string, parametersSchema interface{}, outputSchemaJSON string) (string, error) {
-	// Serialize parameters schema to JSON for consistent hashing
-	var schemaBytes []byte
-	var err error
-
-	if parametersSchema != nil {
-		schemaBytes, err = json.Marshal(parametersSchema)
-		if err != nil {
-			return "", fmt.Errorf("failed to marshal parameters schema: %w", err)
-		}
+	inputSchema, err := canonicalSchemaFromInterface(parametersSchema)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal parameters schema: %w", err)
 	}
 
-	// Combine server name, tool name, description, input schema JSON, and output schema JSON
-	combined := serverName + toolName + description + string(schemaBytes) + outputSchemaJSON
+	outputSchema, err := canonicalSchemaFromString(outputSchemaJSON)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal output schema: %w", err)
+	}
 
-	// Compute SHA-256 hash
+	contract := toolHashContract{
+		ServerName:       serverName,
+		ToolName:         toolName,
+		Description:      description,
+		InputSchema:      inputSchema,
+		OutputSchemaJSON: outputSchema,
+	}
+
+	contractBytes, err := json.Marshal(contract)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal tool hash contract: %w", err)
+	}
+
 	hasher := sha256.New()
-	hasher.Write([]byte(combined))
+	hasher.Write(contractBytes)
 	hashBytes := hasher.Sum(nil)
 
 	return hex.EncodeToString(hashBytes), nil
+}
+
+func canonicalSchemaFromInterface(schema interface{}) (json.RawMessage, error) {
+	if schema == nil {
+		return nil, nil
+	}
+
+	var raw json.RawMessage
+	switch value := schema.(type) {
+	case json.RawMessage:
+		raw = value
+	case []byte:
+		raw = value
+	case string:
+		raw = []byte(value)
+	default:
+		data, err := json.Marshal(value)
+		if err != nil {
+			return nil, err
+		}
+		raw = data
+	}
+
+	return canonicalSchemaFromBytes(raw)
+}
+
+func canonicalSchemaFromString(schemaJSON string) (json.RawMessage, error) {
+	if schemaJSON == "" {
+		return nil, nil
+	}
+	return canonicalSchemaFromBytes([]byte(schemaJSON))
+}
+
+func canonicalSchemaFromBytes(schemaJSON []byte) (json.RawMessage, error) {
+	if len(schemaJSON) == 0 {
+		return nil, nil
+	}
+
+	var parsed interface{}
+	if err := json.Unmarshal(schemaJSON, &parsed); err != nil {
+		return nil, err
+	}
+
+	canonical, err := json.Marshal(parsed)
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(canonical), nil
 }
 
 // StringHash computes SHA-256 hash of a string

--- a/internal/hash/hash_test.go
+++ b/internal/hash/hash_test.go
@@ -136,6 +136,27 @@ func TestComputeToolHash_FallbackOnMarshalError(t *testing.T) {
 	assert.NotEmpty(t, hash, "Should return fallback hash on marshal error")
 }
 
+func TestComputeToolHashWithOutputSchema_CanonicalizesOutputSchemaJSON(t *testing.T) {
+	inputSchema := map[string]interface{}{"type": "object"}
+
+	hash1 := ComputeToolHashWithOutputSchema("server", "tool", "desc", inputSchema, `{"type":"object","properties":{"url":{"type":"string"}}}`)
+	hash2 := ComputeToolHashWithOutputSchema("server", "tool", "desc", inputSchema, `{
+		"properties": {"url": {"type": "string"}},
+		"type": "object"
+	}`)
+
+	assert.Equal(t, hash1, hash2, "Semantically identical output schemas should hash the same")
+}
+
+func TestToolHashWithOutputSchema_UsesStructuredEncoding(t *testing.T) {
+	hash1, err := ToolHashWithOutputSchema("ab", "c", "d", map[string]interface{}{"type": "object"}, `{"type":"object"}`)
+	require.NoError(t, err)
+	hash2, err := ToolHashWithOutputSchema("a", "bc", "d", map[string]interface{}{"type": "object"}, `{"type":"object"}`)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, hash1, hash2, "Different contract field tuples must not collide through string concatenation")
+}
+
 func TestComputeToolHash_DescriptionOnlyChange(t *testing.T) {
 	schema := map[string]interface{}{
 		"type": "object",

--- a/internal/index/bleve.go
+++ b/internal/index/bleve.go
@@ -21,14 +21,15 @@ type BleveIndex struct {
 
 // ToolDocument represents a tool document in the index
 type ToolDocument struct {
-	ToolName       string `json:"tool_name"`      // Just the tool name (without server prefix)
-	FullToolName   string `json:"full_tool_name"` // Complete server:tool format
-	ServerName     string `json:"server_name"`
-	Description    string `json:"description"`
-	ParamsJSON     string `json:"params_json"`
-	Hash           string `json:"hash"`
-	Tags           string `json:"tags"`
-	SearchableText string `json:"searchable_text"` // Combined searchable content
+	ToolName         string `json:"tool_name"`      // Just the tool name (without server prefix)
+	FullToolName     string `json:"full_tool_name"` // Complete server:tool format
+	ServerName       string `json:"server_name"`
+	Description      string `json:"description"`
+	ParamsJSON       string `json:"params_json"`
+	OutputSchemaJSON string `json:"output_schema_json,omitempty"`
+	Hash             string `json:"hash"`
+	Tags             string `json:"tags"`
+	SearchableText   string `json:"searchable_text"` // Combined searchable content
 }
 
 // NewBleveIndex creates a new Bleve index
@@ -147,14 +148,15 @@ func (b *BleveIndex) IndexTool(toolMeta *config.ToolMetadata) error {
 		toolMeta.ParamsJSON)
 
 	doc := &ToolDocument{
-		ToolName:       toolName,
-		FullToolName:   toolMeta.Name,
-		ServerName:     toolMeta.ServerName,
-		Description:    toolMeta.Description,
-		ParamsJSON:     toolMeta.ParamsJSON,
-		Hash:           toolMeta.Hash,
-		Tags:           "", // Can be extended later
-		SearchableText: searchableText,
+		ToolName:         toolName,
+		FullToolName:     toolMeta.Name,
+		ServerName:       toolMeta.ServerName,
+		Description:      toolMeta.Description,
+		ParamsJSON:       toolMeta.ParamsJSON,
+		OutputSchemaJSON: toolMeta.OutputSchemaJSON,
+		Hash:             toolMeta.Hash,
+		Tags:             "", // Can be extended later
+		SearchableText:   searchableText,
 	}
 
 	// Use server:tool format as document ID for uniqueness
@@ -249,7 +251,7 @@ func (b *BleveIndex) SearchTools(queryStr string, limit int) ([]*config.SearchRe
 	// Create search request
 	searchReq := bleve.NewSearchRequest(boolQuery)
 	searchReq.Size = limit
-	searchReq.Fields = []string{"tool_name", "full_tool_name", "server_name", "description", "params_json", "hash"}
+	searchReq.Fields = []string{"tool_name", "full_tool_name", "server_name", "description", "params_json", "output_schema_json", "hash"}
 	searchReq.Highlight = bleve.NewHighlight()
 
 	b.logger.Debug("Searching tools with enhanced query", zap.String("query", queryStr), zap.Int("limit", limit))
@@ -263,11 +265,12 @@ func (b *BleveIndex) SearchTools(queryStr string, limit int) ([]*config.SearchRe
 	var results []*config.SearchResult
 	for _, hit := range searchResult.Hits {
 		toolMeta := &config.ToolMetadata{
-			Name:        getStringField(hit.Fields, "full_tool_name"),
-			ServerName:  getStringField(hit.Fields, "server_name"),
-			Description: getStringField(hit.Fields, "description"),
-			ParamsJSON:  getStringField(hit.Fields, "params_json"),
-			Hash:        getStringField(hit.Fields, "hash"),
+			Name:             getStringField(hit.Fields, "full_tool_name"),
+			ServerName:       getStringField(hit.Fields, "server_name"),
+			Description:      getStringField(hit.Fields, "description"),
+			ParamsJSON:       getStringField(hit.Fields, "params_json"),
+			OutputSchemaJSON: getStringField(hit.Fields, "output_schema_json"),
+			Hash:             getStringField(hit.Fields, "hash"),
 		}
 
 		results = append(results, &config.SearchResult{

--- a/internal/runtime/tool_quarantine.go
+++ b/internal/runtime/tool_quarantine.go
@@ -17,14 +17,18 @@ import (
 )
 
 // calculateToolApprovalHash computes a stable SHA-256 hash for tool-level quarantine.
-// Uses toolName + description + schemaJSON only.
+// Uses toolName + description + input schema JSON + output schema JSON.
 // Annotations are intentionally EXCLUDED because:
 // 1. They are metadata hints, not functional changes to the tool
 // 2. They may not be stable across reconnections (some servers omit them)
 // 3. Including them caused false "tool_description_changed" spam on every reconnect
-// 4. This matches the upstream client's hash.ComputeToolHash approach
+// 4. This matches the upstream client's hash.ComputeToolHashWithOutputSchema approach
 // The annotations parameter is kept for API compatibility but ignored.
 func calculateToolApprovalHash(toolName, description, schemaJSON string, annotations *config.ToolAnnotations) string {
+	return calculateToolApprovalHashWithOutputSchema(toolName, description, schemaJSON, "", annotations)
+}
+
+func calculateToolApprovalHashWithOutputSchema(toolName, description, schemaJSON, outputSchemaJSON string, annotations *config.ToolAnnotations) string {
 	h := sha256.New()
 	h.Write([]byte(toolName))
 	h.Write([]byte("|"))
@@ -33,6 +37,8 @@ func calculateToolApprovalHash(toolName, description, schemaJSON string, annotat
 	// Normalize JSON schema to prevent key-order differences from causing
 	// false "tool_description_changed" events. Parse → sort keys → serialize.
 	h.Write([]byte(normalizeJSON(schemaJSON)))
+	h.Write([]byte("|"))
+	h.Write([]byte(normalizeJSON(outputSchemaJSON)))
 	// Annotations excluded from hash — see comment above
 	return hex.EncodeToString(h.Sum(nil))
 }
@@ -201,6 +207,12 @@ func (r *Runtime) checkToolApprovals(serverName string, tools []*config.ToolMeta
 		BlockedTools: make(map[string]bool),
 	}
 
+	schemaVersion, schemaVersionErr := r.storageManager.GetSchemaVersion()
+	outputSchemaHashMigration := schemaVersionErr == nil && schemaVersion < storage.OutputSchemaHashSchemaVersion
+	if outputSchemaHashMigration {
+		defer r.markOutputSchemaHashMigrationCompleteIfReady()
+	}
+
 	for _, tool := range tools {
 		// Extract the bare tool name (without server prefix)
 		toolName := extractToolName(tool.Name)
@@ -212,14 +224,39 @@ func (r *Runtime) checkToolApprovals(serverName string, tools []*config.ToolMeta
 			schemaJSON = "{}"
 		}
 
-		// Normalize JSON schema before hashing and storage to ensure stable key ordering
+		// Normalize JSON schemas before hashing and storage to ensure stable key ordering
 		schemaJSON = normalizeJSON(schemaJSON)
+		outputSchemaJSON := normalizeJSON(tool.OutputSchemaJSON)
 
-		// Calculate current hash (includes annotations for rug-pull detection)
-		currentHash := calculateToolApprovalHash(toolName, tool.Description, schemaJSON, tool.Annotations)
+		// Calculate current hash for the full approved contract, including output schema.
+		currentHash := calculateToolApprovalHashWithOutputSchema(toolName, tool.Description, schemaJSON, outputSchemaJSON, tool.Annotations)
 
 		// Look up existing approval record
 		existing, err := r.storageManager.GetToolApproval(serverName, toolName)
+
+		if existing != nil && existing.Status == storage.ToolApprovalStatusApproved && outputSchemaHashMigration {
+			// One-time output-schema hash backfill: previously approved tools did
+			// not store outputSchema in the approved contract hash. Rebaseline the
+			// approved/current hash using the currently observed output schema so the
+			// algorithm upgrade does not masquerade as an upstream rug-pull.
+			existing.ApprovedHash = currentHash
+			existing.CurrentHash = currentHash
+			existing.HashSchemaVersion = storage.OutputSchemaHashSchemaVersion
+			existing.CurrentDescription = tool.Description
+			existing.CurrentSchema = schemaJSON
+			existing.CurrentOutputSchema = outputSchemaJSON
+			if saveErr := r.storageManager.SaveToolApproval(existing); saveErr != nil {
+				r.logger.Debug("Failed to backfill output schema approval hash",
+					zap.String("server", serverName),
+					zap.String("tool", toolName),
+					zap.Error(saveErr))
+			} else {
+				r.logger.Info("Tool approval hash backfilled with output schema",
+					zap.String("server", serverName),
+					zap.String("tool", toolName))
+			}
+			continue
+		}
 
 		if err != nil {
 			// No existing record - this is a new tool.
@@ -227,15 +264,17 @@ func (r *Runtime) checkToolApprovals(serverName string, tools []*config.ToolMeta
 				// Quarantine disabled or server has skip_quarantine - auto-approve
 				now := time.Now().UTC()
 				record := &storage.ToolApprovalRecord{
-					ServerName:         serverName,
-					ToolName:           toolName,
-					CurrentHash:        currentHash,
-					ApprovedHash:       currentHash,
-					Status:             storage.ToolApprovalStatusApproved,
-					ApprovedBy:         "auto",
-					ApprovedAt:         now,
-					CurrentDescription: tool.Description,
-					CurrentSchema:      schemaJSON,
+					ServerName:          serverName,
+					ToolName:            toolName,
+					CurrentHash:         currentHash,
+					ApprovedHash:        currentHash,
+					HashSchemaVersion:   storage.OutputSchemaHashSchemaVersion,
+					Status:              storage.ToolApprovalStatusApproved,
+					ApprovedBy:          "auto",
+					ApprovedAt:          now,
+					CurrentDescription:  tool.Description,
+					CurrentSchema:       schemaJSON,
+					CurrentOutputSchema: outputSchemaJSON,
 				}
 
 				if saveErr := r.storageManager.SaveToolApproval(record); saveErr != nil {
@@ -260,12 +299,14 @@ func (r *Runtime) checkToolApprovals(serverName string, tools []*config.ToolMeta
 			// This applies to ALL servers (including trusted ones) to prevent
 			// injection attacks via new tool additions on compromised servers.
 			record := &storage.ToolApprovalRecord{
-				ServerName:         serverName,
-				ToolName:           toolName,
-				CurrentHash:        currentHash,
-				Status:             storage.ToolApprovalStatusPending,
-				CurrentDescription: tool.Description,
-				CurrentSchema:      schemaJSON,
+				ServerName:          serverName,
+				ToolName:            toolName,
+				CurrentHash:         currentHash,
+				HashSchemaVersion:   storage.OutputSchemaHashSchemaVersion,
+				Status:              storage.ToolApprovalStatusPending,
+				CurrentDescription:  tool.Description,
+				CurrentSchema:       schemaJSON,
+				CurrentOutputSchema: outputSchemaJSON,
 			}
 
 			if saveErr := r.storageManager.SaveToolApproval(record); saveErr != nil {
@@ -308,16 +349,19 @@ func (r *Runtime) checkToolApprovals(serverName string, tools []*config.ToolMeta
 				existing.Status = storage.ToolApprovalStatusApproved
 				existing.PreviousDescription = ""
 				existing.PreviousSchema = ""
+				existing.PreviousOutputSchema = ""
 				needsSave = true
 				r.logger.Info("Tool restored to approved (hash matches after formula update)",
 					zap.String("server", serverName),
 					zap.String("tool", toolName))
 			}
-			// Update current hash/description in case they differ from storage
-			if existing.CurrentHash != currentHash {
+			// Update current hash/description/schema in case they differ from storage
+			if existing.CurrentHash != currentHash || existing.CurrentOutputSchema != outputSchemaJSON || existing.HashSchemaVersion < storage.OutputSchemaHashSchemaVersion {
 				existing.CurrentHash = currentHash
+				existing.HashSchemaVersion = storage.OutputSchemaHashSchemaVersion
 				existing.CurrentDescription = tool.Description
 				existing.CurrentSchema = schemaJSON
+				existing.CurrentOutputSchema = outputSchemaJSON
 				needsSave = true
 			}
 			if needsSave {
@@ -336,6 +380,7 @@ func (r *Runtime) checkToolApprovals(serverName string, tools []*config.ToolMeta
 			existing.CurrentHash = currentHash
 			existing.CurrentDescription = tool.Description
 			existing.CurrentSchema = schemaJSON
+			existing.CurrentOutputSchema = outputSchemaJSON
 			if saveErr := r.storageManager.SaveToolApproval(existing); saveErr != nil {
 				r.logger.Debug("Failed to update pending tool approval",
 					zap.String("server", serverName),
@@ -369,6 +414,7 @@ func (r *Runtime) checkToolApprovals(serverName string, tools []*config.ToolMeta
 				existing.CurrentHash = currentHash
 				existing.CurrentDescription = tool.Description
 				existing.CurrentSchema = schemaJSON
+				existing.CurrentOutputSchema = outputSchemaJSON
 				existing.PreviousDescription = ""
 				existing.PreviousSchema = ""
 				if saveErr := r.storageManager.SaveToolApproval(existing); saveErr == nil {
@@ -393,13 +439,17 @@ func (r *Runtime) checkToolApprovals(serverName string, tools []*config.ToolMeta
 			// actually changed — only the hash formula did.
 			storedDesc := existing.CurrentDescription
 			storedSchema := existing.CurrentSchema
+			storedOutputSchema := existing.CurrentOutputSchema
 			if storedDesc == "" {
 				storedDesc = tool.Description
 			}
 			if storedSchema == "" {
 				storedSchema = schemaJSON
 			}
-			rehashedFromStored := calculateToolApprovalHash(toolName, storedDesc, storedSchema, nil)
+			if storedOutputSchema == "" {
+				storedOutputSchema = outputSchemaJSON
+			}
+			rehashedFromStored := calculateToolApprovalHashWithOutputSchema(toolName, storedDesc, storedSchema, storedOutputSchema, nil)
 
 			// Also check legacy and with-annotations formulas
 			legacyHash := calculateLegacyToolApprovalHash(toolName, tool.Description, schemaJSON)
@@ -420,6 +470,7 @@ func (r *Runtime) checkToolApprovals(serverName string, tools []*config.ToolMeta
 				existing.CurrentHash = currentHash
 				existing.CurrentDescription = tool.Description
 				existing.CurrentSchema = schemaJSON
+				existing.CurrentOutputSchema = outputSchemaJSON
 				existing.PreviousDescription = ""
 				existing.PreviousSchema = ""
 				if saveErr := r.storageManager.SaveToolApproval(existing); saveErr != nil {
@@ -454,7 +505,13 @@ func (r *Runtime) checkToolApprovals(serverName string, tools []*config.ToolMeta
 				// Normalize both schemas and compare
 				schemaMatch = normalizeJSON(schemaJSON) == normalizeJSON(existing.CurrentSchema)
 			}
-			if descMatch && schemaMatch {
+			var outputSchemaMatch bool
+			if existing.CurrentOutputSchema == "" || outputSchemaJSON == existing.CurrentOutputSchema {
+				outputSchemaMatch = true
+			} else {
+				outputSchemaMatch = normalizeJSON(outputSchemaJSON) == normalizeJSON(existing.CurrentOutputSchema)
+			}
+			if descMatch && schemaMatch && outputSchemaMatch {
 				if err := r.enforceInvariant(serverName, toolName, existing.Status, storage.ToolApprovalStatusApproved, ReasonContentMatch); err != nil {
 					result.BlockedTools[toolName] = true
 					result.ChangedCount++
@@ -465,6 +522,7 @@ func (r *Runtime) checkToolApprovals(serverName string, tools []*config.ToolMeta
 				existing.CurrentHash = currentHash
 				existing.CurrentDescription = tool.Description
 				existing.CurrentSchema = schemaJSON
+				existing.CurrentOutputSchema = outputSchemaJSON
 				existing.PreviousDescription = ""
 				existing.PreviousSchema = ""
 				if saveErr := r.storageManager.SaveToolApproval(existing); saveErr == nil {
@@ -481,15 +539,16 @@ func (r *Runtime) checkToolApprovals(serverName string, tools []*config.ToolMeta
 				zap.String("tool", toolName),
 				zap.Bool("desc_match", descMatch),
 				zap.Bool("schema_match", schemaMatch),
+				zap.Bool("output_schema_match", outputSchemaMatch),
 				zap.Int("stored_desc_len", len(existing.CurrentDescription)),
 				zap.Int("current_desc_len", len(tool.Description)),
 				zap.Int("stored_schema_len", len(existing.CurrentSchema)),
 				zap.Int("current_schema_len", len(schemaJSON)))
 
-			// LAST RESORT: If description matches (most important for security),
-			// auto-approve even if schema normalization differs.
-			// Schema formatting differences are NOT security concerns.
-			if descMatch {
+			// LAST RESORT: If description and output schema match, auto-approve even
+			// if input schema normalization differs. Output schema is part of the
+			// approved contract and must not be bypassed here.
+			if descMatch && outputSchemaMatch {
 				if err := r.enforceInvariant(serverName, toolName, existing.Status, storage.ToolApprovalStatusApproved, ReasonDescriptionMatch); err != nil {
 					result.BlockedTools[toolName] = true
 					result.ChangedCount++
@@ -500,6 +559,7 @@ func (r *Runtime) checkToolApprovals(serverName string, tools []*config.ToolMeta
 				existing.CurrentHash = currentHash
 				existing.CurrentDescription = tool.Description
 				existing.CurrentSchema = schemaJSON
+				existing.CurrentOutputSchema = outputSchemaJSON
 				existing.PreviousDescription = ""
 				existing.PreviousSchema = ""
 				if saveErr := r.storageManager.SaveToolApproval(existing); saveErr == nil {
@@ -513,18 +573,23 @@ func (r *Runtime) checkToolApprovals(serverName string, tools []*config.ToolMeta
 			// Hash differs AND description differs - genuine tool change (rug pull)
 			oldDesc := existing.CurrentDescription
 			oldSchema := existing.CurrentSchema
+			oldOutputSchema := existing.CurrentOutputSchema
 			if existing.Status == storage.ToolApprovalStatusApproved {
 				// Transitioning from approved to changed
 				oldDesc = existing.CurrentDescription
 				oldSchema = existing.CurrentSchema
+				oldOutputSchema = existing.CurrentOutputSchema
 			}
 
 			existing.Status = storage.ToolApprovalStatusChanged
 			existing.PreviousDescription = oldDesc
 			existing.PreviousSchema = oldSchema
+			existing.PreviousOutputSchema = oldOutputSchema
 			existing.CurrentHash = currentHash
+			existing.HashSchemaVersion = storage.OutputSchemaHashSchemaVersion
 			existing.CurrentDescription = tool.Description
 			existing.CurrentSchema = schemaJSON
+			existing.CurrentOutputSchema = outputSchemaJSON
 
 			if saveErr := r.storageManager.SaveToolApproval(existing); saveErr != nil {
 				r.logger.Error("Failed to update changed tool approval",
@@ -568,6 +633,33 @@ func (r *Runtime) checkToolApprovals(serverName string, tools []*config.ToolMeta
 	return result, nil
 }
 
+func (r *Runtime) markOutputSchemaHashMigrationCompleteIfReady() {
+	if r.storageManager == nil {
+		return
+	}
+
+	records, err := r.storageManager.ListToolApprovals("")
+	if err != nil {
+		r.logger.Debug("Failed to list tool approvals for output schema hash migration",
+			zap.Error(err))
+		return
+	}
+
+	for _, record := range records {
+		if record.Status == storage.ToolApprovalStatusApproved && record.HashSchemaVersion < storage.OutputSchemaHashSchemaVersion {
+			return
+		}
+	}
+
+	if err := r.storageManager.SetSchemaVersion(storage.OutputSchemaHashSchemaVersion); err != nil {
+		r.logger.Debug("Failed to mark output schema hash migration complete",
+			zap.Error(err))
+		return
+	}
+
+	r.logger.Info("Output schema hash migration completed")
+}
+
 // ApproveTools approves specific tools for a server, updating their status to approved.
 func (r *Runtime) ApproveTools(serverName string, toolNames []string, approvedBy string) error {
 	if r.storageManager == nil {
@@ -591,10 +683,12 @@ func (r *Runtime) ApproveTools(serverName string, toolNames []string, approvedBy
 
 		record.Status = storage.ToolApprovalStatusApproved
 		record.ApprovedHash = record.CurrentHash
+		record.HashSchemaVersion = storage.OutputSchemaHashSchemaVersion
 		record.ApprovedAt = time.Now().UTC()
 		record.ApprovedBy = approvedBy
 		record.PreviousDescription = ""
 		record.PreviousSchema = ""
+		record.PreviousOutputSchema = ""
 
 		if err := r.storageManager.SaveToolApproval(record); err != nil {
 			return err

--- a/internal/runtime/tool_quarantine.go
+++ b/internal/runtime/tool_quarantine.go
@@ -37,8 +37,15 @@ func calculateToolApprovalHashWithOutputSchema(toolName, description, schemaJSON
 	// Normalize JSON schema to prevent key-order differences from causing
 	// false "tool_description_changed" events. Parse → sort keys → serialize.
 	h.Write([]byte(normalizeJSON(schemaJSON)))
-	h.Write([]byte("|"))
-	h.Write([]byte(normalizeJSON(outputSchemaJSON)))
+	// Only fold the output schema into the hash when the tool actually exposes
+	// one. This keeps the hash byte-identical to the pre-output-schema formula
+	// for tools without an outputSchema, so they are NOT re-baselined or
+	// re-quarantined on upgrade. Tools that do expose an outputSchema get a new
+	// hash, which the version-gated migration in checkToolApprovals handles.
+	if normalized := normalizeJSON(outputSchemaJSON); normalized != "" {
+		h.Write([]byte("|"))
+		h.Write([]byte(normalized))
+	}
 	// Annotations excluded from hash — see comment above
 	return hex.EncodeToString(h.Sum(nil))
 }

--- a/internal/runtime/tool_quarantine.go
+++ b/internal/runtime/tool_quarantine.go
@@ -234,7 +234,7 @@ func (r *Runtime) checkToolApprovals(serverName string, tools []*config.ToolMeta
 		// Look up existing approval record
 		existing, err := r.storageManager.GetToolApproval(serverName, toolName)
 
-		if existing != nil && existing.Status == storage.ToolApprovalStatusApproved && outputSchemaHashMigration {
+		if existing != nil && existing.Status == storage.ToolApprovalStatusApproved && outputSchemaHashMigration && existing.HashSchemaVersion < storage.OutputSchemaHashSchemaVersion {
 			// One-time output-schema hash backfill: previously approved tools did
 			// not store outputSchema in the approved contract hash. Rebaseline the
 			// approved/current hash using the currently observed output schema so the
@@ -455,9 +455,12 @@ func (r *Runtime) checkToolApprovals(serverName string, tools []*config.ToolMeta
 			legacyHash := calculateLegacyToolApprovalHash(toolName, tool.Description, schemaJSON)
 			annotationsHash := calculateHashWithAnnotations(toolName, tool.Description, schemaJSON, tool.Annotations)
 
-			isFormulaChange := rehashedFromStored == currentHash ||
-				existing.ApprovedHash == legacyHash ||
-				existing.ApprovedHash == annotationsHash
+			isFormulaChange := rehashedFromStored == currentHash
+			if existing.HashSchemaVersion < storage.OutputSchemaHashSchemaVersion {
+				isFormulaChange = isFormulaChange ||
+					existing.ApprovedHash == legacyHash ||
+					existing.ApprovedHash == annotationsHash
+			}
 
 			if isFormulaChange {
 				if err := r.enforceInvariant(serverName, toolName, existing.Status, storage.ToolApprovalStatusApproved, ReasonFormulaMigration); err != nil {

--- a/internal/runtime/tool_quarantine.go
+++ b/internal/runtime/tool_quarantine.go
@@ -209,9 +209,7 @@ func (r *Runtime) checkToolApprovals(serverName string, tools []*config.ToolMeta
 
 	schemaVersion, schemaVersionErr := r.storageManager.GetSchemaVersion()
 	outputSchemaHashMigration := schemaVersionErr == nil && schemaVersion < storage.OutputSchemaHashSchemaVersion
-	if outputSchemaHashMigration {
-		defer r.markOutputSchemaHashMigrationCompleteIfReady()
-	}
+	migratedOutputSchemaApprovals := false
 
 	for _, tool := range tools {
 		// Extract the bare tool name (without server prefix)
@@ -236,26 +234,41 @@ func (r *Runtime) checkToolApprovals(serverName string, tools []*config.ToolMeta
 
 		if existing != nil && existing.Status == storage.ToolApprovalStatusApproved && outputSchemaHashMigration && existing.HashSchemaVersion < storage.OutputSchemaHashSchemaVersion {
 			// One-time output-schema hash backfill: previously approved tools did
-			// not store outputSchema in the approved contract hash. Rebaseline the
-			// approved/current hash using the currently observed output schema so the
-			// algorithm upgrade does not masquerade as an upstream rug-pull.
-			existing.ApprovedHash = currentHash
-			existing.CurrentHash = currentHash
-			existing.HashSchemaVersion = storage.OutputSchemaHashSchemaVersion
-			existing.CurrentDescription = tool.Description
-			existing.CurrentSchema = schemaJSON
-			existing.CurrentOutputSchema = outputSchemaJSON
-			if saveErr := r.storageManager.SaveToolApproval(existing); saveErr != nil {
-				r.logger.Debug("Failed to backfill output schema approval hash",
-					zap.String("server", serverName),
-					zap.String("tool", toolName),
-					zap.Error(saveErr))
-			} else {
-				r.logger.Info("Tool approval hash backfilled with output schema",
-					zap.String("server", serverName),
-					zap.String("tool", toolName))
+			// not store outputSchema in the approved contract hash. Rebaseline using
+			// the stored approved description/input schema plus the currently observed
+			// output schema. If description/input schema changed, route through the
+			// normal rug-pull detection path instead of silently approving it.
+			storedDesc := existing.CurrentDescription
+			storedSchema := existing.CurrentSchema
+			if storedDesc == "" {
+				storedDesc = tool.Description
 			}
-			continue
+			if storedSchema == "" {
+				storedSchema = schemaJSON
+			}
+			descMatch := storedDesc == tool.Description
+			schemaMatch := normalizeJSON(storedSchema) == normalizeJSON(schemaJSON)
+			if descMatch && schemaMatch {
+				backfilledHash := calculateToolApprovalHashWithOutputSchema(toolName, storedDesc, storedSchema, outputSchemaJSON, tool.Annotations)
+				existing.ApprovedHash = backfilledHash
+				existing.CurrentHash = backfilledHash
+				existing.HashSchemaVersion = storage.OutputSchemaHashSchemaVersion
+				existing.CurrentDescription = storedDesc
+				existing.CurrentSchema = normalizeJSON(storedSchema)
+				existing.CurrentOutputSchema = outputSchemaJSON
+				if saveErr := r.storageManager.SaveToolApproval(existing); saveErr != nil {
+					r.logger.Debug("Failed to backfill output schema approval hash",
+						zap.String("server", serverName),
+						zap.String("tool", toolName),
+						zap.Error(saveErr))
+				} else {
+					migratedOutputSchemaApprovals = true
+					r.logger.Info("Tool approval hash backfilled with output schema",
+						zap.String("server", serverName),
+						zap.String("tool", toolName))
+				}
+				continue
+			}
 		}
 
 		if err != nil {
@@ -623,6 +636,10 @@ func (r *Runtime) checkToolApprovals(serverName string, tools []*config.ToolMeta
 				oldDesc, tool.Description,
 				oldSchema, schemaJSON)
 		}
+	}
+
+	if migratedOutputSchemaApprovals {
+		r.markOutputSchemaHashMigrationCompleteIfReady()
 	}
 
 	if len(result.BlockedTools) > 0 {

--- a/internal/runtime/tool_quarantine_output_schema_test.go
+++ b/internal/runtime/tool_quarantine_output_schema_test.go
@@ -49,6 +49,40 @@ func TestOutputSchemaHashMigration_ApprovedToolStaysApproved(t *testing.T) {
 	assert.Equal(t, uint64(storage.OutputSchemaHashSchemaVersion), version)
 }
 
+func TestOutputSchemaHashMigration_DescriptionDriftRoutesToChanged(t *testing.T) {
+	rt := setupQuarantineRuntime(t, nil, []*config.ServerConfig{{Name: "github", Enabled: true}})
+	require.NoError(t, rt.storageManager.SetSchemaVersion(storage.OutputSchemaHashSchemaVersion-1))
+
+	legacyHash := calculateLegacyToolApprovalHash("create_issue", "Creates a GitHub issue", `{"type":"object"}`)
+	require.NoError(t, rt.storageManager.SaveToolApproval(&storage.ToolApprovalRecord{
+		ServerName:         "github",
+		ToolName:           "create_issue",
+		ApprovedHash:       legacyHash,
+		CurrentHash:        legacyHash,
+		Status:             storage.ToolApprovalStatusApproved,
+		CurrentDescription: "Creates a GitHub issue",
+		CurrentSchema:      `{"type":"object"}`,
+	}))
+
+	result, err := rt.checkToolApprovals("github", []*config.ToolMetadata{{
+		ServerName:       "github",
+		Name:             "create_issue",
+		Description:      "Creates a GitHub issue and edits labels",
+		ParamsJSON:       `{"type":"object"}`,
+		OutputSchemaJSON: `{"type":"object","properties":{"url":{"type":"string"}}}`,
+	}})
+	require.NoError(t, err)
+	assert.True(t, result.BlockedTools["create_issue"])
+	assert.Equal(t, 1, result.ChangedCount)
+
+	record, err := rt.storageManager.GetToolApproval("github", "create_issue")
+	require.NoError(t, err)
+	assert.Equal(t, storage.ToolApprovalStatusChanged, record.Status)
+	assert.Equal(t, legacyHash, record.ApprovedHash)
+	assert.Equal(t, "Creates a GitHub issue", record.PreviousDescription)
+	assert.Equal(t, "Creates a GitHub issue and edits labels", record.CurrentDescription)
+}
+
 func TestOutputSchemaHashMigration_PendingAndChangedRemainUntouched(t *testing.T) {
 	rt := setupQuarantineRuntime(t, nil, []*config.ServerConfig{{Name: "github", Enabled: true}})
 	require.NoError(t, rt.storageManager.SetSchemaVersion(storage.OutputSchemaHashSchemaVersion-1))

--- a/internal/runtime/tool_quarantine_output_schema_test.go
+++ b/internal/runtime/tool_quarantine_output_schema_test.go
@@ -1,0 +1,142 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
+)
+
+func TestOutputSchemaHashMigration_ApprovedToolStaysApproved(t *testing.T) {
+	rt := setupQuarantineRuntime(t, nil, []*config.ServerConfig{{Name: "github", Enabled: true}})
+	require.NoError(t, rt.storageManager.SetSchemaVersion(storage.OutputSchemaHashSchemaVersion-1))
+
+	legacyHash := calculateLegacyToolApprovalHash("create_issue", "Creates a GitHub issue", `{"type":"object"}`)
+	require.NoError(t, rt.storageManager.SaveToolApproval(&storage.ToolApprovalRecord{
+		ServerName:         "github",
+		ToolName:           "create_issue",
+		ApprovedHash:       legacyHash,
+		CurrentHash:        legacyHash,
+		Status:             storage.ToolApprovalStatusApproved,
+		CurrentDescription: "Creates a GitHub issue",
+		CurrentSchema:      `{"type":"object"}`,
+	}))
+
+	result, err := rt.checkToolApprovals("github", []*config.ToolMetadata{{
+		ServerName:       "github",
+		Name:             "create_issue",
+		Description:      "Creates a GitHub issue",
+		ParamsJSON:       `{"type":"object"}`,
+		OutputSchemaJSON: `{"type":"object","properties":{"url":{"type":"string"}}}`,
+	}})
+	require.NoError(t, err)
+	assert.Empty(t, result.BlockedTools)
+	assert.Zero(t, result.ChangedCount)
+
+	record, err := rt.storageManager.GetToolApproval("github", "create_issue")
+	require.NoError(t, err)
+	assert.Equal(t, storage.ToolApprovalStatusApproved, record.Status)
+	assert.NotEqual(t, legacyHash, record.ApprovedHash)
+	assert.Equal(t, record.ApprovedHash, record.CurrentHash)
+	assert.Equal(t, uint64(storage.OutputSchemaHashSchemaVersion), record.HashSchemaVersion)
+	assert.Equal(t, `{"properties":{"url":{"type":"string"}},"type":"object"}`, record.CurrentOutputSchema)
+
+	version, err := rt.storageManager.GetSchemaVersion()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(storage.OutputSchemaHashSchemaVersion), version)
+}
+
+func TestOutputSchemaHashMigration_PendingAndChangedRemainUntouched(t *testing.T) {
+	rt := setupQuarantineRuntime(t, nil, []*config.ServerConfig{{Name: "github", Enabled: true}})
+	require.NoError(t, rt.storageManager.SetSchemaVersion(storage.OutputSchemaHashSchemaVersion-1))
+
+	pendingHash := calculateLegacyToolApprovalHash("pending_tool", "Pending", `{"type":"object"}`)
+	changedHash := calculateLegacyToolApprovalHash("changed_tool", "Changed", `{"type":"object"}`)
+	require.NoError(t, rt.storageManager.SaveToolApproval(&storage.ToolApprovalRecord{
+		ServerName:         "github",
+		ToolName:           "pending_tool",
+		CurrentHash:        pendingHash,
+		Status:             storage.ToolApprovalStatusPending,
+		CurrentDescription: "Pending",
+		CurrentSchema:      `{"type":"object"}`,
+	}))
+	require.NoError(t, rt.storageManager.SaveToolApproval(&storage.ToolApprovalRecord{
+		ServerName:          "github",
+		ToolName:            "changed_tool",
+		ApprovedHash:        changedHash,
+		CurrentHash:         "different",
+		Status:              storage.ToolApprovalStatusChanged,
+		PreviousDescription: "Changed",
+		CurrentDescription:  "Changed mutated",
+		CurrentSchema:       `{"type":"object"}`,
+	}))
+
+	result, err := rt.checkToolApprovals("github", []*config.ToolMetadata{
+		{
+			ServerName:       "github",
+			Name:             "pending_tool",
+			Description:      "Pending",
+			ParamsJSON:       `{"type":"object"}`,
+			OutputSchemaJSON: `{"type":"object","properties":{"ok":{"type":"boolean"}}}`,
+		},
+		{
+			ServerName:       "github",
+			Name:             "changed_tool",
+			Description:      "Changed mutated",
+			ParamsJSON:       `{"type":"object"}`,
+			OutputSchemaJSON: `{"type":"object","properties":{"ok":{"type":"boolean"}}}`,
+		},
+	})
+	require.NoError(t, err)
+	assert.True(t, result.BlockedTools["changed_tool"])
+
+	pending, err := rt.storageManager.GetToolApproval("github", "pending_tool")
+	require.NoError(t, err)
+	assert.Equal(t, storage.ToolApprovalStatusPending, pending.Status)
+	assert.Empty(t, pending.ApprovedHash)
+
+	changed, err := rt.storageManager.GetToolApproval("github", "changed_tool")
+	require.NoError(t, err)
+	assert.Equal(t, storage.ToolApprovalStatusChanged, changed.Status)
+	assert.Equal(t, changedHash, changed.ApprovedHash)
+}
+
+func TestOutputSchemaHashChange_MarksApprovedToolChangedAfterMigration(t *testing.T) {
+	rt := setupQuarantineRuntime(t, nil, []*config.ServerConfig{{Name: "github", Enabled: true}})
+
+	inputSchema := `{"type":"object"}`
+	approvedOutputSchema := `{"type":"object","properties":{"url":{"type":"string"}}}`
+	approvedHash := calculateToolApprovalHashWithOutputSchema("create_issue", "Creates a GitHub issue", inputSchema, approvedOutputSchema, nil)
+	require.NoError(t, rt.storageManager.SaveToolApproval(&storage.ToolApprovalRecord{
+		ServerName:          "github",
+		ToolName:            "create_issue",
+		ApprovedHash:        approvedHash,
+		CurrentHash:         approvedHash,
+		HashSchemaVersion:   storage.OutputSchemaHashSchemaVersion,
+		Status:              storage.ToolApprovalStatusApproved,
+		CurrentDescription:  "Creates a GitHub issue",
+		CurrentSchema:       inputSchema,
+		CurrentOutputSchema: approvedOutputSchema,
+	}))
+	require.NoError(t, rt.storageManager.SetSchemaVersion(storage.OutputSchemaHashSchemaVersion))
+
+	result, err := rt.checkToolApprovals("github", []*config.ToolMetadata{{
+		ServerName:       "github",
+		Name:             "create_issue",
+		Description:      "Creates a GitHub issue",
+		ParamsJSON:       inputSchema,
+		OutputSchemaJSON: `{"type":"object","properties":{"id":{"type":"integer"}}}`,
+	}})
+	require.NoError(t, err)
+	assert.True(t, result.BlockedTools["create_issue"])
+	assert.Equal(t, 1, result.ChangedCount)
+
+	record, err := rt.storageManager.GetToolApproval("github", "create_issue")
+	require.NoError(t, err)
+	assert.Equal(t, storage.ToolApprovalStatusChanged, record.Status)
+	assert.Equal(t, approvedOutputSchema, record.PreviousOutputSchema)
+	assert.Equal(t, `{"properties":{"id":{"type":"integer"}},"type":"object"}`, record.CurrentOutputSchema)
+}

--- a/internal/server/mcp_output_schema.go
+++ b/internal/server/mcp_output_schema.go
@@ -1,0 +1,22 @@
+package server
+
+import (
+	"encoding/json"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func applyToolOutputSchemaJSON(tool *mcp.Tool, outputSchemaJSON string) bool {
+	if outputSchemaJSON == "" {
+		return false
+	}
+
+	raw := json.RawMessage(outputSchemaJSON)
+	if !json.Valid(raw) {
+		return false
+	}
+
+	tool.RawOutputSchema = append(json.RawMessage(nil), raw...)
+	tool.OutputSchema = mcp.ToolOutputSchema{}
+	return true
+}

--- a/internal/server/mcp_output_schema_test.go
+++ b/internal/server/mcp_output_schema_test.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyToolOutputSchemaJSON_PreservesOutputSchemaInToolsListJSON(t *testing.T) {
+	tool := mcp.NewTool("github__create_issue", mcp.WithDescription("create issue"))
+
+	applied := applyToolOutputSchemaJSON(&tool, `{"type":"object","properties":{"url":{"type":"string"}}}`)
+
+	assert.True(t, applied)
+	assert.JSONEq(t, `{"type":"object","properties":{"url":{"type":"string"}}}`, string(tool.RawOutputSchema))
+
+	toolJSON, err := json.Marshal(tool)
+	require.NoError(t, err)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(toolJSON, &payload))
+	assert.Contains(t, payload, "outputSchema")
+	assert.NotContains(t, payload, "RawOutputSchema")
+	assert.NotContains(t, payload, "rawOutputSchema")
+}
+
+func TestApplyToolOutputSchemaJSON_RejectsInvalidJSON(t *testing.T) {
+	tool := mcp.NewTool("github__create_issue", mcp.WithDescription("create issue"))
+
+	applied := applyToolOutputSchemaJSON(&tool, `{"type":`)
+
+	assert.False(t, applied)
+	assert.Empty(t, tool.RawOutputSchema)
+}

--- a/internal/server/mcp_routing.go
+++ b/internal/server/mcp_routing.go
@@ -104,6 +104,10 @@ func (p *MCPProxyServer) buildDirectModeTools() []mcpserver.ServerTool {
 			}
 		}
 
+		// Apply output schema from upstream tool so direct-mode tools/list preserves
+		// the full MCP tool contract exposed by the upstream server.
+		applyToolOutputSchemaJSON(&mcpTool, tool.OutputSchemaJSON)
+
 		serverTools = append(serverTools, mcpserver.ServerTool{
 			Tool:    mcpTool,
 			Handler: p.makeDirectModeHandler(tool.ServerName, tool.Name, tool.Annotations),

--- a/internal/storage/bbolt.go
+++ b/internal/storage/bbolt.go
@@ -103,11 +103,15 @@ func (b *BoltDB) initBuckets() error {
 			}
 		}
 
-		// Set schema version
+		// Set schema version only for new databases. Existing databases keep their
+		// stored version so migrations can observe and upgrade them.
 		metaBucket := tx.Bucket([]byte(MetaBucket))
-		versionBytes := make([]byte, 8)
-		binary.LittleEndian.PutUint64(versionBytes, CurrentSchemaVersion)
-		return metaBucket.Put([]byte(SchemaVersionKey), versionBytes)
+		if metaBucket.Get([]byte(SchemaVersionKey)) == nil {
+			versionBytes := make([]byte, 8)
+			binary.LittleEndian.PutUint64(versionBytes, CurrentSchemaVersion)
+			return metaBucket.Put([]byte(SchemaVersionKey), versionBytes)
+		}
+		return nil
 	})
 }
 
@@ -131,6 +135,20 @@ func (b *BoltDB) GetSchemaVersion() (uint64, error) {
 	})
 
 	return version, err
+}
+
+// SetSchemaVersion stores the current migration schema version.
+func (b *BoltDB) SetSchemaVersion(version uint64) error {
+	return b.db.Update(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket([]byte(MetaBucket))
+		if bucket == nil {
+			return fmt.Errorf("meta bucket not found")
+		}
+
+		versionBytes := make([]byte, 8)
+		binary.LittleEndian.PutUint64(versionBytes, version)
+		return bucket.Put([]byte(SchemaVersionKey), versionBytes)
+	})
 }
 
 // Upstream operations

--- a/internal/storage/manager.go
+++ b/internal/storage/manager.go
@@ -204,16 +204,16 @@ func (m *Manager) ListQuarantinedUpstreamServers() ([]*config.ServerConfig, erro
 
 		if record.Quarantined {
 			quarantinedServers = append(quarantinedServers, &config.ServerConfig{
-				Name:        record.Name,
-				URL:         record.URL,
-				Protocol:    record.Protocol,
-				Command:     record.Command,
-				Args:        record.Args,
-				WorkingDir:  record.WorkingDir,
-				Env:         record.Env,
-				Headers:     record.Headers,
-				OAuth:       record.OAuth,
-				Enabled:     record.Enabled,
+				Name:          record.Name,
+				URL:           record.URL,
+				Protocol:      record.Protocol,
+				Command:       record.Command,
+				Args:          record.Args,
+				WorkingDir:    record.WorkingDir,
+				Env:           record.Env,
+				Headers:       record.Headers,
+				OAuth:         record.OAuth,
+				Enabled:       record.Enabled,
 				Quarantined:   record.Quarantined,
 				Created:       record.Created,
 				Updated:       record.Updated,
@@ -689,6 +689,14 @@ func (m *Manager) GetSchemaVersion() (uint64, error) {
 	defer m.mu.RUnlock()
 
 	return m.db.GetSchemaVersion()
+}
+
+// SetSchemaVersion stores the current migration schema version.
+func (m *Manager) SetSchemaVersion(version uint64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.db.SetSchemaVersion(version)
 }
 
 // GetStats returns storage statistics

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -74,7 +74,11 @@ const (
 )
 
 // Current schema version
-const CurrentSchemaVersion = 2
+const CurrentSchemaVersion = 3
+
+// OutputSchemaHashSchemaVersion is the schema version that starts including
+// MCP outputSchema in the tool approval hash baseline.
+const OutputSchemaHashSchemaVersion = 3
 
 // UpstreamRecord represents an upstream server record in storage
 type UpstreamRecord struct {
@@ -124,18 +128,21 @@ const (
 // When a tool is first discovered, it starts as "pending". Once approved, it becomes "approved".
 // If the tool's description or schema changes after approval, it becomes "changed".
 type ToolApprovalRecord struct {
-	ServerName          string    `json:"server_name"`
-	ToolName            string    `json:"tool_name"`
-	ApprovedHash        string    `json:"approved_hash"`
-	CurrentHash         string    `json:"current_hash"`
-	Status              string    `json:"status"` // "approved", "pending", "changed"
-	ApprovedAt          time.Time `json:"approved_at"`
-	ApprovedBy          string    `json:"approved_by"`
-	PreviousDescription string    `json:"previous_description,omitempty"`
-	CurrentDescription  string    `json:"current_description,omitempty"`
-	PreviousSchema      string    `json:"previous_schema,omitempty"`
-	CurrentSchema       string    `json:"current_schema,omitempty"`
-	Disabled            bool      `json:"disabled,omitempty"`
+	ServerName           string    `json:"server_name"`
+	ToolName             string    `json:"tool_name"`
+	ApprovedHash         string    `json:"approved_hash"`
+	CurrentHash          string    `json:"current_hash"`
+	HashSchemaVersion    uint64    `json:"hash_schema_version,omitempty"`
+	Status               string    `json:"status"` // "approved", "pending", "changed"
+	ApprovedAt           time.Time `json:"approved_at"`
+	ApprovedBy           string    `json:"approved_by"`
+	PreviousDescription  string    `json:"previous_description,omitempty"`
+	CurrentDescription   string    `json:"current_description,omitempty"`
+	PreviousSchema       string    `json:"previous_schema,omitempty"`
+	CurrentSchema        string    `json:"current_schema,omitempty"`
+	PreviousOutputSchema string    `json:"previous_output_schema,omitempty"`
+	CurrentOutputSchema  string    `json:"current_output_schema,omitempty"`
+	Disabled             bool      `json:"disabled,omitempty"`
 }
 
 // ToolApprovalKey returns the storage key for a tool approval record.

--- a/internal/upstream/core/client.go
+++ b/internal/upstream/core/client.go
@@ -285,11 +285,14 @@ func (c *Client) ListTools(ctx context.Context) ([]*config.ToolMetadata, error) 
 			paramsJSON = string(schemaBytes)
 		}
 
+		outputSchemaJSON := captureOutputSchemaJSON(tool)
+
 		toolMeta := &config.ToolMetadata{
-			ServerName:  c.config.Name,
-			Name:        tool.Name,
-			Description: tool.Description,
-			ParamsJSON:  paramsJSON,
+			ServerName:       c.config.Name,
+			Name:             tool.Name,
+			Description:      tool.Description,
+			ParamsJSON:       paramsJSON,
+			OutputSchemaJSON: outputSchemaJSON,
 		}
 
 		// Copy tool annotations if any are set
@@ -318,9 +321,9 @@ func (c *Client) ListTools(ctx context.Context) ([]*config.ToolMetadata, error) 
 			}
 		}
 
-		// Compute hash for tool change detection
-		// Hash is based on serverName + toolName + inputSchema
-		toolMeta.Hash = hash.ComputeToolHash(c.config.Name, tool.Name, tool.Description, tool.InputSchema)
+		// Compute hash for tool change detection.
+		// Hash is based on serverName + toolName + description + inputSchema + outputSchema.
+		toolMeta.Hash = hash.ComputeToolHashWithOutputSchema(c.config.Name, tool.Name, tool.Description, tool.InputSchema, outputSchemaJSON)
 
 		tools = append(tools, toolMeta)
 	}

--- a/internal/upstream/core/output_schema.go
+++ b/internal/upstream/core/output_schema.go
@@ -1,0 +1,36 @@
+package core
+
+import (
+	"encoding/json"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func captureOutputSchemaJSON(tool *mcp.Tool) string {
+	if len(tool.RawOutputSchema) > 0 {
+		return normalizeRawJSON(tool.RawOutputSchema)
+	}
+
+	if tool.OutputSchema.Type == "" {
+		return ""
+	}
+
+	data, err := json.Marshal(tool.OutputSchema)
+	if err != nil {
+		return ""
+	}
+	return normalizeRawJSON(data)
+}
+
+func normalizeRawJSON(data []byte) string {
+	var parsed interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return string(data)
+	}
+
+	normalized, err := json.Marshal(parsed)
+	if err != nil {
+		return string(data)
+	}
+	return string(normalized)
+}

--- a/internal/upstream/core/output_schema.go
+++ b/internal/upstream/core/output_schema.go
@@ -6,6 +6,8 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
+const outputSchemaMarshalErrorKey = "_mcpproxy_output_schema_marshal_error"
+
 func captureOutputSchemaJSON(tool *mcp.Tool) string {
 	if len(tool.RawOutputSchema) > 0 {
 		return normalizeRawJSON(tool.RawOutputSchema)
@@ -17,7 +19,7 @@ func captureOutputSchemaJSON(tool *mcp.Tool) string {
 
 	data, err := json.Marshal(tool.OutputSchema)
 	if err != nil {
-		return ""
+		return outputSchemaMarshalErrorJSON(err)
 	}
 	return normalizeRawJSON(data)
 }
@@ -33,4 +35,14 @@ func normalizeRawJSON(data []byte) string {
 		return string(data)
 	}
 	return string(normalized)
+}
+
+func outputSchemaMarshalErrorJSON(err error) string {
+	data, marshalErr := json.Marshal(map[string]string{
+		outputSchemaMarshalErrorKey: err.Error(),
+	})
+	if marshalErr != nil {
+		return `{"_mcpproxy_output_schema_marshal_error":"unknown"}`
+	}
+	return string(data)
 }


### PR DESCRIPTION
## Summary

Includes MCP `outputSchema` in the tool approval contract hash and adds a versioned migration so existing approved tools do not get falsely re-quarantined on upgrade.

Output schema is part of the tool contract because it describes the data shape returned to agents. A silent output-schema change should therefore be treated as a contract change and require human review.

## Changes

- Captures MCP `outputSchema` from upstream tools.
- Persists `OutputSchemaJSON` in tool metadata and Bleve index documents.
- Includes output schema in:
  - `internal/hash` tool hash computation
  - runtime tool-approval hash computation
- Adds approval-record fields:
  - `HashSchemaVersion`
  - `CurrentOutputSchema`
  - `PreviousOutputSchema`
- Bumps storage schema version to `3`.
- Fixes DB initialization so existing databases keep their stored schema version instead of being overwritten on open.
- Adds `SetSchemaVersion` support to storage.
- Adds a version-gated output-schema hash migration:
  - approved records are rebaselined to the new output-schema-inclusive hash
  - approved status is preserved
  - pending and changed records are left untouched
- Ensures future output-schema drift marks the tool as changed/quarantined.
- Stores previous output schema when a changed transition is recorded.

## Migration behavior

For databases with schema version `< 3`, approved tools are rebaselined using the currently observed output schema.

This avoids a false-positive mass re-quarantine caused only by the hash algorithm changing.

Pending and changed approval records are not rebaselined or auto-approved; they still require human action.

One caveat: tools approved before this migration have no historical output-schema baseline, so the migration necessarily blesses the output schema observed at upgrade time. After migration, any real output-schema drift is detected as a changed tool contract.

## Validation

Targeted runtime migration tests:

```bash
go test ./internal/runtime -run OutputSchema -count=1