### PR TITLE
fix(webui): v0.36.0 registry/tools/add-server UX feedback (MCP-991)

### DIFF
--- a/frontend/src/components/AddServerModal.vue
+++ b/frontend/src/components/AddServerModal.vue
@@ -1,6 +1,6 @@
 <template>
-  <dialog :open="show" class="modal">
-    <div class="modal-box max-w-3xl">
+  <dialog :open="show" class="modal" data-test="add-server-modal">
+    <div class="modal-box max-w-3xl" data-test="add-server-modal-box">
       <h3 class="font-bold text-lg mb-4">Add New Server</h3>
 
       <!-- Tab Selection -->
@@ -166,17 +166,17 @@
           <!-- Toggles Section -->
           <div class="divider mt-6">Options</div>
 
-          <div class="space-y-3">
+          <div class="space-y-3" data-test="addserver-options">
             <!-- Enabled -->
             <div class="form-control">
-              <label class="label cursor-pointer justify-start space-x-3">
+              <label class="flex items-center gap-3 cursor-pointer py-1">
                 <input
                   type="checkbox"
                   v-model="formData.enabled"
                   class="toggle toggle-primary"
                 />
                 <span class="label-text font-semibold">Enabled</span>
-                <div class="tooltip tooltip-right" data-tip="Start this server immediately after adding">
+                <div class="tooltip tooltip-right before:whitespace-normal before:w-56 before:max-w-[14rem]" data-tip="Start this server immediately after adding">
                   <svg class="w-4 h-4 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
@@ -186,14 +186,14 @@
 
             <!-- Quarantined -->
             <div class="form-control">
-              <label class="label cursor-pointer justify-start space-x-3">
+              <label class="flex items-center gap-3 cursor-pointer py-1">
                 <input
                   type="checkbox"
                   v-model="formData.quarantined"
                   class="toggle toggle-warning"
                 />
                 <span class="label-text font-semibold">Quarantined</span>
-                <div class="tooltip tooltip-right" data-tip="Prevent tool execution until security review is complete. Recommended for new servers.">
+                <div class="tooltip tooltip-right before:whitespace-normal before:w-56 before:max-w-[14rem]" data-tip="Prevent tool execution until security review is complete. Recommended for new servers.">
                   <svg class="w-4 h-4 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
@@ -203,7 +203,7 @@
 
             <!-- Isolated (Docker) -->
             <div class="form-control">
-              <label class="label cursor-pointer justify-start space-x-3">
+              <label class="flex items-center gap-3 cursor-pointer py-1">
                 <input
                   type="checkbox"
                   v-model="formData.isolated"
@@ -211,7 +211,7 @@
                   :disabled="formData.type !== 'stdio'"
                 />
                 <span class="label-text font-semibold">Docker Isolation</span>
-                <div class="tooltip tooltip-right" data-tip="Run stdio server in isolated Docker container for enhanced security (stdio only)">
+                <div class="tooltip tooltip-right before:whitespace-normal before:w-56 before:max-w-[14rem]" data-tip="Run stdio server in isolated Docker container for enhanced security (stdio only)">
                   <svg class="w-4 h-4 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
@@ -221,7 +221,7 @@
 
             <!-- Idle on Inactivity -->
             <div class="form-control">
-              <label class="label cursor-pointer justify-start space-x-3">
+              <label class="flex items-center gap-3 cursor-pointer py-1">
                 <input
                   type="checkbox"
                   v-model="formData.idleOnInactivity"
@@ -229,7 +229,7 @@
                   disabled
                 />
                 <span class="label-text font-semibold opacity-50">Idle on Inactivity</span>
-                <div class="tooltip tooltip-right" data-tip="Future feature: Automatically stop server after period of inactivity to save resources">
+                <div class="tooltip tooltip-right before:whitespace-normal before:w-56 before:max-w-[14rem]" data-tip="Future feature: Automatically stop server after period of inactivity to save resources">
                   <svg class="w-4 h-4 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>

--- a/frontend/src/components/TopHeader.vue
+++ b/frontend/src/components/TopHeader.vue
@@ -34,7 +34,7 @@
         </div>
 
         <!-- Add Server Button -->
-        <button @click="showAddServerModal = true" class="btn btn-primary">
+        <button @click="showAddServerModal = true" class="btn btn-primary" data-test="header-add-server">
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
           </svg>

