### PR TITLE
ci: de-conflict stable/prerelease workflows for RC builds (MCP-1012)

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -33,16 +33,16 @@ jobs:
             cgo: "0"
             name: mcpproxy-linux-arm64
             archive_format: tar.gz
-          - os: ubuntu-latest
+          - os: windows-latest
             goos: windows
             goarch: amd64
-            cgo: "0"
+            cgo: "1"
             name: mcpproxy-windows-amd64.exe
             archive_format: zip
-          - os: ubuntu-latest
+          - os: windows-latest
             goos: windows
             goarch: arm64
-            cgo: "0"
+            cgo: "1"
             name: mcpproxy-windows-arm64.exe
             archive_format: zip
           - os: macos-15
@@ -97,10 +97,14 @@ jobs:
         run: cd frontend && npm run build
 
       - name: Copy frontend dist to embed location
+        shell: bash
         run: |
           rm -rf web/frontend
-          mkdir -p web/frontend
-          cp -r frontend/dist web/frontend/
+          mkdir -p web/frontend/dist
+          cp -r frontend/dist/. web/frontend/dist/
+          # Recreate the tracked .gitkeep so //go:embed all:frontend/dist
+          # always has something to embed (matches the Makefile frontend-build target).
+          touch web/frontend/dist/.gitkeep
 
       - name: Import Code-Signing Certificates (macOS)
         if: matrix.goos == 'darwin'
@@ -182,6 +186,7 @@ jobs:
 
 
       - name: Build binary and create archives
+        shell: bash
         env:
           CGO_ENABLED: ${{ matrix.cgo }}
           GOOS: ${{ matrix.goos }}
@@ -215,10 +220,15 @@ jobs:
           # Create clean core binary for archive
           go build -ldflags "${LDFLAGS}" -o ${CLEAN_BINARY} ./cmd/mcpproxy
 
-          # Build tray binary for macOS
-          if [ "${{ matrix.goos }}" = "darwin" ]; then
-            echo "Building mcpproxy-tray for macOS..."
-            go build -ldflags "${LDFLAGS}" -o mcpproxy-tray ./cmd/mcpproxy-tray
+          # Build tray binary for platforms with GUI support (macOS and Windows)
+          if [ "${{ matrix.goos }}" = "darwin" ] || [ "${{ matrix.goos }}" = "windows" ]; then
+            echo "Building mcpproxy-tray for ${{ matrix.goos }}..."
+            if [ "${{ matrix.goos }}" = "windows" ]; then
+              TRAY_BINARY="mcpproxy-tray.exe"
+            else
+              TRAY_BINARY="mcpproxy-tray"
+            fi
+            go build -ldflags "${LDFLAGS}" -o ${TRAY_BINARY} ./cmd/mcpproxy-tray
           fi
 
           # Build Swift tray app (macOS only — replaces Go tray in .app bundle for DMG/PKG)
@@ -404,12 +414,30 @@ jobs:
           # Create archive with version info - DO NOT create "latest" archives for prereleases
           ARCHIVE_BASE="mcpproxy-${VERSION#v}-${{ matrix.goos }}-${{ matrix.goarch }}"
 
+          # Determine files to include in archive
+          FILES_TO_ARCHIVE="${CLEAN_BINARY}"
+
+          # Add tray binary if it exists (Windows and macOS)
+          if [ "${{ matrix.goos }}" = "windows" ] && [ -f "mcpproxy-tray.exe" ]; then
+            FILES_TO_ARCHIVE="${FILES_TO_ARCHIVE} mcpproxy-tray.exe"
+            echo "Including mcpproxy-tray.exe in archive"
+          elif [ "${{ matrix.goos }}" = "darwin" ] && [ -f "mcpproxy-tray" ]; then
+            FILES_TO_ARCHIVE="${FILES_TO_ARCHIVE} mcpproxy-tray"
+            echo "Including mcpproxy-tray in archive"
+          fi
+
           if [ "${{ matrix.archive_format }}" = "zip" ]; then
             # Create only versioned archive (no latest for prereleases)
-            zip "${ARCHIVE_BASE}.zip" ${CLEAN_BINARY}
+            # Use PowerShell Compress-Archive on Windows since zip command isn't available
+            if [ "${{ matrix.goos }}" = "windows" ]; then
+              PS_FILES=$(echo ${FILES_TO_ARCHIVE} | sed 's/ /,/g')
+              powershell -Command "Compress-Archive -Path ${PS_FILES} -DestinationPath '${ARCHIVE_BASE}.zip'"
+            else
+              zip "${ARCHIVE_BASE}.zip" ${FILES_TO_ARCHIVE}
+            fi
           else
             # Create only versioned archive (no latest for prereleases)
