### PR TITLE
feat(storage): GC orphaned tool-approval records on config load (MCP-1002)

### DIFF
--- a/internal/runtime/lifecycle.go
+++ b/internal/runtime/lifecycle.go
@@ -715,6 +715,23 @@ func (r *Runtime) LoadConfiguredServers(cfg *config.Config) error {
 		storedServerMap[storedServer.Name] = storedServer
 	}
 
+	// GC orphaned tool-approval records (MCP-1002): drop approvals whose server
+	// is no longer configured. Configured-but-disabled servers are preserved so
+	// a later re-enable doesn't re-quarantine their previously-approved tools.
+	// Guard against a transient empty config nuking every approval — explicit
+	// server deletion already cleans up via DeleteServerToolApprovals.
+	if len(configuredServers) > 0 {
+		configuredNames := make([]string, 0, len(configuredServers))
+		for name := range configuredServers {
+			configuredNames = append(configuredNames, name)
+		}
+		if pruned, perr := r.storageManager.PruneOrphanToolApprovals(configuredNames); perr != nil {
+			r.logger.Warn("Failed to prune orphan tool approvals", zap.Error(perr))
+		} else if pruned > 0 {
+			r.logger.Info("Pruned orphan tool-approval records", zap.Int("removed", pruned))
+		}
+	}
+
 	// Add/remove servers asynchronously to prevent blocking on slow connections
 	// All server operations now happen in background goroutines with timeouts
 

--- a/internal/storage/bbolt.go
+++ b/internal/storage/bbolt.go
@@ -431,6 +431,45 @@ func (b *BoltDB) DeleteServerToolApprovals(serverName string) error {
 	})
 }
 
+// PruneToolApprovalsNotIn deletes tool-approval records whose ServerName is not
+// present in keep, returning the number removed. This GCs orphaned approvals
+// for servers that left the config without an explicit delete (e.g. the config
+// file was hand-edited, or an old migration). Records for configured servers —
+// including disabled ones — are kept so re-enabling a server doesn't re-trigger
+// quarantine of its previously-approved tools (MCP-1002).
+func (b *BoltDB) PruneToolApprovalsNotIn(keep map[string]bool) (int, error) {
+	removed := 0
+	err := b.db.Update(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket([]byte(ToolApprovalBucket))
+		if bucket == nil {
+			return nil
+		}
+		var keysToDelete [][]byte
+		scanErr := bucket.ForEach(func(k, v []byte) error {
+			var record ToolApprovalRecord
+			if err := json.Unmarshal(v, &record); err != nil {
+				// Unparseable record: leave it alone rather than risk dropping data.
+				return nil
+			}
+			if !keep[record.ServerName] {
+				keysToDelete = append(keysToDelete, append([]byte(nil), k...))
+			}
+			return nil
+		})
+		if scanErr != nil {
+			return scanErr
+		}
+		for _, key := range keysToDelete {
+			if err := bucket.Delete(key); err != nil {
+				return err
+			}
+			removed++
+		}
+		return nil
+	})
+	return removed, err
+}
+
 // Generic operations
 
 // Backup creates a backup of the database

