### PR TITLE
feat(teams): CredentialStore interface + AES-256-GCM BBolt backend (074-T1)

### DIFF
--- a/internal/config/teams_config.go
+++ b/internal/config/teams_config.go
@@ -17,6 +17,13 @@ type TeamsConfig struct {
 	BearerTokenTTL       Duration          `json:"bearer_token_ttl,omitempty" mapstructure:"bearer-token-ttl"`
 	WorkspaceIdleTimeout Duration          `json:"workspace_idle_timeout,omitempty" mapstructure:"workspace-idle-timeout"`
 	MaxUserServers       int               `json:"max_user_servers,omitempty" mapstructure:"max-user-servers"`
+
+	// CredentialEncryptionKey is the base64-encoded 32-byte AES-256 master key
+	// used by the upstream token broker (spec 074) to encrypt stored
+	// credentials at rest. The MCPPROXY_CRED_KEY environment variable takes
+	// precedence over this value. When neither is set, the broker is disabled
+	// gracefully (the rest of the gateway is unaffected).
+	CredentialEncryptionKey string `json:"credential_encryption_key,omitempty" mapstructure:"credential-encryption-key"`
 }
 
 // TeamsOAuthConfig holds OAuth identity provider configuration for the server edition.

--- a/internal/teams/broker/bbolt_aes.go
+++ b/internal/teams/broker/bbolt_aes.go
@@ -1,0 +1,268 @@
+//go:build server
+
+package broker
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"go.etcd.io/bbolt"
+	"go.uber.org/zap"
+)
+
+// credentialBucket holds AES-256-GCM encrypted UpstreamCredential records.
+//
+// Key scheme:
+//   - upstream credential:   "<userID>:<serverKey>"
+//   - idp subject token:     "<userID>"            (no colon)
+//
+// serverKey follows the existing SHA256(name+url) scheme from
+// internal/oauth.GenerateServerKey.
+const credentialBucket = "user_upstream_credentials" //nolint:gosec // bucket name, not a credential
+
+// aesKeyLen is the required key length for AES-256.
+const aesKeyLen = 32
+
+// BBoltAESStore is the default CredentialStore backed by BBolt with
+// AES-256-GCM authenticated encryption and a per-record random nonce.
+//
+// When no master key is configured the store is constructed in a disabled
+// state: every operation returns ErrStoreDisabled and the rest of the gateway
+// is unaffected (FR-022).
+type BBoltAESStore struct {
+	db      *bbolt.DB
+	gcm     cipher.AEAD // nil when disabled
+	enabled bool
+	logger  *zap.Logger
+}
+
+// NewBBoltAESStore constructs a credential store over the given BBolt database.
+//
+// base64Key is the base64-encoded 32-byte AES-256 master key (see
+// ResolveMasterKey). Behaviour by key state:
+//   - empty key     -> store disabled (no error); the condition is logged so it
+//     can be surfaced at startup.
+//   - present but invalid (bad base64 / wrong length) -> error (loud
+//     misconfiguration, not silent degradation).
+//   - valid 32-byte -> store enabled.
+func NewBBoltAESStore(db *bbolt.DB, base64Key string, logger *zap.Logger) (*BBoltAESStore, error) {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	logger = logger.Named("credential-store")
+
+	if strings.TrimSpace(base64Key) == "" {
+		logger.Warn("upstream credential broker disabled: no encryption key configured " +
+			"(set MCPPROXY_CRED_KEY or teams.credential_encryption_key to enable)")
+		return &BBoltAESStore{db: db, enabled: false, logger: logger}, nil
+	}
+
+	key, err := base64.StdEncoding.DecodeString(strings.TrimSpace(base64Key))
+	if err != nil {
+		return nil, fmt.Errorf("decode credential encryption key (must be base64): %w", err)
+	}
+	if len(key) != aesKeyLen {
+		return nil, fmt.Errorf("credential encryption key must be %d bytes (got %d) for AES-256", aesKeyLen, len(key))
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("create AES cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("create GCM: %w", err)
+	}
+
+	// Ensure the bucket exists up front so reads on a fresh DB don't trip on a
+	// missing bucket.
+	if err := db.Update(func(tx *bbolt.Tx) error {
+		_, e := tx.CreateBucketIfNotExists([]byte(credentialBucket))
+		return e
+	}); err != nil {
+		return nil, fmt.Errorf("init credential bucket: %w", err)
+	}
+
+	logger.Info("upstream credential broker enabled (AES-256-GCM at rest)")
+	return &BBoltAESStore{db: db, gcm: gcm, enabled: true, logger: logger}, nil
+}
+
+// Enabled reports whether a usable encryption key is configured.
+func (s *BBoltAESStore) Enabled() bool { return s.enabled }
+
+// recordKey builds the BBolt key for a (userID, serverKey) pair. An empty
+// serverKey yields the bare userID, used for the idp subject token.
+func recordKey(userID, serverKey string) string {
+	if serverKey == "" {
+		return userID
+	}
+	return userID + ":" + serverKey
+}
+
+// Get implements CredentialStore.
+func (s *BBoltAESStore) Get(userID, serverKey string) (*UpstreamCredential, error) {
+	if !s.enabled {
+		return nil, ErrStoreDisabled
+	}
+	key := recordKey(userID, serverKey)
+
+	var ciphertext []byte
+	if err := s.db.View(func(tx *bbolt.Tx) error {
+		b := tx.Bucket([]byte(credentialBucket))
+		if b == nil {
+			return nil
+		}
+		if v := b.Get([]byte(key)); v != nil {
+			ciphertext = append(ciphertext, v...)
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("read credential: %w", err)
+	}
+	if ciphertext == nil {
+		return nil, ErrNotFound
+	}
+
+	cred, err := s.decrypt(ciphertext)
+	if err != nil {
+		// Undecryptable (e.g. rotated key) -> treat as absent, never crash.
+		s.logger.Warn("credential record could not be decrypted; treating as absent",
+			zap.String("user", userID), zap.String("server_key", serverKey), zap.Error(err))
+		return nil, ErrNotFound
+	}
+	return cred, nil
+}
+
+// Put implements CredentialStore.
+func (s *BBoltAESStore) Put(userID, serverKey string, cred *UpstreamCredential) error {
+	if !s.enabled {
+		return ErrStoreDisabled
+	}
+	if cred == nil {
+		return fmt.Errorf("nil credential")
+	}
+	cred.UpdatedAt = time.Now().UTC()
+
+	ciphertext, err := s.encrypt(cred)
+	if err != nil {
+		return fmt.Errorf("encrypt credential: %w", err)
+	}
+	key := recordKey(userID, serverKey)
+	if err := s.db.Update(func(tx *bbolt.Tx) error {
+		b, e := tx.CreateBucketIfNotExists([]byte(credentialBucket))
+		if e != nil {
+			return e
+		}
+		return b.Put([]byte(key), ciphertext)
+	}); err != nil {
+		return fmt.Errorf("write credential: %w", err)
+	}
+	return nil
+}
+
+// Delete implements CredentialStore.
+func (s *BBoltAESStore) Delete(userID, serverKey string) error {
+	if !s.enabled {
+		return ErrStoreDisabled
+	}
+	key := recordKey(userID, serverKey)
+	if err := s.db.Update(func(tx *bbolt.Tx) error {
+		b := tx.Bucket([]byte(credentialBucket))
+		if b == nil {
+			return nil
+		}
+		return b.Delete([]byte(key))
+	}); err != nil {
+		return fmt.Errorf("delete credential: %w", err)
+	}
+	return nil
+}
+
+// List implements CredentialStore. It returns only upstream credentials
+// (prefix "<userID>:"); the idp subject token (bare userID) is excluded.
+// Undecryptable records are skipped rather than failing the whole listing.
+func (s *BBoltAESStore) List(userID string) ([]CredentialEntry, error) {
+	if !s.enabled {
+		return nil, ErrStoreDisabled
+	}
+	prefix := []byte(userID + ":")
+
+	var entries []CredentialEntry
+	if err := s.db.View(func(tx *bbolt.Tx) error {
+		b := tx.Bucket([]byte(credentialBucket))
+		if b == nil {
+			return nil
+		}
+		c := b.Cursor()
+		for k, v := c.Seek(prefix); k != nil && hasPrefix(k, prefix); k, v = c.Next() {
+			cred, err := s.decrypt(v)
+			if err != nil {
+				s.logger.Warn("skipping undecryptable credential in list",
+					zap.String("user", userID), zap.ByteString("key", k), zap.Error(err))
+				continue
+			}
+			entries = append(entries, CredentialEntry{
+				ServerKey:  string(k[len(prefix):]),
+				Credential: cred,
+			})
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("list credentials: %w", err)
+	}
+	return entries, nil
+}
+
+// hasPrefix reports whether b begins with prefix.
+func hasPrefix(b, prefix []byte) bool {
+	if len(b) < len(prefix) {
+		return false
+	}
+	for i := range prefix {
+		if b[i] != prefix[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// encrypt serializes the credential to JSON and AES-256-GCM encrypts it,
+// returning nonce||ciphertext with a fresh random nonce per call (FR-020).
+func (s *BBoltAESStore) encrypt(cred *UpstreamCredential) ([]byte, error) {
+	plaintext, err := json.Marshal(cred)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, s.gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("generate nonce: %w", err)
+	}
+	// Seal appends the ciphertext to nonce, yielding nonce||ciphertext.
+	return s.gcm.Seal(nonce, nonce, plaintext, nil), nil
+}
+
+// decrypt reverses encrypt. It returns an error on any tampering, truncation,
+// or wrong-key condition (callers treat that as ErrNotFound).
+func (s *BBoltAESStore) decrypt(data []byte) (*UpstreamCredential, error) {
+	ns := s.gcm.NonceSize()
+	if len(data) < ns {
+		return nil, fmt.Errorf("ciphertext too short")
+	}
+	nonce, ciphertext := data[:ns], data[ns:]
+	plaintext, err := s.gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, err
+	}
+	var cred UpstreamCredential
+	if err := json.Unmarshal(plaintext, &cred); err != nil {
+		return nil, err
+	}
+	return &cred, nil
+}

--- a/internal/teams/broker/credential_store.go
+++ b/internal/teams/broker/credential_store.go
@@ -1,0 +1,138 @@
+//go:build server
+
+// Package broker provides per-user, per-upstream credential storage for the
+// server edition's upstream token-brokering feature (spec 074).
+//
+// Credentials are persisted encrypted-at-rest using authenticated encryption
+// (AES-256-GCM with a unique nonce per record). The storage backend is hidden
+// behind the CredentialStore interface so that alternative backends (external
+// secret managers such as HashiCorp Vault or AWS Secrets Manager) can be added
+// later without changing callers (FR-023).
+package broker
+
+import (
+	"errors"
+	"os"
+	"time"
+)
+
+// MasterKeyEnvVar is the environment variable that supplies the base64-encoded
+// 32-byte AES-256 master key. It takes precedence over the configuration value.
+const MasterKeyEnvVar = "MCPPROXY_CRED_KEY" //nolint:gosec // env var name, not a credential
+
+// Sentinel errors returned by CredentialStore implementations.
+var (
+	// ErrStoreDisabled is returned by every operation when the store has no
+	// encryption key configured. The broker degrades gracefully: the rest of
+	// the gateway is unaffected (FR-022).
+	ErrStoreDisabled = errors.New("credential store disabled: no encryption key configured")
+
+	// ErrNotFound is returned when no credential exists for the given key, or
+	// when an existing record cannot be decrypted (e.g. the master key was
+	// rotated). Undecryptable records are treated as absent rather than fatal.
+	ErrNotFound = errors.New("credential not found")
+)
+
+// UpstreamCredential is the value model persisted for each user/upstream pair
+// and for each identity-provider subject token. It is serialized and then
+// AES-256-GCM encrypted before being written to the backend (FR-020).
+type UpstreamCredential struct {
+	// Type identifies the credential flavour, e.g. "oauth2", "api_key",
+	// "idp_subject_token".
+	Type string `json:"type"`
+	// AccessToken is the bearer/access credential presented to the upstream.
+	AccessToken string `json:"access_token"`
+	// RefreshToken, when present, is used to mint a fresh access token.
+	RefreshToken string `json:"refresh_token,omitempty"`
+	// ExpiresAt is the access-token expiry. A zero value means never-expiring
+	// (matches Go's oauth2 convention).
+	ExpiresAt time.Time `json:"expires_at,omitempty"`
+	// Scopes granted to the access token.
+	Scopes []string `json:"scopes,omitempty"`
+	// TokenType, e.g. "Bearer".
+	TokenType string `json:"token_type,omitempty"`
+	// Audience is the intended audience of the token (RFC 8693).
+	Audience string `json:"audience,omitempty"`
+	// ObtainedVia records how the credential was acquired, e.g.
+	// "token_exchange", "connect_flow", "static".
+	ObtainedVia string `json:"obtained_via,omitempty"`
+	// UpdatedAt is the last write time for this record.
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+}
+
+// IsExpired reports whether the credential's access token has expired. A zero
+// ExpiresAt is treated as never-expiring.
+func (c *UpstreamCredential) IsExpired() bool {
+	if c.ExpiresAt.IsZero() {
+		return false
+	}
+	return time.Now().After(c.ExpiresAt)
+}
+
+// IsValid reports whether the credential has a non-expired access token.
+func (c *UpstreamCredential) IsValid() bool {
+	return !c.IsExpired()
+}
+
+// ExpiresWithin reports whether the credential expires within the given
+// duration from now. A never-expiring credential always returns false.
+func (c *UpstreamCredential) ExpiresWithin(d time.Duration) bool {
+	if c.ExpiresAt.IsZero() {
+		return false
+	}
+	return time.Now().Add(d).After(c.ExpiresAt)
+}
+
+// CredentialEntry pairs a stored upstream credential with the serverKey it was
+// stored under. Returned by CredentialStore.List.
+type CredentialEntry struct {
+	ServerKey  string
+	Credential *UpstreamCredential
+}
+
+// CredentialStore is the abstraction over credential persistence. Callers
+// depend only on this interface so that the BBolt+AES backend can be swapped
+// for an external secret manager later (FR-023).
+//
+// serverKey identifies an upstream and is the existing SHA256(name+url) scheme
+// from internal/oauth (see oauth.GenerateServerKey). An empty serverKey selects
+// the identity-provider subject-token record, which is keyed by userID alone.
+//
+// All implementations isolate records per user (FR-021): no user can read or
+// enumerate another user's credentials.
+type CredentialStore interface {
+	// Enabled reports whether the store has a usable encryption key. When
+	// false, all other methods return ErrStoreDisabled.
+	Enabled() bool
+
+	// Get returns the credential for (userID, serverKey). An empty serverKey
+	// selects the user's idp subject token. Returns ErrNotFound if absent or
+	// undecryptable.
+	Get(userID, serverKey string) (*UpstreamCredential, error)
+
+	// Put stores (or overwrites) the credential for (userID, serverKey). An
+	// empty serverKey stores the user's idp subject token.
+	Put(userID, serverKey string, cred *UpstreamCredential) error
+
+	// Delete removes the credential for (userID, serverKey). Deleting a
+	// non-existent record is a no-op.
+	Delete(userID, serverKey string) error
+
+	// List returns all upstream credentials for the user. The idp subject
+	// token (serverKey == "") is NOT included.
+	List(userID string) ([]CredentialEntry, error)
+}
+
+// Compile-time assertion that the BBolt+AES backend satisfies the interface.
+var _ CredentialStore = (*BBoltAESStore)(nil)
+
+// ResolveMasterKey returns the base64-encoded master key, preferring the
+// MCPPROXY_CRED_KEY environment variable over the supplied configuration value
+// (e.g. teams.credential_encryption_key). Returns "" when neither is set, in
+// which case the store is disabled.
+func ResolveMasterKey(configKey string) string {
+	if v := os.Getenv(MasterKeyEnvVar); v != "" {
+		return v
+	}
+	return configKey
+}

--- a/internal/teams/broker/credential_store_test.go
+++ b/internal/teams/broker/credential_store_test.go
@@ -1,0 +1,339 @@
+//go:build server
+
+package broker
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.etcd.io/bbolt"
+	"go.uber.org/zap"
+)
+
+// newTestKey returns a freshly generated, base64-encoded 32-byte AES-256 key.
+func newTestKey(t *testing.T) string {
+	t.Helper()
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(key)
+}
+
+// openTestDB opens a throwaway BBolt database in the test's temp dir.
+func openTestDB(t *testing.T) *bbolt.DB {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "creds.db")
+	db, err := bbolt.Open(path, 0o600, &bbolt.Options{Timeout: time.Second})
+	if err != nil {
+		t.Fatalf("open bbolt: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func newTestStore(t *testing.T, db *bbolt.DB, key string) *BBoltAESStore {
+	t.Helper()
+	store, err := NewBBoltAESStore(db, key, zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewBBoltAESStore: %v", err)
+	}
+	return store
+}
+
+func sampleCred() *UpstreamCredential {
+	return &UpstreamCredential{
+		Type:         "oauth2",
+		AccessToken:  "at-secret-12345",
+		RefreshToken: "rt-secret-67890",
+		ExpiresAt:    time.Now().Add(time.Hour).UTC().Truncate(time.Second),
+		Scopes:       []string{"read", "write"},
+		TokenType:    "Bearer",
+		Audience:     "https://api.example.com",
+		ObtainedVia:  "token_exchange",
+		UpdatedAt:    time.Now().UTC().Truncate(time.Second),
+	}
+}
+
+func TestUpstreamCredential_ExpiryHelpers(t *testing.T) {
+	// Zero ExpiresAt means never-expiring (matches oauth convention).
+	never := &UpstreamCredential{}
+	if never.IsExpired() {
+		t.Errorf("zero ExpiresAt should not be expired")
+	}
+	if !never.IsValid() {
+		t.Errorf("zero ExpiresAt should be valid")
+	}
+
+	past := &UpstreamCredential{ExpiresAt: time.Now().Add(-time.Minute)}
+	if !past.IsExpired() {
+		t.Errorf("past ExpiresAt should be expired")
+	}
+	if past.IsValid() {
+		t.Errorf("past ExpiresAt should not be valid")
+	}
+
+	future := &UpstreamCredential{ExpiresAt: time.Now().Add(time.Hour)}
+	if future.IsExpired() {
+		t.Errorf("future ExpiresAt should not be expired")
+	}
+
+	// ExpiresWithin: true when within grace, false otherwise; never-expiring is always false.
+	soon := &UpstreamCredential{ExpiresAt: time.Now().Add(time.Minute)}
+	if !soon.ExpiresWithin(5 * time.Minute) {
+		t.Errorf("token expiring in 1m should be within 5m grace")
+	}
+	if future.ExpiresWithin(5 * time.Minute) {
+		t.Errorf("token expiring in 1h should not be within 5m grace")
+	}
+	if never.ExpiresWithin(5 * time.Minute) {
+		t.Errorf("never-expiring token should not be within any grace window")
+	}
+}
+
+func TestBBoltAESStore_EncryptDecryptRoundtrip(t *testing.T) {
+	db := openTestDB(t)
+	store := newTestStore(t, db, newTestKey(t))
+
+	cred := sampleCred()
+	if err := store.Put("alice", "github_abc", cred); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	got, err := store.Get("alice", "github_abc")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.AccessToken != cred.AccessToken ||
+		got.RefreshToken != cred.RefreshToken ||
+		got.TokenType != cred.TokenType ||
+		got.Audience != cred.Audience ||
+		got.ObtainedVia != cred.ObtainedVia ||
+		!got.ExpiresAt.Equal(cred.ExpiresAt) ||
+		len(got.Scopes) != len(cred.Scopes) {
+		t.Errorf("roundtrip mismatch: got %+v want %+v", got, cred)
+	}
+
+	// On-disk bytes must NOT contain the plaintext secret.
+	if err := db.View(func(tx *bbolt.Tx) error {
+		b := tx.Bucket([]byte(credentialBucket))
+		if b == nil {
+			t.Fatalf("bucket missing")
+		}
+		raw := b.Get([]byte("alice:github_abc"))
+		if raw == nil {
+			t.Fatalf("record missing on disk")
+		}
+		if bytes.Contains(raw, []byte(cred.AccessToken)) {
+			t.Errorf("access token stored in plaintext on disk")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBBoltAESStore_NonceUniqueness(t *testing.T) {
+	db := openTestDB(t)
+	store := newTestStore(t, db, newTestKey(t))
+	cred := sampleCred()
+
+	if err := store.Put("alice", "k1", cred); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	var c1 []byte
+	_ = db.View(func(tx *bbolt.Tx) error {
+		c1 = append(c1, tx.Bucket([]byte(credentialBucket)).Get([]byte("alice:k1"))...)
+		return nil
+	})
+
+	if err := store.Put("alice", "k2", cred); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	var c2 []byte
+	_ = db.View(func(tx *bbolt.Tx) error {
+		c2 = append(c2, tx.Bucket([]byte(credentialBucket)).Get([]byte("alice:k2"))...)
+		return nil
+	})
+
+	if bytes.Equal(c1, c2) {
+		t.Errorf("identical plaintext encrypted to identical ciphertext — nonce not random")
+	}
+}
+
+func TestBBoltAESStore_PerUserIsolation(t *testing.T) {
+	db := openTestDB(t)
+	store := newTestStore(t, db, newTestKey(t))
+
+	if err := store.Put("alice", "srv", sampleCred()); err != nil {
+		t.Fatalf("Put alice: %v", err)
+	}
+	bobCred := sampleCred()
+	bobCred.AccessToken = "bob-token"
+	if err := store.Put("bob", "srv", bobCred); err != nil {
+		t.Fatalf("Put bob: %v", err)
+	}
+
+	// bob cannot read alice's record via his own userID.
+	got, err := store.Get("bob", "srv")
+	if err != nil {
+		t.Fatalf("Get bob: %v", err)
+	}
+	if got.AccessToken != "bob-token" {
+		t.Errorf("isolation breach: bob got %q", got.AccessToken)
+	}
+
+	// List is scoped per user.
+	aliceList, err := store.List("alice")
+	if err != nil {
+		t.Fatalf("List alice: %v", err)
+	}
+	if len(aliceList) != 1 || aliceList[0].ServerKey != "srv" {
+		t.Errorf("alice list = %+v, want 1 entry for srv", aliceList)
+	}
+
+	// A userID that is a prefix of another must not bleed.
+	if err := store.Put("alice2", "srv", sampleCred()); err != nil {
+		t.Fatalf("Put alice2: %v", err)
+	}
+	aliceList, _ = store.List("alice")
+	if len(aliceList) != 1 {
+		t.Errorf("alice list leaked alice2 records: %+v", aliceList)
+	}
+}
+
+func TestBBoltAESStore_SubjectToken(t *testing.T) {
+	db := openTestDB(t)
+	store := newTestStore(t, db, newTestKey(t))
+
+	subj := sampleCred()
+	subj.Type = "idp_subject_token"
+	// Empty serverKey => idp subject token record keyed by userID.
+	if err := store.Put("alice", "", subj); err != nil {
+		t.Fatalf("Put subject: %v", err)
+	}
+	got, err := store.Get("alice", "")
+	if err != nil {
+		t.Fatalf("Get subject: %v", err)
+	}
+	if got.Type != "idp_subject_token" {
+		t.Errorf("subject token type mismatch: %q", got.Type)
+	}
+
+	// Subject token must be keyed by bare userID (no colon).
+	if err := db.View(func(tx *bbolt.Tx) error {
+		if tx.Bucket([]byte(credentialBucket)).Get([]byte("alice")) == nil {
+			t.Errorf("subject token not keyed by bare userID")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// List (upstream creds) must not include the subject token.
+	if err := store.Put("alice", "srv", sampleCred()); err != nil {
+		t.Fatalf("Put upstream: %v", err)
+	}
+	list, _ := store.List("alice")
+	if len(list) != 1 || list[0].ServerKey != "srv" {
+		t.Errorf("List should exclude subject token, got %+v", list)
+	}
+}
+
+func TestBBoltAESStore_DeleteAndNotFound(t *testing.T) {
+	db := openTestDB(t)
+	store := newTestStore(t, db, newTestKey(t))
+
+	if _, err := store.Get("alice", "missing"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Get missing = %v, want ErrNotFound", err)
+	}
+
+	if err := store.Put("alice", "srv", sampleCred()); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if err := store.Delete("alice", "srv"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := store.Get("alice", "srv"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Get after delete = %v, want ErrNotFound", err)
+	}
+}
+
+func TestNewBBoltAESStore_MissingKeyDisabled(t *testing.T) {
+	db := openTestDB(t)
+	store, err := NewBBoltAESStore(db, "", zap.NewNop())
+	if err != nil {
+		t.Fatalf("missing key should not error, got %v", err)
+	}
+	if store.Enabled() {
+		t.Errorf("store with no key should be disabled")
+	}
+	if err := store.Put("alice", "srv", sampleCred()); !errors.Is(err, ErrStoreDisabled) {
+		t.Errorf("Put on disabled = %v, want ErrStoreDisabled", err)
+	}
+	if _, err := store.Get("alice", "srv"); !errors.Is(err, ErrStoreDisabled) {
+		t.Errorf("Get on disabled = %v, want ErrStoreDisabled", err)
+	}
+	if _, err := store.List("alice"); !errors.Is(err, ErrStoreDisabled) {
+		t.Errorf("List on disabled = %v, want ErrStoreDisabled", err)
+	}
+	if err := store.Delete("alice", "srv"); !errors.Is(err, ErrStoreDisabled) {
+		t.Errorf("Delete on disabled = %v, want ErrStoreDisabled", err)
+	}
+}
+
+func TestNewBBoltAESStore_InvalidKey(t *testing.T) {
+	db := openTestDB(t)
+
+	// Non-base64 garbage.
+	if _, err := NewBBoltAESStore(db, "not!!base64!!", zap.NewNop()); err == nil {
+		t.Errorf("invalid base64 key should error")
+	}
+	// Valid base64 but wrong length (16 bytes, not 32).
+	short := base64.StdEncoding.EncodeToString(make([]byte, 16))
+	if _, err := NewBBoltAESStore(db, short, zap.NewNop()); err == nil {
+		t.Errorf("wrong-length key should error")
+	}
+}
+
+func TestBBoltAESStore_KeyChangedNotConnected(t *testing.T) {
+	db := openTestDB(t)
+	store := newTestStore(t, db, newTestKey(t))
+	if err := store.Put("alice", "srv", sampleCred()); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	// Re-open with a different key (simulates key rotation/misconfig).
+	rotated := newTestStore(t, db, newTestKey(t))
+	if _, err := rotated.Get("alice", "srv"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Get with rotated key = %v, want ErrNotFound (record undecryptable => absent)", err)
+	}
+	// List must also tolerate undecryptable records without crashing.
+	list, err := rotated.List("alice")
+	if err != nil {
+		t.Fatalf("List with rotated key errored: %v", err)
+	}
+	if len(list) != 0 {
+		t.Errorf("List with rotated key should skip undecryptable records, got %+v", list)
+	}
+}
+
+func TestResolveMasterKey(t *testing.T) {
+	t.Setenv(MasterKeyEnvVar, "")
+	if got := ResolveMasterKey("from-config"); got != "from-config" {
+		t.Errorf("empty env should fall back to config, got %q", got)
+	}
+	t.Setenv(MasterKeyEnvVar, "from-env")
+	if got := ResolveMasterKey("from-config"); got != "from-env" {
+		t.Errorf("env should override config, got %q", got)
+	}
+	t.Setenv(MasterKeyEnvVar, "")
+	if got := ResolveMasterKey(""); got != "" {
+		t.Errorf("both empty should be empty, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Foundation task **MCP-1034 / 074-T1** for upstream token brokering (spec 074). No blockers. New server-edition package `internal/teams/broker/` (`//go:build server`).

- **`CredentialStore`** interface (`Get/Put/Delete/List`) — the abstraction seam so external secret managers (Vault/AWS) can be added later without changing callers (**FR-023**).
- **`BBoltAESStore`** backend — bucket `user_upstream_credentials`:
  - upstream creds keyed `<userID>:<serverKey>` (serverKey = existing `SHA256(name+url)` scheme, see `oauth.GenerateServerKey`)
  - idp subject tokens keyed by bare `<userID>` (empty `serverKey` selects them)
- **`UpstreamCredential`** value model (`Type, AccessToken, RefreshToken, ExpiresAt, Scopes, TokenType, Audience, ObtainedVia, UpdatedAt`), JSON-serialized then **AES-256-GCM** encrypted with a **per-record random nonce** (**FR-020**), isolated per user (**FR-021**).
- **Master key** from env `MCPPROXY_CRED_KEY` or `teams.credential_encryption_key` (32-byte base64). Missing key → store **disabled gracefully** (rest of gateway unaffected, logged for startup surfacing); present-but-invalid → loud error (**FR-022**).
- **Decryption failure** (e.g. rotated key) → record treated as **absent**, never fatal; `List` skips undecryptable records.
- Adds `teams.credential_encryption_key` config field as the config-side key source.

Mirrors the obot-platform/mcp-oauth-proxy AES approach.

## Tests (TDD — test-first, all green with `-race`)

- encrypt/decrypt roundtrip (+ asserts plaintext token absent on disk)
- per-user isolation (incl. userID-prefix bleed guard)
- subject-token keying + `List` exclusion
- nonce uniqueness (same plaintext → different ciphertext)
- expiry helpers (`IsExpired`/`IsValid`/`ExpiresWithin`, zero = never)
- missing-key disabled path (all ops → `ErrStoreDisabled`)
- invalid/short key → constructor error
- key-changed → `ErrNotFound` (not-connected)
- `ResolveMasterKey` env-over-config precedence

## Verification

```
go build ./cmd/mcpproxy                         # personal: OK
go build -tags server ./cmd/mcpproxy            # server:   OK
go test -tags server -race ./internal/teams/broker/ ./internal/config/   # ok
golangci-lint run --build-tags=server ./internal/teams/broker/...        # 0 issues
```

## Notes
- Docs: no `docs/` file documents teams config keys (they live in CLAUDE.md, which is at the 40k CI size limit); the field is an inert foundation seam not yet wired/activated, so user-facing docs are deferred to the downstream startup-wiring task. Spec FRs already documented in `specs/074-upstream-token-brokering/spec.md`.
- Out of scope (downstream tasks): startup wiring + "surface disabled at startup", token-exchange/refresh, callers.

Related spec: `specs/074-upstream-token-brokering` · FR-020..FR-023