--- a/frontend/src/views/Repositories.vue
+++ b/frontend/src/views/Repositories.vue
@@ -57,6 +57,22 @@
             />
           </div>
 
+          <!-- Transport Filter (R3) -->
+          <div class="form-control">
+            <label class="label">
+              <span class="label-text font-semibold">Transport</span>
+            </label>
+            <select
+              v-model="transportFilter"
+              class="select select-bordered"
+              data-test="registry-transport-filter"
+            >
+              <option value="all">All</option>
+              <option value="remote">Remote</option>
+              <option value="stdio">Stdio</option>
+            </select>
+          </div>
+
           <!-- Search Button -->
           <div class="form-control sm:self-end">
             <button
@@ -68,45 +84,6 @@
               <span v-if="loadingServers" class="loading loading-spinner loading-sm"></span>
               <span v-else>Search</span>
             </button>
-          </div>
-        </div>
-
-        <!-- Registry Info + provenance/trust (MCP-866/MCP-867) -->
-        <div
-          v-if="selectedRegistryInfo"
-          class="alert mt-4"
-          :class="isCustomRegistry(selectedRegistryInfo) ? 'alert-warning' : 'alert-info'"
-          :data-test="`registry-info-${selectedRegistryInfo.id}`"
-        >
-          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-          </svg>
-          <div>
-            <p class="font-semibold flex items-center gap-2 flex-wrap">
-              {{ selectedRegistryInfo.name }}
-              <span
-                v-if="isCustomRegistry(selectedRegistryInfo)"
-                class="badge badge-warning badge-sm gap-1"
-                data-test="registry-provenance-badge-custom"
-              >
-                Third-party · unverified
-              </span>
-              <span
-                v-else
-                class="badge badge-success badge-sm gap-1"
-                data-test="registry-provenance-badge-official"
-              >
-                Official · trusted
-              </span>
-            </p>
-            <p class="text-sm">{{ selectedRegistryInfo.description }}</p>
-            <p
-              v-if="isCustomRegistry(selectedRegistryInfo)"
-              class="text-xs mt-1 opacity-90"
-              data-test="registry-custom-quarantine-note"
-            >
-              Servers added from this third-party registry are always quarantined and cannot skip security review.
-            </p>
           </div>
         </div>
       </div>
@@ -133,7 +110,9 @@
     <!-- Server Results -->
     <div v-else-if="servers.length > 0" class="space-y-4">
       <div class="flex justify-between items-center">
-        <p class="text-sm text-base-content/70">Found {{ servers.length }} server(s)</p>
+        <p class="text-sm text-base-content/70" data-test="registry-results-count">
+          Found {{ filteredServers.length }} server(s)<span v-if="transportFilter !== 'all'"> of {{ servers.length }}</span>
+        </p>
       </div>
 
       <!-- Server Cards with Smooth Transitions -->
@@ -142,40 +121,39 @@
         tag="div"
         class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4"
       >
-        <div v-for="server in servers" :key="server.id" :data-test="`registry-server-${server.id}`" class="card bg-base-100 shadow-md hover:shadow-lg transition-shadow">
+        <div v-for="server in filteredServers" :key="server.id" :data-test="`registry-server-${server.id}`" class="card bg-base-100 shadow-md hover:shadow-lg transition-shadow">
           <div class="card-body">
-            <div class="flex justify-between items-start">
-              <h3 class="card-title text-lg">{{ server.name }}</h3>
-              <div class="badge badge-outline badge-sm">{{ server.registry }}</div>
+            <div class="flex justify-between items-start gap-2">
+              <h3 class="card-title text-lg min-w-0 [overflow-wrap:anywhere]">{{ server.name }}</h3>
+              <div
+                v-if="server.registry"
+                class="badge badge-ghost badge-sm shrink-0 whitespace-nowrap font-normal"
+                :data-test="`registry-source-${server.id}`"
+                :title="`From registry: ${server.registry}`"
+              >
+                {{ server.registry }}
+              </div>
             </div>
 
             <p class="text-sm text-base-content/70 line-clamp-3">
               {{ server.description }}
             </p>
 
-            <!-- Repository Info Badges -->
+            <!-- Transport + requirements (neutral, non-colorful tags — R2) -->
             <div class="flex flex-wrap gap-2 mt-2">
