### PR TITLE
ci: bump setup-node to Node 22 across all workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: website/package-lock.json
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
         cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install frontend dependencies
         run: cd frontend && npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,7 +282,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install frontend dependencies
         run: cd frontend && npm ci
@@ -1609,7 +1609,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: website/package-lock.json
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 


### PR DESCRIPTION
## Problem

The [v0.34.0 release run](https://github.com/smart-mcp-proxy/mcpproxy-go/actions/runs/26674375798) failed: the `build (windows, arm64)` job's **Setup Node.js** step died right after `Attempting to download 20...`.

## Root cause

- `windows-latest` is migrating to the **windows-2025** runner image, which no longer pre-installs **Node 20** in the hosted toolcache.
- With Node 20 absent from the cache, `actions/setup-node@v6` falls back to **downloading** it — an unreliable path. The amd64 Windows job happened to land on an image that still had Node 20 cached and passed; the arm64 job did not and failed.
- Node 20 was also **inconsistent with the project's own requirements**: `frontend/package.json` engines is `>=22.18.0` and `frontend/.nvmrc` already pins `22`.

## Fix

Pin every workflow's `node-version` to **22** (current LTS, present in the 2025 toolcache). This removes the flaky download path and matches local dev.

Files touched: `release.yml` (×2), `prerelease.yml`, `frontend.yml`, `pr-build.yml`, `unit-tests.yml`, `e2e-tests.yml`, `docs.yml`.

## Note on v0.34.0

I also re-ran the failed jobs of the original release run to attempt an immediate unblock. If that re-run lands on another Node-20-less image and fails again, re-cut the tag once this is merged.