### PR TITLE
feat(registries): Web UI add-registry affordance + provenance + third-party warning (MCP-867)

### DIFF
--- a/docs/registries.md
+++ b/docs/registries.md
@@ -67,9 +67,14 @@ Equivalent surfaces:
 
 - **REST:** `POST /api/v1/registries` with `{ "url": "https://…", "protocol": "…", "id": "…", "name": "…" }`.
 - **CLI:** `mcpproxy registry add-source <https-url>`.
+- **Web UI:** the **Repositories** page has an **Add Registry** button (URL + optional
+  protocol/name). Each registry in the selector is flagged **Official · trusted** or
+  **Third-party · unverified** from its `provenance`, and the first custom add shows a
+  one-time third-party-registry warning (the acknowledgement is remembered locally).
 
 Errors share a stable code across surfaces: `invalid_registry_url` (400),
 `registries_locked` (403), `registry_shadows_builtin` / `duplicate_registry` (409).
+The Web UI maps each code to an actionable message.
 
 ### Enterprise: `registries_locked` (stub)
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,4 @@
-import type { APIResponse, Server, Tool, ToolApproval, SearchResult, StatusUpdate, SecretRef, MigrationAnalysis, ConfigSecretsResponse, GetToolCallsResponse, GetToolCallDetailResponse, GetServerToolCallsResponse, GetConfigResponse, ValidateConfigResponse, ConfigApplyResult, ServerTokenMetrics, GetRegistriesResponse, SearchRegistryServersResponse, GetSessionsResponse, GetSessionDetailResponse, InfoResponse, ActivityListResponse, ActivityDetailResponse, ActivitySummaryResponse, ImportResponse, AgentTokenInfo, CreateAgentTokenRequest, CreateAgentTokenResponse, RoutingInfo, ConnectStatusResponse, ConnectResult, OnboardingStateResponse, OnboardingMarkRequest, DiagnosticFixResponse, GlobalToolsResponse, UsageAggregateResponse, UsageWindow, UsageSort, UsageStatus } from '@/types'
+import type { APIResponse, Server, Tool, ToolApproval, SearchResult, StatusUpdate, SecretRef, MigrationAnalysis, ConfigSecretsResponse, GetToolCallsResponse, GetToolCallDetailResponse, GetServerToolCallsResponse, GetConfigResponse, ValidateConfigResponse, ConfigApplyResult, ServerTokenMetrics, GetRegistriesResponse, SearchRegistryServersResponse, RegistrySummary, GetSessionsResponse, GetSessionDetailResponse, InfoResponse, ActivityListResponse, ActivityDetailResponse, ActivitySummaryResponse, ImportResponse, AgentTokenInfo, CreateAgentTokenRequest, CreateAgentTokenResponse, RoutingInfo, ConnectStatusResponse, ConnectResult, OnboardingStateResponse, OnboardingMarkRequest, DiagnosticFixResponse, GlobalToolsResponse, UsageAggregateResponse, UsageWindow, UsageSort, UsageStatus } from '@/types'
 
 // Event types for API service
 export interface APIAuthEvent {
@@ -31,6 +31,17 @@ export interface AddFromRegistryResult {
   code?: string
   // Names of unmet required inputs; present when code === 'missing_required_input'.
   missingInputs?: string[]
+}
+
+// MCP-866 / MCP-867: result of adding a *registry source* (POST /registries).
+// Carries the stable error `code` (invalid_registry_url | registries_locked |
+// registry_shadows_builtin | duplicate_registry) so the UI can render an
+// actionable message instead of a generic string.
+export interface AddRegistrySourceResult {
+  success: boolean
+  registry?: RegistrySummary
+  error?: string
+  code?: string
 }
 
 class APIService {
@@ -665,6 +676,58 @@ class APIService {
 
     const url = `/api/v1/registries/${encodeURIComponent(registryId)}/servers${params.toString() ? '?' + params.toString() : ''}`
     return this.request<SearchRegistryServersResponse>(url)
+  }
+
+  // MCP-866 / MCP-867: add a user-supplied registry source. The server always
+  // tags an added source custom/unverified (provenance is NOT part of the
+  // request), so every server later discovered through it lands quarantined and
+  // can never skip quarantine. We mirror the structured-error pattern of
+  // addServerFromRegistry so the UI can branch on the stable `code`
+  // (invalid_registry_url | registries_locked | registry_shadows_builtin |
+  // duplicate_registry).
+  async addRegistrySource(
+    url: string,
+    opts?: { protocol?: string; id?: string; name?: string }
+  ): Promise<AddRegistrySourceResult> {
+    const body: Record<string, unknown> = { url }
+    if (opts?.protocol) body.protocol = opts.protocol
+    if (opts?.id) body.id = opts.id
+    if (opts?.name) body.name = opts.name
+
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+    if (this.apiKey) headers['X-API-Key'] = this.apiKey
+
+    try {
+      const response = await fetch(`${this.baseUrl}/api/v1/registries`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body)
+      })
+
+      const payload: any = await response.json().catch(() => ({}))
+
+      if (!response.ok) {
+        if (response.status === 401 || response.status === 403) {
+          // registries_locked is a 403 but is a policy decision, not an auth
+          // failure — only emit the auth-error path for a missing/invalid key.
+          if (payload?.code !== 'registries_locked') {
+            this.emitAuthError(payload?.error || `HTTP ${response.status}`, response.status)
+          }
+        }
+        return {
+          success: false,
+          error: payload?.error || `HTTP ${response.status}: ${response.statusText}`,
+          code: payload?.code
+        }
+      }
+
+      return { success: true, registry: payload?.data?.registry }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      }
+    }
   }
 
   // Spec 070 (CN-001): add a server to upstream by *reference* — the server

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -562,6 +562,28 @@ export interface Registry {
   tags?: string[]
   protocol?: string
   count?: number | string
+  // MCP-866: trust tag — "official/trusted" for built-in defaults,
+  // "custom/unverified" for user-added sources. Derived server-side from
+  // membership in the default set, never from self-assertion in config.
+  provenance?: string
+  // Convenience boolean mirror of provenance === "official/trusted".
+  trusted?: boolean
+}
+
+// MCP-866 trust-tag constants (mirror config.RegistryProvenance*).
+export const REGISTRY_PROVENANCE_OFFICIAL = 'official/trusted'
+export const REGISTRY_PROVENANCE_CUSTOM = 'custom/unverified'
+
+// RegistrySummary is the slim projection returned by POST /api/v1/registries
+// (add-source). Mirrors contracts.RegistrySummary.
+export interface RegistrySummary {
+  id: string
+  name: string
+  url?: string
+  servers_url?: string
+  protocol?: string
+  provenance?: string
+  trusted?: boolean
 }
 
 export interface NPMPackageInfo {

--- a/frontend/src/views/Repositories.vue
+++ b/frontend/src/views/Repositories.vue
@@ -6,6 +6,16 @@
         <h1 class="text-3xl font-bold">Repositories</h1>
         <p class="text-base-content/70 mt-1">Browse and discover MCP server repositories</p>
       </div>
+      <button
+        @click="openAddRegistry"
+        class="btn btn-outline btn-sm"
+        data-test="registry-add-source-button"
+      >
+        <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+        </svg>
+        Add Registry
+      </button>
     </div>
 
     <!-- Registry Selector & Search -->
@@ -26,7 +36,7 @@
             >
               <option disabled value="">Choose a registry...</option>
               <option v-for="registry in registries" :key="registry.id" :value="registry.id">
-                {{ registry.name }}
+                {{ registry.name }}{{ isCustomRegistry(registry) ? ' — unverified' : '' }}
               </option>
             </select>
           </div>
@@ -61,14 +71,42 @@
           </div>
         </div>
 
-        <!-- Registry Info -->
-        <div v-if="selectedRegistryInfo" class="alert alert-info mt-4">
+        <!-- Registry Info + provenance/trust (MCP-866/MCP-867) -->
+        <div
+          v-if="selectedRegistryInfo"
+          class="alert mt-4"
+          :class="isCustomRegistry(selectedRegistryInfo) ? 'alert-warning' : 'alert-info'"
+          :data-test="`registry-info-${selectedRegistryInfo.id}`"
+        >
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
           <div>
-            <p class="font-semibold">{{ selectedRegistryInfo.name }}</p>
+            <p class="font-semibold flex items-center gap-2 flex-wrap">
+              {{ selectedRegistryInfo.name }}
+              <span
+                v-if="isCustomRegistry(selectedRegistryInfo)"
+                class="badge badge-warning badge-sm gap-1"
+                data-test="registry-provenance-badge-custom"
+              >
+                Third-party · unverified
+              </span>
+              <span
+                v-else
+                class="badge badge-success badge-sm gap-1"
+                data-test="registry-provenance-badge-official"
+              >
+                Official · trusted
+              </span>
+            </p>
             <p class="text-sm">{{ selectedRegistryInfo.description }}</p>
+            <p
+              v-if="isCustomRegistry(selectedRegistryInfo)"
+              class="text-xs mt-1 opacity-90"
+              data-test="registry-custom-quarantine-note"
+            >
+              Servers added from this third-party registry are always quarantined and cannot skip security review.
+            </p>
           </div>
         </div>
       </div>
@@ -262,6 +300,130 @@
       </form>
     </dialog>
 
+    <!-- Add Registry Source dialog (MCP-866/MCP-867) -->
+    <dialog :open="showAddRegistry" class="modal" data-test="registry-add-source-dialog">
+      <div class="modal-box">
+        <h3 class="font-bold text-lg">Add a registry</h3>
+        <p class="text-sm text-base-content/70 mt-1">
+          Add a custom <code>modelcontextprotocol/registry</code> v0.1 source by its HTTPS URL.
+          Added registries are marked
+          <span class="badge badge-warning badge-xs align-middle">third-party · unverified</span>;
+          their servers are always quarantined.
+        </p>
+
+        <form @submit.prevent="submitAddRegistry" class="mt-4 space-y-3" data-test="registry-add-form">
+          <div class="form-control">
+            <label class="label">
+              <span class="label-text font-semibold">Registry URL</span>
+            </label>
+            <input
+              v-model="addRegistryUrl"
+              type="url"
+              placeholder="https://registry.example.com/"
+              data-test="registry-add-url-input"
+              class="input input-bordered w-full"
+              autocomplete="off"
+              required
+            />
+          </div>
+
+          <div class="form-control">
+            <label class="label">
+              <span class="label-text font-semibold">Protocol</span>
+            </label>
+            <select
+              v-model="addRegistryProtocol"
+              class="select select-bordered w-full"
+              data-test="registry-add-protocol-select"
+            >
+              <option value="modelcontextprotocol/registry">modelcontextprotocol/registry (default)</option>
+            </select>
+          </div>
+
+          <div class="form-control">
+            <label class="label">
+              <span class="label-text font-semibold">Name <span class="font-normal opacity-60">(optional)</span></span>
+            </label>
+            <input
+              v-model="addRegistryName"
+              type="text"
+              placeholder="Derived from the URL host when empty"
+              data-test="registry-add-name-input"
+              class="input input-bordered w-full"
+              autocomplete="off"
+            />
+          </div>
+
+          <div v-if="addRegistryError" class="alert alert-error text-sm" data-test="registry-add-error">
+            <span>{{ addRegistryError }}</span>
+          </div>
+
+          <div class="modal-action">
+            <button type="button" class="btn btn-ghost" data-test="registry-add-cancel" @click="closeAddRegistry">
+              Cancel
+            </button>
+            <button
+              type="submit"
+              class="btn btn-primary"
+              data-test="registry-add-submit"
+              :disabled="!addRegistryUrl.trim() || addingRegistry"
+            >
+              <span v-if="addingRegistry" class="loading loading-spinner loading-xs"></span>
+              <span v-else>Add Registry</span>
+            </button>
+          </div>
+        </form>
+      </div>
+      <form method="dialog" class="modal-backdrop">
+        <button @click="closeAddRegistry">close</button>
+      </form>
+    </dialog>
+
+    <!-- One-time third-party registry warning (MCP-867) -->
+    <dialog :open="showThirdPartyWarning" class="modal" data-test="registry-third-party-warning">
+      <div class="modal-box">
+        <h3 class="font-bold text-lg text-warning flex items-center gap-2">
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+          </svg>
+          Adding a third-party registry
+        </h3>
+        <div class="text-sm py-3 space-y-2">
+          <p>
+            You're about to add a registry that is <strong>not</strong> shipped with MCPProxy.
+            Custom registries are <strong>unverified</strong> — MCPProxy cannot vouch for the
+            servers they list.
+          </p>
+          <p>
+            For your safety, every server you add from a custom registry is
+            <strong>always quarantined</strong> and can never skip security review.
+            Only add registries operated by parties you trust.
+          </p>
+        </div>
+        <div class="modal-action">
+          <button
+            type="button"
+            class="btn btn-ghost"
+            data-test="registry-third-party-cancel"
+            @click="cancelThirdPartyWarning"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            class="btn btn-warning"
+            data-test="registry-third-party-acknowledge"
+            @click="acknowledgeThirdPartyWarning"
+          >
+            I understand, continue
+          </button>
+        </div>
+      </div>
+      <form method="dialog" class="modal-backdrop">
+        <button @click="cancelThirdPartyWarning">close</button>
+      </form>
+    </dialog>
+
     <!-- Success Toast -->
     <div v-if="showSuccessToast" class="toast toast-end" data-test="registry-add-success">
       <div class="alert alert-success">
@@ -283,6 +445,12 @@ import api from '@/services/api'
 import CollapsibleHintsPanel from '@/components/CollapsibleHintsPanel.vue'
 import type { Hint } from '@/components/CollapsibleHintsPanel.vue'
 import type { Registry, RepositoryServer, RequiredInput } from '@/types'
+import { REGISTRY_PROVENANCE_CUSTOM } from '@/types'
+
+// localStorage key recording that the user has acknowledged the one-time
+// third-party registry warning (MCP-867). Once acknowledged, subsequent custom
+// adds skip the warning.
+const THIRD_PARTY_ACK_KEY = 'mcpproxy-thirdparty-registry-ack'
 
 // State
 const registries = ref<Registry[]>([])
@@ -301,12 +469,29 @@ const promptServer = ref<RepositoryServer | null>(null)
 const promptInputs = ref<RequiredInput[]>([])
 const promptValues = ref<Record<string, string>>({})
 
+// Add-registry-source state (MCP-866/MCP-867)
+const showAddRegistry = ref(false)
+const addRegistryUrl = ref('')
+const addRegistryProtocol = ref('modelcontextprotocol/registry')
+const addRegistryName = ref('')
+const addRegistryError = ref<string | null>(null)
+const addingRegistry = ref(false)
+const showThirdPartyWarning = ref(false)
+
 let searchDebounceTimer: ReturnType<typeof setTimeout> | null = null
 
 // Computed
 const selectedRegistryInfo = computed(() => {
   return registries.value.find(r => r.id === selectedRegistry.value)
 })
+
+// A registry is "custom/unverified" (third-party) when its provenance says so,
+// or — defensively — when trusted is explicitly false. Anything else (including
+// older payloads without the field) is treated as official/trusted.
+function isCustomRegistry(registry?: Registry | null): boolean {
+  if (!registry) return false
+  return registry.provenance === REGISTRY_PROVENANCE_CUSTOM || registry.trusted === false
+}
 
 const showPrompt = computed(() => promptServer.value !== null)
 
@@ -498,6 +683,107 @@ function closePrompt() {
   promptServer.value = null
   promptInputs.value = []
   promptValues.value = {}
+}
+
+// --- Add registry source (MCP-866/MCP-867) ---
+
+function openAddRegistry() {
+  addRegistryUrl.value = ''
+  addRegistryProtocol.value = 'modelcontextprotocol/registry'
+  addRegistryName.value = ''
+  addRegistryError.value = null
+  showThirdPartyWarning.value = false
+  showAddRegistry.value = true
+}
+
+function closeAddRegistry() {
+  if (addingRegistry.value) return
+  showAddRegistry.value = false
+  showThirdPartyWarning.value = false
+}
+
+function hasAcknowledgedThirdParty(): boolean {
+  try {
+    return localStorage.getItem(THIRD_PARTY_ACK_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+// Form submit: gate the first-ever custom add behind the one-time third-party
+// warning. Every user-added source is custom/unverified server-side, so the
+// warning applies to all adds — but only until the user acknowledges it once.
+function submitAddRegistry() {
+  if (!addRegistryUrl.value.trim() || addingRegistry.value) return
+  addRegistryError.value = null
+
+  if (!hasAcknowledgedThirdParty()) {
+    showThirdPartyWarning.value = true
+    return
+  }
+  doAddRegistry()
+}
+
+function cancelThirdPartyWarning() {
+  showThirdPartyWarning.value = false
+}
+
+function acknowledgeThirdPartyWarning() {
+  try {
+    localStorage.setItem(THIRD_PARTY_ACK_KEY, 'true')
+  } catch {
+    // Non-fatal: if storage is unavailable the warning simply re-appears next time.
+  }
+  showThirdPartyWarning.value = false
+  doAddRegistry()
+}
+
+// Map the backend's stable error codes to actionable messages.
+function addRegistryErrorMessage(code: string | undefined, fallback: string | undefined): string {
+  switch (code) {
+    case 'invalid_registry_url':
+      return fallback || 'That URL is not a valid HTTPS registry endpoint.'
+    case 'registries_locked':
+      return 'Adding registries is locked by an administrator on this instance.'
+    case 'registry_shadows_builtin':
+      return 'That id/host collides with a built-in registry. Try a different id.'
+    case 'duplicate_registry':
+      return 'A registry with that id is already configured.'
+    default:
+      return fallback || 'Failed to add registry.'
+  }
+}
+
+async function doAddRegistry() {
+  addingRegistry.value = true
+  addRegistryError.value = null
+
+  try {
+    const result = await api.addRegistrySource(addRegistryUrl.value.trim(), {
+      protocol: addRegistryProtocol.value || undefined,
+      name: addRegistryName.value.trim() || undefined
+    })
+
+    if (result.success) {
+      const added = result.registry
+      showAddRegistry.value = false
+      // Refresh the list so the new (custom/unverified) entry appears with its
+      // provenance, then select it for immediate browsing.
+      await loadRegistries()
+      if (added?.id) {
+        selectedRegistry.value = added.id
+        servers.value = []
+      }
+      showToast(`Added registry "${added?.name || added?.id || addRegistryUrl.value}" — third-party · unverified.`)
+      return
+    }
+
+    addRegistryError.value = addRegistryErrorMessage(result.code, result.error)
+  } catch (err) {
+    addRegistryError.value = 'Failed to add registry: ' + (err as Error).message
+  } finally {
+    addingRegistry.value = false
+  }
 }
 
 function copyToClipboard(text: string) {

--- a/frontend/tests/unit/registry-add-source.spec.ts
+++ b/frontend/tests/unit/registry-add-source.spec.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import api from '@/services/api'
+
+// MCP-866 / MCP-867: the Web UI adds a *registry source* (not a server) through
+// POST /api/v1/registries. The client posts (url + optional protocol/id/name),
+// surfaces the slim RegistrySummary on success, and exposes the stable error
+// `code` (invalid_registry_url | registries_locked | registry_shadows_builtin |
+// duplicate_registry) so the UI can render an actionable message. The backend
+// always tags an added source custom/unverified — the client never sends a
+// provenance/trusted claim.
+
+describe('api.addRegistrySource', () => {
+  beforeEach(() => {
+    api.setAPIKey('test-key')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    api.clearAPIKey()
+  })
+
+  it('POSTs the url (and default-free body) and returns the added registry summary', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        success: true,
+        data: {
+          registry: {
+            id: 'acme-registry',
+            name: 'acme-registry',
+            url: 'https://acme.example/registry',
+            servers_url: 'https://acme.example/registry/v0.1/servers',
+            protocol: 'modelcontextprotocol/registry',
+            provenance: 'custom/unverified',
+            trusted: false
+          }
+        },
+        request_id: 'req-1'
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await api.addRegistrySource('https://acme.example/registry')
+
+    expect(result.success).toBe(true)
+    expect(result.registry?.id).toBe('acme-registry')
+    expect(result.registry?.provenance).toBe('custom/unverified')
+    expect(result.registry?.trusted).toBe(false)
+
+    const [calledUrl, calledInit] = fetchMock.mock.calls[0]
+    expect(calledUrl).toBe('/api/v1/registries')
+    expect(calledInit.method).toBe('POST')
+    expect((calledInit.headers as Record<string, string>)['X-API-Key']).toBe('test-key')
+    expect(JSON.parse(calledInit.body)).toEqual({ url: 'https://acme.example/registry' })
+  })
+
+  it('includes optional protocol/id/name only when supplied', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, data: { registry: { id: 'acme', name: 'Acme' } } })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await api.addRegistrySource('https://acme.example/registry', {
+      protocol: 'modelcontextprotocol/registry',
+      id: 'acme',
+      name: 'Acme'
+    })
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+      url: 'https://acme.example/registry',
+      protocol: 'modelcontextprotocol/registry',
+      id: 'acme',
+      name: 'Acme'
+    })
+  })
+
+  it('surfaces invalid_registry_url as a structured error', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      json: async () => ({
+        success: false,
+        error: 'Registry URL must be HTTPS',
+        code: 'invalid_registry_url',
+        request_id: 'req-2'
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await api.addRegistrySource('http://insecure.example')
+
+    expect(result.success).toBe(false)
+    expect(result.code).toBe('invalid_registry_url')
+    expect(result.error).toContain('HTTPS')
+  })
+
+  it('surfaces registries_locked (admin pinned discovery sources)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+      json: async () => ({ success: false, error: 'Registry additions are locked', code: 'registries_locked' })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await api.addRegistrySource('https://acme.example/registry')
+
+    expect(result.success).toBe(false)
+    expect(result.code).toBe('registries_locked')
+  })
+
+  it('surfaces duplicate_registry / registry_shadows_builtin conflicts', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 409,
+      statusText: 'Conflict',
+      json: async () => ({ success: false, error: 'A registry with id "official" already exists', code: 'registry_shadows_builtin' })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await api.addRegistrySource('https://acme.example/registry', { id: 'official' })
+
+    expect(result.success).toBe(false)
+    expect(result.code).toBe('registry_shadows_builtin')
+  })
+})