-              <div v-if="server.repository_info?.npm?.exists" class="badge badge-success badge-sm">
-                <svg class="w-3 h-3 mr-1" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M0 0h24v24H0z" fill="none"/>
-                  <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/>
-                </svg>
-                NPM
-              </div>
-              <div v-if="server.url" class="badge badge-info badge-sm">
-                <svg class="w-3 h-3 mr-1" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M0 0h24v24H0z" fill="none"/>
-                  <path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/>
-                </svg>
-                Remote
+              <div
+                class="badge badge-outline badge-sm font-mono"
+                :data-test="`registry-transport-${server.id}`"
+              >
+                {{ serverTransport(server) }}
               </div>
               <div
                 v-if="server.required_inputs && server.required_inputs.length > 0"
-                class="badge badge-warning badge-sm"
+                class="badge badge-outline badge-sm"
                 :data-test="`registry-requires-input-${server.id}`"
                 :title="`Requires: ${server.required_inputs.map(i => i.name).join(', ')}`"
               >
-                Requires input
+                requires input
               </div>
             </div>
 
@@ -480,11 +458,6 @@ const showThirdPartyWarning = ref(false)
 
 let searchDebounceTimer: ReturnType<typeof setTimeout> | null = null
 
-// Computed
-const selectedRegistryInfo = computed(() => {
-  return registries.value.find(r => r.id === selectedRegistry.value)
-})
-
 // A registry is "custom/unverified" (third-party) when its provenance says so,
 // or — defensively — when trusted is explicitly false. Anything else (including
 // older payloads without the field) is treated as official/trusted.
@@ -492,6 +465,35 @@ function isCustomRegistry(registry?: Registry | null): boolean {
   if (!registry) return false
   return registry.provenance === REGISTRY_PROVENANCE_CUSTOM || registry.trusted === false
 }
+
+// Transport classification (R2) + filter (R3). Derived purely from the
+// install command / url already returned by the registry search API:
+//   url set, no install cmd        -> remote
+//   npx / npm / node               -> stdio:npm
+//   uvx / uv / pip / python        -> stdio:python
+//   docker                         -> stdio:docker
+//   anything else with install cmd -> stdio
+const transportFilter = ref<'all' | 'remote' | 'stdio'>('all')
+
+function serverTransport(server: RepositoryServer): string {
+  const cmd = (server.install_cmd || '').trim().toLowerCase()
+  if (cmd) {
+    if (cmd.startsWith('docker')) return 'stdio:docker'
+    if (cmd.startsWith('npx') || /(^|\s)(npm|node)(\s|$)/.test(cmd)) return 'stdio:npm'
+    if (cmd.startsWith('uvx') || cmd.startsWith('uv ') || /(^|\s)(pipx?|python3?)(\s|$)/.test(cmd)) return 'stdio:python'
+    return 'stdio'
+  }
+  if (server.url) return 'remote'
+  return 'stdio'
+}
+
+const filteredServers = computed(() => {
+  if (transportFilter.value === 'all') return servers.value
+  return servers.value.filter(s => {
+    const t = serverTransport(s)
+    return transportFilter.value === 'remote' ? t === 'remote' : t.startsWith('stdio')
+  })
+})
 
 const showPrompt = computed(() => promptServer.value !== null)
 

--- a/frontend/src/views/Tools.vue
+++ b/frontend/src/views/Tools.vue
@@ -138,6 +138,7 @@
             </label>
             <select v-model="filterApproval" class="select select-bordered select-sm" data-test="filter-approval">
               <option value="">All</option>
+              <option value="awaiting">Awaiting approval</option>
               <option value="approved">Approved</option>
               <option value="pending">Pending</option>
               <option value="changed">Changed</option>
