### PR TITLE
fix(runtime): drain in-flight reconcile actions before client disconnect (MCP-783)

### DIFF
--- a/internal/runtime/supervisor/lifecycle_drain_test.go
+++ b/internal/runtime/supervisor/lifecycle_drain_test.go
@@ -1,0 +1,178 @@
+package supervisor
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/runtime/configsvc"
+)
+
+// blockingUpstream is a test double whose ConnectServer blocks until released,
+// so a test can hold a Connect "in flight" and observe whether Close() (the
+// upstream disconnect path driven by Supervisor.Stop) overlaps it.
+//
+// This reproduces the MCP-770 root cause: runtime.Close -> Supervisor.Stop ->
+// ShutdownAll/Disconnect must NOT run while a reconcile-dispatched Connect is
+// still executing on the same client.
+type blockingUpstream struct {
+	mu sync.Mutex
+
+	connectStarted chan struct{} // closed when ConnectServer first enters
+	releaseConnect chan struct{} // ConnectServer blocks until this is closed
+
+	connectInFlight bool // true while ConnectServer is blocked
+	overlapDetected bool // set true if Close() ran while a Connect was in flight
+	closed          bool
+
+	states  map[string]*ServerState
+	eventCh chan Event
+}
+
+func newBlockingUpstream() *blockingUpstream {
+	return &blockingUpstream{
+		connectStarted: make(chan struct{}),
+		releaseConnect: make(chan struct{}),
+		states:         make(map[string]*ServerState),
+		eventCh:        make(chan Event, 10),
+	}
+}
+
+func (b *blockingUpstream) AddServer(name string, cfg *config.ServerConfig) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.states[name] = &ServerState{Name: name, Config: cfg, Enabled: cfg.Enabled, Connected: false}
+	return nil
+}
+
+func (b *blockingUpstream) RemoveServer(name string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	delete(b.states, name)
+	return nil
+}
+
+func (b *blockingUpstream) ConnectServer(_ context.Context, name string) error {
+	b.mu.Lock()
+	b.connectInFlight = true
+	// Signal exactly once that a connect is in flight.
+	select {
+	case <-b.connectStarted:
+	default:
+		close(b.connectStarted)
+	}
+	b.mu.Unlock()
+
+	<-b.releaseConnect // block here, simulating a slow Connect
+
+	b.mu.Lock()
+	b.connectInFlight = false
+	if state, ok := b.states[name]; ok {
+		state.Connected = true
+	}
+	b.mu.Unlock()
+	return nil
+}
+
+func (b *blockingUpstream) DisconnectServer(string) error    { return nil }
+func (b *blockingUpstream) ConnectAll(context.Context) error { return nil }
+
+func (b *blockingUpstream) GetServerState(name string) (*ServerState, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if s, ok := b.states[name]; ok {
+		cp := *s
+		return &cp, nil
+	}
+	return nil, nil
+}
+
+func (b *blockingUpstream) GetAllStates() map[string]*ServerState {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make(map[string]*ServerState, len(b.states))
+	for k, v := range b.states {
+		cp := *v
+		out[k] = &cp
+	}
+	return out
+}
+
+func (b *blockingUpstream) IsUserLoggedOut(string) bool { return false }
+func (b *blockingUpstream) Subscribe() <-chan Event     { return b.eventCh }
+func (b *blockingUpstream) Unsubscribe(<-chan Event)    {}
+
+func (b *blockingUpstream) Close() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.connectInFlight {
+		b.overlapDetected = true
+	}
+	b.closed = true
+}
+
+func (b *blockingUpstream) release() { close(b.releaseConnect) }
+
+func (b *blockingUpstream) sawOverlap() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.overlapDetected
+}
+
+// TestSupervisor_Stop_DrainsInFlightConnectBeforeClose is the MCP-783 regression
+// guard. Stop() must wait for in-flight reconcile action goroutines (here, a slow
+// Connect) to finish before it disconnects upstream clients via upstream.Close().
+// Before the drain fix, Stop() returned immediately and Close() overlapped the
+// still-running Connect — the root of the MCP-770 race cascade.
+func TestSupervisor_Stop_DrainsInFlightConnectBeforeClose(t *testing.T) {
+	cfg := &config.Config{
+		Listen:  "127.0.0.1:8080",
+		Servers: []*config.ServerConfig{{Name: "slow-server", Enabled: true, Quarantined: false}},
+	}
+	configSvc := configsvc.NewService(cfg, "/tmp/config.json", zap.NewNop())
+	defer configSvc.Close()
+
+	up := newBlockingUpstream()
+	sup := New(configSvc, up, zap.NewNop())
+
+	// Dispatch the Connect action (runs in its own goroutine).
+	require.NoError(t, sup.reconcile(configSvc.Current()))
+
+	// Wait until Connect is actually in flight (blocked on releaseConnect).
+	select {
+	case <-up.connectStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ConnectServer never started")
+	}
+
+	// Call Stop() in the background; it must block on draining the in-flight Connect.
+	stopReturned := make(chan struct{})
+	go func() {
+		sup.Stop()
+		close(stopReturned)
+	}()
+
+	// Stop() must NOT return while Connect is still in flight.
+	select {
+	case <-stopReturned:
+		t.Fatal("Stop() returned before in-flight Connect completed (no drain)")
+	case <-time.After(200 * time.Millisecond):
+		// expected: Stop is draining
+	}
+
+	// Release the Connect; Stop() should now complete.
+	up.release()
+	select {
+	case <-stopReturned:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Stop() did not return after Connect was released")
+	}
+
+	require.False(t, up.sawOverlap(),
+		"upstream.Close() overlapped an in-flight Connect — drain-before-disconnect failed")
+}

