### PR TITLE
feat(macos): registry-info popup on badge click; drop configured-registries panel

### DIFF
--- a/native/macos/MCPProxy/MCPProxy/API/RegistryModels.swift
+++ b/native/macos/MCPProxy/MCPProxy/API/RegistryModels.swift
@@ -45,6 +45,17 @@ struct Registry: Codable, Identifiable, Equatable {
     var isCustom: Bool {
         provenance == RegistryProvenance.custom || trusted == false
     }
+
+    /// Resolve the full `Registry` that a search result's `registry` field
+    /// refers to. That field may carry the registry id OR its display name (the
+    /// backend search response uses the name — see `RepositoryServer.registry`),
+    /// so match on id first, then fall back to a case-insensitive name match.
+    /// Returns nil when nothing matches; the badge popup then shows the raw
+    /// label only. Used by the macOS browse view (MCP-1050).
+    static func lookup(_ nameOrID: String, in registries: [Registry]) -> Registry? {
+        if let byID = registries.first(where: { $0.id == nameOrID }) { return byID }
+        return registries.first { $0.name.caseInsensitiveCompare(nameOrID) == .orderedSame }
+    }
 }
 
 /// Slim projection returned by `POST /api/v1/registries` (add-source).

--- a/native/macos/MCPProxy/MCPProxy/Views/RegistriesView.swift
+++ b/native/macos/MCPProxy/MCPProxy/Views/RegistriesView.swift
@@ -48,21 +48,15 @@ struct RegistriesView: View {
             if let success = successMessage {
                 banner(icon: "checkmark.circle.fill", tint: .green, text: success)
             }
+            if let err = loadError {
+                banner(icon: "exclamationmark.triangle.fill", tint: .orange, text: err)
+            }
 
             // Browse + add servers across one or more registries (R1 parity).
+            // The configured-registries list lives in the browse multiselect and
+            // the per-result registry badge → info popup (MCP-1050); there is no
+            // longer a bottom "Configured registries" description panel.
             ServerBrowseView(appState: appState, registries: registries)
-
-            HStack {
-                Text("Configured registries")
-                    .font(.scaled(.caption, scale: fontScale).bold())
-                    .foregroundStyle(.secondary)
-                Spacer()
-            }
-            .padding(.horizontal)
-            .padding(.top, 4)
-            Divider()
-
-            content
         }
         .sheet(isPresented: $showAddRegistry) {
             AddRegistryView(appState: appState, isPresented: $showAddRegistry) { added in
@@ -101,109 +95,6 @@ struct RegistriesView: View {
     }
 
     // MARK: Content
-
-    @ViewBuilder
-    private var content: some View {
-        if let err = loadError, registries.isEmpty {
-            VStack(spacing: 12) {
-                Spacer()
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .font(.system(size: 40 * fontScale))
-                    .foregroundStyle(.orange)
-                Text("Couldn't load registries")
-                    .font(.scaled(.title3, scale: fontScale))
-                    .foregroundStyle(.secondary)
-                Text(err)
-                    .font(.scaled(.caption, scale: fontScale))
-                    .foregroundStyle(.tertiary)
-                    .multilineTextAlignment(.center)
-                Spacer()
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .padding()
-        } else if registries.isEmpty && !isLoading {
-            VStack(spacing: 12) {
-                Spacer()
-                Image(systemName: "books.vertical")
-                    .font(.system(size: 40 * fontScale))
-                    .foregroundStyle(.tertiary)
-                Text("No registries")
-                    .font(.scaled(.title3, scale: fontScale))
-                    .foregroundStyle(.secondary)
-                Spacer()
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 8) {
-                    ForEach(registries) { registry in
-                        registryRow(registry)
-                    }
-                }
-                .padding()
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func registryRow(_ registry: Registry) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack(spacing: 8) {
-                Text(registry.name.isEmpty ? registry.id : registry.name)
-                    .font(.scaled(.headline, scale: fontScale))
-                provenanceBadge(registry)
-                Spacer()
-            }
-
-            if let desc = registry.description, !desc.isEmpty {
-                Text(desc)
-                    .font(.scaled(.caption, scale: fontScale))
-                    .foregroundStyle(.secondary)
-            }
-
-            if let url = registry.serversURL ?? registry.url, !url.isEmpty {
-                Text(url)
-                    .font(.scaledMonospaced(.caption, scale: fontScale))
-                    .foregroundStyle(.tertiary)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-            }
-
-            if registry.isCustom {
-                Text("Servers added from this third-party registry are always quarantined and cannot skip security review.")
-                    .font(.scaled(.caption2, scale: fontScale))
-                    .foregroundStyle(.orange)
-                    .accessibilityIdentifier("registry-custom-quarantine-note")
-            }
-        }
-        .padding(10)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color(nsColor: .controlBackgroundColor))
-        .cornerRadius(8)
-        .accessibilityIdentifier("registry-row-\(registry.id)")
-    }
-
-    @ViewBuilder
-    private func provenanceBadge(_ registry: Registry) -> some View {
-        if registry.isCustom {
-            badge(text: "Third-party \u{00B7} unverified", tint: .orange)
-                .accessibilityIdentifier("registry-provenance-badge-custom")
-        } else {
-            badge(text: "Official \u{00B7} trusted", tint: .green)
-                .accessibilityIdentifier("registry-provenance-badge-official")
-        }
-    }
-
-    @ViewBuilder
-    private func badge(text: String, tint: Color) -> some View {
-        Text(text)
-            .font(.scaled(.caption2, scale: fontScale).weight(.medium))
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(tint.opacity(0.18))
-            .foregroundStyle(tint)
-            .clipShape(Capsule())
-    }
 
     @ViewBuilder
     private func banner(icon: String, tint: Color, text: String) -> some View {

--- a/native/macos/MCPProxy/MCPProxy/Views/ServerBrowseView.swift
+++ b/native/macos/MCPProxy/MCPProxy/Views/ServerBrowseView.swift
@@ -25,8 +25,18 @@ struct ServerBrowseView: View {
     @State private var searchError: String?
     @State private var addingID: String?
     @State private var addNote: String?
+    @State private var registryInfo: RegistryInfoContext?
 
     private var apiClient: APIClient? { appState.apiClient }
+
+    /// Identifiable context for the registry-info popup (`.sheet(item:)`). Holds
+    /// the looked-up `Registry` (nil when the result's label matched nothing in
+    /// the loaded list) plus the raw `label` so the popup always has a title.
+    struct RegistryInfoContext: Identifiable {
+        let id = UUID()
+        let registry: Registry?
+        let label: String
+    }
 
     private func registryName(_ id: String) -> String {
         registries.first { $0.id == id }?.name ?? id
@@ -64,6 +74,93 @@ struct ServerBrowseView: View {
             resultsArea
         }
         .accessibilityIdentifier("server-browse")
+        .sheet(item: $registryInfo) { ctx in
+            registryInfoSheet(ctx)
+        }
+    }
+
+    // MARK: Registry-info popup (MCP-1050)
+
+    @ViewBuilder
+    private func registryInfoSheet(_ ctx: RegistryInfoContext) -> some View {
+        let displayName = ctx.registry.map { $0.name.isEmpty ? $0.id : $0.name } ?? ctx.label
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(spacing: 8) {
+                Text(displayName)
+                    .font(.scaled(.title3, scale: fontScale).bold())
+                if let reg = ctx.registry { provenanceBadge(reg) }
+                Spacer()
+                Button {
+                    registryInfo = nil
+                } label: {
+                    Image(systemName: "xmark.circle.fill").foregroundStyle(.secondary)
+                }
+                .buttonStyle(.borderless)
+                .accessibilityIdentifier("registry-info-close")
+            }
+
+            if let reg = ctx.registry {
+                if let desc = reg.description, !desc.isEmpty {
+                    Text(desc)
+                        .font(.scaled(.subheadline, scale: fontScale))
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                if let url = reg.serversURL ?? reg.url, !url.isEmpty {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("URL")
+                            .font(.scaled(.caption2, scale: fontScale))
+                            .foregroundStyle(.secondary)
+                        Text(url)
+                            .font(.scaledMonospaced(.caption, scale: fontScale))
+                            .foregroundStyle(.tertiary)
+                            .textSelection(.enabled)
+                            .lineLimit(2)
+                            .truncationMode(.middle)
+                    }
+                }
+
+                if reg.isCustom {
+                    Text("Servers added from this third-party registry are always quarantined and cannot skip security review.")
+                        .font(.scaled(.caption, scale: fontScale))
+                        .foregroundStyle(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityIdentifier("registry-info-quarantine-note")
+                }
+            } else {
+                Text("No additional details are available for this registry.")
+                    .font(.scaled(.subheadline, scale: fontScale))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding()
+        .frame(width: 420, height: 220)
+        .accessibilityIdentifier("registry-info-popup")
+    }
+
+    @ViewBuilder
+    private func provenanceBadge(_ registry: Registry) -> some View {
+        if registry.isCustom {
+            badge(text: "Third-party \u{00B7} unverified", tint: .orange)
+                .accessibilityIdentifier("registry-info-badge-custom")
+        } else {
+            badge(text: "Official \u{00B7} trusted", tint: .green)
+                .accessibilityIdentifier("registry-info-badge-official")
+        }
+    }
+
+    @ViewBuilder
+    private func badge(text: String, tint: Color) -> some View {
+        Text(text)
+            .font(.scaled(.caption2, scale: fontScale).weight(.medium))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(tint.opacity(0.18))
+            .foregroundStyle(tint)
+            .clipShape(Capsule())
     }
 
     // MARK: Filter bar (multiselect + search)
@@ -167,12 +264,25 @@ struct ServerBrowseView: View {
                     .fixedSize(horizontal: false, vertical: true)
                 Spacer()
                 if let reg = server.registry, !reg.isEmpty {
-                    Text(reg)
+                    // Tappable: opens an info popup for the originating registry
+                    // (name/url/description/provenance) — MCP-1050.
+                    Button {
+                        registryInfo = RegistryInfoContext(
+                            registry: Registry.lookup(reg, in: registries), label: reg)
+                    } label: {
+                        HStack(spacing: 3) {
+                            Text(reg)
+                            Image(systemName: "info.circle")
+                                .font(.system(size: 9 * fontScale))
+                        }
                         .font(.scaled(.caption2, scale: fontScale))
                         .padding(.horizontal, 6).padding(.vertical, 2)
                         .background(Color.secondary.opacity(0.15))
                         .clipShape(Capsule())
-                        .accessibilityIdentifier("browse-source-\(server.id)")
+                    }
+                    .buttonStyle(.plain)
+                    .help("Show registry info")
+                    .accessibilityIdentifier("browse-source-\(server.id)")
                 }
             }
             if let desc = server.description, !desc.isEmpty {

--- a/native/macos/MCPProxy/MCPProxyTests/RegistryModelsTests.swift
+++ b/native/macos/MCPProxy/MCPProxyTests/RegistryModelsTests.swift
@@ -139,6 +139,42 @@ final class RegistryModelsTests: XCTestCase {
         )
     }
 
+    // MARK: - Registry lookup by name-or-id (MCP-1050 badge → info popup)
+
+    private func sampleRegistries() throws -> [Registry] {
+        let json = """
+        {"registries":[
+          {"id":"official","name":"Official MCP Registry",
+           "description":"Primary aggregator","url":"https://registry.modelcontextprotocol.io",
+           "provenance":"official/trusted","trusted":true},
+          {"id":"acme","name":"Acme","provenance":"custom/unverified","trusted":false}
+        ],"total":2}
+        """
+        return try decode(GetRegistriesResponse.self, from: json).registries
+    }
+
+    func testLookupMatchesByID() throws {
+        let regs = try sampleRegistries()
+        XCTAssertEqual(Registry.lookup("official", in: regs)?.id, "official")
+    }
+
+    func testLookupFallsBackToName() throws {
+        // A search result's `registry` field carries the registry *name*, so a
+        // name match must resolve when no id matches.
+        let regs = try sampleRegistries()
+        XCTAssertEqual(Registry.lookup("Acme", in: regs)?.id, "acme")
+    }
+
+    func testLookupNameIsCaseInsensitive() throws {
+        let regs = try sampleRegistries()
+        XCTAssertEqual(Registry.lookup("ACME", in: regs)?.id, "acme")
+    }
+
+    func testLookupReturnsNilWhenNotFound() throws {
+        let regs = try sampleRegistries()
+        XCTAssertNil(Registry.lookup("nonexistent", in: regs))
+    }
+
     // MARK: - One-time third-party warning ack persistence (mirrors localStorage)
 
     func testThirdPartyAckPersistence() throws {


### PR DESCRIPTION
## What & why (MCP-1050, v0.37.0 blocker)

macOS Registries/browse view polish:

**(a) Removed the bottom "Configured registries" description panel.** The registry list is already reachable via the browse multiselect and now via the per-result badge popup, so the redundant bottom panel is gone. The **Add-Registry** affordance is kept; registry-load errors now surface via an inline banner (the panel previously owned that error state).

**(b) Made the per-result registry badge tappable → info popup.** Clicking the `<registry> ⓘ` badge on a search-result card opens a sheet showing the registry's **name**, **provenance badge** (reuses the official/custom styling), **description**, and **URL**. The full `Registry` is looked up from the loaded list by id, then by name (case-insensitive) — search results carry the registry *name*, while the add endpoint uses the id, so both are handled. Custom/unverified registries show the always-quarantined note; an unmatched label degrades gracefully to a name-only popup.

## Files
- `API/RegistryModels.swift` — `Registry.lookup(_:in:)` (id-then-name, case-insensitive).
- `Views/RegistriesView.swift` — drop the bottom panel + dead `content`/`registryRow`/badge helpers; inline load-error banner.
- `Views/ServerBrowseView.swift` — tappable badge `Button`, `RegistryInfoContext`, `.sheet(item:)` info popup + provenance/badge helpers.
- `MCPProxyTests/RegistryModelsTests.swift` — 4 lookup tests (TDD: red → green).

## Verification
- `swift build` — clean (only pre-existing resource warnings).
- `swift test --filter RegistryModelsTests` — 17/17 green (incl. 4 new). The 7 failures in the full suite (AutoStart/MergePatch/SSE) are **pre-existing on `origin/main`** and unrelated; macOS CI builds the app and does not run `swift test`.
- **ui-test MCP visual verification** (dev app attached read-only to the running core via socket):
  - Registries view: bottom "Configured registries" panel is **gone**, Add-Registry kept.
  - Drove a search (Reference Servers → "fetch"), clicked the `Reference Servers ⓘ` badge → info popup opened showing name + `Official · trusted` badge + description + `builtin://reference` URL.

Related: MCP-1050