### PR TITLE
fix(registries): trim default registries to 3 + prune deprecated former-defaults (MCP-1049)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -791,17 +791,20 @@ See [Code Execution Documentation](code_execution/overview.md) for complete deta
 
 ## Registries
 
+The three default registries ship built-in and require no configuration. Use
+the `registries` array only to **add your own** custom source:
+
 ```json
 {
   "registries": [
     {
-      "id": "pulse",
-      "name": "Pulse MCP",
-      "description": "Browse and discover MCP use-cases, servers, clients, and news",
-      "url": "https://www.pulsemcp.com/",
-      "servers_url": "https://api.pulsemcp.com/v0beta/servers",
-      "tags": ["verified"],
-      "protocol": "custom/pulse"
+      "id": "mycorp",
+      "name": "My Corp Registry",
+      "description": "Internal MCP server catalog",
+      "url": "https://registry.mycorp.example/",
+      "servers_url": "https://registry.mycorp.example/v0.1/servers",
+      "tags": ["internal"],
+      "protocol": "modelcontextprotocol/registry"
     }
   ]
 }
@@ -818,14 +821,14 @@ See [Code Execution Documentation](code_execution/overview.md) for complete deta
 | `protocol` | string | Registry protocol type |
 | `count` | number/string | Number of servers in registry (auto-populated) |
 
-**Default Registries:**
-- Pulse MCP
-- Docker MCP Catalog
-- Fleur
-- Azure MCP Registry Demo
-- Remote MCP Servers
+**Default Registries** (shipped built-in, no configuration required):
+- `official` — Official MCP Registry (`modelcontextprotocol/registry`): primary, zero-config aggregator
+- `reference` — Reference Servers (`builtin/reference`): curated `@modelcontextprotocol` servers, shipped in-binary so the basics work offline
+- `docker-mcp-catalog` — Docker MCP Catalog (`custom/docker`): signed-container MCP server inventory
 
-See [Search Servers Documentation](search_servers.md) for complete details.
+> **Deprecated former-defaults:** earlier versions also shipped `pulse`, `smithery`, `fleur`, `azure-mcp-demo`, and `remote-mcp-servers` as defaults. These were removed and are pruned from an existing `mcp_config.json` on load, so upgrades converge to the three defaults above. Genuinely user-added custom registries are never touched; `pulse`/`smithery` can be added back as custom sources.
+
+See [Registries Documentation](registries.md) and [Search Servers Documentation](search_servers.md) for complete details.
 
 ---
 

--- a/docs/registries.md
+++ b/docs/registries.md
@@ -11,8 +11,14 @@ available via the `search_servers` / `list_registries` MCP tools, the
 | `official` | Official MCP Registry | `modelcontextprotocol/registry` | no | Primary, zero-config aggregator (`registry.modelcontextprotocol.io/v0.1/servers`). |
 | `reference` | Reference Servers | `builtin/reference` | no | Curated `@modelcontextprotocol` servers, **shipped in-binary** so the basics work offline. |
 | `docker-mcp-catalog` | Docker MCP Catalog | `custom/docker` | no | Signed-container MCP server inventory. |
-| `pulse` | Pulse MCP | `custom/pulse` | **yes** | Opt-in; set `MCPPROXY_REGISTRY_PULSE_API_KEY`. |
-| `smithery` | Smithery | `modelcontextprotocol/registry` | **yes** | Opt-in; set `MCPPROXY_REGISTRY_SMITHERY_API_KEY`. |
+
+The shipped default set is exactly these **three** official/trusted entries. Earlier
+versions also shipped `pulse`, `smithery`, `fleur`, `azure-mcp-demo`, and
+`remote-mcp-servers` as defaults; these were removed. They are pruned from an
+existing `mcp_config.json` on load (genuinely user-added custom registries are never
+touched), so upgrading installs converge to the three above. `pulse` and `smithery`
+can still be **added back** as custom sources (see *Adding your own registry source*);
+when added they read `MCPPROXY_REGISTRY_PULSE_API_KEY` / `MCPPROXY_REGISTRY_SMITHERY_API_KEY`.
 
 Key-requiring registries are **skipped** (not failed) when no key is configured, so
 a default search always succeeds. The API-key env var is
@@ -29,7 +35,7 @@ Every registry carries a **provenance** tag:
 
 | Provenance | Meaning |
 |---|---|
-| `official/trusted` | A shipped, built-in default (the five above). |
+| `official/trusted` | A shipped, built-in default (the three above). |
 | `custom/unverified` | Any registry the user added at runtime, or any non-default ID in `mcp_config.json`. |
 
 Trust is **derived, not asserted** — it comes solely from whether the registry ID

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -912,29 +912,52 @@ func DefaultRegistries() []RegistryEntry {
 			Protocol:    "custom/docker",
 			Provenance:  RegistryProvenanceOfficial,
 		},
-		{
-			ID:          "pulse",
-			Name:        "Pulse MCP",
-			Description: "Browse and discover MCP use-cases, servers, clients, and news (opt-in: requires an API key)",
-			URL:         "https://www.pulsemcp.com/",
-			ServersURL:  "https://api.pulsemcp.com/v0.1/servers",
-			Tags:        []string{"verified"},
-			Protocol:    "custom/pulse",
-			RequiresKey: true,
-			Provenance:  RegistryProvenanceOfficial,
-		},
-		{
-			ID:          "smithery",
-			Name:        "Smithery",
-			Description: "Smithery MCP server registry (opt-in: requires an API key)",
-			URL:         "https://smithery.ai/",
-			ServersURL:  "https://api.smithery.ai/servers",
-			Tags:        []string{"verified"},
-			Protocol:    "modelcontextprotocol/registry",
-			RequiresKey: true,
-			Provenance:  RegistryProvenanceOfficial,
-		},
 	}
+}
+
+// deprecatedDefaultRegistryIDs are registry ids that were SHIPPED as built-in
+// defaults in earlier versions and have since been removed from
+// DefaultRegistries(). Because the registries merge (registry_data.go) keys by id
+// and never prunes, a former default persisted in a user's config would otherwise
+// resurface forever. They are pruned from the persisted config on load
+// (PruneDeprecatedRegistries) and skipped by the merge so the running app
+// converges to the trimmed default set (MCP-1049). Genuinely user-added custom
+// registries are never in this set, so they are always preserved.
+var deprecatedDefaultRegistryIDs = map[string]bool{
+	"pulse":              true,
+	"smithery":           true,
+	"fleur":              true,
+	"azure-mcp-demo":     true,
+	"remote-mcp-servers": true,
+}
+
+// IsDeprecatedDefaultRegistry reports whether id is a known former-default
+// registry that was removed from the shipped set and must not be resurrected.
+func IsDeprecatedDefaultRegistry(id string) bool {
+	return deprecatedDefaultRegistryIDs[id]
+}
+
+// PruneDeprecatedRegistries removes deprecated former-default registries
+// (IsDeprecatedDefaultRegistry) from cfg.Registries in place and returns the
+// number removed. It is idempotent and matches by the known former-default id set
+// ONLY, so a genuinely user-added custom registry is never dropped.
+func PruneDeprecatedRegistries(cfg *Config) int {
+	if cfg == nil || len(cfg.Registries) == 0 {
+		return 0
+	}
+	kept := make([]RegistryEntry, 0, len(cfg.Registries))
+	removed := 0
+	for _, r := range cfg.Registries {
+		if IsDeprecatedDefaultRegistry(r.ID) {
+			removed++
+			continue
+		}
+		kept = append(kept, r)
+	}
+	if removed > 0 {
+		cfg.Registries = kept
+	}
+	return removed
 }
 
 // DefaultConfig returns a default configuration

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -485,6 +485,12 @@ func createDefaultConfigFile(path string, cfg *Config) error {
 
 // initializeRegistries initializes the registries package with config data
 func initializeRegistries(cfg *Config) {
+	// One-time migration (MCP-1049): drop former-default registries that were
+	// trimmed from the shipped set so an existing config converges to the current
+	// defaults instead of resurrecting them on every load. Idempotent and only
+	// touches the known former-default id set, never user-added customs.
+	PruneDeprecatedRegistries(cfg)
+
 	// This function will be implemented to avoid circular imports
 	// For now, we'll create a callback mechanism
 	if registriesInitCallback != nil {

--- a/internal/config/registry_prune_test.go
+++ b/internal/config/registry_prune_test.go
@@ -1,0 +1,114 @@
+package config
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// MCP-1049: the shipped default registry set is trimmed to exactly three
+// official/trusted entries, and former-default registries that were removed from
+// the shipped set are pruned from a user's persisted config on load (the merge in
+// registry_data.go keys by id and never prunes, so without this they live forever
+// in ~/.mcpproxy/config.json).
+
+func TestDefaultRegistries_ExactlyThree(t *testing.T) {
+	defaults := DefaultRegistries()
+	ids := make([]string, 0, len(defaults))
+	for _, r := range defaults {
+		ids = append(ids, r.ID)
+	}
+	sort.Strings(ids)
+	assert.Equal(t, []string{"docker-mcp-catalog", "official", "reference"}, ids,
+		"the shipped default registry set must be exactly official/reference/docker-mcp-catalog")
+}
+
+func TestDefaultRegistries_DoesNotShipDeprecated(t *testing.T) {
+	for _, r := range DefaultRegistries() {
+		assert.Falsef(t, IsDeprecatedDefaultRegistry(r.ID),
+			"shipped default %q must not also be in the deprecated former-default set", r.ID)
+	}
+}
+
+func TestIsDeprecatedDefaultRegistry(t *testing.T) {
+	for _, id := range []string{"pulse", "smithery", "fleur", "azure-mcp-demo", "remote-mcp-servers"} {
+		assert.Truef(t, IsDeprecatedDefaultRegistry(id), "%q must be a known deprecated former-default", id)
+	}
+	for _, id := range []string{"official", "reference", "docker-mcp-catalog", "my-custom-registry", ""} {
+		assert.Falsef(t, IsDeprecatedDefaultRegistry(id), "%q must NOT be flagged deprecated", id)
+	}
+}
+
+func TestPruneDeprecatedRegistries_RemovesFormerDefaultsPreservesCustom(t *testing.T) {
+	cfg := &Config{
+		Registries: []RegistryEntry{
+			{ID: "official", Name: "Official MCP Registry"},
+			{ID: "reference", Name: "Reference Servers"},
+			{ID: "docker-mcp-catalog", Name: "Docker MCP Catalog"},
+			{ID: "pulse", Name: "Pulse MCP"},
+			{ID: "smithery", Name: "Smithery"},
+			{ID: "fleur", Name: "Fleur"},
+			{ID: "azure-mcp-demo", Name: "Azure MCP Registry Demo"},
+			{ID: "remote-mcp-servers", Name: "Remote MCP Servers"},
+			{ID: "my-custom-registry", Name: "My Custom Registry"},
+		},
+	}
+
+	removed := PruneDeprecatedRegistries(cfg)
+	assert.Equal(t, 5, removed, "all five deprecated former-defaults must be removed")
+
+	ids := make([]string, 0, len(cfg.Registries))
+	for _, r := range cfg.Registries {
+		ids = append(ids, r.ID)
+	}
+	sort.Strings(ids)
+	assert.Equal(t, []string{"docker-mcp-catalog", "my-custom-registry", "official", "reference"}, ids,
+		"prune must keep the 3 current defaults plus the genuinely user-added custom registry")
+}
+
+func TestPruneDeprecatedRegistries_Idempotent(t *testing.T) {
+	cfg := &Config{
+		Registries: []RegistryEntry{
+			{ID: "official"},
+			{ID: "pulse"},
+			{ID: "my-custom-registry"},
+		},
+	}
+	first := PruneDeprecatedRegistries(cfg)
+	require.Equal(t, 1, first)
+	second := PruneDeprecatedRegistries(cfg)
+	assert.Equal(t, 0, second, "a second prune must be a no-op (idempotent)")
+	assert.Len(t, cfg.Registries, 2)
+}
+
+func TestPruneDeprecatedRegistries_NilAndEmptySafe(t *testing.T) {
+	assert.Equal(t, 0, PruneDeprecatedRegistries(nil))
+	assert.Equal(t, 0, PruneDeprecatedRegistries(&Config{}))
+}
+
+// initializeRegistries runs on every config load; it must prune the persisted
+// deprecated entries so an existing install converges to the trimmed set.
+func TestInitializeRegistries_PrunesDeprecatedOnLoad(t *testing.T) {
+	cfg := &Config{
+		Registries: []RegistryEntry{
+			{ID: "official"},
+			{ID: "pulse"},
+			{ID: "smithery"},
+			{ID: "fleur"},
+			{ID: "azure-mcp-demo"},
+			{ID: "remote-mcp-servers"},
+			{ID: "my-custom-registry"},
+		},
+	}
+	initializeRegistries(cfg)
+
+	ids := make([]string, 0, len(cfg.Registries))
+	for _, r := range cfg.Registries {
+		ids = append(ids, r.ID)
+	}
+	sort.Strings(ids)
+	assert.Equal(t, []string{"my-custom-registry", "official"}, ids,
+		"load must prune deprecated former-defaults from the persisted config")
+}

--- a/internal/registries/integration_test.go
+++ b/internal/registries/integration_test.go
@@ -146,9 +146,9 @@ func TestCompleteWorkflow(t *testing.T) {
 			t.Error("expected default registries, got none")
 		}
 
-		// Verify we have the expected default registries (official + reference
-		// primary, Docker kept, Pulse opt-in) per MCP-865.
-		expectedIDs := []string{"official", "reference", "docker-mcp-catalog", "pulse"}
+		// Verify we have the trimmed default registry set (MCP-1049): exactly the
+		// three official/trusted entries.
+		expectedIDs := []string{"official", "reference", "docker-mcp-catalog"}
 		found := make(map[string]bool)
 
 		for _, reg := range registries {
@@ -163,11 +163,11 @@ func TestCompleteWorkflow(t *testing.T) {
 	})
 
 	t.Run("find registry by name", func(t *testing.T) {
-		reg := FindRegistry("Pulse MCP")
+		reg := FindRegistry("Docker MCP Catalog")
 		if reg == nil {
-			t.Error("expected to find Pulse MCP registry")
-		} else if reg.ID != "pulse" {
-			t.Errorf("expected ID 'pulse', got '%s'", reg.ID)
+			t.Error("expected to find Docker MCP Catalog registry")
+		} else if reg.ID != "docker-mcp-catalog" {
+			t.Errorf("expected ID 'docker-mcp-catalog', got '%s'", reg.ID)
 		}
 	})
 

--- a/internal/registries/registry_data.go
+++ b/internal/registries/registry_data.go
@@ -45,6 +45,15 @@ func SetRegistriesFromConfig(cfg *config.Config) {
 	}
 	if cfg != nil {
 		for i := range cfg.Registries {
+			// MCP-1049: never resurface a deprecated former-default registry that
+			// is still persisted in an existing config. The load-time prune
+			// (config.PruneDeprecatedRegistries) cleans the persisted slice, and
+			// this skip guarantees convergence even for a stale in-memory config
+			// (hot-reload, direct construction). A genuine custom registry is never
+			// in the deprecated set, so it is always merged.
+			if config.IsDeprecatedDefaultRegistry(cfg.Registries[i].ID) {
+				continue
+			}
 			upsert(fromConfigEntry(&cfg.Registries[i]))
 		}
 	}

--- a/internal/registries/registry_data_test.go
+++ b/internal/registries/registry_data_test.go
@@ -8,15 +8,13 @@ import (
 
 // defaultRegistryIDs are the built-in registries shipped in
 // config.DefaultConfig(). A user-supplied config must MERGE with these, not
-// replace them (FR-006). The set was standardized on the official MCP registry
-// protocol (MCP-865): official + built-in reference primary, Docker kept, Pulse
-// and Smithery demoted to opt-in.
+// replace them (FR-006). The shipped set was trimmed to exactly three
+// official/trusted entries (MCP-1049): the official MCP registry, the built-in
+// reference servers, and the Docker MCP catalog. Pulse and Smithery were removed.
 var defaultRegistryIDs = []string{
 	"official",
 	"reference",
 	"docker-mcp-catalog",
-	"pulse",
-	"smithery",
 }
 
 func registryIDSet(t *testing.T) map[string]RegistryEntry {
@@ -57,7 +55,7 @@ func TestSetRegistriesFromConfig_MergesCustomWithDefaults(t *testing.T) {
 func TestSetRegistriesFromConfig_CustomOverridesDefaultByID(t *testing.T) {
 	cfg := &config.Config{
 		Registries: []config.RegistryEntry{
-			{ID: "pulse", Name: "Pulse OVERRIDDEN", ServersURL: "https://override.example/servers"},
+			{ID: "official", Name: "Official OVERRIDDEN", ServersURL: "https://override.example/servers"},
 		},
 	}
 
@@ -67,8 +65,38 @@ func TestSetRegistriesFromConfig_CustomOverridesDefaultByID(t *testing.T) {
 	if len(got) != len(defaultRegistryIDs) {
 		t.Errorf("override should not change registry count: want %d got %d", len(defaultRegistryIDs), len(got))
 	}
-	if got["pulse"].Name != "Pulse OVERRIDDEN" {
-		t.Errorf("colliding-ID config entry did not override default: got name %q", got["pulse"].Name)
+	if got["official"].Name != "Official OVERRIDDEN" {
+		t.Errorf("colliding-ID config entry did not override default: got name %q", got["official"].Name)
+	}
+}
+
+// MCP-1049: a deprecated former-default registry still persisted in config must
+// NOT resurface in the merged list, while a genuine custom registry is kept.
+func TestSetRegistriesFromConfig_SkipsDeprecatedFormerDefaults(t *testing.T) {
+	cfg := &config.Config{
+		Registries: []config.RegistryEntry{
+			{ID: "pulse", Name: "Pulse MCP"},
+			{ID: "smithery", Name: "Smithery"},
+			{ID: "fleur", Name: "Fleur"},
+			{ID: "azure-mcp-demo", Name: "Azure MCP Registry Demo"},
+			{ID: "remote-mcp-servers", Name: "Remote MCP Servers"},
+			{ID: "mycorp", Name: "My Corp Registry", ServersURL: "https://reg.mycorp.example/servers"},
+		},
+	}
+
+	SetRegistriesFromConfig(cfg)
+
+	got := registryIDSet(t)
+	for _, gone := range []string{"pulse", "smithery", "fleur", "azure-mcp-demo", "remote-mcp-servers"} {
+		if _, ok := got[gone]; ok {
+			t.Errorf("deprecated former-default %q must not resurface in the merged list", gone)
+		}
+	}
+	if _, ok := got["mycorp"]; !ok {
+		t.Errorf("genuine custom registry %q must be preserved", "mycorp")
+	}
+	if len(got) != len(defaultRegistryIDs)+1 {
+		t.Errorf("expected %d registries (3 defaults + 1 custom), got %d", len(defaultRegistryIDs)+1, len(got))
 	}
 }
 

--- a/internal/runtime/list_registries_test.go
+++ b/internal/runtime/list_registries_test.go
@@ -42,10 +42,13 @@ func TestListRegistries_MergesDefaultsWithCustom(t *testing.T) {
 	for _, d := range defaults {
 		assert.Contains(t, idsEmpty, d.ID, "built-in default %q must be listed", d.ID)
 	}
-	// A dropped legacy registry (Fleur, removed in MCP-865) must not leak; the
-	// list must route through the merged defaults source, not stale hard-coded
-	// entries. (Smithery is now a legitimate opt-in default, so it is present.)
-	assert.NotContains(t, idsEmpty, "fleur", "dropped legacy registry must not leak when defaults exist")
+	// Dropped former-default registries must not leak; the list must route
+	// through the merged defaults source, not stale hard-coded entries. The
+	// shipped set is now exactly official/reference/docker-mcp-catalog (MCP-1049),
+	// so pulse, smithery, fleur, azure and remote-mcp-servers are all gone.
+	for _, gone := range []string{"fleur", "pulse", "smithery", "azure-mcp-demo", "remote-mcp-servers"} {
+		assert.NotContainsf(t, idsEmpty, gone, "deprecated former-default %q must not leak when defaults exist", gone)
+	}
 
 	// Custom config → custom entry merges WITH the defaults (does not replace them).
 	rtCustom := &Runtime{logger: logger, cfg: &config.Config{
@@ -61,4 +64,37 @@ func TestListRegistries_MergesDefaultsWithCustom(t *testing.T) {
 		assert.Contains(t, idsCustom, d.ID, "built-in default %q must still appear alongside custom", d.ID)
 	}
 	assert.Len(t, idsCustom, len(defaults)+1, "custom registry must be additive to defaults")
+}
+
+// MCP-1049: the app is config-authoritative — deprecated former-default
+// registries (pulse/smithery/fleur/azure/remote) persisted in an existing
+// install must NOT resurface in the listing. The merge skips them, so the
+// running app converges to the 3 trusted defaults (+ any genuine custom entry)
+// regardless of what stale ids are still on disk.
+func TestListRegistries_DeprecatedPersistedEntriesDoNotResurface(t *testing.T) {
+	logger := zap.NewNop()
+	defaults := config.DefaultRegistries()
+
+	rt := &Runtime{logger: logger, cfg: &config.Config{
+		Registries: []config.RegistryEntry{
+			{ID: "pulse", Name: "Pulse MCP"},
+			{ID: "smithery", Name: "Smithery"},
+			{ID: "fleur", Name: "Fleur"},
+			{ID: "azure-mcp-demo", Name: "Azure MCP Registry Demo"},
+			{ID: "remote-mcp-servers", Name: "Remote MCP Servers"},
+			{ID: "team-internal", Name: "Team Internal", ServersURL: "http://example.test/x", Protocol: "modelcontextprotocol/registry"},
+		},
+	}}
+	got, err := rt.ListRegistries()
+	require.NoError(t, err)
+	ids := registryIDsFromList(t, got)
+
+	for _, gone := range []string{"pulse", "smithery", "fleur", "azure-mcp-demo", "remote-mcp-servers"} {
+		assert.NotContainsf(t, ids, gone, "deprecated former-default %q must not resurface from persisted config", gone)
+	}
+	assert.Contains(t, ids, "team-internal", "a genuine user-added custom registry must be preserved")
+	for _, d := range defaults {
+		assert.Contains(t, ids, d.ID, "built-in default %q must be present", d.ID)
+	}
+	assert.Len(t, ids, len(defaults)+1, "list must be exactly the 3 defaults plus the custom registry")
 }


### PR DESCRIPTION
## What & why

**Release blocker for v0.37.0 (MCP-1049).** The configured-registries list now ships exactly **3** official/trusted entries: `official`, `reference`, `docker-mcp-catalog`. `pulse` and `smithery` are removed from the shipped defaults.

### The config-authoritative catch
The registries merge (`SetRegistriesFromConfig`) keys by id and **never prunes**, so former defaults persisted in an existing config (`pulse`, `smithery`, `fleur`, `azure-mcp-demo`, `remote-mcp-servers`) would resurface forever — that's why the reporter's running app still showed Fleur/Azure/Remote. A pure `DefaultRegistries()` edit does not clean existing installs.

## Changes
- **`internal/config/config.go`** — `DefaultRegistries()` trimmed to the 3 entries. New `IsDeprecatedDefaultRegistry(id)` + `PruneDeprecatedRegistries(cfg)` (idempotent, matches the known former-default id set **only** — never drops a user-added custom registry).
- **`internal/config/loader.go`** — `initializeRegistries` runs the prune on every load (one-time migration, mirrors the MCP-1002 GC-on-config-load placement/idempotency).
- **`internal/registries/registry_data.go`** — merge skips deprecated former-default ids as defense-in-depth, so a stale in-memory config (hot-reload / direct construction) converges too.
- **`docs/registries.md`** — default-set table + trust model updated; documents the prune and that pulse/smithery remain addable as custom sources.

`pulse`/`smithery` protocol + API-key env-var support is intentionally kept so they can still be **added back** as custom sources.

## Tests (TDD)
- New `internal/config/registry_prune_test.go`: `DefaultRegistries()` == exactly 3; prune removes the 5 deprecated ids but preserves a custom registry; idempotent; nil/empty-safe; load-path prunes; deprecated set is disjoint from current defaults.
- `internal/runtime/list_registries_test.go`: extended non-leak guard to pulse/smithery/azure/remote + new case proving persisted deprecated entries don't resurface while a custom one is preserved.
- Updated `internal/registries/{registry_data_test,integration_test}.go` for the trimmed set.
- `go test -race ./internal/config/ ./internal/registries/ ./internal/runtime/` green; golangci-lint 0 issues.

## Verification (mandatory criteria)
Queried the authoritative `GET /api/v1/registries` (the source the Web UI and macOS app both read — no hardcoded copies):
- **Fresh `--data-dir` instance** → exactly **3**: official, reference, docker-mcp-catalog.
- **Existing config** carrying all 5 deprecated former-defaults + 1 custom (`team-internal`) → converges to **3 defaults + team-internal** (deprecated all pruned, custom preserved).

macOS cross-check via `mcpproxy-ui-test` is delegated to the macOS task (propagation is purely via the core API).

Closes MCP-1049.