--- a/internal/runtime/supervisor/supervisor.go
+++ b/internal/runtime/supervisor/supervisor.go
@@ -97,6 +97,15 @@ type Supervisor struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
+
+	// actionWg tracks in-flight reconcile action goroutines (Connect/Disconnect/
+	// Reconnect/Remove). Stop() drains it BEFORE disconnecting upstream clients so
+	// a Connect can never overlap a Disconnect on the same client (root fix for the
+	// MCP-770 race cascade, MCP-783). stopping (guarded by stateMu) gates dispatch
+	// so no new action is added once Stop() begins — preventing a WaitGroup
+	// Add-after-Wait.
+	actionWg sync.WaitGroup
+	stopping bool
 }
 
 // inspectionFailureInfo tracks inspection failures for circuit breaker pattern
@@ -311,6 +320,16 @@ func (s *Supervisor) reconcile(configSnapshot *configsvc.Snapshot) error {
 
 	plan := s.computeReconcilePlan(configSnapshot, actualStates, userLoggedOut)
 
+	// MCP-783: once Stop() has begun (stopping set under stateMu), do not dispatch
+	// new action goroutines. This keeps all actionWg.Add calls strictly ordered
+	// before Stop()'s actionWg.Wait (no Add-after-Wait) and guarantees no Connect
+	// can start after we begin draining for disconnect.
+	if s.stopping {
+		s.logger.Debug("Supervisor stopping, skipping reconcile action dispatch")
+		s.updateSnapshot(configSnapshot, actualStates)
+		return nil
+	}
+
 	// Phase 6 Fix: Execute actions asynchronously to prevent blocking
 	// Each action runs in its own goroutine with timeout
 	actionCount := 0
@@ -324,8 +343,12 @@ func (s *Supervisor) reconcile(configSnapshot *configsvc.Snapshot) error {
 			zap.String("server", serverName),
 			zap.String("action", string(action)))
 
-		// Launch each action in a goroutine - no waiting!
+		// Launch each action in a goroutine. Tracked by actionWg (Add under stateMu,
+		// before the goroutine starts) so Stop() can drain in-flight actions before
+		// disconnecting clients.
+		s.actionWg.Add(1)
 		go func(name string, act ReconcileAction, snapshot *configsvc.Snapshot) {
+			defer s.actionWg.Done()
 			if err := s.executeAction(name, act, snapshot); err != nil {
 				s.logger.Error("Failed to execute action",
 					zap.String("server", name),
@@ -1038,11 +1061,31 @@ func (s *Supervisor) emitEvent(event Event) {
 	}
 }
 
+// actionDrainTimeout bounds how long Stop() waits for in-flight reconcile action
+// goroutines to finish before disconnecting clients. It exceeds the per-action
+// context timeout (executeAction, 30s) so a well-behaved action that observes the
+// cancelled context returns first; the timeout is only a backstop against a wedged
+// Connect so shutdown can't hang forever.
+const actionDrainTimeout = 35 * time.Second
+
 // Stop gracefully stops the supervisor.
 func (s *Supervisor) Stop() {
 	s.logger.Info("Stopping supervisor")
+
+	// MCP-783: mark stopping under stateMu so reconcile() dispatches no further
+	// action goroutines. Serializing on stateMu (the same lock reconcile holds while
+	// dispatching) ensures every actionWg.Add has happened before the drain below.
+	s.stateMu.Lock()
+	s.stopping = true
+	s.stateMu.Unlock()
+
 	s.cancel()
 	s.wg.Wait()
+
+	// Drain in-flight reconcile actions (Connect/Disconnect/...) BEFORE disconnecting
+	// upstream clients. Without this, ShutdownAll -> Disconnect overlaps an in-flight
+	// Connect on the same client — the root of the MCP-770 race cascade.
+	s.drainActions()
 
 	// Close upstream adapter
 	s.upstream.Close()
@@ -1056,6 +1099,26 @@ func (s *Supervisor) Stop() {
 	s.eventMu.Unlock()
 
 	s.logger.Info("Supervisor stopped")
+}
+
+// drainActions waits for in-flight reconcile action goroutines to finish, bounded
+// by actionDrainTimeout. Called from Stop() before disconnecting clients so a
+// Connect can never overlap a Disconnect on the same client (MCP-783).
+func (s *Supervisor) drainActions() {
+	done := make(chan struct{})
+	go func() {
+		s.actionWg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		s.logger.Debug("Drained in-flight reconcile actions before disconnect")
+	case <-time.After(actionDrainTimeout):
+		s.logger.Warn("Timed out draining in-flight reconcile actions before disconnect; "+
+			"proceeding to disconnect (a Connect may still be in flight)",
+			zap.Duration("timeout", actionDrainTimeout))
+	}
 }
 
 // RequestInspectionExemption grants temporary connection permission for a quarantined server.


### PR DESCRIPTION
## Root fix for the MCP-770 race cascade

MCP-770 surfaced five distinct `-race`/test failures one-by-one, each unmasking the next. All shared one defect: `runtime.Close` → `ShutdownAll` disconnects upstream clients **while the supervisor reconcile loop is still connecting** the just-added server. Connect and Disconnect overlapped on one `*managed.Client`, racing every lifecycle field that assumed no overlap (Config pointer, stderr/process-monitor ctx + waitgroup, …). The symptoms were each fixed individually in #555/#556; this removes the source.

### Sharpened root cause
The reconcile **action goroutines are fire-and-forget and untracked**:
- `reconcile()` dispatches each action in a bare goroutine with an explicit `// no waiting!` comment (`supervisor.go`), running `executeAction` → `ConnectServer` → `client.Connect()`.
- `Supervisor.Stop()` cancelled `s.ctx` and waited only on `s.wg` — which tracks the **three long-lived loops**, not the per-action goroutines.
- So `Stop()` could return with a `Connect()` still in flight; `runtime.Close` then ran `ShutdownAll` → `Disconnect()`, overlapping on the same client.

Cancelling the context alone is insufficient — cancellation only *signals*; the in-flight `Connect()` keeps touching client fields while `Disconnect()` starts. The fix must **wait**.

## Change (confined to `internal/runtime/supervisor/`)
- Add `actionWg sync.WaitGroup` tracking in-flight reconcile action goroutines (`Add` under `stateMu`, before `go`; `defer Done` inside).
- Add a `stopping` flag set under `stateMu` in `Stop()`; `reconcile()` skips dispatch once stopping, so no `actionWg.Add` can happen after the drain (no Add-after-Wait).
- `Stop()` now: set `stopping` → `cancel()` → `wg.Wait()` → **`drainActions()`** → `upstream.Close()`. The drain is bounded by a 35s backstop (> the 30s per-action context timeout) so a wedged Connect can't hang shutdown.

## Tests / verification
- **New `-race` regression guard** `TestSupervisor_Stop_DrainsInFlightConnectBeforeClose`: holds a Connect in flight, asserts `Stop()` blocks until it completes and that `upstream.Close()` never overlaps an in-flight Connect. Verified red before the fix, green after (`-count=2 -race`).
- `go test ./internal/runtime/... -race` ✅
- `go test ./internal/upstream/... -race` ✅
- `go test ./internal/server/ -run TestHandleUpstreamServers_AddFromRegistry -race -count=3` (MCP-770 amplifier) ✅
- `make build` ✅ · `./scripts/run-linter.sh` → 0 issues ✅

## Notes
- Defense-in-depth: `main` is already green via the symptom fixes, so revert is safe (single PR).
- Option (b) from the issue (hermetic add-op tests) is a separate follow-on.
- `Related #556` (no auto-close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)