### PR TITLE
fix(scanner): strip hardcoded deepwiki URL from Cisco scanner raw stdout

### DIFF
--- a/docs/features/security-scanner-plugins.md
+++ b/docs/features/security-scanner-plugins.md
@@ -313,7 +313,7 @@ The Security page at `/security` in the Web UI mirrors the CLI and provides:
 ## Known limitations
 
 - **Ramparts on arm64 macOS** — the upstream scanner image ships a binary linked against a newer GLIBC than the image base and fails every run on arm64. Track the [scanner-ramparts image rebuild](https://github.com/smart-mcp-proxy/mcpproxy-go/issues) for a fix. Other 6 of 7 scanners work out of the box on arm64 macOS.
-- **Cisco scanner output has a hardcoded `server_url`** header in its stdout (`https://mcp.deepwiki.com/mcp`). Cosmetic, does not affect findings.
+- **Cisco scanner output has a hardcoded `server_url`** header in its stdout (`https://mcp.deepwiki.com/mcp`). This is cosmetic and does not affect findings. Since #383, mcpproxy strips this line from the user-visible execution log and replaces it with an annotation explaining no network request was made.
 - **Pass 2 (supply-chain audit)** currently requires Docker isolation to be enabled, otherwise it fails source resolution. The UI doesn't yet surface this precondition.
 
 ## Related reading

--- a/internal/security/scanner/engine.go
+++ b/internal/security/scanner/engine.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -606,6 +607,9 @@ type scannerLogs struct {
 func (e *Engine) setScannerLogs(job *ScanJob, scannerID string, logs scannerLogs) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
+	if scannerID == "cisco-mcp-scanner" {
+		logs.Stdout = sanitizeCiscoStdout(logs.Stdout)
+	}
 	for i := range job.ScannerStatuses {
 		if job.ScannerStatuses[i].ScannerID == scannerID {
 			job.ScannerStatuses[i].Stdout = truncate(logs.Stdout, MaxLogBytes)
@@ -1040,4 +1044,27 @@ func truncate(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen] + "..."
+}
+
+// ciscoServerURLPattern matches the placeholder server_url line emitted by
+// the upstream cisco-ai-mcp-scanner PyPI package in its raw stdout output.
+// The URL is hardcoded in the upstream tool and does not represent a real
+// network request; mcpproxy strips it from the user-visible execution log
+// to avoid the false impression of data exfiltration. See issue #383.
+var ciscoServerURLPattern = regexp.MustCompile(
+	`(?m)^\s*"server_url"\s*:\s*"https?://[^"]*deepwiki[^"]*"\s*,?\s*\r?\n?`,
+)
+
+// sanitizeCiscoStdout replaces the upstream-hardcoded deepwiki placeholder
+// URL line with a short annotation referencing the tracking issue. The rest
+// of the raw output is preserved for debugging.
+func sanitizeCiscoStdout(stdout string) string {
+	if !strings.Contains(stdout, "deepwiki") {
+		return stdout
+	}
+	return ciscoServerURLPattern.ReplaceAllString(
+		stdout,
+		"// [mcpproxy] upstream cisco-ai-mcp-scanner emits a hardcoded "+
+			"placeholder server_url; no network request was made (see issue #383)\n",
+	)
 }

--- a/internal/security/scanner/engine.go
+++ b/internal/security/scanner/engine.go
@@ -1046,8 +1046,9 @@ func truncate(s string, maxLen int) string {
 	return s[:maxLen] + "..."
 }
 
-// ciscoScannerID matches the bundled Cisco AI Defense scanner registered
-// in registry_bundled.go. Keep in sync with that file's ID literal.
+// ciscoScannerID is the single source of truth for the bundled Cisco AI Defense
+// scanner's plugin ID. registry_bundled.go references this const, and
+// setScannerLogs uses it to gate Cisco-specific stdout sanitization.
 const ciscoScannerID = "cisco-mcp-scanner"
 
 // ciscoServerURLPattern matches the placeholder server_url line emitted by

--- a/internal/security/scanner/engine.go
+++ b/internal/security/scanner/engine.go
@@ -605,11 +605,11 @@ type scannerLogs struct {
 
 // setScannerLogs stores stdout/stderr on a scanner's job status
 func (e *Engine) setScannerLogs(job *ScanJob, scannerID string, logs scannerLogs) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	if scannerID == "cisco-mcp-scanner" {
+	if scannerID == ciscoScannerID {
 		logs.Stdout = sanitizeCiscoStdout(logs.Stdout)
 	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	for i := range job.ScannerStatuses {
 		if job.ScannerStatuses[i].ScannerID == scannerID {
 			job.ScannerStatuses[i].Stdout = truncate(logs.Stdout, MaxLogBytes)
@@ -1046,18 +1046,25 @@ func truncate(s string, maxLen int) string {
 	return s[:maxLen] + "..."
 }
 
+// ciscoScannerID matches the bundled Cisco AI Defense scanner registered
+// in registry_bundled.go. Keep in sync with that file's ID literal.
+const ciscoScannerID = "cisco-mcp-scanner"
+
 // ciscoServerURLPattern matches the placeholder server_url line emitted by
 // the upstream cisco-ai-mcp-scanner PyPI package in its raw stdout output.
 // The URL is hardcoded in the upstream tool and does not represent a real
 // network request; mcpproxy strips it from the user-visible execution log
 // to avoid the false impression of data exfiltration. See issue #383.
 var ciscoServerURLPattern = regexp.MustCompile(
-	`(?m)^\s*"server_url"\s*:\s*"https?://[^"]*deepwiki[^"]*"\s*,?\s*\r?\n?`,
+	`(?m)^[ \t]*"server_url"[ \t]*:[ \t]*"https?://[^"]*deepwiki[^"]*"[ \t]*,?[ \t]*\r?\n?`,
 )
 
 // sanitizeCiscoStdout replaces the upstream-hardcoded deepwiki placeholder
 // URL line with a short annotation referencing the tracking issue. The rest
 // of the raw output is preserved for debugging.
+//
+// Assumes pretty-printed multi-line output; minified single-line JSON
+// bypasses this filter (acceptable since the cisco scanner emits multi-line).
 func sanitizeCiscoStdout(stdout string) string {
 	if !strings.Contains(stdout, "deepwiki") {
 		return stdout

--- a/internal/security/scanner/engine_test.go
+++ b/internal/security/scanner/engine_test.go
@@ -737,12 +737,77 @@ func TestSanitizeCiscoStdout_HandlesCRLF(t *testing.T) {
 	}
 }
 
-func TestParseCiscoScannerOutput_UnaffectedBySanitization(t *testing.T) {
-	raw := []byte(`{"scan_results": [{"tool_name": "t1", "is_safe": false,
-		"findings": {"yara_analyzer": {"severity": "HIGH",
-		"threat_names": ["test"], "total_findings": 1}}}]}`)
-	findings := parseCiscoScannerOutput(raw, "cisco-mcp-scanner")
-	if len(findings) != 1 {
-		t.Errorf("expected 1 finding, got %d", len(findings))
+func TestSetScannerLogs_CiscoStdoutSanitized(t *testing.T) {
+	dir := t.TempDir()
+	logger := zap.NewNop()
+	registry := NewRegistry(dir, logger)
+	docker := NewDockerRunner(logger)
+	engine := NewEngine(docker, registry, dir, logger)
+
+	job := &ScanJob{
+		ID:         "job-sanitize",
+		ServerName: "test-server",
+		ScannerStatuses: []ScannerJobStatus{
+			{ScannerID: ciscoScannerID, Status: ScanJobStatusRunning},
+		},
+	}
+
+	rawStdout := `{
+  "server_url": "https://mcp.deepwiki.com/mcp",
+  "scan_results": [{"tool_name": "test_tool", "is_safe": true}]
+}`
+	engine.setScannerLogs(job, ciscoScannerID, scannerLogs{
+		Stdout:   rawStdout,
+		Stderr:   "some stderr",
+		ExitCode: 0,
+	})
+
+	got := job.ScannerStatuses[0].Stdout
+	if strings.Contains(got, "deepwiki") {
+		t.Errorf("expected deepwiki URL removed from cisco stdout, got:\n%s", got)
+	}
+	if !strings.Contains(got, "// [mcpproxy]") {
+		t.Error("expected annotation comment in sanitized output")
+	}
+	if !strings.Contains(got, `"scan_results"`) {
+		t.Error("scan_results should be preserved after sanitization")
+	}
+	// Verify indentation of the line following the removed URL is intact.
+	if !strings.Contains(got, `  "scan_results"`) {
+		t.Errorf("next line indentation damaged, got:\n%s", got)
+	}
+}
+
+func TestSetScannerLogs_NonCiscoScannerStdoutPreserved(t *testing.T) {
+	dir := t.TempDir()
+	logger := zap.NewNop()
+	registry := NewRegistry(dir, logger)
+	docker := NewDockerRunner(logger)
+	engine := NewEngine(docker, registry, dir, logger)
+
+	const otherScanner = "semgrep"
+	job := &ScanJob{
+		ID:         "job-preserve",
+		ServerName: "test-server",
+		ScannerStatuses: []ScannerJobStatus{
+			{ScannerID: otherScanner, Status: ScanJobStatusRunning},
+		},
+	}
+
+	// Stdout happens to contain "deepwiki" but should NOT be sanitized
+	// because this is not the cisco scanner.
+	rawStdout := `{"server_url": "https://mcp.deepwiki.com/mcp", "results": []}`
+	engine.setScannerLogs(job, otherScanner, scannerLogs{
+		Stdout:   rawStdout,
+		Stderr:   "",
+		ExitCode: 0,
+	})
+
+	got := job.ScannerStatuses[0].Stdout
+	if !strings.Contains(got, "deepwiki") {
+		t.Errorf("non-cisco scanner stdout should not be sanitized, got:\n%s", got)
+	}
+	if got != rawStdout {
+		t.Errorf("stdout should be preserved verbatim for non-cisco scanner\nwant: %s\ngot:  %s", rawStdout, got)
 	}
 }

--- a/internal/security/scanner/engine_test.go
+++ b/internal/security/scanner/engine_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -690,5 +691,58 @@ func TestPrepareReportDirForEngine(t *testing.T) {
 	}
 	if _, err := os.Stat(reportDir); os.IsNotExist(err) {
 		t.Error("directory should exist")
+	}
+}
+
+func TestSanitizeCiscoStdout_RemovesHardcodedDeepwikiURL(t *testing.T) {
+	in := `{
+  "server_url": "https://mcp.deepwiki.com/mcp",
+  "scan_results": [{"tool_name": "test_tool", "is_safe": true}]
+}`
+	out := sanitizeCiscoStdout(in)
+	if strings.Contains(out, "deepwiki") {
+		t.Errorf("expected deepwiki URL stripped, got: %s", out)
+	}
+	if !strings.Contains(out, "// [mcpproxy] upstream cisco-ai-mcp-scanner") {
+		t.Error("expected explanatory annotation")
+	}
+}
+
+func TestSanitizeCiscoStdout_PreservesScanResults(t *testing.T) {
+	in := `{
+  "server_url": "https://mcp.deepwiki.com/mcp",
+  "scan_results": [{"tool_name": "test_tool", "is_safe": true}]
+}`
+	out := sanitizeCiscoStdout(in)
+	if !strings.Contains(out, `"scan_results"`) {
+		t.Error("scan_results lost")
+	}
+	if !strings.Contains(out, "test_tool") {
+		t.Error("tool_name lost")
+	}
+}
+
+func TestSanitizeCiscoStdout_NoOpWithoutDeepwiki(t *testing.T) {
+	in := `{"scan_results": [{"tool_name": "x", "is_safe": true}]}`
+	if got := sanitizeCiscoStdout(in); got != in {
+		t.Errorf("expected no-op, got diff: %s", got)
+	}
+}
+
+func TestSanitizeCiscoStdout_HandlesCRLF(t *testing.T) {
+	in := "  \"server_url\": \"https://mcp.deepwiki.com/mcp\",\r\n{...}\r\n"
+	out := sanitizeCiscoStdout(in)
+	if strings.Contains(out, "deepwiki") {
+		t.Error("CRLF variant not handled")
+	}
+}
+
+func TestParseCiscoScannerOutput_UnaffectedBySanitization(t *testing.T) {
+	raw := []byte(`{"scan_results": [{"tool_name": "t1", "is_safe": false,
+		"findings": {"yara_analyzer": {"severity": "HIGH",
+		"threat_names": ["test"], "total_findings": 1}}}]}`)
+	findings := parseCiscoScannerOutput(raw, "cisco-mcp-scanner")
+	if len(findings) != 1 {
+		t.Errorf("expected 1 finding, got %d", len(findings))
 	}
 }

--- a/internal/security/scanner/registry_bundled.go
+++ b/internal/security/scanner/registry_bundled.go
@@ -16,7 +16,7 @@ package scanner
 // deterministic across API, CLI, and UI.
 var bundledScanners = []*ScannerPlugin{
 	{
-		ID:          "cisco-mcp-scanner",
+		ID:          ciscoScannerID,
 		Name:        "Cisco MCP Scanner",
 		Vendor:      "Cisco AI Defense",
 		Description: "YARA rules + readiness analysis. Detects tool poisoning, prompt injection, credential harvesting, and data exfiltration. No API key needed for offline mode.",


### PR DESCRIPTION
## Summary

The upstream \`cisco-ai-mcp-scanner\` PyPI package hardcodes \`\"server_url\": \"https://mcp.deepwiki.com/mcp\"\` in its raw stdout output. When mcpproxy renders this in the UI it looks like tool definitions are being exfiltrated to a third party, even though \`NetworkReq=false\` and no request is actually made. This PR sanitizes the display-only \`ScannerJobStatus.Stdout\` at write time, replacing the offending line with an explanatory annotation while leaving \`reportData\` (used for findings parsing) untouched.

Implements **Option A** from #383 as spec'd by @algis-dumbris. Option C (upstream fix at \`cisco-ai-defense/mcp-scanner\`) is orthogonal and not covered here.

Fixes #383

## What changes

- \`setScannerLogs\` runs \`sanitizeCiscoStdout\` only when \`scannerID == ciscoScannerID\`; the rest of scanners' logs are untouched.
- The sanitizer regex is narrow: it only matches \`server_url\` lines pointing at \`deepwiki\`, and uses \`[ \t]*\` instead of \`\s*\` so the next line's indentation is preserved.
- The replacement is a one-line annotation; raw stdout that follows is preserved for debugging.
- The display stdout is sanitized on the way into \`ScannerJobStatus.Stdout\`. The \`reportData\` consumed by \`parseCiscoScannerOutput\` is independent and untouched.
- \`sanitizeCiscoStdout\` runs outside the engine mutex (pure function, no shared state).

## Test plan

- [x] \`go build -o /dev/null ./cmd/mcpproxy\`
- [x] \`go vet ./internal/security/scanner/...\`
- [x] \`go test -v ./internal/security/scanner/...\` — all green incl. 6 new tests
- [x] \`gofmt -l internal/security/scanner/\` — empty
- [x] \`prek run --all-files\`
- [ ] Manual: have not run a real Cisco scan locally; happy to add a screenshot if useful

New tests:

- \`TestSanitizeCiscoStdout_RemovesHardcodedDeepwikiURL\` / \`_PreservesScanResults\` / \`_NoOpWithoutDeepwiki\` / \`_HandlesCRLF\` — sanitizer in isolation.
- \`TestSetScannerLogs_CiscoStdoutSanitized\` / \`_NonCiscoScannerStdoutPreserved\` — scanner-id dispatch is exercised, including a sanity check that a non-cisco scanner with \`deepwiki\` literally in its stdout is left alone.

## Notes

- The replacement uses a \`//\`-style annotation, so the sanitized stdout is no longer valid JSON. Findings parsing is unaffected (\`parseCiscoScannerOutput\` reads \`reportData\`, not \`Stdout\`), but if any downstream consumer pipes \`scanner_statuses[].stdout\` into a JSON parser this would be a behavior change. Not aware of any such consumer; flagging in case I'm missing one.
- The regex assumes pretty-printed multi-line output. If upstream ever minifies to single-line JSON, the sanitizer would silently no-op; documented in the helper godoc and tracked as a follow-up if it ever happens.
- Did not extract the scanner-id literal in \`registry_bundled.go\` to share a const with \`engine.go\`. Left a \`// keep in sync\` note on the new const; happy to do the cross-file refactor in a separate PR if you want.