### PR TITLE
feat(069-A1): byte capture on ActivityRecord (pre-truncation RequestBytes/ResponseBytes)

### DIFF
--- a/internal/runtime/activity_service.go
+++ b/internal/runtime/activity_service.go
@@ -258,6 +258,10 @@ func (s *ActivityService) handleToolCallCompleted(evt Event) {
 		}
 	}
 
+	// Spec 069 A1: byte sizes measured pre-truncation by the emitter.
+	requestBytes := int(getInt64Payload(evt.Payload, "request_bytes"))
+	responseBytes := int(getInt64Payload(evt.Payload, "response_bytes"))
+
 	record := &storage.ActivityRecord{
 		Type:              storage.ActivityTypeToolCall,
 		Source:            activitySource,
@@ -273,6 +277,8 @@ func (s *ActivityService) handleToolCallCompleted(evt Event) {
 		SessionID:         sessionID,
 		RequestID:         requestID,
 		Metadata:          metadata,
+		RequestBytes:      requestBytes,
+		ResponseBytes:     responseBytes,
 	}
 
 	// Extract user identity from auth metadata injected into arguments (teams edition)

--- a/internal/runtime/activity_service_test.go
+++ b/internal/runtime/activity_service_test.go
@@ -799,3 +799,42 @@ func TestHandleInternalToolCall_NoUserIdentity(t *testing.T) {
 	assert.Empty(t, records[0].UserID)
 	assert.Empty(t, records[0].UserEmail)
 }
+
+// TestHandleToolCallCompleted_ByteCapture verifies that RequestBytes and ResponseBytes
+// are populated from the event payload pre-truncation values. T003 Spec 069 A1.
+func TestHandleToolCallCompleted_ByteCapture(t *testing.T) {
+	store, cleanup := setupTestStorage(t)
+	defer cleanup()
+
+	logger := zap.NewNop()
+	svc := NewActivityService(store, logger)
+
+	evt := Event{
+		Type:      EventTypeActivityToolCallCompleted,
+		Timestamp: time.Now().UTC(),
+		Payload: map[string]any{
+			"server_name":    "test-server",
+			"tool_name":      "test-tool",
+			"session_id":     "sess-bytes",
+			"request_id":     "req-bytes",
+			"source":         "mcp",
+			"status":         "success",
+			"duration_ms":    int64(50),
+			"response":       "truncated...",
+			"request_bytes":  1500,
+			"response_bytes": 98304,
+		},
+	}
+
+	svc.handleEvent(evt)
+
+	filter := storage.DefaultActivityFilter()
+	filter.ExcludeCallToolSuccess = false
+	records, _, err := store.ListActivities(filter)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+
+	record := records[0]
+	assert.Equal(t, 1500, record.RequestBytes, "RequestBytes must reflect pre-truncation request size")
+	assert.Equal(t, 98304, record.ResponseBytes, "ResponseBytes must reflect pre-truncation response size")
+}

--- a/internal/runtime/event_bus.go
+++ b/internal/runtime/event_bus.go
@@ -397,7 +397,7 @@ func (r *Runtime) EmitActivityToolCallStarted(serverName, toolName, sessionID, r
 // arguments is the input parameters passed to the tool call
 // toolVariant is the MCP tool variant used (call_tool_read/write/destructive) - optional
 // intent is the intent declaration metadata - optional
-func (r *Runtime) EmitActivityToolCallCompleted(serverName, toolName, sessionID, requestID, source, status, errorMsg string, durationMs int64, arguments map[string]interface{}, response string, responseTruncated bool, toolVariant string, intent map[string]interface{}, contentTrust string) {
+func (r *Runtime) EmitActivityToolCallCompleted(serverName, toolName, sessionID, requestID, source, status, errorMsg string, durationMs int64, arguments map[string]interface{}, response string, responseTruncated bool, toolVariant string, intent map[string]interface{}, contentTrust string, requestBytes, responseBytes int) {
 	// Spec 042: classify failed tool calls into the upstream error categories.
 	// We never record the error message itself; only a fixed enum value.
 	if status == "error" && errorMsg != "" {
@@ -437,6 +437,13 @@ func (r *Runtime) EmitActivityToolCallCompleted(serverName, toolName, sessionID,
 	// Add content trust metadata if provided (Spec 035)
 	if contentTrust != "" {
 		payload["content_trust"] = contentTrust
+	}
+	// Spec 069 A1: pre-truncation byte sizes (0 means not measured / legacy callers)
+	if requestBytes > 0 {
+		payload["request_bytes"] = requestBytes
+	}
+	if responseBytes > 0 {
+		payload["response_bytes"] = responseBytes
 	}
 	r.publishEvent(newEvent(EventTypeActivityToolCallCompleted, payload))
 }

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -420,9 +420,9 @@ func (p *MCPProxyServer) emitActivityToolCallStarted(serverName, toolName, sessi
 // arguments is the input parameters passed to the tool call
 // toolVariant is the MCP tool variant used (call_tool_read/write/destructive) - optional
 // intent is the intent declaration metadata - optional
-func (p *MCPProxyServer) emitActivityToolCallCompleted(serverName, toolName, sessionID, requestID, source, status, errorMsg string, durationMs int64, arguments map[string]interface{}, response string, responseTruncated bool, toolVariant string, intent map[string]interface{}, contentTrust string) {
+func (p *MCPProxyServer) emitActivityToolCallCompleted(serverName, toolName, sessionID, requestID, source, status, errorMsg string, durationMs int64, arguments map[string]interface{}, response string, responseTruncated bool, toolVariant string, intent map[string]interface{}, contentTrust string, requestBytes, responseBytes int) {
 	if p.mainServer != nil && p.mainServer.runtime != nil {
-		p.mainServer.runtime.EmitActivityToolCallCompleted(serverName, toolName, sessionID, requestID, source, status, errorMsg, durationMs, arguments, response, responseTruncated, toolVariant, intent, contentTrust)
+		p.mainServer.runtime.EmitActivityToolCallCompleted(serverName, toolName, sessionID, requestID, source, status, errorMsg, durationMs, arguments, response, responseTruncated, toolVariant, intent, contentTrust, requestBytes, responseBytes)
 	}
 }
 
@@ -1643,7 +1643,7 @@ func (p *MCPProxyServer) handleCallToolVariant(ctx context.Context, request mcp.
 				intentMap = intent.ToMap()
 			}
 			p.emitActivityToolCallStarted(serverName, actualToolName, sessionID, requestID, activitySource, activityArgs)
-			p.emitActivityToolCallCompleted(serverName, actualToolName, sessionID, requestID, activitySource, "error", errMsg, 0, activityArgs, errMsg, false, toolVariant, intentMap, contentTrust)
+			p.emitActivityToolCallCompleted(serverName, actualToolName, sessionID, requestID, activitySource, "error", errMsg, 0, activityArgs, errMsg, false, toolVariant, intentMap, contentTrust, 0, 0)
 			return mcp.NewToolResultError(errMsg), nil
 		}
 	} else {
@@ -1668,7 +1668,7 @@ func (p *MCPProxyServer) handleCallToolVariant(ctx context.Context, request mcp.
 			intentMap = intent.ToMap()
 		}
 		p.emitActivityToolCallStarted(serverName, actualToolName, sessionID, requestID, activitySource, activityArgs)
-		p.emitActivityToolCallCompleted(serverName, actualToolName, sessionID, requestID, activitySource, "error", errMsg, 0, activityArgs, errMsg, false, toolVariant, intentMap, contentTrust)
+		p.emitActivityToolCallCompleted(serverName, actualToolName, sessionID, requestID, activitySource, "error", errMsg, 0, activityArgs, errMsg, false, toolVariant, intentMap, contentTrust, 0, 0)
 		return mcp.NewToolResultError(errMsg), nil
 	}
 
@@ -1765,7 +1765,7 @@ func (p *MCPProxyServer) handleCallToolVariant(ctx context.Context, request mcp.
 		if intent != nil {
 			intentMap = intent.ToMap()
 		}
-		p.emitActivityToolCallCompleted(serverName, actualToolName, sessionID, requestID, activitySource, "error", err.Error(), duration.Milliseconds(), activityArgs, "", false, toolVariant, intentMap, contentTrust)
+		p.emitActivityToolCallCompleted(serverName, actualToolName, sessionID, requestID, activitySource, "error", err.Error(), duration.Milliseconds(), activityArgs, "", false, toolVariant, intentMap, contentTrust, 0, 0)
 
 		// Spec 024: Emit internal tool call event for error
 		internalToolName := "call_tool_" + intent.OperationType // e.g., "call_tool_read"
@@ -1812,6 +1812,10 @@ func (p *MCPProxyServer) handleCallToolVariant(ctx context.Context, request mcp.
 		return blockResult, nil
 	}
 
+	// Spec 069 A1: measure raw sizes before truncation.
+	activityResponseBytes := rawByteSize(result)
+	activityRequestBytes := rawByteSize(activityArgs)
+
 	forwarded, response, wasTruncated := forwardContentResult(result, p.truncator, p.cacheManager, p.logger, toolName, args)
 
 	// Spec 056: output-schema validation. Strict mode blocks a violating result
@@ -1857,7 +1861,7 @@ func (p *MCPProxyServer) handleCallToolVariant(ctx context.Context, request mcp.
 	if intent != nil {
 		intentMap = intent.ToMap()
 	}
-	p.emitActivityToolCallCompleted(serverName, actualToolName, sessionID, requestID, activitySource, "success", "", duration.Milliseconds(), activityArgs, response, responseTruncated, toolVariant, intentMap, contentTrust)
+	p.emitActivityToolCallCompleted(serverName, actualToolName, sessionID, requestID, activitySource, "success", "", duration.Milliseconds(), activityArgs, response, responseTruncated, toolVariant, intentMap, contentTrust, activityRequestBytes, activityResponseBytes)
 
 	// Spec 024: Emit internal tool call event for success
 	internalToolName := "call_tool_" + intent.OperationType // e.g., "call_tool_read"
@@ -2036,7 +2040,7 @@ func (p *MCPProxyServer) handleCallTool(ctx context.Context, request mcp.CallToo
 			}
 			// Log the early failure to activity (Spec 024)
 			p.emitActivityToolCallStarted(serverName, actualToolName, sessionID, requestID, activitySource, activityArgs)
-			p.emitActivityToolCallCompleted(serverName, actualToolName, sessionID, requestID, activitySource, "error", errMsg, 0, activityArgs, errMsg, false, "", nil, "")
+			p.emitActivityToolCallCompleted(serverName, actualToolName, sessionID, requestID, activitySource, "error", errMsg, 0, activityArgs, errMsg, false, "", nil, "", 0, 0)
 			return mcp.NewToolResultError(errMsg), nil
 		}
 	} else {
@@ -2045,7 +2049,7 @@ func (p *MCPProxyServer) handleCallTool(ctx context.Context, request mcp.CallToo
 		errMsg := fmt.Sprintf("No client found for server: %s", serverName)
 		// Log the early failure to activity (Spec 024)
 		p.emitActivityToolCallStarted(serverName, actualToolName, sessionID, requestID, activitySource, activityArgs)
-		p.emitActivityToolCallCompleted(serverName, actualToolName, sessionID, requestID, activitySource, "error", errMsg, 0, activityArgs, errMsg, false, "", nil, "")
+		p.emitActivityToolCallCompleted(serverName, actualToolName, sessionID, requestID, activitySource, "error", errMsg, 0, activityArgs, errMsg, false, "", nil, "", 0, 0)
 		return mcp.NewToolResultError(errMsg), nil
 	}
 
@@ -2167,7 +2171,7 @@ func (p *MCPProxyServer) handleCallTool(ctx context.Context, request mcp.CallToo
 		}
 
 		// Emit activity completed event for error with determined source (legacy - no intent)
-		p.emitActivityToolCallCompleted(serverName, actualToolName, sessionID, requestID, activitySource, "error", err.Error(), duration.Milliseconds(), activityArgs, "", false, "", nil, "")
+		p.emitActivityToolCallCompleted(serverName, actualToolName, sessionID, requestID, activitySource, "error", err.Error(), duration.Milliseconds(), activityArgs, "", false, "", nil, "", 0, 0)
 
 		return p.createDetailedErrorResponse(err, serverName, actualToolName), nil
 	}
@@ -2210,6 +2214,10 @@ func (p *MCPProxyServer) handleCallTool(ctx context.Context, request mcp.CallToo
 		return blockResult, nil
 	}
 
+	// Spec 069 A1: measure raw sizes before truncation.
+	legacyResponseBytes := rawByteSize(result)
+	legacyRequestBytes := rawByteSize(activityArgs)
+
 	forwarded, response, wasTruncated := forwardContentResult(result, p.truncator, p.cacheManager, p.logger, toolName, args)
 
 	// Spec 056: output-schema validation. Strict mode blocks a violating result
@@ -2251,7 +2259,7 @@ func (p *MCPProxyServer) handleCallTool(ctx context.Context, request mcp.CallToo
 
 	// Emit activity completed event for success with determined source (legacy - no intent)
 	responseTruncated := tokenMetrics != nil && tokenMetrics.WasTruncated
-	p.emitActivityToolCallCompleted(serverName, actualToolName, sessionID, requestID, activitySource, "success", "", duration.Milliseconds(), activityArgs, response, responseTruncated, "", nil, "")
+	p.emitActivityToolCallCompleted(serverName, actualToolName, sessionID, requestID, activitySource, "success", "", duration.Milliseconds(), activityArgs, response, responseTruncated, "", nil, "", legacyRequestBytes, legacyResponseBytes)
 
 	return forwarded, nil
 }
@@ -5072,4 +5080,17 @@ func (p *MCPProxyServer) applyOutputValidation(ctx context.Context, serverName, 
 	}
 	// Warn mode: forward the original payload unchanged (FR-A11).
 	return nil
+}
+
+// rawByteSize returns the JSON-serialized byte count of v, or 0 on error.
+// Used to capture pre-truncation sizes for Spec 069 A1.
+func rawByteSize(v interface{}) int {
+	if v == nil {
+		return 0
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return 0
+	}
+	return len(b)
 }

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -5084,6 +5084,10 @@ func (p *MCPProxyServer) applyOutputValidation(ctx context.Context, serverName, 
 
 // rawByteSize returns the JSON-serialized byte count of v, or 0 on error.
 // Used to capture pre-truncation sizes for Spec 069 A1.
+//
+// Profiling note: on the call-tool hot path the result is Marshaled here and
+// again inside forwardContentResult, so a large response is JSON-encoded twice.
+// If this shows up in profiles, capture the size from a single shared Marshal.
 func rawByteSize(v interface{}) int {
 	if v == nil {
 		return 0

--- a/internal/server/mcp_routing.go
+++ b/internal/server/mcp_routing.go
@@ -186,7 +186,7 @@ func (p *MCPProxyServer) makeDirectModeHandler(serverName, toolName string, anno
 
 		if err != nil {
 			// Emit error activity
-			p.emitActivityToolCallCompleted(serverName, toolName, sessionID, requestID, "mcp", "error", err.Error(), durationMs, enrichedArgs, "", false, "", nil, directContentTrust)
+			p.emitActivityToolCallCompleted(serverName, toolName, sessionID, requestID, "mcp", "error", err.Error(), durationMs, enrichedArgs, "", false, "", nil, directContentTrust, 0, 0)
 			return mcp.NewToolResultError(fmt.Sprintf("Error calling %s:%s: %v", serverName, toolName, err)), nil
 		}
 
@@ -257,7 +257,10 @@ func (p *MCPProxyServer) makeDirectModeHandler(serverName, toolName string, anno
 		}
 
 		// Emit success activity
-		p.emitActivityToolCallCompleted(serverName, toolName, sessionID, requestID, "mcp", "success", "", durationMs, enrichedArgs, responseText, truncated, toolVariant, nil, directContentTrust)
+		// Spec 069 A1: pre-truncation sizes; result was measured before the truncation loop above.
+		routingResponseBytes := rawByteSize(result)
+		routingRequestBytes := rawByteSize(enrichedArgs)
+		p.emitActivityToolCallCompleted(serverName, toolName, sessionID, requestID, "mcp", "success", "", durationMs, enrichedArgs, responseText, truncated, toolVariant, nil, directContentTrust, routingRequestBytes, routingResponseBytes)
 
 		return forwarded, nil
 	}

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/contracts"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/secret"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/truncate"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/upstream"
 )
 
@@ -1886,4 +1887,57 @@ func TestPatchDeepMergeIsolation(t *testing.T) {
 	// Verify the diff contains isolation changes
 	assert.NotNil(t, diff)
 	assert.Contains(t, diff.Modified, "isolation", "Diff should include isolation changes")
+}
+
+// TestRawByteSize_MeasuredBeforeTruncation verifies the spec-069 A1 invariant
+// end-to-end: handleCallToolVariant (mcp.go:1816-1819) captures rawByteSize on
+// the RAW result/args BEFORE forwardContentResult truncates, and those counts
+// become ActivityRecord.RequestBytes/ResponseBytes. The existing
+// TestHandleToolCallCompleted_ByteCapture (runtime pkg) only asserts the
+// activity service stores values it is handed; it does not exercise the
+// measure-then-truncate sequence. This closes the gap flagged in MCP-786 by
+// driving an over-threshold response through the real helpers and asserting the
+// captured bytes reflect the full payload while the forwarded body is truncated.
+func TestRawByteSize_MeasuredBeforeTruncation(t *testing.T) {
+	const limit = 500
+
+	bigText := strings.Repeat("x", 8000) // well over the truncation limit
+	result := &mcp.CallToolResult{
+		Content: []mcp.Content{mcp.NewTextContent(bigText)},
+	}
+	args := map[string]interface{}{"payload": strings.Repeat("q", 4000)}
+
+	// Same call sequence as handleCallToolVariant: measure raw, then forward.
+	responseBytes := rawByteSize(result)
+	requestBytes := rawByteSize(args)
+
+	truncator := truncate.NewTruncator(limit)
+	forwarded, _, wasTruncated := forwardContentResult(result, truncator, nil, nil, "test:tool", args)
+
+	// (2) Captured byte counts reflect the FULL pre-truncation payload.
+	rawResponseJSON, err := json.Marshal(result)
+	require.NoError(t, err)
+	assert.Equal(t, len(rawResponseJSON), responseBytes,
+		"ResponseBytes must equal the full pre-truncation response size")
+	assert.Greater(t, responseBytes, limit,
+		"sanity: the test response must exceed the truncation limit")
+
+	rawArgsJSON, err := json.Marshal(args)
+	require.NoError(t, err)
+	assert.Equal(t, len(rawArgsJSON), requestBytes,
+		"RequestBytes must equal the full pre-truncation request size")
+
+	// (3) The forwarded/stored response body is actually truncated.
+	require.True(t, wasTruncated, "an over-threshold response must be truncated")
+	require.NotNil(t, forwarded)
+	require.NotEmpty(t, forwarded.Content)
+	tc, ok := forwarded.Content[0].(mcp.TextContent)
+	require.True(t, ok, "forwarded block 0 should be TextContent")
+	assert.Less(t, len(tc.Text), len(bigText),
+		"forwarded text must be shorter than the raw response")
+
+	// The captured count is strictly larger than the truncated payload — proving
+	// measurement happened before truncation, not after.
+	assert.Greater(t, responseBytes, rawByteSize(forwarded),
+		"captured ResponseBytes must exceed the post-truncation payload size")
 }

--- a/internal/storage/activity.go
+++ b/internal/storage/activity.go
@@ -176,6 +176,8 @@ func (m *Manager) ListActivities(filter ActivityFilter) ([]*ActivityRecord, int,
 					Metadata:          record.Metadata,
 					UserID:            record.UserID,
 					UserEmail:         record.UserEmail,
+					RequestBytes:      record.RequestBytes,
+					ResponseBytes:     record.ResponseBytes,
 				})
 			}
 		}

--- a/internal/storage/activity_models.go
+++ b/internal/storage/activity_models.go
@@ -81,6 +81,10 @@ type ActivityRecord struct {
 	RequestID         string                 `json:"request_id,omitempty"`         // HTTP request ID for correlation
 	Metadata          map[string]interface{} `json:"metadata,omitempty"`           // Additional context-specific data
 
+	// Byte sizes measured pre-truncation (Spec 069 A1). Zero means unknown (legacy records).
+	RequestBytes  int `json:"request_bytes,omitempty"`  // JSON-serialized request arguments size in bytes
+	ResponseBytes int `json:"response_bytes,omitempty"` // Raw upstream response size in bytes before truncation
+
 	// Multi-user identity fields (server edition). Empty/omitted for personal edition.
 	UserID    string `json:"user_id,omitempty"`    // User's unique identifier (set when server auth is active)
 	UserEmail string `json:"user_email,omitempty"` // User's email address (set when server auth is active)

--- a/internal/storage/activity_test.go
+++ b/internal/storage/activity_test.go
@@ -71,6 +71,36 @@ func TestActivityRecord_MarshalUnmarshal(t *testing.T) {
 	assert.Equal(t, record.Response, result.Response)
 }
 
+// TestActivityRecord_ByteFieldsRoundTrip verifies RequestBytes/ResponseBytes survive
+// JSON round-trip and that legacy records (missing fields) decode to 0. T001 Spec 069.
+func TestActivityRecord_ByteFieldsRoundTrip(t *testing.T) {
+	record := &ActivityRecord{
+		ID:            "01HQWX1Y2Z3A4B5C6D7E8F9G0H",
+		Type:          ActivityTypeToolCall,
+		ServerName:    "test-server",
+		ToolName:      "test-tool",
+		Status:        "success",
+		Timestamp:     time.Now().UTC(),
+		RequestBytes:  1234,
+		ResponseBytes: 5678,
+	}
+
+	data, err := record.MarshalBinary()
+	require.NoError(t, err)
+
+	var got ActivityRecord
+	require.NoError(t, got.UnmarshalBinary(data))
+	assert.Equal(t, 1234, got.RequestBytes)
+	assert.Equal(t, 5678, got.ResponseBytes)
+
+	// Legacy record (no byte fields) must decode to 0.
+	legacyJSON := []byte(`{"id":"abc","type":"tool_call","status":"success","timestamp":"2024-01-01T00:00:00Z"}`)
+	var legacy ActivityRecord
+	require.NoError(t, legacy.UnmarshalBinary(legacyJSON))
+	assert.Equal(t, 0, legacy.RequestBytes, "legacy record: RequestBytes must default to 0")
+	assert.Equal(t, 0, legacy.ResponseBytes, "legacy record: ResponseBytes must default to 0")
+}
+
 func TestActivityFilter_Validate(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/specs/069-observability-usage-graphs/checklists/requirements.md
+++ b/specs/069-observability-usage-graphs/checklists/requirements.md
@@ -1,0 +1,29 @@
+# Specification Quality Checklist: Observability — Usage Statistics & Graphs
+
+**Created**: 2026-05-31 · **Feature**: [spec.md](../spec.md)
+
+## Content Quality
+- [x] No implementation details in requirements (names backend/UI files only as dependencies)
+- [x] Focused on user value (save tokens / speed up MCP)
+- [x] Written for stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements testable and unambiguous
+- [x] Success criteria measurable + technology-agnostic
+- [x] All acceptance scenarios defined
+- [x] Edge cases identified (large log, restart, bytes≠tokens, empty, high-cardinality)
+- [x] Scope bounded (surface existing data; no new telemetry; tokens-accurate deferred)
+- [x] Dependencies + assumptions identified
+
+## Feature Readiness
+- [x] All FRs have acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Meets measurable outcomes in SC
+- [x] No implementation leakage
+
+## Notes
+- Scaffolder (`create-new-feature.sh`) not used — broken on this repo's contributor-fork remotes (git fetch --all numbering bug). Branch `069-observability-usage-graphs` + artifacts created directly in standard speckit format. 069 confirmed free (060 highest on main; 064/065 on branches; 066–068 reserved: 067=B1 scanner-noise draft, 068=B2 audit draft).
+- Grounded in research (activity log already has per-call bytes/status/duration; `/api/v1/activity/stats` + Activity.vue exist; NO charting lib installed; tokens-per-call is the one capture gap).
+- Plan (`/speckit.plan`) should pin: charting-library choice, the per-tool aggregation endpoint shape (`?groupBy=tool&window=&buckets=`), the actor-owned incremental `StatsAggregator` + `activity_stats` BBolt rollup bucket + TTL cache, and the Dashboard switcher component location.

--- a/specs/069-observability-usage-graphs/contracts/usage-endpoint.md
+++ b/specs/069-observability-usage-graphs/contracts/usage-endpoint.md
@@ -1,0 +1,72 @@
+# Contract: GET /api/v1/activity/usage
+
+Serves the actor-owned usage aggregate (per-tool rollup + timeline + tokens-saved headline). Reads from the in-memory snapshot / TTL cache — **never** a full-log scan per request (SC-005).
+
+## Request
+
+`GET /api/v1/activity/usage`
+
+| Query param | Type | Default | Notes |
+|-------------|------|---------|-------|
+| `window` | `24h` \| `7d` \| `all` | `24h` | Time span for both per-tool rollup and timeline (FR-004). |
+| `server` | string | — | Filter to one server (FR-008). |
+| `tool` | string | — | Filter to one tool. |
+| `status` | `success` \| `error` \| `blocked` | — | Filter by status (FR-008). |
+| `top` | int | `20` | Top-N tools by sort key; remainder folded into `other`. |
+| `sort` | `calls` \| `resp_bytes` \| `error_rate` \| `p95` | `resp_bytes` | Drives the token-sink default ordering (US1). |
+
+Auth: `X-API-Key` (REST default).
+
+## Response 200 (`UsageAggregateResponse`)
+
+```json
+{
+  "window": "24h",
+  "generated_at": "2026-05-31T12:00:00Z",
+  "freshness_ms": 1200,
+  "token_source": "bytes",
+  "tokens_saved": 184320,
+  "tokens_saved_percentage": 92.4,
+  "tools": [
+    {
+      "server": "github",
+      "tool": "search_issues",
+      "calls": 142,
+      "errors": 3,
+      "error_rate": 0.021,
+      "blocked": 0,
+      "total_resp_bytes": 5872013,
+      "avg_resp_bytes": 41352,
+      "total_req_bytes": 28400,
+      "avg_req_bytes": 200,
+      "sized_calls": 142,
+      "p50_ms": 120,
+      "p95_ms": 480,
+      "last_used": "2026-05-31T11:58:00Z"
+    }
+  ],
+  "other": { "tools_folded": 7, "calls": 33, "total_resp_bytes": 91240 },
+  "timeline": [
+    { "start": "2026-05-31T11:00:00Z", "calls": 40, "errors": 1, "total_resp_bytes": 1200000 }
+  ]
+}
+```
+
+- `token_source: "bytes"` labels the size-based proxy (FR-006); FR-010 will switch this to `"estimated_tokens"`.
+- `tokens_saved*` echoed from existing `ServerTokenMetrics` (FR-007 / SC-008).
+- `avg_*` computed over `sized_calls` only (records with `0` bytes excluded); `null`/omitted when `sized_calls == 0`.
+- `other` present only when the tool list was truncated to `top`.
+- Empty log → `tools: []`, `timeline: []`, `tokens_saved` from metrics (or 0) — never an error (FR-009 / SC-007).
+
+## Response codes
+
+| Code | When |
+|------|------|
+| 200 | Always on success, including empty data. |
+| 400 | Invalid `window`/`sort`/`status` enum or non-int `top`. |
+| 401 | Missing/invalid API key. |
+
+## Test obligations (FR-011)
+
+- API test: populate activity log (mix of servers/tools/statuses/durations/sizes incl. legacy 0-byte records), assert ranking order, error_rate math, avg excludes 0-byte calls, window filter, top-N + `other` fold, empty-state.
+- Contract documented in `oas/swagger.yaml`; `./scripts/verify-oas-coverage.sh` must pass.

--- a/specs/069-observability-usage-graphs/data-model.md
+++ b/specs/069-observability-usage-graphs/data-model.md
@@ -1,0 +1,65 @@
+# Phase 1 Data Model: Observability Usage Graphs
+
+## 1. ActivityRecord (additive change)
+
+`internal/storage/activity_models.go` — add two fields:
+
+| Field | Type | JSON | Notes |
+|-------|------|------|-------|
+| `RequestBytes` | `int` | `request_bytes` | Full serialized request arg size, captured pre-truncation at the write path. Legacy records → `0` ("unknown"). |
+| `ResponseBytes` | `int` | `response_bytes` | Full response payload size, captured **before** `Response` truncation. Legacy records → `0`. |
+
+Backward-compatible: BBolt JSON decode of old records yields `0`; aggregates and UI render `0`-byte records as "size unknown" and exclude them from byte averages.
+
+## 2. UsageAggregate (in-memory, actor-owned)
+
+Owned by `ActivityService`; updated in `handleEvent`; exposed to readers as an immutable snapshot via atomic pointer swap (copy-on-write).
+
+```
+UsageAggregate
+  Tools     map[string]*ToolUsage   // key = "<server>:<tool>"
+  Buckets   []TimeBucket            // ring of fixed-width time buckets (timeline)
+  UpdatedAt time.Time               // freshness stamp (drives TTL/freshness bound)
+
+ToolUsage
+  Server, Tool   string
+  Calls          int64
+  Errors         int64              // Status == "error"
+  Blocked        int64              // Status == "blocked"
+  ReqBytesSum    int64              // excludes RequestBytes==0
+  RespBytesSum   int64              // excludes ResponseBytes==0
+  SizedCalls     int64              // # calls with known byte size (for averages)
+  LatencyBuckets [N]int64           // fixed DurationMs buckets → approx p50/p95
+  LastUsed       time.Time
+
+TimeBucket
+  Start    time.Time               // bucket-aligned (e.g. hourly for 7d, minute for 24h)
+  Calls    int64
+  Errors   int64
+  RespBytesSum int64
+```
+
+**Derivations**: `ErrorRate = Errors / Calls`; `AvgRespBytes = RespBytesSum / SizedCalls` (guard div-by-zero → null); `p50/p95` interpolated from `LatencyBuckets`.
+
+**Time windows**: bucket width chosen per window — 24h → minute/5-min buckets; 7d → hourly; all → daily. Window selection trims the ring to the requested span server-side.
+
+**High cardinality (edge case)**: endpoint returns top-N tools by the requested sort key + a synthesized `"other"` aggregate folding the tail, so charts stay readable (spec Edge Cases).
+
+## 3. Persisted snapshot (`activity_stats` bucket)
+
+New BBolt bucket `activity_stats`, single key (e.g. `usage_aggregate_v1`) → gob/JSON-encoded `UsageAggregate`. Written on a periodic flush (default 30s, configurable) and on graceful shutdown. On cold start: load if present and recent; else one full `AggregateToolUsage`-style scan to rebuild. Schema-versioned key so a future shape change forces a clean rebuild rather than mis-decoding.
+
+## 4. Config (additive, sensible defaults — Constitution III)
+
+```
+"observability": {
+  "usage_cache_ttl": "5s",       // wide-window read cache / freshness bound (FR-005)
+  "usage_persist_interval": "30s" // snapshot flush cadence
+}
+```
+
+Both optional with defaults; env override allowed; hot-reloadable like other config.
+
+## 5. API response (see contracts/usage-endpoint.md)
+
+`UsageAggregateResponse` in `internal/contracts/types.go`: `window`, `generated_at`, `freshness` (cache age), `token_source: "bytes"` (FR-006 label), `tools[]` (per-tool rollup incl. error rate + p50/p95 + avg/total bytes), `timeline[]` (time buckets), `tokens_saved` (echoed `ServerTokenMetrics.SavedTokens`), and an `other` bucket when truncated.

--- a/specs/069-observability-usage-graphs/plan.md
+++ b/specs/069-observability-usage-graphs/plan.md
@@ -1,0 +1,108 @@
+# Implementation Plan: Observability — Usage Statistics & Graphs in the Web UI
+
+**Branch**: `069-observability-usage-graphs` | **Date**: 2026-05-31 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/069-observability-usage-graphs/spec.md`
+
+## Summary
+
+Surface the existing activity log as fast, glanceable usage graphs in the Web UI: a per-tool call histogram, a response-size "token-sink" ranking, per-tool error rate + latency, and a call-volume timeline, behind a Dashboard switcher (Overview ↔ Usage) with a time-window selector (24h / 7d / all) and a "tokens saved by mcpproxy" headline.
+
+The backend serves these from an **actor-owned, incrementally-maintained usage aggregate** updated on each activity write (O(1) per write), snapshot copy-on-write for readers, periodically persisted, with a short-TTL cache for wide windows — never an on-demand full scan of the log (CN-002/CN-003/FR-005). The frontend reuses the **already-installed chart.js + vue-chartjs**.
+
+> **Codebase verification changed three spec assumptions** (see [research.md](./research.md)). These are the gating design decisions for the board:
+> 1. **`ActivityRecord` does NOT store request/response byte sizes today** — it stores a truncated `Response` string + `ResponseTruncated` bool (`internal/storage/activity_models.go:66-87`). FR-006's "response bytes as token proxy" needs a real byte source. **Decision: capture `RequestBytes`/`ResponseBytes` (full, pre-truncation) at the single write path** rather than deriving `len(truncatedResponse)` (which undercounts and lacks request bytes). Additive + backward-compatible (legacy records report 0 → rendered "unknown").
+> 2. **chart.js + vue-chartjs are ALREADY dependencies** (`frontend/package.json`, used by `TokenPieChart.vue`). The spec's "select a charting library" decision is moot — we reuse chart.js. One fewer work-stream.
+> 3. **There is no `GET /api/v1/activity/stats`** — `GET /api/v1/activity/summary` exists (counts + top-5 servers/tools, period param). We add a new `GET /api/v1/activity/usage` rather than overload `summary`.
+
+## Technical Context
+
+**Language/Version**: Go 1.24 (toolchain go1.24.10); TypeScript 6.0 / Vue 3.5 (frontend)
+**Primary Dependencies**: backend — `go.etcd.io/bbolt` (existing), `go.uber.org/zap`, Chi router, existing `ActivityService` actor; frontend — Vue 3.5, Pinia 3, Tailwind 4 / DaisyUI 5, **chart.js ^4.5 + vue-chartjs ^5.3 (already present)**, Vite 8
+**Storage**: BBolt (`~/.mcpproxy/config.db`) — read-only reuse of `activity_records` bucket; **one new `activity_stats` bucket** for the periodically-persisted aggregate snapshot (cold-start fast path). Additive ActivityRecord fields (`RequestBytes`, `ResponseBytes`).
+**Testing**: `go test ./internal/... -race` (unit + API), `./scripts/test-api-e2e.sh`, Playwright Web-UI sweep + HTML report (FR-011)
+**Target Platform**: macOS/Linux/Windows desktop (embedded Web UI)
+**Project Type**: web (Go backend + embedded Vue frontend)
+**Performance Goals**: usage endpoint returns from the in-memory snapshot / TTL cache, no full-log scan per request (SC-005); does not block dashboard first paint (graphs load async — SC-004); aggregate update O(1) per activity write (CN-002)
+**Constraints**: all-local, no new external calls (CN-004); actor-owned aggregation, no new locks on the hot path (Constitution II / CN-003); stated freshness bound for the TTL cache (FR-005); CLAUDE.md edits constrained by the 40k-char CI gate (put notes in specs/)
+**Scale/Scope**: activity logs up to ~10^5–10^6 records; per-(server,tool) cardinality up to ~1k tools (Constitution I) → top-N + "other" bucket for charts (edge case)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Performance at Scale | ✅ PASS | Incremental O(1) aggregate + snapshot reads + TTL cache; no full-scan-per-request. Cold-start single rebuild only. |
+| II. Actor-Based Concurrency | ✅ PASS | Aggregate is owned by the existing `ActivityService` goroutine, updated inside `handleEvent` on the single `SaveActivity` write path; readers get a copy-on-write snapshot. No new shared-memory locks on the hot path. |
+| III. Configuration-Driven | ✅ PASS | Freshness/TTL + persistence interval exposed as config with sensible defaults; no tray-local state (REST only). |
+| IV. Security by Default | ✅ PASS | Aggregates expose only counts/sizes/latency the user already owns; sensitive-data flags are NOT surfaced in aggregates (CN-004). No new network listeners. |
+| V. TDD | ✅ PASS | Failing tests first for byte capture, aggregate math, endpoint contract; Playwright for UI. |
+| VI. Documentation Hygiene | ✅ PASS | Spec/plan/tasks trace + swagger update for the new endpoint; CLAUDE.md kept under 40k. |
+
+**No violations** → Complexity Tracking section omitted.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/069-observability-usage-graphs/
+├── plan.md              # This file
+├── research.md          # Phase 0 — assumption corrections + design decisions
+├── data-model.md        # Phase 1 — aggregate / time-bucket / endpoint shapes
+├── quickstart.md        # Phase 1 — how to run + verify
+├── contracts/
+│   └── usage-endpoint.md # Phase 1 — GET /api/v1/activity/usage contract
+├── checklists/
+│   └── requirements.md   # (existing)
+└── tasks.md             # Phase 2 — /speckit.tasks output
+```
+
+### Source Code (repository root)
+
+```text
+internal/
+├── storage/
+│   ├── activity_models.go   # +RequestBytes, +ResponseBytes (additive)
+│   ├── activity.go          # AggregateToolUsage already exists (cold-start basis)
+│   └── activity_stats.go    # NEW: persist/load aggregate snapshot (activity_stats bucket)
+├── runtime/
+│   ├── activity_service.go  # capture bytes at write; own + update incremental aggregate
+│   └── usage_aggregate.go   # NEW: actor-owned aggregate type, snapshot, TTL cache, rebuild
+├── httpapi/
+│   ├── activity.go          # NEW handler: handleActivityUsage (+ filters/window)
+│   └── server.go            # register GET /api/v1/activity/usage
+└── contracts/
+    └── types.go             # NEW: UsageAggregateResponse + sub-structs
+
+frontend/src/
+├── views/Dashboard.vue      # add Overview ↔ Usage switcher (preserve Overview state)
+├── views/Usage.vue          # NEW: usage view, window selector, 4 charts + tokens-saved headline
+├── components/usage/*.vue    # NEW: chart components (chart.js/vue-chartjs)
+└── services/api.ts          # add getActivityUsage()
+
+oas/swagger.yaml             # document GET /api/v1/activity/usage
+e2e/ or specs/069-.../verification/  # Playwright sweep + HTML report (FR-011)
+```
+
+**Structure Decision**: Web application (Go backend + embedded Vue frontend). Backend changes are confined to `internal/` (Backend-engineer lane). Frontend changes (`frontend/src/`) are the **Frontend/Vue engineer's lane** and are delegated via a child issue (see Decomposition below).
+
+## Decomposition / Plan-of-Attack (Gate 1)
+
+Cross-lane work split into dependency-ordered streams. **Backend streams (A) are my lane; the Frontend stream (B) is delegated to the Frontend/Vue engineer.**
+
+| ID | Stream | Lane | Depends on | Deliverable |
+|----|--------|------|-----------|-------------|
+| **A1** | Byte capture | Backend | — | Add `RequestBytes`/`ResponseBytes` to `ActivityRecord`, populate (full, pre-truncation) at the `SaveActivity` write path; failing tests first. |
+| **A2** | Usage aggregate | Backend | A1 | Actor-owned incremental aggregate in `ActivityService` (per-(server,tool) counts/byte sums/error counts/latency buckets + time buckets); copy-on-write snapshot; periodic persist to `activity_stats`; cold-start rebuild; short-TTL cache for wide windows. |
+| **A3** | Usage endpoint | Backend | A2 | `GET /api/v1/activity/usage` (window 24h/7d/all + tool/server/status filters, top-N + "other"); contract + API tests + swagger. |
+| **B1** | Dashboard switcher | Frontend | A3 | Overview ↔ Usage switcher on Dashboard, preserve Overview state; window selector. |
+| **B2** | Usage charts | Frontend | A3 | `Usage.vue` + 4 chart.js visualizations (call histogram, response-size ranking, error rate, timeline) + tokens-saved headline (from existing `ServerTokenMetrics`); Playwright verification + HTML report. |
+
+Order: **A1 → A2 → A3**, then **A3 unblocks B1 + B2** (parallel). FR-010 (per-call token estimation) stays a tracked phase-2 follow-on, not in this decomposition.
+
+**Open question for the board** (decided at this gate): Approve capturing two new `int` byte fields on `ActivityRecord` at the write path (Decision 1 above), vs. deriving sizes from the truncated `Response` string. Recommendation: capture fields (accurate, request-side coverage, additive/backward-compatible). This is the only spec assumption that requires a capture-path change; everything else is pure read-side aggregation.
+
+## Complexity Tracking
+
+> No constitution violations — section intentionally omitted.

--- a/specs/069-observability-usage-graphs/quickstart.md
+++ b/specs/069-observability-usage-graphs/quickstart.md
@@ -1,0 +1,35 @@
+# Quickstart: Observability Usage Graphs
+
+## Build & run
+
+```bash
+make build                      # backend + embedded frontend (frontend changes need this)
+./mcpproxy serve --config=/tmp/mcpproxy-uitest/mcp_config.json --listen=127.0.0.1:18081
+```
+
+## Verify the backend endpoint
+
+```bash
+# After driving some tool calls through the proxy:
+curl -s -H "X-API-Key: <key>" "http://127.0.0.1:18081/api/v1/activity/usage?window=24h&sort=resp_bytes" | jq
+curl -s -H "X-API-Key: <key>" "http://127.0.0.1:18081/api/v1/activity/usage?window=all&server=github" | jq
+```
+
+Expect: per-tool rollup ordered by total response bytes, `token_source:"bytes"`, a `tokens_saved` headline, a `timeline[]`, and (with >`top` tools) an `other` bucket. Empty log → `tools:[]`, no error.
+
+## Tests
+
+```bash
+go test ./internal/storage/... ./internal/runtime/... ./internal/httpapi/... -race   # unit + API
+./scripts/test-api-e2e.sh
+./scripts/verify-oas-coverage.sh                                                     # swagger coverage
+# When touching ActivityRecord/approval-adjacent code, run the full runtime suite (approval-hash canary).
+```
+
+## Web UI verification (FR-011)
+
+Follow the Playwright sweep pattern in `CLAUDE.md` → "Verifying Web UI changes": fresh mcpproxy on a throwaway data-dir, drive the Dashboard Overview↔Usage switcher + window selector, snapshot each chart state, build the self-contained HTML report under `specs/069-observability-usage-graphs/verification/`. Keep the report + screenshots **local** (do not commit QA reports — repo convention).
+
+## Performance check (SC-005)
+
+Confirm the `/usage` handler reads the snapshot/TTL cache and does not call `AggregateToolUsage` (full scan) per request — only on cold start. A large synthetic log should not change p95 of the endpoint materially.

--- a/specs/069-observability-usage-graphs/research.md
+++ b/specs/069-observability-usage-graphs/research.md
@@ -1,0 +1,62 @@
+# Phase 0 Research: Observability Usage Graphs
+
+All claims below cite the current codebase (verified 2026-05-31). Where a finding contradicts the spec's stated assumption, it is marked **⚠ CORRECTION** and feeds a design decision.
+
+## R1. ActivityRecord shape — ⚠ CORRECTION (byte sizes are NOT stored)
+
+**Finding**: `ActivityRecord` (`internal/storage/activity_models.go:66-87`) has `Type`, `Source`, `ServerName`, `ToolName`, `Status`, `ErrorMessage`, `DurationMs`, `Timestamp`, `SessionID`, `RequestID`, plus `Response string` (truncated) and `ResponseTruncated bool`. There are **no** `RequestBytes`/`ResponseBytes` (or equivalent size) fields. The activity service truncates the response before storage (`activity_service.go:~231`, `storage/activity.go:35-43`).
+
+**Spec assumption it contradicts**: Spec "Assumptions" and Clarification ("Bytes are recorded") state request/response byte sizes are already captured. They are not.
+
+- **Decision**: Add `RequestBytes int` and `ResponseBytes int` to `ActivityRecord`, populated with the **full** byte length at the single write path (`ActivityService.handleEvent` → before truncation), so the size is accurate even when the stored `Response` string is truncated.
+- **Rationale**: (a) FR-006 ("response bytes as token proxy") requires an accurate response size; deriving `len(record.Response)` undercounts truncated responses and gives no request size. (b) The change is additive and backward-compatible — legacy records decode `0`, treated as "size unknown" in aggregates/UI. (c) It is a 2-int capture at an existing write, not a parallel telemetry system (honors CN-001's intent).
+- **Alternatives rejected**: derive `len(truncatedResponse)` (inaccurate, no request side); add a separate sizes bucket (more storage churn, no benefit over two ints on the record).
+- **Board gate**: this is the one capture-path change and is the explicit Gate-1 question.
+
+## R2. Activity service is already actor-based (good for CN-003)
+
+**Finding**: `ActivityService` (`internal/runtime/activity_service.go:33-52`) owns a goroutine started by `Start(ctx, rt)`, consuming a buffered `eventCh chan Event` (100). Every event funnels through `handleEvent` (~line 181) which calls `storage.SaveActivity(record)` exactly once (~line 288).
+
+- **Decision**: Own the incremental usage aggregate inside the `ActivityService` goroutine and update it in `handleEvent` right where the record is built. Readers (the HTTP handler) receive an immutable **copy-on-write snapshot** (atomic pointer swap), mirroring the stateview pattern used elsewhere in `internal/runtime/stateview`.
+- **Rationale**: single-writer goroutine = no locks on the hot path (Constitution II); snapshot reads are O(1) and never block writes (CN-002).
+
+## R3. Aggregation fast-path + cold start
+
+**Finding**: `storage.AggregateToolUsage(since time.Time)` (`internal/storage/activity.go:251-292`) does a single-pass scan returning `map[string]ToolUsageStat` (count + last_used), used by `GET /api/v1/tools` (spec 050). `activity_records` bucket is keyed `{nanosecond-ts}_{ULID}` enabling time-ordered iteration. `CountActivities` uses `bucket.Stats().KeyN`.
+
+- **Decision**: Persist the aggregate snapshot periodically to a new `activity_stats` bucket. On cold start: load the persisted snapshot if present; otherwise run **one** `AggregateToolUsage`-style full scan to rebuild, then switch to incremental. Wide-window reads ("all") served from snapshot; a short-TTL cache (default 5s, configurable) absorbs bursts. **No full scan per request** (SC-005).
+- **Rationale**: bounds cold-start cost to one scan; steady-state is O(1)/write and O(1)/read (FR-005, CN-002).
+- **Open detail**: exact-percentile latency can't be maintained incrementally without storing all samples → use fixed latency buckets per (server,tool) for approximate p50/p95 (documented in data-model.md). Acceptable for "spot slow tools" (US2); exactness is not a requirement.
+
+## R4. Endpoint surface — ⚠ CORRECTION (no /stats)
+
+**Finding**: registered activity routes (`internal/httpapi/server.go:624-627`): `GET /api/v1/activity`, `/activity/summary` (`handleActivitySummary`, `activity.go:520-598`: counts + top-5 servers/tools, `period` ∈ 1h/24h/7d/30d), `/activity/export`, `/activity/{id}`. Filters parsed in `parseActivityFilters` (`activity.go:17-113`): type, server, tool, session_id, status, start/end_time, limit/offset, intent_type, request_id, sensitive_data, etc. **No `/activity/stats`.**
+
+- **Decision**: Add a new `GET /api/v1/activity/usage` (window `24h|7d|all` + tool/server/status filters; top-N + "other" bucket). Do not overload `/summary` (different shape, existing consumers).
+- **Rationale**: clean contract, reuses existing filter parsing; FR-008 filter parity for free.
+
+## R5. Charting library — ⚠ CORRECTION (already installed)
+
+**Finding**: `frontend/package.json` already depends on `chart.js ^4.5.0` + `vue-chartjs ^5.3.2`, used by `frontend/src/components/...TokenPieChart.vue`.
+
+- **Decision**: Reuse chart.js + vue-chartjs for all four visualizations. No new dependency, no library-selection task.
+- **Rationale**: removes a spec decision (and a supply-chain/bundle-size review); consistent with the existing pie chart.
+
+## R6. Tokens-saved headline source (FR-007 / SC-008)
+
+**Finding**: `ServerTokenMetrics` (`internal/contracts/types.go:256-263`: `SavedTokens`, `SavedTokensPercentage`, …) is embedded in `ServerStats.TokenMetrics` and returned by `GET /api/v1/servers`; already rendered by `TokenPieChart.vue`.
+
+- **Decision**: The Usage view reuses this existing metric for the headline — no new backend work for FR-007. Optionally echo it in the `/usage` response for one-call convenience (decided in B2/A3).
+
+## R7. Frontend integration points
+
+**Finding**: `Dashboard.vue` renders overview cards + `TokenPieChart`; `Activity.vue` has KPI stat cards with `data-test="kpi-card-*"`, filters, and calls `api.listActivities/getActivitySummary/getActivityDetail` via the `frontend/src/services/api.ts` singleton; state via `useSystemStore()` (Pinia). No tab/switcher exists yet.
+
+- **Decision**: Add the Overview↔Usage switcher on `Dashboard.vue` (preserve Overview state on switch-back, SC-006); new `Usage.vue` + chart components under `frontend/src/components/usage/`; `api.getActivityUsage()`; `data-test` attributes on all new elements for Playwright (FR-011).
+
+## Resolved unknowns
+
+- Charting library: **resolved** (chart.js, already present) — no NEEDS CLARIFICATION remains.
+- Byte source: **resolved** (capture two int fields) — pending board accept at Gate 1.
+- Endpoint name/shape: **resolved** (`/activity/usage`).
+- Percentile strategy: **resolved** (bucketed approximate).

--- a/specs/069-observability-usage-graphs/spec.md
+++ b/specs/069-observability-usage-graphs/spec.md
@@ -1,0 +1,161 @@
+# Feature Specification: Observability — Usage Statistics & Graphs in the Web UI
+
+**Feature Branch**: `069-observability-usage-graphs`
+**Created**: 2026-05-31
+**Status**: Draft
+**Lineage**: H2-2026 roadmap PILLAR A (Adopt / usability). Builds on the activity log (specs 016/019/024). Paperclip goal `d7164fdf`.
+**Input**: Help users SEE where their AI agents spend tokens and time, so they can speed up MCP usage and cut token cost. Surface usage statistics as graphs in the Web UI — tool-call histogram (calls + tokens per tool), response-size-by-tool, tool errors, a tool-call timeline — behind a dashboard switcher, with a fast backend (caching / precomputation).
+
+## Clarifications
+
+### Session 2026-05-31
+
+- Q: Build new telemetry, or surface existing data? → A: Surface existing data. The activity log already records per-call server, tool, status, duration, and request/response byte sizes; this feature aggregates and visualizes it.
+- Q: Tokens per tool — do we have them? → A: Not per call. Bytes are recorded; tokens are not. v1 uses response **bytes** as the token proxy and shows the existing "tokens saved by retrieve_tools" metric; accurate per-call token estimation is an explicit later requirement.
+- Q: Where do the graphs live? → A: On the existing Dashboard, behind a switcher/tab ("Overview" ↔ "Usage"), reusing the activity REST API.
+- Q: How is fast response guaranteed? → A: An incrementally-maintained, actor-owned stats aggregate updated on each activity write (O(1) per write/read), periodically persisted, with a short-TTL cache for wide windows — not an on-demand full scan.
+- Q: Charting library? → A: None is installed today; the plan selects one lightweight Vue-compatible library (decision recorded in plan.md). The spec stays library-agnostic.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — See which tools consume the most tokens (Priority: P1)
+
+A user whose agent burns through context opens the Web UI dashboard, switches to the Usage view, and immediately sees which tools return the largest responses (the "token sinks") and which are called most often. They learn that one tool returns huge blobs on every call, and adjust how their agent uses it — saving tokens.
+
+**Why this priority**: This is the core value — "where do my tokens go?" — and it answers the user's primary goal (save tokens / speed up MCP). It is buildable entirely on data already captured (response bytes + call counts), so it delivers the headline insight with no new capture.
+
+**Independent Test**: With a populated activity log, open the Usage view; confirm a per-tool ranking by total + average response size and a per-tool call-count histogram render, ordered correctly, matching the underlying records.
+
+**Acceptance Scenarios**:
+
+1. **Given** recorded tool calls with response sizes, **When** the user opens the Usage view, **Then** tools are shown ranked by total response bytes (the token-sink view) and by call count.
+2. **Given** the same data, **When** the user inspects a tool, **Then** its average and total response size and call count are shown.
+3. **Given** no activity yet, **When** the user opens the Usage view, **Then** an empty-state is shown (no error).
+
+---
+
+### User Story 2 — Spot failing and slow tools (Priority: P1)
+
+A user sees an error-rate breakdown per tool and per-tool latency, so they can identify tools that fail often (wasting agent round-trips) or respond slowly (slowing the agent), and fix or replace them.
+
+**Why this priority**: Errors and latency directly waste tokens and time — a tool that fails half the time doubles the agent's round-trips. Same data is already captured (status, error, duration). Equal priority to US1 as the other half of "speed up MCP usage."
+
+**Independent Test**: With a log containing successes and errors across tools, confirm an error-rate-per-tool graph and a latency (e.g. p50/p95) view render and match the records.
+
+**Acceptance Scenarios**:
+
+1. **Given** tool calls with success/error statuses, **When** the user opens the Usage view, **Then** error rate (and count) per tool is shown.
+2. **Given** calls with recorded durations, **When** viewed, **Then** per-tool latency (median and a high percentile) is shown.
+
+---
+
+### User Story 3 — See activity over time on a timeline (Priority: P2)
+
+A user views a timeline of tool calls (volume over time, sliceable by tool/server/status) to understand usage patterns and correlate spikes with their agent sessions — an at-a-glance companion to the activity log.
+
+**Why this priority**: Valuable for understanding *when* and *in what bursts* tokens are spent, and a natural visual layer over the existing activity log. P2 because US1/US2 deliver the primary "what's expensive" insight first.
+
+**Independent Test**: With time-distributed records, confirm a timeline/volume graph renders with correct buckets and respects the active filters.
+
+**Acceptance Scenarios**:
+
+1. **Given** records across a time window, **When** the user opens the timeline, **Then** call volume is shown bucketed over time.
+2. **Given** an active filter (tool/server/status), **When** applied, **Then** the timeline reflects only matching calls.
+
+---
+
+### User Story 4 — Toggle graphs without losing the existing dashboard (Priority: P2)
+
+A user switches between the current status/overview dashboard and the new usage graphs via a clear switcher, and can pick a time window (e.g. 24h / 7d / all). The graphs load fast enough not to delay the dashboard's first paint.
+
+**Why this priority**: The switcher + windowing is what makes the graphs usable day-to-day rather than a separate page; the performance bar is what keeps the dashboard snappy. P2 because the graphs (US1–3) must exist first.
+
+**Independent Test**: Confirm the switcher toggles Overview ↔ Usage, the window selector changes the data range, and the dashboard's initial render is not blocked waiting on graph data.
+
+**Acceptance Scenarios**:
+
+1. **Given** the dashboard, **When** the user toggles to Usage, **Then** the graphs appear and Overview state is preserved on switch-back.
+2. **Given** a window selector, **When** the user picks 7d, **Then** all graphs reflect that window.
+
+---
+
+### User Story 5 — Headline "tokens saved by mcpproxy" (Priority: P3)
+
+The dashboard shows a hero number: tokens saved by serving tool discovery through `retrieve_tools` instead of exposing all tools — making mcpproxy's core value visible.
+
+**Why this priority**: Strong motivational/marketing metric and the data partially exists (token-savings metrics). P3 because it draws on a different (discovery-side) data source than the per-call graphs and is a single number, not a graph suite.
+
+**Independent Test**: Confirm the saved-tokens figure renders from the existing token-savings metrics and updates with usage.
+
+**Acceptance Scenarios**:
+
+1. **Given** discovery token-savings metrics, **When** the dashboard loads, **Then** a tokens-saved figure is shown.
+
+## Requirements *(mandatory)*
+
+### Context & Constraints (locked)
+
+- **CN-001**: Surface and aggregate EXISTING activity-log data; do not add a parallel telemetry system. (External telemetry, spec 042, is separate and unaffected.)
+- **CN-002**: The graphs backend MUST be fast — incremental precompute + cache, not an on-demand full scan of the log on every request. It MUST NOT block the dashboard's first paint or the request hot path (Constitution I).
+- **CN-003**: Aggregation MUST follow actor-based concurrency (Constitution II) — owned by the activity service, updated on write, snapshot for readers.
+- **CN-004**: All data stays local (no new external calls). Privacy: graphs show the user their own usage; any sensitive-data flags already in the activity log are not exposed in aggregates.
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a per-tool usage aggregation: for each tool (and server), total calls, total + average response size, total + average request size, error count/rate, and latency (median + a high percentile), over a selectable time window.
+- **FR-002**: The Web UI MUST present at minimum four visualizations: (a) per-tool call histogram, (b) per-tool response-size ranking (token-sink view), (c) per-tool error rate, (d) a tool-call timeline — all reading the aggregation.
+- **FR-003**: The Web UI MUST provide a dashboard switcher between the existing overview and the usage graphs, preserving overview state.
+- **FR-004**: The system MUST support time-window selection (at least 24h, 7d, all) applied consistently across all graphs.
+- **FR-005**: The aggregation MUST be served fast via incremental precomputation maintained on each activity write and/or a short-TTL cache, with a stated freshness bound; cold start MUST rebuild from the log.
+- **FR-006**: v1 MUST use response bytes as the token proxy for the token-spend graphs and clearly label them as size-based.
+- **FR-007**: The system MUST display the existing "tokens saved by retrieve_tools / discovery" metric as a headline figure.
+- **FR-008**: Graphs MUST honor filtering by tool, server, and status consistent with the existing activity log filters.
+- **FR-009**: Empty/low-data states MUST render gracefully (no errors, clear "no data yet").
+- **FR-010**: (Phase 2) The system SHOULD capture an estimated token count per call (request and response) and switch the token graphs from bytes to estimated tokens, recorded as an explicit follow-on requirement.
+- **FR-011**: The graphs endpoint MUST be covered by API tests, and the UI by the project's Web-UI verification workflow (Playwright + report).
+
+### Key Entities
+
+- **Tool usage aggregate**: per (server, tool) rollup — counts, byte sums/averages, error count, latency percentiles — over a window.
+- **Time bucket**: pre-bucketed call counts/sizes over time for the timeline.
+- **Tokens-saved figure**: the discovery-side savings metric surfaced on the dashboard.
+- **Usage view + switcher**: the dashboard toggle, window selector, and graph components.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: A user can identify their top token-consuming (largest-response) tools within one view, without reading raw logs.
+- **SC-002**: A user can see error rate and latency per tool in the same view.
+- **SC-003**: The timeline shows call volume over time and respects active filters.
+- **SC-004**: The usage graphs do not measurably delay the dashboard's first paint (graphs load asynchronously).
+- **SC-005**: The aggregation endpoint returns within a fast bound on a large activity log (precompute/cache proven by not scanning the full log per request).
+- **SC-006**: Switching Overview ↔ Usage and changing the time window updates all graphs consistently.
+- **SC-007**: With an empty log, the Usage view shows a clean empty state.
+- **SC-008**: The tokens-saved headline renders from existing metrics.
+
+## Assumptions
+
+- `ActivityRecord` already carries timestamp, type, server, tool, status, error, duration, and request/response byte sizes (confirmed in the activity-log backend); no new per-call capture is needed for v1 graphs.
+- A `GET /api/v1/activity/stats` endpoint and an `Activity.vue` view already exist and can be extended rather than replaced.
+- No charting library is currently a frontend dependency; adding one lightweight library is acceptable (recorded in plan.md). Frontend changes require `make build` (the UI is embedded).
+- Accurate per-call token counts are out of scope for v1 (bytes proxy); FR-010 tracks the upgrade.
+
+## Dependencies
+
+- The activity-log backend (`internal/runtime/activity_service.go`, `internal/storage/activity.go`, `internal/storage/models.go`) and its REST surface (`internal/httpapi/activity.go`).
+- The existing token-savings metrics (`internal/config/config.go` TokenMetrics / discovery path).
+- The Vue Web UI (`frontend/src/views/Dashboard.vue`, `Activity.vue`) + a charting library.
+
+## Out of Scope
+
+- A new/parallel telemetry pipeline (external telemetry is spec 042).
+- Accurate per-call token counting (FR-010 is the phase-2 hook; not v1).
+- Cost-in-currency estimates (needs token + pricing; later).
+- Cross-session/historical export beyond the existing activity export.
+
+## Edge Cases
+
+- **Very large activity log**: aggregation must not scan it per request (incremental precompute + cache; CN-002/FR-005).
+- **Restart**: precomputed aggregate rebuilds from the persisted log/rollup on cold start.
+- **Bytes ≠ tokens**: token graphs labeled as size-based until FR-010 lands; avoid implying exact token counts.
+- **Sparse/empty data**: clean empty states (FR-009).
+- **High-cardinality tools**: rank + top-N with an "other" bucket so the histogram stays readable.

--- a/specs/069-observability-usage-graphs/tasks.md
+++ b/specs/069-observability-usage-graphs/tasks.md
@@ -1,0 +1,86 @@
+# Tasks: Observability — Usage Statistics & Graphs in the Web UI
+
+**Input**: Design documents from `/specs/069-observability-usage-graphs/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/usage-endpoint.md
+
+**Tests**: Included and required (Constitution V TDD + FR-011). Write the failing test first for every backend sub-task.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency)
+- Lanes: **(BE)** Backend/Go — Backend-engineer lane (`internal/`, `cmd/`, `oas/`); **(FE)** Frontend/Vue — delegated to the Frontend engineer (`frontend/src/`).
+
+## Path Conventions
+
+Web app: Go backend under `internal/`; embedded Vue frontend under `frontend/src/`.
+
+---
+
+## Phase 1: Foundational — byte capture (Stream A1, BE) ⚠ GATE-1 decision
+
+**Purpose**: Give the token-sink graphs a real byte source (research.md R1). Blocks all aggregate work.
+
+- [ ] T001 [BE] Failing test in `internal/storage/activity_test.go`: `ActivityRecord` round-trips new `RequestBytes`/`ResponseBytes`; legacy records (no fields) decode to `0`.
+- [ ] T002 [BE] Add `RequestBytes int` (`request_bytes`) + `ResponseBytes int` (`response_bytes`) to `ActivityRecord` in `internal/storage/activity_models.go`.
+- [ ] T003 [BE] Failing test in `internal/runtime/activity_service_test.go`: byte sizes captured **pre-truncation** (truncated `Response` still reports full `ResponseBytes`; request args measured).
+- [ ] T004 [BE] Populate `RequestBytes`/`ResponseBytes` in `ActivityService.handleEvent` before truncation; make T001/T003 green.
+
+---
+
+## Phase 2: Usage aggregate (Stream A2, BE) — US1/US2/US3 core
+
+**Purpose**: Actor-owned incremental aggregate + snapshot + persistence + cold-start + TTL (CN-002/CN-003/FR-005).
+
+- [ ] T005 [BE] Failing unit tests in `internal/runtime/usage_aggregate_test.go`: incremental update math (calls, errors, blocked, byte sums excluding 0-byte, latency-bucket → approx p50/p95, time buckets per window).
+- [ ] T006 [BE] Implement `UsageAggregate`/`ToolUsage`/`TimeBucket` + incremental `Apply(record)` in `internal/runtime/usage_aggregate.go` (data-model.md §2); copy-on-write snapshot via atomic pointer.
+- [ ] T007 [BE] Wire aggregate into `ActivityService`: own it on the goroutine, `Apply` inside `handleEvent`; expose `UsageSnapshot()` returning the immutable snapshot. Test: snapshot reflects writes, reads never block.
+- [ ] T008 [BE] Failing test for persistence/rebuild in `internal/storage/activity_stats_test.go`: persist snapshot to `activity_stats` bucket (versioned key) + load; cold start with no snapshot triggers exactly one full-scan rebuild.
+- [ ] T009 [BE] Implement `internal/storage/activity_stats.go` persist/load; periodic flush (default 30s) + flush-on-shutdown; cold-start load-or-rebuild (reuse `AggregateToolUsage` scan). Make T008 green.
+- [ ] T010 [BE] [P] Add `observability.usage_cache_ttl` (5s) + `usage_persist_interval` (30s) to `internal/config/config.go` with defaults + hot-reload; test defaults.
+
+---
+
+## Phase 3: Usage endpoint (Stream A3, BE) — serves US1–US4
+
+**Purpose**: `GET /api/v1/activity/usage` reading the snapshot/TTL cache (contracts/usage-endpoint.md).
+
+- [ ] T011 [BE] Failing API test in `internal/httpapi/activity_usage_test.go`: ranking by `sort`, `error_rate` math, avg excludes 0-byte calls, `window` filter (24h/7d/all), tool/server/status filters (FR-008), top-N + `other` fold, empty-state 200 (FR-009), 400 on bad enum.
+- [ ] T012 [BE] Add `UsageAggregateResponse` + sub-structs to `internal/contracts/types.go`.
+- [ ] T013 [BE] Implement `handleActivityUsage` in `internal/httpapi/activity.go` (reuse `parseActivityFilters`); short-TTL cache for wide windows; echo `tokens_saved` from `ServerTokenMetrics`. Register `GET /api/v1/activity/usage` in `internal/httpapi/server.go`.
+- [ ] T014 [BE] [P] Document endpoint in `oas/swagger.yaml`; `./scripts/verify-oas-coverage.sh` passes.
+- [ ] T015 [BE] Perf assertion (SC-005): test/benchmark proves `handleActivityUsage` does not call the full-scan path per request (only cold start).
+
+---
+
+## Phase 4: Frontend — switcher + charts (Streams B1/B2, FE — DELEGATED)
+
+**Purpose**: Dashboard switcher + four chart.js visualizations + tokens-saved headline. Depends on T013 (endpoint/contract). **Owned by the Frontend/Vue engineer via a child issue.**
+
+- [ ] T016 [FE] [US4] Add Overview↔Usage switcher to `frontend/src/views/Dashboard.vue`, preserving Overview state on switch-back (SC-006); window selector (24h/7d/all); `data-test` attrs.
+- [ ] T017 [FE] Add `getActivityUsage()` to `frontend/src/services/api.ts`.
+- [ ] T018 [FE] [US1] `frontend/src/components/usage/CallHistogram.vue` + `ResponseSizeRanking.vue` (token-sink, labeled size-based per FR-006) using vue-chartjs.
+- [ ] T019 [FE] [US2] `frontend/src/components/usage/ErrorRateChart.vue` + per-tool latency (p50/p95).
+- [ ] T020 [FE] [US3] `frontend/src/components/usage/Timeline.vue` honoring active filters (FR-008).
+- [ ] T021 [FE] [US5] Tokens-saved headline in `Usage.vue` from existing `ServerTokenMetrics` (FR-007); empty/low-data states (FR-009).
+- [ ] T022 [FE] Compose `frontend/src/views/Usage.vue`; async-load graphs so Dashboard first paint is not blocked (SC-004); `make build`.
+- [ ] T023 [FE] Playwright sweep (CLAUDE.md Web-UI workflow) → switcher, window, four charts, empty-state; HTML report in `specs/069-observability-usage-graphs/verification/` (kept local, not committed).
+
+---
+
+## Phase 5: Polish & cross-cutting
+
+- [ ] T024 [BE][P] `./scripts/test-api-e2e.sh` green end-to-end with the new endpoint.
+- [ ] T025 [BE][P] Run full `internal/runtime` suite (approval-hash canary safety) since `ActivityRecord` changed.
+- [ ] T026 [P] Spec trace + swagger committed; conventional commits, no Claude attribution.
+
+---
+
+## Dependencies & ordering
+
+- **A1 (T001–T004) → A2 (T005–T010) → A3 (T011–T015)** — strict backend order.
+- **A3 (T013) → B1/B2 (T016–T023)** — frontend needs the endpoint/contract.
+- FR-010 (per-call token estimation) is an explicit **phase-2 follow-on**, not in this task set.
+
+## Lane / delegation note
+
+T001–T015 + T024–T026 are Backend-engineer tasks (my lane). T016–T023 are Frontend/Vue tasks delegated via a child issue blocked by A3. This split is the Gate-1 decomposition; child issues are created **only after board acceptance**.


### PR DESCRIPTION
## Summary

- Adds `request_bytes` and `response_bytes` (int, omitempty) to `ActivityRecord` — foundational byte data for Spec 069 usage graphs.
- Captures both sizes **pre-truncation**: `rawByteSize(result)` and `rawByteSize(activityArgs)` measured before `forwardContentResult` / the legacy truncation loop in `mcp_routing.go`.
- Legacy records without the fields decode to `0` (unknown), preserving backwards compatibility.
- Fixes `ListActivities` field copy to propagate the new fields from storage.
- `EmitActivityToolCallCompleted` / `emitActivityToolCallCompleted` wrappers extended with `requestBytes, responseBytes int`; error call sites pass `0, 0`.

## Test plan

- [x] `TestActivityRecord_ByteFieldsRoundTrip` — JSON round-trip + legacy decode-to-0 (T001)
- [x] `TestHandleToolCallCompleted_ByteCapture` — service stores pre-truncation sizes from event payload (T003)
- [x] Full `internal/...` suite green (approval-hash canary, required by tasks.md T025)

Blocks: A2 aggregate work (T005+).