--- a/frontend/tests/unit/repositories-add-registry.spec.ts
+++ b/frontend/tests/unit/repositories-add-registry.spec.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import Repositories from '@/views/Repositories.vue'
+import api from '@/services/api'
+
+// MCP-867: the Repositories view gains an add-registry affordance, provenance
+// surfacing, and a one-time third-party warning. These tests lock the gating
+// (warning shown before the first custom add; skipped after acknowledgement)
+// and the provenance badge selection.
+
+vi.mock('@/services/api', () => ({
+  default: {
+    listRegistries: vi.fn(),
+    searchRegistryServers: vi.fn(),
+    addRegistrySource: vi.fn(),
+    addServerFromRegistry: vi.fn(),
+  },
+}))
+
+// Stub the hints child so we don't drag its dependencies into the mount.
+const globalStubs = {
+  CollapsibleHintsPanel: { template: '<div />' },
+}
+
+function mountView() {
+  return mount(Repositories, {
+    global: { plugins: [createPinia()], stubs: globalStubs },
+  })
+}
+
+const officialRegistry = {
+  id: 'official',
+  name: 'Official MCP Registry',
+  description: 'The official registry',
+  url: 'https://registry.modelcontextprotocol.io/',
+  provenance: 'official/trusted',
+  trusted: true,
+}
+
+const customRegistry = {
+  id: 'acme',
+  name: 'Acme Registry',
+  description: 'A custom source',
+  url: 'https://acme.example/registry',
+  provenance: 'custom/unverified',
+  trusted: false,
+}
+
+describe('Repositories — add registry + provenance + third-party warning', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+    ;(api.listRegistries as any).mockResolvedValue({
+      success: true,
+      data: { registries: [officialRegistry, customRegistry], total: 2 },
+    })
+    ;(api.searchRegistryServers as any).mockResolvedValue({
+      success: true,
+      data: { registry_id: 'official', servers: [], total: 0 },
+    })
+    ;(api.addRegistrySource as any).mockReset()
+  })
+
+  it('renders an Add Registry affordance', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+    expect(wrapper.find('[data-test="registry-add-source-button"]').exists()).toBe(true)
+  })
+
+  it('flags a custom registry as third-party/unverified and an official one as trusted', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    const select = wrapper.find('[data-test="registry-select"]')
+    await select.setValue('acme')
+    await flushPromises()
+    expect(wrapper.find('[data-test="registry-provenance-badge-custom"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="registry-custom-quarantine-note"]').exists()).toBe(true)
+
+    await select.setValue('official')
+    await flushPromises()
+    expect(wrapper.find('[data-test="registry-provenance-badge-official"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="registry-provenance-badge-custom"]').exists()).toBe(false)
+  })
+
+  it('shows the one-time third-party warning before the first add and does NOT call the API yet', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.find('[data-test="registry-add-source-button"]').trigger('click')
+    await wrapper.find('[data-test="registry-add-url-input"]').setValue('https://acme.example/registry')
+    await wrapper.find('[data-test="registry-add-form"]').trigger('submit')
+    await flushPromises()
+
+    // Warning is shown; the add request has not gone out.
+    expect((wrapper.find('[data-test="registry-third-party-warning"]').element as HTMLDialogElement).hasAttribute('open')).toBe(true)
+    expect(api.addRegistrySource).not.toHaveBeenCalled()
+  })
+
+  it('proceeds with the add after acknowledging, and persists acknowledgement so the warning is skipped next time', async () => {
+    ;(api.addRegistrySource as any).mockResolvedValue({
+      success: true,
+      registry: { id: 'acme', name: 'Acme Registry', provenance: 'custom/unverified', trusted: false },
+    })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    // First add → warning → acknowledge → API called once.
+    await wrapper.find('[data-test="registry-add-source-button"]').trigger('click')
+    await wrapper.find('[data-test="registry-add-url-input"]').setValue('https://acme.example/registry')
+    await wrapper.find('[data-test="registry-add-form"]').trigger('submit')
+    await flushPromises()
+    await wrapper.find('[data-test="registry-third-party-acknowledge"]').trigger('click')
+    await flushPromises()
+
+    expect(api.addRegistrySource).toHaveBeenCalledTimes(1)
+    expect(api.addRegistrySource).toHaveBeenCalledWith('https://acme.example/registry', {
+      protocol: 'modelcontextprotocol/registry',
+      name: undefined,
+    })
+    expect(localStorage.getItem('mcpproxy-thirdparty-registry-ack')).toBe('true')
+
+    // Second add → no warning, API called directly.
+    await wrapper.find('[data-test="registry-add-source-button"]').trigger('click')
+    await wrapper.find('[data-test="registry-add-url-input"]').setValue('https://other.example/registry')
+    await wrapper.find('[data-test="registry-add-form"]').trigger('submit')
+    await flushPromises()
+
+    expect((wrapper.find('[data-test="registry-third-party-warning"]').element as HTMLDialogElement).hasAttribute('open')).toBe(false)
+    expect(api.addRegistrySource).toHaveBeenCalledTimes(2)
+  })
+
+  it('surfaces a friendly message for a locked-registries error', async () => {
+    localStorage.setItem('mcpproxy-thirdparty-registry-ack', 'true')
+    ;(api.addRegistrySource as any).mockResolvedValue({
+      success: false,
+      code: 'registries_locked',
+      error: 'locked',
+    })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.find('[data-test="registry-add-source-button"]').trigger('click')
+    await wrapper.find('[data-test="registry-add-url-input"]').setValue('https://acme.example/registry')
+    await wrapper.find('[data-test="registry-add-form"]').trigger('submit')
+    await flushPromises()
+
+    const err = wrapper.find('[data-test="registry-add-error"]')
+    expect(err.exists()).toBe(true)
+    expect(err.text().toLowerCase()).toContain('locked')
+  })
+})


