### PR TITLE
ci(065): trigger eval gate on D1 retrieval paths (Related MCP-833)

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -17,8 +17,18 @@ name: Eval (Spec 065 regression gate)
 on:
   pull_request:
     paths:
-      - "cmd/scan-eval/**"
+      # D2 (security) system under test
       - "internal/security/**"
+      # D1 (retrieval) system under test — BM25 index, MCP tool-discovery
+      # routing, the REST search envelope, and server/CLI boot behavior the
+      # retrieval eval depends on. Spec 065 requires CI to catch discovery
+      # regressions when search/index/tool-discovery behavior changes.
+      - "internal/index/**"
+      - "internal/server/**"
+      - "internal/httpapi/**"
+      - "cmd/mcpproxy/**"
+      # Eval harness + frozen datasets + this workflow
+      - "cmd/scan-eval/**"
       - "specs/065-evaluation-foundation/datasets/**"
       - "scripts/eval-ci-smoke.sh"
       - ".github/workflows/eval.yml"


### PR DESCRIPTION
## Context
Codex review of PR #561 / MCP-831 found that `.github/workflows/eval.yml` is **not** triggered by changes to the retrieval implementation it is meant to gate. The `pull_request.paths` filter only matched the D2 security surface (`internal/security/**`, `cmd/scan-eval/**`) plus the harness/datasets — so an edit to the BM25 index, MCP tool-discovery routing, the REST search envelope, or server/CLI boot would never run the Eval workflow.

Spec 065 requires CI to catch discovery regressions when search/index/tool-discovery behavior changes (`specs/065-evaluation-foundation/spec.md:22,24,61,88`).

## Change
Add the D1 retrieval system-under-test paths to `on.pull_request.paths`:

- `internal/index/**` — BM25 Bleve index
- `internal/server/**` — `mcp_routing.go` (`retrieve_tools`) + adjacent MCP serving
- `internal/httpapi/**` — REST `index/search` envelope the D1 readiness probe/eval consume
- `cmd/mcpproxy/**` — server/CLI boot behavior the eval depends on

Job logic is unchanged — D2 security and D1 retrieval stay green; this only widens what triggers the workflow.

## Verification
Simulated GitHub's minimatch path-glob semantics against the new filter:

| Path | Triggers Eval? |
|------|----------------|
| `internal/index/manager.go` | ✅ yes (the issue's verification target) |
| `internal/server/mcp_routing.go` | ✅ yes |
| `cmd/mcpproxy/main.go` | ✅ yes |
| `internal/httpapi/server.go` | ✅ yes |
| `README.md` | ❌ no |
| `frontend/src/App.vue` | ❌ no |

An otherwise-empty PR touching `internal/index/manager.go` now creates the Eval workflow checks. YAML validated with `yaml.safe_load`.

> Targets the `065-evaluation-foundation` integration branch (where eval.yml lives, awaiting PR #562 → main), not `main`.

Related MCP-833