### PR TITLE
ci(065): widen eval.yml path-filter to cover the retrieval system (MCP-836)

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -17,8 +17,20 @@ name: Eval (Spec 065 regression gate)
 on:
   pull_request:
     paths:
+      # D2 security gate — the scanner + detector code under test.
       - "cmd/scan-eval/**"
       - "internal/security/**"
+      # D1 retrieval gate — the discovery system under test. Spec 065 requires
+      # CI to catch recall/MRR/nDCG regressions when a maintainer changes the
+      # search index, tokenizer, tool routing/ranking, or tool descriptions
+      # (specs/065-evaluation-foundation/spec.md:22,24,61). Without these, a
+      # retrieval change would silently skip the eval gate (MCP-836).
+      - "internal/index/**"            # Bleve BM25 index + tokenizer
+      - "internal/server/mcp.go"       # retrieve_tools handler
+      - "internal/server/mcp_routing.go"      # tool routing/ranking
+      - "internal/server/mcp_annotations.go"  # tool annotations/descriptions
+      - "cmd/mcpproxy/**"              # CLI + serve wiring
+      # Shared: the frozen datasets, smoke harness, and this workflow itself.
       - "specs/065-evaluation-foundation/datasets/**"
       - "scripts/eval-ci-smoke.sh"
       - ".github/workflows/eval.yml"


### PR DESCRIPTION
## MCP-836 — close the eval-gate path-filter gap (CodexReviewer request_changes on #561)

### Finding (cited)
`.github/workflows/eval.yml` path-filtered the eval workflow to `cmd/scan-eval/**`, `internal/security/**`, the datasets, the smoke script, and the workflow file — but **missed the retrieval system under test**. Spec 065 requires CI to catch discovery (Recall@k/MRR/nDCG) regressions when a maintainer changes the search index / tokenizer / tool descriptions (`specs/065-evaluation-foundation/spec.md:22,24,61`). As-is, a retrieval change would silently skip the D1 retrieval + D2 security gates.

### Fix
Add the discovery code paths to the `pull_request.paths` filter, grouped with explanatory comments:
- `internal/index/**` — Bleve BM25 index + tokenizer
- `internal/server/mcp.go` — `retrieve_tools` handler
- `internal/server/mcp_routing.go` — tool routing/ranking
- `internal/server/mcp_annotations.go` — tool annotations/descriptions
- `cmd/mcpproxy/**` — CLI + serve wiring

All five paths verified to exist in the tree.

### Verification
- `actionlint .github/workflows/eval.yml` → clean (no findings)
- YAML parses; all five retrieval paths asserted present in `pull_request.paths`; both jobs (`security-d2`, `retrieval-d1`) intact

Branched off `065-evaluation-foundation`; targets the same branch so the fix lands before 065 reaches `main`. Push only — not merging (Gate 3).

Related #MCP-836