### PR TITLE
fix(registries): versioned User-Agent for Pulse (410) + Fleur stdio not remote

### DIFF
--- a/cmd/mcpproxy/main.go
+++ b/cmd/mcpproxy/main.go
@@ -502,6 +502,8 @@ func runServer(cmd *cobra.Command, _ []string) error {
 	server.SetMCPServerVersion(version)
 	// Spec 042: surface header for outbound CLI HTTP requests.
 	cliclient.SetClientVersion(version)
+	// Issue #566: registries (e.g. Pulse) require a versioned User-Agent.
+	registries.SetVersion(version)
 
 	// Override other settings from command line
 	cfg.DebugSearch = cmdDebugSearch

--- a/internal/registries/search.go
+++ b/internal/registries/search.go
@@ -41,6 +41,24 @@ const (
 // GitHub URL pattern for matching https://github.com/<author|org>/<repo>
 var githubURLPattern = regexp.MustCompile(`^https://github\.com/([^/]+)/([^/]+)(?:/.*)?$`)
 
+// buildVersion holds the build-time version used in the outbound User-Agent.
+// Set via SetVersion at process startup. Defaults to "dev" so tests run
+// without setup. Some registries (e.g. Pulse, issue #566) reject requests
+// with an empty or bare User-Agent and require a versioned one.
+var buildVersion = "dev"
+
+// SetVersion sets the version reported in the registry User-Agent header.
+func SetVersion(v string) {
+	if v != "" {
+		buildVersion = v
+	}
+}
+
+// registryUserAgent returns the versioned User-Agent for registry HTTP requests.
+func registryUserAgent() string {
+	return "mcpproxy/" + buildVersion
+}
+
 // SearchServers searches the given registry for servers matching optional tag and query
 // with optional repository guessing and result limiting
 func SearchServers(ctx context.Context, registryID, tag, query string, limit int, guesser *experiments.Guesser) ([]ServerEntry, error) {
@@ -134,6 +152,10 @@ func fetchServers(ctx context.Context, reg *RegistryEntry, guesser *experiments.
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
+
+	// Some registries (e.g. Pulse, issue #566) reject requests with an empty
+	// or bare User-Agent and require a versioned one (mirror guesser.go).
+	req.Header.Set("User-Agent", registryUserAgent())
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -628,6 +650,13 @@ func constructServerURL(server *ServerEntry, reg *RegistryEntry) string {
 		// transport (issue #483).
 		return ""
 	case protocolFleur:
+		// Issue #567 (same class as Docker #483): Fleur apps that ship a local
+		// stdio install command carry it in InstallCmd. The URL field is for
+		// HTTP/SSE remote endpoints only — synthesising one makes the frontend
+		// register the server as a remote transport. Leave it empty for stdio.
+		if server.InstallCmd != "" {
+			return ""
+		}
 		if server.ID != "" {
 			return fmt.Sprintf("https://api.fleurmcp.com/apps/%s/mcp", server.ID)
 		}

--- a/internal/registries/search_test.go
+++ b/internal/registries/search_test.go
@@ -794,6 +794,17 @@ func TestConstructServerURL(t *testing.T) {
 			"https://api.fleurmcp.com/apps/app1/mcp",
 		},
 		{
+			// Issue #567: Fleur apps that ship a local stdio install command
+			// (InstallCmd populated by parseFleur) must NOT get a synthesised
+			// https endpoint — same class as the Docker #483 bug. A non-empty
+			// URL makes the frontend register them as "Remote". Launch info
+			// travels via InstallCmd, so the connection URL must stay empty.
+			"fleur protocol with InstallCmd returns empty (stdio not remote)",
+			ServerEntry{ID: "app1", URL: "", InstallCmd: "npx -y @fleur/app1"},
+			RegistryEntry{Protocol: "custom/fleur"},
+			"",
+		},
+		{
 			"unknown protocol",
 			ServerEntry{ID: "test", URL: ""},
 			RegistryEntry{Protocol: "unknown"},
@@ -809,6 +820,38 @@ func TestConstructServerURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestFetchServers_SendsVersionedUserAgent is a regression for issue #566:
+// Pulse's api.pulsemcp.com/v0beta/servers now returns 410 to requests with an
+// empty or bare User-Agent and only 200s a versioned one (e.g. "mcpproxy/0.35.0").
+// fetchServers previously sent no User-Agent at all. This stands up a server
+// that mirrors Pulse's behaviour (410 unless a versioned UA is present) and
+// asserts fetchServers both sends a versioned UA and succeeds.
+func TestFetchServers_SendsVersionedUserAgent(t *testing.T) {
+	var gotUserAgent string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUserAgent = r.Header.Get("User-Agent")
+		// Mirror Pulse: reject empty or bare (no version segment) UAs with 410.
+		if gotUserAgent == "" || !strings.Contains(gotUserAgent, "mcpproxy/") {
+			w.WriteHeader(http.StatusGone) // 410
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"servers":[]}`))
+	}))
+	defer srv.Close()
+
+	reg := &RegistryEntry{
+		ID:         "pulse",
+		Protocol:   "custom/pulse",
+		ServersURL: srv.URL,
+	}
+
+	_, err := fetchServers(context.Background(), reg, nil)
+	require.NoError(t, err, "fetchServers should not get a 410 — it must send a versioned User-Agent")
+	require.NotEmpty(t, gotUserAgent, "fetchServers must send a User-Agent header")
+	require.Contains(t, gotUserAgent, "mcpproxy/", "User-Agent must be versioned (mcpproxy/<version>)")
 }
 
 // Helper function for testing


### PR DESCRIPTION
Fixes two registry-parser bugs in `internal/registries/search.go`. Both edit the same file, so they ship on one branch + one PR (per MCP-855).

## Bug A — Pulse 410 (#566)
`fetchServers()` sent **no** `User-Agent`. `api.pulsemcp.com/v0beta/servers` now `410`s requests with an empty or bare UA and only `200`s a versioned one (reproduced: empty→410, `mcpproxy`→410, `mcpproxy/0.35.0`→200).

**Fix:** set `User-Agent: mcpproxy/<version>` in `fetchServers` (mirrors `internal/experiments/guesser.go:285`). Version is wired via a new `registries.SetVersion(version)` call in `main.go` alongside the existing `cliclient.SetClientVersion` / `server.SetMCPServerVersion`; defaults to `dev`.

## Bug B — Fleur all-remote (#567)
`constructServerURL()` synthesised `https://api.fleurmcp.com/apps/<id>/mcp` for **every** Fleur app. `parseFleur` populates `InstallCmd` (local stdio) and leaves `URL` empty, so the synthesised URL made the frontend register these stdio apps as **Remote**. Same class as the Docker #483 bug.

**Fix:** for `protocolFleur`, return `""` when `server.InstallCmd != ""`. Fleur apps without an install command (true remote endpoints) still get the synthesised URL.

## Tests (test-first, both watched fail then pass)
- `TestFetchServers_SendsVersionedUserAgent` — httptest server that `410`s on empty/bare UA (mirrors Pulse); asserts `fetchServers` sends a versioned UA and succeeds.
- `TestConstructServerURL` — new `fleur protocol with InstallCmd returns empty (stdio not remote)` case (mirrors the #483 regression case).

## Verification
- `go build ./cmd/mcpproxy` — ok
- `go test ./internal/registries/... -race` — ok
- `./scripts/run-linter.sh` — 0 issues

No CLI/REST/MCP/config surface changed (internal registry parsing only), so no docs update is required.

Related #566
Related #567