### PR TITLE
fix(registry): unescape slash serverId so namespaced servers can be added (MCP-1056)

### DIFF
--- a/internal/httpapi/registry_add_test.go
+++ b/internal/httpapi/registry_add_test.go
@@ -1,0 +1,56 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/contracts"
+)
+
+// capturingRegistryController records the exact registryID/serverID the HTTP
+// handler forwards to the controller, so the test can assert they were
+// percent-decoded before lookup (MCP-1056).
+type capturingRegistryController struct {
+	*MockServerController
+	gotRegistryID string
+	gotServerID   string
+}
+
+func (c *capturingRegistryController) AddServerFromRegistryRef(_ context.Context, registryID, serverID, _ string, _ map[string]string, _ *bool) (*config.ServerConfig, *contracts.RegistryAddError, error) {
+	c.gotRegistryID = registryID
+	c.gotServerID = serverID
+	return &config.ServerConfig{Name: "markitdown", Protocol: "stdio", Enabled: true}, nil, nil
+}
+
+// TestAddFromRegistry_SlashServerIDUnescaped reproduces MCP-1056: official v0.1
+// registry ids are namespace/name. chi routes on RawPath, so the {serverId}
+// path param arrives percent-encoded (microsoft%2Fmarkitdown). The handler must
+// url.PathUnescape it before lookup, otherwise the exact-match lookup fails with
+// server_not_found and the server is un-addable on CLI/REST/Web UI.
+func TestAddFromRegistry_SlashServerIDUnescaped(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	controller := &capturingRegistryController{MockServerController: &MockServerController{}}
+	server := NewServer(controller, logger, nil)
+
+	// microsoft/markitdown, percent-encoded as a single path segment.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/registries/github-mcp/servers/microsoft%2Fmarkitdown/add", http.NoBody)
+	w := httptest.NewRecorder()
+	server.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "add should succeed; body=%s", w.Body.String())
+
+	var resp contracts.APIResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success, "response should indicate success")
+
+	assert.Equal(t, "microsoft/markitdown", controller.gotServerID, "serverId must be percent-decoded before registry lookup")
+	assert.Equal(t, "github-mcp", controller.gotRegistryID, "registry id must be percent-decoded before lookup")
+}

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -4136,9 +4137,25 @@ func (s *Server) handleSearchRegistryServers(w http.ResponseWriter, r *http.Requ
 // @Security     ApiKeyAuth
 // @Security     ApiKeyQuery
 // @Router       /api/v1/registries/{id}/servers/{serverId}/add [post]
+// decodePathParam percent-decodes a chi path parameter. chi matches routes on
+// the raw (encoded) path, so parameters that legitimately contain reserved
+// characters such as "/" (encoded as %2F) arrive encoded. On a malformed escape
+// sequence it returns the original value unchanged so the downstream lookup can
+// surface a normal not-found rather than a decode panic.
+func decodePathParam(raw string) string {
+	if decoded, err := url.PathUnescape(raw); err == nil {
+		return decoded
+	}
+	return raw
+}
+
 func (s *Server) handleAddFromRegistry(w http.ResponseWriter, r *http.Request) {
-	registryID := chi.URLParam(r, "id")
-	serverID := chi.URLParam(r, "serverId")
+	// chi routes on RawPath, so path params arrive percent-encoded. Official
+	// modelcontextprotocol/registry v0.1 ids are namespace/name, so the slash
+	// reaches us as %2F and must be decoded before the exact-match registry
+	// lookup, otherwise every namespaced server is un-addable (MCP-1056).
+	registryID := decodePathParam(chi.URLParam(r, "id"))
+	serverID := decodePathParam(chi.URLParam(r, "serverId"))
 	if registryID == "" || serverID == "" {
 		s.writeError(w, r, http.StatusBadRequest, "registry id and server id are required")
 		return


### PR DESCRIPTION
## Summary
Fixes **MCP-1056**: servers whose registry id contains a `/` (every server from the official `modelcontextprotocol/registry` v0.1 protocol — `namespace/name` ids) could not be added. Discovery worked, **add returned `server_not_found`** on CLI, REST, and Web UI.

## Root cause
`handleAddFromRegistry` read `serverID := chi.URLParam(r, "serverId")`. chi routes on RawPath, so the value arrived **percent-encoded** (`microsoft%2Fmarkitdown`) and was never decoded before `FindServerByID`'s exact-match lookup (`entry.ID == serverID`) → `microsoft%2Fmarkitdown` != `microsoft/markitdown` → `ErrServerNotFound`. Both clients escape correctly (CLI `url.PathEscape`, Web UI `encodeURIComponent`); the defect was server-side only.

## Fix
- `handleAddFromRegistry` now `url.PathUnescape`-s both the registry id and the server id (via a small `decodePathParam` helper that falls back to the raw value on a malformed escape) before lookup.
- Regression test `TestAddFromRegistry_SlashServerIDUnescaped` drives a `%2F`-encoded serverId through the chi router and asserts the controller receives the decoded `microsoft/markitdown`. Existing add tests use non-slash ids, which is why spec-070 (pulse) never caught it.

## Verification
- `go test ./internal/httpapi/... -count=1` — green (new test fails before the fix, passes after).
- `go build ./...` — green.
- `./scripts/run-linter.sh` — 0 issues.

## Docs
No user-facing/API surface change — restores the already-documented `POST /registries/{id}/servers/{serverId}/add` behavior. No doc diff needed.

Related MCP-1056