--- a/internal/storage/db_maintenance_test.go
+++ b/internal/storage/db_maintenance_test.go
@@ -1,0 +1,67 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mkApproval(server, tool string) *ToolApprovalRecord {
+	return &ToolApprovalRecord{
+		ServerName: server,
+		ToolName:   tool,
+		Status:     ToolApprovalStatusApproved,
+		ApprovedAt: time.Now().UTC(),
+	}
+}
+
+func TestPruneOrphanToolApprovals(t *testing.T) {
+	manager, cleanup := setupTestStorageForToolApproval(t)
+	defer cleanup()
+
+	require.NoError(t, manager.SaveToolApproval(mkApproval("github", "create_issue")))
+	require.NoError(t, manager.SaveToolApproval(mkApproval("github", "list_repos")))
+	require.NoError(t, manager.SaveToolApproval(mkApproval("disabled-but-configured", "x")))
+	require.NoError(t, manager.SaveToolApproval(mkApproval("old-server", "do_thing")))
+	require.NoError(t, manager.SaveToolApproval(mkApproval("removed", "y")))
+
+	// "disabled-but-configured" stays in config (just disabled) → must be kept.
+	removed, err := manager.PruneOrphanToolApprovals([]string{"github", "disabled-but-configured"})
+	require.NoError(t, err)
+	assert.Equal(t, 2, removed, "only old-server + removed are orphans")
+
+	// configured (incl. disabled) survive
+	for _, tc := range []struct{ s, tool string }{{"github", "create_issue"}, {"github", "list_repos"}, {"disabled-but-configured", "x"}} {
+		rec, err := manager.GetToolApproval(tc.s, tc.tool)
+		require.NoError(t, err)
+		assert.NotNilf(t, rec, "%s:%s should be kept", tc.s, tc.tool)
+	}
+	// orphans gone (GetToolApproval returns a not-found error for missing records)
+	for _, tc := range []struct{ s, tool string }{{"old-server", "do_thing"}, {"removed", "y"}} {
+		_, err := manager.GetToolApproval(tc.s, tc.tool)
+		assert.Errorf(t, err, "%s:%s should be pruned (not found)", tc.s, tc.tool)
+	}
+}
+
+func TestPruneOrphanToolApprovals_EmptyConfigPrunesAll(t *testing.T) {
+	manager, cleanup := setupTestStorageForToolApproval(t)
+	defer cleanup()
+	require.NoError(t, manager.SaveToolApproval(mkApproval("a", "t1")))
+	require.NoError(t, manager.SaveToolApproval(mkApproval("b", "t2")))
+
+	removed, err := manager.PruneOrphanToolApprovals(nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, removed)
+}
+
+func TestPruneOrphanToolApprovals_NoOrphansNoChange(t *testing.T) {
+	manager, cleanup := setupTestStorageForToolApproval(t)
+	defer cleanup()
+	require.NoError(t, manager.SaveToolApproval(mkApproval("a", "t1")))
+
+	removed, err := manager.PruneOrphanToolApprovals([]string{"a", "b", "c"})
+	require.NoError(t, err)
+	assert.Equal(t, 0, removed)
+}

--- a/internal/storage/manager.go
+++ b/internal/storage/manager.go
@@ -453,6 +453,21 @@ func (m *Manager) DeleteServerToolApprovals(serverName string) error {
 	return m.db.DeleteServerToolApprovals(serverName)
 }
 
+// PruneOrphanToolApprovals removes tool-approval records for servers that are
+// no longer in the configured set, returning the number removed. Configured
+// servers (even disabled ones) are preserved so re-enabling never re-quarantines
+// previously-approved tools (MCP-1002).
+func (m *Manager) PruneOrphanToolApprovals(configuredServers []string) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	keep := make(map[string]bool, len(configuredServers))
+	for _, name := range configuredServers {
+		keep[name] = true
+	}
+	return m.db.PruneToolApprovalsNotIn(keep)
+}
+
 // Security Scanner methods (Spec 039)
 
 // SaveScanner saves a scanner plugin record


### PR DESCRIPTION
## Orphan tool-approval GC (MCP-1002, part 1)

Prunes `tool_approvals` records whose server is no longer in the configured set, on `LoadConfiguredServers`. Configured-but-disabled servers are **preserved** so re-enabling never re-quarantines previously-approved tools. Guarded against a transient empty config nuking every approval (explicit server deletion already cleans up via `DeleteServerToolApprovals`).

- `storage.PruneToolApprovalsNotIn(keep)` + `Manager.PruneOrphanToolApprovals(configuredServers)`
- Hooked into `runtime.LoadConfiguredServers`
- Unit tests: prune orphans, preserve disabled, empty-config, no-orphans.

### Scope note (the bigger finding)
The config.db **size** problem investigated under MCP-1002 is **not** free-page bloat or orphans (only 24 orphan records). It's unbounded growth of `activity_records` (~438 MB / ~93k rows) and security scan reports (~231 MB). That needs a **retention policy** — handled in a separate follow-up (in progress). This PR is the small, clean orphan-GC part.

Refs MCP-1002.
