### PR TITLE
ci(prerelease): fix v0.37.0-rc.1 build failure

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -33,16 +33,16 @@ jobs:
             cgo: "0"
             name: mcpproxy-linux-arm64
             archive_format: tar.gz
-          - os: ubuntu-latest
+          - os: windows-latest
             goos: windows
             goarch: amd64
-            cgo: "0"
+            cgo: "1"
             name: mcpproxy-windows-amd64.exe
             archive_format: zip
-          - os: ubuntu-latest
+          - os: windows-latest
             goos: windows
             goarch: arm64
-            cgo: "0"
+            cgo: "1"
             name: mcpproxy-windows-arm64.exe
             archive_format: zip
           - os: macos-15
@@ -97,6 +97,7 @@ jobs:
         run: cd frontend && npm run build
 
       - name: Copy frontend dist to embed location
+        shell: bash
         run: |
           rm -rf web/frontend
           mkdir -p web/frontend
@@ -182,6 +183,7 @@ jobs:
 
 
       - name: Build binary and create archives
+        shell: bash
         env:
           CGO_ENABLED: ${{ matrix.cgo }}
           GOOS: ${{ matrix.goos }}
@@ -406,7 +408,12 @@ jobs:
 
           if [ "${{ matrix.archive_format }}" = "zip" ]; then
             # Create only versioned archive (no latest for prereleases)
-            zip "${ARCHIVE_BASE}.zip" ${CLEAN_BINARY}
+            if [ "${{ matrix.goos }}" = "windows" ]; then
+              # Use PowerShell Compress-Archive on Windows since zip command isn't available
+              powershell -Command "Compress-Archive -Path '${CLEAN_BINARY}' -DestinationPath '${ARCHIVE_BASE}.zip'"
+            else
+              zip "${ARCHIVE_BASE}.zip" ${CLEAN_BINARY}
+            fi
           else
             # Create only versioned archive (no latest for prereleases)
             tar -czf "${ARCHIVE_BASE}.tar.gz" ${CLEAN_BINARY}


### PR DESCRIPTION
## Root cause

The first real RC build — tag `v0.37.0-rc.1` → **prerelease.yml** run [26926147427](https://github.com/smart-mcp-proxy/mcpproxy-go/actions/runs/26926147427) — failed at the **Install Inno Setup (Windows)** step on both Windows matrix entries:

```
choco: The term 'choco' is not recognized as a name of a cmdlet, function, script file, or operable program.
##[error]Process completed with exit code 1.
```

The prerelease Windows matrix entries were configured with **`os: ubuntu-latest`** (cross-compiling the Windows binary on Linux). But the `Install Inno Setup` and `Create Windows installer` steps require a **real Windows runner** — they call `choco install innosetup` and `ISCC.exe`, neither of which exists on Ubuntu. By contrast, `release.yml` runs these same steps on `os: windows-latest`.

This was a latent bug (not introduced by PR #582). It surfaced now because #582 de-conflicted the workflows so an RC tag runs prerelease.yml end-to-end for the first time, exercising the Windows-installer path on the Linux runner.

The task hypothesis about an Inno Setup `VersionInfoVersion` 4-part-numeric rejection of `-rc.1` does **not** apply: `scripts/installer.iss` only sets `AppVersion={#Version}` (accepts arbitrary strings), no `VersionInfoVersion`.

## Fix (`.github/workflows/prerelease.yml`)

Mirror the proven `release.yml` Windows configuration:

1. **Windows matrix → `os: windows-latest`, `cgo: "1"`** (was `ubuntu-latest`, `cgo: "0"`) for both amd64 + arm64 — gives `choco`/`ISCC.exe` and matches release.yml.
2. **Add `shell: bash`** to the cross-platform bash steps (`Copy frontend dist to embed location`, `Build binary and create archives`) — GHA defaults to `pwsh` on `windows-latest`, and these blocks use bash syntax (`[[ ]]`, `${VAR#prefix}`, `rm -rf`, `cp -r`). release.yml sets `shell: bash` for the same reason.
3. **Windows `.zip` via PowerShell `Compress-Archive`** — the `zip` command is unavailable in Git-bash on `windows-latest`; release.yml already does this with the same comment.

macOS/Linux build behavior is unchanged (those matrix entries untouched; the Windows-only `if` branch and the new `shell: bash` match what those steps already used).

## Validation

- `python -c 'import yaml; yaml.safe_load(open(...))'` → valid YAML.
- Each change is a 1:1 port of the corresponding `release.yml` Windows handling, which builds Windows installers successfully today.

## Re-testing the RC build (post-merge)

This PR does **not** re-tag or touch the release. After merge, either:
- move the `v0.37.0-rc.1` tag to the new main commit and re-push, **or**
- cut a fresh `v0.37.0-rc.2` tag.

Then confirm the prerelease.yml run is green (esp. both Windows `build` jobs) and a GitHub **pre-release** is published.

Related: PR #582 (MCP-1012).
