### PR TITLE
docs: fix outdated Homebrew install instructions

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -21,9 +21,16 @@ The DMG installers are signed and notarized by Apple.
 
 ### Homebrew
 
+Install the full macOS tray app (signed & notarized, bundles the core server):
+
 ```bash
-brew tap smart-mcp-proxy/mcpproxy
-brew install mcpproxy
+brew install --cask smart-mcp-proxy/mcpproxy/mcpproxy
+```
+
+Or install just the headless core CLI (no tray app):
+
+```bash
+brew install smart-mcp-proxy/mcpproxy/mcpproxy
 ```
 
 


### PR DESCRIPTION
The Installation page on docs.mcpproxy.app showed a deprecated two-step Homebrew flow:

```bash
brew tap smart-mcp-proxy/mcpproxy
brew install mcpproxy
```

This:
- Collapses it to the one-line `tap/repo/formula` shorthand (auto-taps `smart-mcp-proxy/homebrew-mcpproxy`).
- Splits the **cask** (full macOS tray app — signed & notarized, bundles the core) from the **formula** (headless core CLI), matching what `release.yml` actually publishes (`Casks/mcpproxy.rb` + `Formula/mcpproxy.rb`).

```bash
# macOS tray app
brew install --cask smart-mcp-proxy/mcpproxy/mcpproxy
# headless core CLI
brew install smart-mcp-proxy/mcpproxy/mcpproxy
```