-            tar -czf "${ARCHIVE_BASE}.tar.gz" ${CLEAN_BINARY}
+            tar -czf "${ARCHIVE_BASE}.tar.gz" ${FILES_TO_ARCHIVE}
           fi
 
       - name: Build Linux .deb and .rpm packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
   # Generate AI-powered release notes using Claude API
   generate-notes:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
     outputs:
       notes: ${{ steps.generate.outputs.notes }}
       notes_file: ${{ steps.generate.outputs.notes_file }}
@@ -187,8 +187,8 @@ jobs:
 
   build:
     environment: production
-    # Only run on version tags
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Only run on stable version tags (skip prerelease tags like v*-rc.* / v*-next.*)
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
     strategy:
       fail-fast: false
       matrix:
@@ -961,7 +961,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     environment: production
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
     strategy:
       matrix:
         arch: [amd64, arm64]
@@ -1057,6 +1057,8 @@ jobs:
     needs: [build, sign-windows, generate-notes]  # add build-docker when server MVP is ready
     runs-on: ubuntu-latest
     environment: production
+    # Stable channel only: skip prerelease tags (handled by prerelease.yml)
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
     outputs:
       # base64-encoded checksums.txt — consumed by the SLSA provenance job (WP-C3)
       hashes: ${{ steps.checksums.outputs.hashes }}
@@ -1598,7 +1600,7 @@ jobs:
   deploy-docs:
     needs: release
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'smart-mcp-proxy/mcpproxy-go'
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') && github.repository == 'smart-mcp-proxy/mcpproxy-go'
     # Non-blocking: docs failure doesn't block release
     continue-on-error: true
 
@@ -1643,7 +1645,7 @@ jobs:
   trigger-marketing-update:
     needs: release
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'smart-mcp-proxy/mcpproxy-go'
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') && github.repository == 'smart-mcp-proxy/mcpproxy-go'
     # Non-blocking: marketing update failure doesn't block release
     continue-on-error: true
 


### PR DESCRIPTION
## Problem

`release.yml` triggers on tags `v*`, which **also matches RC tags** like `v0.37.0-rc.1`. So an RC tag currently fires BOTH the stable `release.yml` and `prerelease.yml` workflows. The stable workflow's `update-homebrew` and `publish-linux-repos` jobs already guarded with `!contains(github.ref_name, '-')`, but the rest did not — so a stable GitHub Release would be cut for an RC tag and `releases/latest` would point at the RC.

## Fix: de-conflict (release.yml)

Added `&& !contains(github.ref_name, '-')` to the `if:` of the stable-only jobs that lacked it, using the exact idiom already in `update-homebrew`/`publish-linux-repos`:

| Job | Change |
|-----|--------|
| `generate-notes` | guard added |
| `build` | guard added |
| `sign-windows` | guard added |
| `release` | had **no** `if:` — added `if: startsWith(github.ref,'refs/tags/v') && !contains(github.ref_name,'-')` |
| `deploy-docs` | guard added (preserving the `github.repository == ...` condition) |
| `trigger-marketing-update` | guard added (preserving the `github.repository == ...` condition) |

`provenance` (`needs: [release]`) and `mcp-registry` (`needs: release`) cascade-skip when `release` skips. `build-docker` is `if: false`. Net effect: the stable workflow no-ops on any prerelease (`-`) tag; only `prerelease.yml` runs.

## Prerelease completeness (prerelease.yml)

Brought the prerelease build matrix to parity with stable so an RC is a complete downloadable build:

- **Windows now builds natively** on `windows-latest` with `cgo: "1"` (was cross-compiled on `ubuntu-latest` with `cgo: "0"`, where the `choco install innosetup` / `pwsh` installer steps cannot run).
- Builds the **Windows tray binary** (`mcpproxy-tray.exe`) and includes the tray binary in archives (matching stable).
- Uses **PowerShell `Compress-Archive`** on Windows (the `zip` CLI isn't available on Windows runners).
- Added `shell: bash` to the build + frontend-copy steps so they work on the native Windows runner; aligned the frontend embed-copy with stable (`web/frontend/dist` + `.gitkeep`).

Already at parity (unchanged): Linux `.deb`/`.rpm`, macOS DMG/PKG signing + notarization, all 6 platform archives, `prerelease: true`. SignPath Windows-installer signing remains **stable-only** by design — RCs ship an unsigned installer (the release body already states "use at your own risk").

## Validation

- `actionlint` + `python yaml.safe_load` on both files: no syntax/expression errors introduced (remaining reports are pre-existing shellcheck info/style + the `matrix.edition` fallback warnings).
- Tag-push smoke test with `v0.0.0-rc.1` (see PR checks): only `prerelease.yml` should run; `release.yml` jobs skip; `releases/latest` stays on the prior stable; no Homebrew/Linux-repo publish.
