### PR TITLE
feat(macos): cross-registry server browse + multiselect registry filter (MCP-996)

### DIFF
--- a/native/macos/MCPProxy/MCPProxy/API/APIClient.swift
+++ b/native/macos/MCPProxy/MCPProxy/API/APIClient.swift
@@ -726,4 +726,37 @@ actor APIClient {
             return .failure(code: nil, error: error.localizedDescription)
         }
     }
+
+    /// Search a single registry's servers via
+    /// `GET /api/v1/registries/{id}/servers?q=&limit=`. Throws on transport/HTTP
+    /// errors; a 200 with an `unavailable` marker (e.g. key required) is a
+    /// normal, non-throwing result that the browse view surfaces per-registry.
+    func searchRegistryServers(registryID: String, query: String, limit: Int = 20) async throws -> SearchRegistryServersResponse {
+        var params: [String] = ["limit=\(limit)"]
+        if !query.isEmpty { params.insert("q=\(query.uriComponentEncoded)", at: 0) }
+        let path = "/api/v1/registries/\(registryID.uriComponentEncoded)/servers?\(params.joined(separator: "&"))"
+        return try await fetchWrapped(path: path)
+    }
+
+    /// Add a server discovered through a registry via
+    /// `POST /api/v1/registries/{id}/servers/{serverId}/add`. Returns a
+    /// structured result (does not throw) carrying `missingInputs` when the
+    /// server needs env values the caller hasn't supplied yet.
+    func addServerFromRegistry(registryID: String, serverID: String, env: [String: String]? = nil) async -> AddServerResult {
+        var body: [String: Any] = [:]
+        if let env, !env.isEmpty { body["env"] = env }
+        let path = "/api/v1/registries/\(registryID.uriComponentEncoded)/servers/\(serverID.uriComponentEncoded)/add"
+        do {
+            let bodyData = try JSONSerialization.data(withJSONObject: body)
+            let (data, response) = try await rawRequest(path: path, method: "POST", body: bodyData)
+            if (200...299).contains(response.statusCode) { return .ok() }
+            let err = try? JSONDecoder().decode(RegistryAddServerErrorBody.self, from: data)
+            return .failure(
+                message: err?.message ?? "HTTP \(response.statusCode): \(HTTPURLResponse.localizedString(forStatusCode: response.statusCode))",
+                missingInputs: err?.missingInputs
+            )
+        } catch {
+            return .failure(message: error.localizedDescription)
+        }
+    }
 }

--- a/native/macos/MCPProxy/MCPProxy/API/RegistryModels.swift
+++ b/native/macos/MCPProxy/MCPProxy/API/RegistryModels.swift
@@ -146,3 +146,109 @@ struct ThirdPartyRegistryAck {
         defaults.set(true, forKey: Self.key)
     }
 }