@@ -582,7 +583,7 @@ const hasActiveFilters = computed(() =>
 type StatCard = 'total' | 'enabled' | 'disabled' | 'pending'
 
 const activeStatCard = computed<StatCard>(() => {
-  if (filterApproval.value === 'pending') return 'pending'
+  if (filterApproval.value === 'awaiting' || filterApproval.value === 'pending') return 'pending'
   if (filterStatus.value === 'enabled') return 'enabled'
   if (filterStatus.value === 'disabled') return 'disabled'
   if (!filterStatus.value && !filterApproval.value) return 'total'
@@ -598,7 +599,7 @@ function selectStatCard(card: StatCard) {
   }
   if (card === 'pending') {
     filterStatus.value = ''
-    filterApproval.value = 'pending'
+    filterApproval.value = 'awaiting'
   } else {
     filterApproval.value = ''
     filterStatus.value = card // 'enabled' | 'disabled'
@@ -659,7 +660,11 @@ const filteredTools = computed(() => {
     tools = tools.filter(t => getRisk(t) === filterRisk.value)
   }
 
-  if (filterApproval.value) {
+  if (filterApproval.value === 'awaiting') {
+    // "Awaiting approval" mirrors the Pending Approval stat, which counts both
+    // brand-new (pending) and rug-pull (changed) tools.
+    tools = tools.filter(t => t.approval_status === 'pending' || t.approval_status === 'changed')
+  } else if (filterApproval.value) {
     tools = tools.filter(t => t.approval_status === filterApproval.value)
   }
 

--- a/frontend/tests/unit/repositories-add-registry.spec.ts
+++ b/frontend/tests/unit/repositories-add-registry.spec.ts
@@ -68,20 +68,23 @@ describe('Repositories — add registry + provenance + third-party warning', () 
     expect(wrapper.find('[data-test="registry-add-source-button"]').exists()).toBe(true)
   })
 
-  it('flags a custom registry as third-party/unverified and an official one as trusted', async () => {
+  it('flags a custom registry as unverified in the selector and an official one without that suffix', async () => {
+    // R4 (v0.36.0 feedback): the prominent provenance banner was removed in
+    // favour of surfacing trust inline. The selector option text carries the
+    // "— unverified" suffix for third-party registries; server cards carry the
+    // registry name. No big alert block any more.
     const wrapper = mountView()
     await flushPromises()
 
-    const select = wrapper.find('[data-test="registry-select"]')
-    await select.setValue('acme')
-    await flushPromises()
-    expect(wrapper.find('[data-test="registry-provenance-badge-custom"]').exists()).toBe(true)
-    expect(wrapper.find('[data-test="registry-custom-quarantine-note"]').exists()).toBe(true)
+    const options = wrapper.findAll('[data-test="registry-select"] option')
+    const acme = options.find(o => o.attributes('value') === 'acme')
+    const official = options.find(o => o.attributes('value') === 'official')
+    expect(acme?.text()).toContain('unverified')
+    expect(official?.text()).not.toContain('unverified')
 
-    await select.setValue('official')
-    await flushPromises()
-    expect(wrapper.find('[data-test="registry-provenance-badge-official"]').exists()).toBe(true)
+    // The old prominent banner / quarantine-note block is gone.
     expect(wrapper.find('[data-test="registry-provenance-badge-custom"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="registry-custom-quarantine-note"]').exists()).toBe(false)
   })
 
   it('shows the one-time third-party warning before the first add and does NOT call the API yet', async () => {

--- a/frontend/tests/unit/tools-pending-approval.spec.ts
+++ b/frontend/tests/unit/tools-pending-approval.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import Tools from '@/views/Tools.vue'
+import api from '@/services/api'
+
+// T1 (v0.36.0 feedback): the "Pending Approval" stat counts tools that are
+// pending OR changed, but the Approval=Pending filter matched only "pending",
+// so an instance whose sole awaiting tool was "changed" (a rug-pull) showed a
+// non-zero stat with an EMPTY table. This reproduces that exact data shape —
+// one approved tool + one CHANGED tool, pending_approval = 1 — and locks the
+// fix: clicking the stat applies an "awaiting" filter that surfaces the row.
+
+vi.mock('@/services/api', () => ({
+  default: { getGlobalTools: vi.fn(), setToolEnabled: vi.fn() },
+}))
+
+const globalStubs = { CollapsibleHintsPanel: { template: '<div />' } }
+
+function mountView() {
+  return mount(Tools, { global: { plugins: [createPinia()], stubs: globalStubs } })
+}
+
+describe('Tools — Pending Approval count matches the filtered table', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    ;(api.getGlobalTools as any).mockResolvedValue({
+      success: true,
+      data: {
+        stats: { total: 2, enabled: 2, disabled: 0, pending_approval: 1 },
+        tools: [
+          { name: 'hf_doc_search', server_name: 'hugginface', approval_status: 'changed', enabled: true, description: 'changed tool' },
+          { name: 'list_repos', server_name: 'github', approval_status: 'approved', enabled: true, description: 'ok' },
+        ],
+      },
+    })
+  })
+
+  it('shows the changed tool (not an empty table) when the Pending Approval stat is clicked', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    // Stat reflects the changed tool.
+    expect(wrapper.find('[data-test="stat-pending"] .stat-value').text().trim()).toBe('1')
+
+    // Before the fix this produced "No matching tools"; now it lists the changed row.
+    await wrapper.find('[data-test="stat-pending"]').trigger('click')
+    await flushPromises()
+
+    const rows = wrapper.findAll('[data-test="tool-row"]')
+    expect(rows.length).toBe(1)
+    expect(rows[0].text()).toContain('hf_doc_search')
+  })
+
+  it('the Awaiting-approval filter matches both pending and changed', async () => {
+    ;(api.getGlobalTools as any).mockResolvedValue({
+      success: true,
+      data: {
+        stats: { total: 3, enabled: 3, disabled: 0, pending_approval: 2 },
+        tools: [
+          { name: 'new_tool', server_name: 's', approval_status: 'pending', enabled: true, description: '' },
+          { name: 'rugpull', server_name: 's', approval_status: 'changed', enabled: true, description: '' },
+          { name: 'fine', server_name: 's', approval_status: 'approved', enabled: true, description: '' },
+        ],
+      },
+    })
+    const wrapper = mountView()
+    await flushPromises()
+    await wrapper.find('[data-test="stat-pending"]').trigger('click')
+    await flushPromises()
+    const rows = wrapper.findAll('[data-test="tool-row"]')
+    expect(rows.length).toBe(2) // pending + changed, not approved
+    const text = rows.map(r => r.text()).join(' ')
+    expect(text).toContain('new_tool')
+    expect(text).toContain('rugpull')
+    expect(text).not.toContain('fine')
+  })
+})


### PR DESCRIPTION
## v0.36.0 UX feedback — registry browsing, Tools page, Add Server modal

Batch of UX/bug fixes from a v0.36.0 review. Tracked as **MCP-991** (parent) + children. Each fix verified live with Playwright (5/5 green) and the unit suite (101/101); `vue-tsc` typecheck clean.

### Repositories (registry browse)
- **R4 (MCP-992)** — removed the prominent provenance banner; registry name stays on each server card (`badge-ghost`, non-colliding `registry-source-*` data-test) so multi-registry results stay attributable.
- **R6 (MCP-993)** — card header now wraps long ids (`[overflow-wrap:anywhere]`, `min-w-0`) so e.g. `io.github.daedalus/mcp-sqlite3` no longer collides with / strikes through the registry badge.
- **R2 (MCP-994)** — replaced the colorful NPM/Remote badges with neutral transport labels derived from `install_cmd`/`url`: `remote`, `stdio:npm`, `stdio:python`, `stdio:docker`, `stdio`.
- **R3 (MCP-995)** — added a Transport filter (All / Remote / Stdio) to the search form.

### Tools page
- **T1 (MCP-998)** — the Pending Approval stat counts `pending` + `changed`, but the Approval=Pending filter matched only `pending`, so clicking the stat showed an empty table. Clicking the card now applies an **Awaiting approval** filter (pending OR changed); count == rows.

### Add Server modal
- **A1 (MCP-999)** — dropped DaisyUI `.label` (`justify-between`) for explicit left-aligned flex so Options toggle labels sit beside the toggle instead of centered.
- **A2 (MCP-1000)** — constrained Options tooltips to wrap (`before:w-56`) and moved the (i) inward so `tooltip-right` stays inside the modal frame instead of being clipped.

### Not in this PR
- **R5 (MCP-997)** — product-resolved: v0.36.0 already ships only the 5 official registries; Fleur / Azure MCP Demo / Remote MCP Servers were dropped as defaults in #572. The dead entries a user sees come from their personal `mcp_config.json`, not the product.
- **R1 (MCP-996)** — multiselect registry filter + cross-registry search is deferred to its own PR (largest, most test-disruptive change).

## Verification
Playwright against a fresh instance (official registry + a quarantined stdio server): A1/A2 (labels left-aligned, tooltip inside frame), R4 (no banner), R2/R6 (`['remote','stdio:npm','stdio']`; 55-char title fits in card), R3 (filter narrows by transport), T1 (stat 13 == 13 rows). Report kept local (not committed).

## Test plan
- [x] `vue-tsc && vite build`
- [x] vitest 101/101 (updated `repositories-add-registry.spec.ts` for the removed banner)
- [x] Playwright 5/5 live scenarios