### PR DESCRIPTION
## Summary

Frontend slice of **MCP-856** / **MCP-866** (registry provenance/trust + `add-source`). Surfaces the user-added-registries backend in the **Repositories** page. Web UI only (`frontend/src/`).

- **Add Registry affordance** — modal with https URL + optional protocol (defaults `modelcontextprotocol/registry`) + optional name; POSTs `/api/v1/registries` via new `api.addRegistrySource()`, mapping the stable error codes (`invalid_registry_url` / `registries_locked` / `registry_shadows_builtin` / `duplicate_registry`) to actionable messages.
- **Provenance surfacing** — each registry is flagged **Official · trusted** or **Third-party · unverified** from its `provenance`/`trusted` fields; the selector text marks unverified entries and custom sources carry an always-quarantined note.
- **One-time third-party warning** — gates the first custom add; acknowledgement remembered in `localStorage`.

## Tests / verification
- `frontend/tests/unit/registry-add-source.spec.ts` — api client contract (body shaping, structured error codes).
- `frontend/tests/unit/repositories-add-registry.spec.ts` — provenance badges, warning-gating, ack persistence, error mapping (5 tests).
- Type-check green; `make build` green (frontend re-embedded).
- **Live Playwright smoke** against a real mcpproxy + real `/api/v1/registries` add-source endpoint: official badge → add modal → third-party warning → real POST → custom badge + quarantine note → ack persisted; backend persisted `registry-example-com | custom/unverified`. (Report/screenshots kept local per repo rule.)
- Docs: `docs/registries.md` — added the Web UI surface to "Adding your own registry source".

## ⚠️ CI note
Frontend CI is **red on `main` already** (run for #571, 069-B2) — `dashboard-usage-switcher.spec.ts` (3 tests) fails independently of this diff (`dashboard-usage-panel` / `usage-window-7d` not rendering in the jsdom mount). This PR's own tests pass; the lane needs that pre-existing breakage fixed before checks here can go green. Tracked separately.

## Out of scope (follow-ups)
- **Server/quarantine-view provenance badge** needs the backend to project `source_registry_provenance` onto `contracts.Server` (not currently exposed) — backend lane.
- **macOS tray** add-registry affordance — Swift lane (@MacOSEngineer).

Related #573. Does not merge — pre-merge gate is human/auto.