+
+// MARK: - Server discovery / browse (macOS mirror of Web UI R1)
+//
+// Models `GET /api/v1/registries/{id}/servers` (per-registry search) and
+// `POST /api/v1/registries/{id}/servers/{serverId}/add`. The browse view fans
+// these out across several selected registries and merges the results.
+
+/// A server returned by a registry search. Mirrors `contracts.RepositoryServer`
+/// (only the fields the tray browse UI needs are decoded).
+struct RepositoryServer: Codable, Identifiable, Equatable {
+    let id: String
+    let name: String
+    let description: String?
+    let url: String?
+    let sourceCodeURL: String?
+    let installCmd: String?
+    let connectURL: String?
+    /// Which registry this result came from (used for per-card attribution and
+    /// as the registry id passed to the add endpoint).
+    let registry: String?
+    let requiredInputs: [RequiredInput]?
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, description, url, registry
+        case sourceCodeURL = "source_code_url"
+        case installCmd = "install_cmd"
+        case connectURL = "connect_url"
+        case requiredInputs = "required_inputs"
+    }
+
+    struct RequiredInput: Codable, Equatable {
+        let name: String
+        let description: String?
+        let secret: Bool?
+    }
+
+    /// Neutral transport label mirroring the Web UI's `serverTransport` (R2):
+    /// remote / stdio:npm / stdio:python / stdio:docker / stdio.
+    var transport: String {
+        let cmd = (installCmd ?? "").trimmingCharacters(in: .whitespaces).lowercased()
+        if !cmd.isEmpty {
+            if cmd.hasPrefix("docker") { return "stdio:docker" }
+            if cmd.hasPrefix("npx") || cmd.range(of: #"(^|\s)(npm|node)(\s|$)"#, options: .regularExpression) != nil { return "stdio:npm" }
+            if cmd.hasPrefix("uvx") || cmd.hasPrefix("uv ") || cmd.range(of: #"(^|\s)(pipx?|python3?)(\s|$)"#, options: .regularExpression) != nil { return "stdio:python" }
+            return "stdio"
+        }
+        if let url, !url.isEmpty { return "remote" }
+        return "stdio"
+    }
+}
+
+/// Per-registry "unavailable" marker (e.g. key required). Mirrors
+/// `contracts.RegistryUnavailable`.
+struct RegistryUnavailable: Codable, Equatable {
+    let reason: String?
+}
+
+/// Response of `GET /api/v1/registries/{id}/servers`. Mirrors
+/// `contracts.SearchRegistryServersResponse`.
+struct SearchRegistryServersResponse: Codable {
+    let registryID: String?
+    let servers: [RepositoryServer]?
+    let total: Int?
+    let unavailable: RegistryUnavailable?
+
+    enum CodingKeys: String, CodingKey {
+        case registryID = "registry_id"
+        case servers, total, unavailable
+    }
+}
+
+/// Result of adding a server from a registry. Carries `missingInputs` when the
+/// backend rejects with `missing_required_input` so the UI can tell the user
+/// which env vars are needed (the full prompt flow is a follow-up).
+struct AddServerResult: Equatable {
+    let success: Bool
+    let message: String?
+    let missingInputs: [String]?
+
+    static func ok() -> AddServerResult { AddServerResult(success: true, message: nil, missingInputs: nil) }
+    static func failure(message: String?, missingInputs: [String]? = nil) -> AddServerResult {
+        AddServerResult(success: false, message: message, missingInputs: missingInputs)
+    }
+}
+
+/// Structured error body of a failed add-from-registry. Mirrors
+/// `contracts.RegistryAddError`.
+struct RegistryAddServerErrorBody: Decodable {
+    let code: String?
+    let message: String?
+    let missingInputs: [String]?
+    enum CodingKeys: String, CodingKey {
+        case code, message
+        case missingInputs = "missing_inputs"
+    }
+}
+
+/// JS `encodeURIComponent` equivalent for safe path-segment encoding (the Web
+/// UI uses encodeURIComponent on the registry id and server id).
+extension String {
+    var uriComponentEncoded: String {
+        let allowed = CharacterSet(charactersIn:
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.!~*'()")
+        return addingPercentEncoding(withAllowedCharacters: allowed) ?? self
+    }
+}

--- a/native/macos/MCPProxy/MCPProxy/Views/MainWindow.swift
+++ b/native/macos/MCPProxy/MCPProxy/Views/MainWindow.swift
@@ -75,12 +75,31 @@ struct MainWindow: View {
             .accessibilityIdentifier("detail-view")
         }
         .frame(minWidth: 800, minHeight: 500)
+        .background(sidebarShortcuts)
         .onReceive(NotificationCenter.default.publisher(for: .switchToActivity)) { _ in
             selectedItem = .activity
         }
         .onReceive(NotificationCenter.default.publisher(for: .switchToServers)) { _ in
             selectedItem = .servers
         }
+    }
+
+    /// Hidden ⌘1…⌘5 shortcuts to jump straight to each sidebar section. Keeps
+    /// keyboard navigation fast for users and lets UI-test automation reach a
+    /// section (the sidebar List rows aren't directly clickable via the
+    /// accessibility menu API).
+    @ViewBuilder
+    private var sidebarShortcuts: some View {
+        VStack {
+            ForEach(Array(SidebarItem.allCases.enumerated()), id: \.element) { index, item in
+                Button("") { selectedItem = item }
+                    .keyboardShortcut(KeyEquivalent(Character(String(index + 1))), modifiers: .command)
+                    .accessibilityIdentifier("sidebar-shortcut-\(item.rawValue)")
+            }
+        }
+        .opacity(0)
+        .frame(width: 0, height: 0)
+        .accessibilityHidden(true)
     }
 
     // MARK: - Core Status Banner

--- a/native/macos/MCPProxy/MCPProxy/Views/RegistriesView.swift
+++ b/native/macos/MCPProxy/MCPProxy/Views/RegistriesView.swift
@@ -49,6 +49,19 @@ struct RegistriesView: View {
                 banner(icon: "checkmark.circle.fill", tint: .green, text: success)
             }
 
+            // Browse + add servers across one or more registries (R1 parity).
+            ServerBrowseView(appState: appState, registries: registries)
+
+            HStack {
+                Text("Configured registries")
+                    .font(.scaled(.caption, scale: fontScale).bold())
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+            .padding(.horizontal)
+            .padding(.top, 4)
+            Divider()
+
             content
         }
         .sheet(isPresented: $showAddRegistry) {

--- a/native/macos/MCPProxy/MCPProxy/Views/ServerBrowseView.swift
+++ b/native/macos/MCPProxy/MCPProxy/Views/ServerBrowseView.swift
@@ -1,0 +1,269 @@
+// ServerBrowseView.swift
+// MCPProxy
+//
+// macOS-tray mirror of the Web UI R1 feature: a MULTISELECT registry filter
+// plus cross-registry server search. The user ticks one or more registries,
+// searches, and sees a merged, registry-attributed result list. Registries
+// that need an API key / are unreachable are surfaced as a non-fatal notice so
+// the registries that DID return still render. Each result can be added
+// (servers from custom registries land quarantined server-side).
+
+import SwiftUI
+
+struct ServerBrowseView: View {
+    @ObservedObject var appState: AppState
+    @Environment(\.fontScale) var fontScale
+
+    /// Registries to offer in the multiselect (loaded by the parent view).
+    let registries: [Registry]
+
+    @State private var selectedIDs: Set<String> = []
+    @State private var query: String = ""
+    @State private var results: [RepositoryServer] = []
+    @State private var unavailable: [String] = []
+    @State private var isSearching = false
+    @State private var searchError: String?
+    @State private var addingID: String?
+    @State private var addNote: String?
+
+    private var apiClient: APIClient? { appState.apiClient }
+
+    private func registryName(_ id: String) -> String {
+        registries.first { $0.id == id }?.name ?? id
+    }
+
+    private var selectionLabel: String {
+        let n = selectedIDs.count
+        if n == 0 { return "Choose registries…" }
+        if n == 1 { return registryName(selectedIDs.first!) }
+        if !registries.isEmpty, n == registries.count { return "All registries (\(n))" }
+        return "\(n) registries"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            filterBar
+
+            if !unavailable.isEmpty {
+                Label("Some registries returned no results: \(unavailable.joined(separator: "; "))",
+                      systemImage: "exclamationmark.triangle.fill")
+                    .font(.scaled(.caption, scale: fontScale))
+                    .foregroundStyle(.orange)
+                    .padding(.horizontal)
+                    .accessibilityIdentifier("browse-unavailable-notice")
+            }
+
+            if let note = addNote {
+                Text(note)
+                    .font(.scaled(.caption, scale: fontScale))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal)
+                    .accessibilityIdentifier("browse-add-note")
+            }
+
+            resultsArea
+        }
+        .accessibilityIdentifier("server-browse")
+    }
+
+    // MARK: Filter bar (multiselect + search)
+
+    @ViewBuilder
+    private var filterBar: some View {
+        HStack(spacing: 8) {
+            Menu {
+                if registries.count > 1 {
+                    Button("Select all") { selectedIDs = Set(registries.map(\.id)) }
+                    Button("Clear") { selectedIDs.removeAll() }
+                    Divider()
+                }
+                ForEach(registries) { registry in
+                    Button {
+                        toggle(registry.id)
+                    } label: {
+                        Label(
+                            registry.name + (registry.isCustom ? " — unverified" : ""),
+                            systemImage: selectedIDs.contains(registry.id) ? "checkmark.square.fill" : "square"
+                        )
+                    }
+                    .accessibilityIdentifier("browse-registry-option-\(registry.id)")
+                }
+            } label: {
+                Label(selectionLabel, systemImage: "line.3.horizontal.decrease.circle")
+            }
+            .frame(minWidth: 160)
+            .accessibilityIdentifier("browse-registry-multiselect")
+
+            TextField("Search servers by name or description…", text: $query)
+                .textFieldStyle(.roundedBorder)
+                .onSubmit { Task { await search() } }
+                .accessibilityIdentifier("browse-search-input")
+
+            Button {
+                Task { await search() }
+            } label: {
+                if isSearching { ProgressView().controlSize(.small) } else { Text("Search") }
+            }
+            .keyboardShortcut(.defaultAction)
+            .disabled(selectedIDs.isEmpty || isSearching || apiClient == nil)
+            .accessibilityIdentifier("browse-search-button")
+        }
+        .padding(.horizontal)
+        .padding(.top, 8)
+    }
+
+    private func toggle(_ id: String) {
+        if selectedIDs.contains(id) { selectedIDs.remove(id) } else { selectedIDs.insert(id) }
+    }
+
+    // MARK: Results
+
+    @ViewBuilder
+    private var resultsArea: some View {
+        if isSearching {
+            VStack { Spacer(); ProgressView("Searching…"); Spacer() }
+                .frame(maxWidth: .infinity, minHeight: 120)
+        } else if let err = searchError {
+            Label(err, systemImage: "xmark.octagon.fill")
+                .foregroundStyle(.red)
+                .font(.scaled(.callout, scale: fontScale))
+                .padding()
+                .accessibilityIdentifier("browse-error")
+        } else if results.isEmpty {
+            Text(selectedIDs.isEmpty ? "Pick one or more registries, then search."
+                                     : "No servers found. Try a different search.")
+                .foregroundStyle(.secondary)
+                .font(.scaled(.callout, scale: fontScale))
+                .padding(.horizontal)
+                .accessibilityIdentifier("browse-empty")
+        } else {
+            HStack {
+                Text("Found \(results.count) server(s)" + (selectedIDs.count > 1 ? " across \(selectedIDs.count) registries" : ""))
+                    .font(.scaled(.caption, scale: fontScale))
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+            .padding(.horizontal)
+            .accessibilityIdentifier("browse-results-count")
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(results) { server in
+                        serverCard(server)
+                    }
+                }
+                .padding(.horizontal)
+                .padding(.bottom, 8)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func serverCard(_ server: RepositoryServer) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .top) {
+                Text(server.name)
+                    .font(.scaled(.headline, scale: fontScale))
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer()
+                if let reg = server.registry, !reg.isEmpty {
+                    Text(reg)
+                        .font(.scaled(.caption2, scale: fontScale))
+                        .padding(.horizontal, 6).padding(.vertical, 2)
+                        .background(Color.secondary.opacity(0.15))
+                        .clipShape(Capsule())
+                        .accessibilityIdentifier("browse-source-\(server.id)")
+                }
+            }
+            if let desc = server.description, !desc.isEmpty {
+                Text(desc).font(.scaled(.caption, scale: fontScale))
+                    .foregroundStyle(.secondary).lineLimit(3)
+            }
+            HStack(spacing: 6) {
+                Text(server.transport)
+                    .font(.system(.caption2, design: .monospaced))
+                    .padding(.horizontal, 6).padding(.vertical, 2)
+                    .overlay(Capsule().stroke(Color.secondary.opacity(0.4)))
+                    .accessibilityIdentifier("browse-transport-\(server.id)")
+                if let inputs = server.requiredInputs, !inputs.isEmpty {
+                    Text("requires input")
+                        .font(.caption2)
+                        .padding(.horizontal, 6).padding(.vertical, 2)
+                        .overlay(Capsule().stroke(Color.secondary.opacity(0.4)))
+                }
+                Spacer()
+                Button {
+                    Task { await add(server) }
+                } label: {
+                    if addingID == server.id { ProgressView().controlSize(.small) } else { Text("Add to MCP") }
+                }
+                .controlSize(.small)
+                .disabled(addingID != nil || server.registry == nil)
+                .accessibilityIdentifier("browse-add-\(server.id)")
+            }
+        }
+        .padding(10)
+        .background(Color.secondary.opacity(0.06))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .accessibilityIdentifier("browse-server-\(server.id)")
+    }
+
+    // MARK: Actions
+
+    /// Cross-registry search: fan out to every selected registry (sequentially —
+    /// a handful of registries, and it keeps us clear of Sendable concerns),
+    /// merge + dedupe results, and collect per-registry failures as a non-fatal
+    /// notice. A hard error is raised only when every selected registry fails.
+    private func search() async {
+        let ids = Array(selectedIDs)
+        guard !ids.isEmpty, let client = apiClient else { return }
+        let q = query
+        isSearching = true
+        searchError = nil
+        unavailable = []
+        addNote = nil
+
+        var merged: [RepositoryServer] = []
+        var seen = Set<String>()
+        var failures: [String] = []
+
+        for id in ids {
+            do {
+                let resp = try await client.searchRegistryServers(registryID: id, query: q)
+                if let u = resp.unavailable {
+                    failures.append("\(registryName(id)): \(u.reason ?? "unavailable")")
+                }
+                for s in resp.servers ?? [] {
+                    let key = "\(s.registry ?? id)::\(s.id)"
+                    if seen.contains(key) { continue }
+                    seen.insert(key)
+                    merged.append(s)
+                }
+            } catch {
+                failures.append("\(registryName(id)): \(error.localizedDescription)")
+            }
+        }
+
+        results = merged
+        unavailable = failures
+        if merged.isEmpty, !failures.isEmpty, failures.count == ids.count {
+            searchError = "No results — " + failures.joined(separator: "; ")
+        }
+        isSearching = false
+    }
+
+    private func add(_ server: RepositoryServer) async {
+        guard let client = apiClient, let reg = server.registry else { return }
+        addingID = server.id
+        addNote = nil
+        let result = await client.addServerFromRegistry(registryID: reg, serverID: server.id)
+        if result.success {
+            addNote = "Added “\(server.name)”. New servers start quarantined — review under Servers."
+        } else if let missing = result.missingInputs, !missing.isEmpty {
+            addNote = "“\(server.name)” needs input: \(missing.joined(separator: ", ")). Add it from the Web UI to supply those values."
+        } else {
+            addNote = "Couldn’t add “\(server.name)”: \(result.message ?? "unknown error")"
+        }
+        addingID = nil
+    }
+}

--- a/native/macos/MCPProxy/MCPProxyTests/ServerBrowseModelsTests.swift
+++ b/native/macos/MCPProxy/MCPProxyTests/ServerBrowseModelsTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+@testable import MCPProxy
+
+/// macOS mirror of Web UI R1 (cross-registry browse). Covers the pure units the
+/// ServerBrowseView relies on: transport classification (R2 parity), the
+/// search-response decode (incl. the per-registry `unavailable` marker), the
+/// add-from-registry error decode (`missing_inputs`), and the
+/// encodeURIComponent-equivalent path encoder.
+final class ServerBrowseModelsTests: XCTestCase {
+
+    private func decode<T: Decodable>(_ type: T.Type, from jsonString: String) throws -> T {
+        try JSONDecoder().decode(T.self, from: jsonString.data(using: .utf8)!)
+    }
+
+    private func server(install: String? = nil, url: String? = nil) -> RepositoryServer {
+        RepositoryServer(id: "x", name: "x", description: nil, url: url, sourceCodeURL: nil,
+                         installCmd: install, connectURL: nil, registry: "r", requiredInputs: nil)
+    }
+
+    // MARK: - Transport classification (mirrors Web UI serverTransport)
+
+    func testTransportNpm() {
+        XCTAssertEqual(server(install: "npx -y @modelcontextprotocol/server-memory").transport, "stdio:npm")
+        XCTAssertEqual(server(install: "npm exec foo").transport, "stdio:npm")
+    }
+
+    func testTransportPython() {
+        XCTAssertEqual(server(install: "uvx mcp-server-fetch").transport, "stdio:python")
+        XCTAssertEqual(server(install: "pipx run mcp-hn").transport, "stdio:python")
+        XCTAssertEqual(server(install: "python3 -m server").transport, "stdio:python")
+    }
+
+    func testTransportDocker() {
+        XCTAssertEqual(server(install: "docker run -i --rm mcp/everything").transport, "stdio:docker")
+    }
+
+    func testTransportRemote() {
+        XCTAssertEqual(server(install: nil, url: "https://api.example.com/mcp").transport, "remote")
+    }
+
+    func testTransportStdioFallbackAndUrlIgnoredWhenInstallPresent() {
+        XCTAssertEqual(server(install: "./run.sh").transport, "stdio")
+        // A hybrid entry (install cmd + url) prefers the stdio classification.
+        XCTAssertEqual(server(install: "uvx foo", url: "https://x/mcp").transport, "stdio:python")
+    }
+
+    // MARK: - Search response decode
+
+    func testSearchResponseDecodesServersAndUnavailable() throws {
+        let json = """
+        {"registry_id":"pulse","servers":[],"total":0,
+         "unavailable":{"reason":"registry requires an API key"}}
+        """
+        let resp = try decode(SearchRegistryServersResponse.self, from: json)
+        XCTAssertEqual(resp.registryID, "pulse")
+        XCTAssertEqual(resp.servers?.count, 0)
+        XCTAssertEqual(resp.unavailable?.reason, "registry requires an API key")
+    }
+
+    func testRepositoryServerDecodesSnakeCaseFields() throws {
+        let json = """
+        {"id":"io.github.x/y","name":"Y","description":"d",
+         "install_cmd":"uvx y","source_code_url":"https://github.com/x/y",
+         "registry":"Reference Servers",
+         "required_inputs":[{"name":"TOKEN","secret":true}]}
+        """
+        let s = try decode(RepositoryServer.self, from: json)
+        XCTAssertEqual(s.installCmd, "uvx y")
+        XCTAssertEqual(s.sourceCodeURL, "https://github.com/x/y")
+        XCTAssertEqual(s.registry, "Reference Servers")
+        XCTAssertEqual(s.requiredInputs?.first?.name, "TOKEN")
+        XCTAssertEqual(s.transport, "stdio:python")
+    }
+
+    // MARK: - Add-from-registry error decode
+
+    func testAddServerErrorDecodesMissingInputs() throws {
+        let json = """
+        {"code":"missing_required_input","message":"needs env",
+         "missing_inputs":["GITHUB_TOKEN","ORG"]}
+        """
+        let err = try decode(RegistryAddServerErrorBody.self, from: json)
+        XCTAssertEqual(err.code, "missing_required_input")
+        XCTAssertEqual(err.missingInputs, ["GITHUB_TOKEN", "ORG"])
+    }
+
+    func testAddServerResultFactories() {
+        XCTAssertTrue(AddServerResult.ok().success)
+        let f = AddServerResult.failure(message: "boom", missingInputs: ["A"])
+        XCTAssertFalse(f.success)
+        XCTAssertEqual(f.missingInputs, ["A"])
+    }
+
+    // MARK: - encodeURIComponent-equivalent path encoder
+
+    func testURIComponentEncodingEscapesSlashesAndSpaces() {
+        XCTAssertEqual("io.github.x/y".uriComponentEncoded, "io.github.x%2Fy")
+        XCTAssertEqual("a b".uriComponentEncoded, "a%20b")
+        XCTAssertEqual("plain-id_1.0".uriComponentEncoded, "plain-id_1.0")
+    }
+}


### PR DESCRIPTION
## macOS: cross-registry server browse + multiselect registry filter

Ports the Web UI **R1** experience (#580) into the macOS tray's **Registries** tab — MCP-996 parity for macOS.

### What's new
- **Multiselect registry filter**: a Menu with checkable registry rows + **Select all / Clear**, summarised by a selection label (`3 registries` / `All registries (N)`).
- **Cross-registry search**: fans out to every selected registry, merges + dedupes results; each result card is attributed to its registry. Registries that need an API key / are unreachable are surfaced in a **non-fatal notice** (a hard error only when every selected registry fails).
- **Neutral transport labels** on cards (mirrors Web UI R2): `remote` / `stdio:npm` / `stdio:python` / `stdio:docker` / `stdio`.
- **Add to MCP** per result (`POST .../servers/{serverId}/add`); reports `missing_inputs` when a server needs env values (full prompt flow is a follow-up).
- **APIClient**: `searchRegistryServers` + `addServerFromRegistry`, with `encodeURIComponent`-equivalent path encoding for ids containing slashes.
- **MainWindow**: hidden **⌘1–⌘5** shortcuts to jump between sidebar sections (keyboard nav + lets UI-test automation reach a section).

### Verification
- `swiftc -O` full-app compile: clean (0 errors).
- **23 SwiftPM unit tests pass** (`RegistryModelsTests` + new `ServerBrowseModelsTests`): transport classification, snake_case decode, `unavailable` marker, `missing_inputs` decode, URI-component encoding.
- Data layer bash-checked against a live core: reference + docker return servers; pulse/smithery report `unavailable` (need keys).
- **ui-test MCP**: confirmed the app runs this build (tray reads `MCPProxy v0.36.0`, accessibility granted) and the new **⌘3** navigation is accepted. Pixel screenshots came back blank/black — the ui-test helper is missing macOS **Screen Recording** permission (a system-settings grant), so visual capture of the rendered tab is blocked in this environment. Grant it and I can attach screenshots.

Refs MCP-996. Builds on #580 (web R1) / #578 (macOS registry surface).
