### PR TITLE
feat(frontend): manage custom registries + drop alarming warnings (MCP-1073)

### DIFF
--- a/docs/registries.md
+++ b/docs/registries.md
@@ -52,8 +52,8 @@ Provenance is **informational only** (it no longer changes quarantine behavior):
   recorded on its config as `source_registry_id` / `source_registry_provenance`
   and surfaced in the approval/quarantine view.
 - The `list_registries` output (MCP, REST, CLI) includes `provenance` and a
-  `trusted` boolean (derived `official == trusted`) so a UI can show a one-time
-  third-party-registry warning.
+  `trusted` boolean (derived `official == trusted`) so a UI can show a neutral
+  **Official / Custom** badge.
 - **Migration:** earlier builds persisted the two-word tags `official/trusted` /
   `custom/unverified`; these are normalized to `official` / `custom` on read, so
   an existing `config.db` / `mcp_config.json` keeps working unchanged.
@@ -79,9 +79,12 @@ Equivalent surfaces:
 - **REST:** `POST /api/v1/registries` with `{ "url": "https://…", "protocol": "…", "id": "…", "name": "…" }`.
 - **CLI:** `mcpproxy registry add-source <https-url>`.
 - **Web UI:** the **Repositories** page has an **Add Registry** button (URL + optional
-  protocol/name). Each registry in the selector is flagged **Official · trusted** or
-  **Third-party · unverified** from its `provenance`, and the first custom add shows a
-  one-time third-party-registry warning (the acknowledgement is remembered locally).
+  protocol/name) and a **Registries** section listing every configured source as a
+  card with a neutral **Official / Custom** badge (official cards also carry a
+  **Built-in** tag). There is no warning gate — adding a custom source goes straight
+  through. Custom cards expose a **kebab (⋮) menu** with **Edit** (reuses the
+  add dialog, pre-filled, id read-only) and **Delete** (destructive confirmation);
+  official cards are read-only.
 - **macOS tray:** the **Registries** sidebar tab lists every configured registry
   with its provenance/trust badge, offers an **Add Registry** affordance,
   and shows a one-time third-party warning before the first custom add.
@@ -109,6 +112,7 @@ Equivalent surfaces:
 
 - **REST:** `DELETE /api/v1/registries/{id}` → `{ "registry": { … } }` echoing the removed entry.
 - **CLI:** `mcpproxy registry remove <id>`.
+- **Web UI:** the custom registry card's kebab (⋮) → **Delete**, behind a destructive confirmation modal.
 
 Errors share a stable code across surfaces: `registry_not_found` (404),
 `registry_shadows_builtin` (409, built-in cannot be removed),
@@ -134,6 +138,7 @@ Equivalent surfaces:
 
 - **REST:** `PUT /api/v1/registries/{id}` with `{ "name": "…", "url": "https://…", "servers_url": "https://…" }` (all optional) → `{ "registry": { … } }` echoing the updated entry.
 - **CLI:** `mcpproxy registry edit <id> [--name … --url … --servers-url …]`.
+- **Web UI:** the custom registry card's kebab (⋮) → **Edit**, which reuses the add dialog pre-filled with the current name/URL (id shown read-only).
 
 Errors share a stable code across surfaces: `registry_not_found` (404),
 `registry_shadows_builtin` (409, built-in cannot be edited),

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -678,10 +678,10 @@ class APIService {
     return this.request<SearchRegistryServersResponse>(url)
   }
 
-  // MCP-866 / MCP-867: add a user-supplied registry source. The server always
-  // tags an added source custom/unverified (provenance is NOT part of the
-  // request), so every server later discovered through it lands quarantined and
-  // can never skip quarantine. We mirror the structured-error pattern of
+  // MCP-866 / MCP-867: add a user-supplied registry source. The server tags an
+  // added source as custom provenance (provenance is NOT part of the request) —
+  // informational only (MCP-1072); servers added from it follow the global
+  // quarantine default like any other. We mirror the structured-error pattern of
   // addServerFromRegistry so the UI can branch on the stable `code`
   // (invalid_registry_url | registries_locked | registry_shadows_builtin |
   // duplicate_registry).
@@ -710,6 +710,92 @@ class APIService {
         if (response.status === 401 || response.status === 403) {
           // registries_locked is a 403 but is a policy decision, not an auth
           // failure — only emit the auth-error path for a missing/invalid key.
+          if (payload?.code !== 'registries_locked') {
+            this.emitAuthError(payload?.error || `HTTP ${response.status}`, response.status)
+          }
+        }
+        return {
+          success: false,
+          error: payload?.error || `HTTP ${response.status}: ${response.statusText}`,
+          code: payload?.code
+        }
+      }
+
+      return { success: true, registry: payload?.data?.registry }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      }
+    }
+  }
+
+  // MCP-1073: edit a user-added custom registry source via
+  // PUT /api/v1/registries/{id}. Only the fields supplied are sent; empty fields
+  // are left unchanged server-side. Built-in registries are read-only and the
+  // backend refuses them with registry_shadows_builtin. Mirrors
+  // addRegistrySource's structured-error contract (registry_not_found |
+  // registry_shadows_builtin | invalid_registry_url | registries_locked).
+  async editRegistrySource(
+    id: string,
+    opts: { name?: string; url?: string; serversUrl?: string }
+  ): Promise<AddRegistrySourceResult> {
+    const body: Record<string, unknown> = {}
+    if (opts.name) body.name = opts.name
+    if (opts.url) body.url = opts.url
+    if (opts.serversUrl) body.servers_url = opts.serversUrl
+
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+    if (this.apiKey) headers['X-API-Key'] = this.apiKey
+
+    try {
+      const response = await fetch(`${this.baseUrl}/api/v1/registries/${encodeURIComponent(id)}`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify(body)
+      })
+
+      const payload: any = await response.json().catch(() => ({}))
+
+      if (!response.ok) {
+        if (response.status === 401 || response.status === 403) {
+          if (payload?.code !== 'registries_locked') {
+            this.emitAuthError(payload?.error || `HTTP ${response.status}`, response.status)
+          }
+        }
+        return {
+          success: false,
+          error: payload?.error || `HTTP ${response.status}: ${response.statusText}`,
+          code: payload?.code
+        }
+      }
+
+      return { success: true, registry: payload?.data?.registry }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      }
+    }
+  }
+
+  // MCP-1073: remove a user-added custom registry source via
+  // DELETE /api/v1/registries/{id}. Servers already added from it stay; only the
+  // source is removed. Built-in registries are read-only (registry_shadows_builtin).
+  async removeRegistrySource(id: string): Promise<AddRegistrySourceResult> {
+    const headers: Record<string, string> = {}
+    if (this.apiKey) headers['X-API-Key'] = this.apiKey
+
+    try {
+      const response = await fetch(`${this.baseUrl}/api/v1/registries/${encodeURIComponent(id)}`, {
+        method: 'DELETE',
+        headers
+      })
+
+      const payload: any = await response.json().catch(() => ({}))
+
+      if (!response.ok) {
+        if (response.status === 401 || response.status === 403) {
           if (payload?.code !== 'registries_locked') {
             this.emitAuthError(payload?.error || `HTTP ${response.status}`, response.status)
           }

--- a/frontend/src/views/Repositories.vue
+++ b/frontend/src/views/Repositories.vue
@@ -18,6 +18,80 @@
       </button>
     </div>
 
+    <!-- Configured registries (manage sources) — MCP-1073 -->
+    <div class="card bg-base-100 shadow-md" data-test="registries-manage-section">
+      <div class="card-body">
+        <div>
+          <h2 class="card-title text-lg">Registries</h2>
+          <p class="text-sm text-base-content/70">Sources MCPProxy browses for MCP servers. Custom sources you add can be edited or removed.</p>
+        </div>
+
+        <!-- Loading -->
+        <div v-if="loadingRegistries" class="flex items-center gap-2 py-4 text-base-content/70" data-test="registries-loading">
+          <span class="loading loading-spinner loading-sm"></span>
+          <span>Loading registries…</span>
+        </div>
+
+        <!-- Empty (rare — defaults are always present) -->
+        <div v-else-if="registries.length === 0" class="text-sm text-base-content/60 py-4" data-test="registries-empty">
+          No registries configured.
+        </div>
+
+        <!-- Cards grid -->
+        <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3 mt-2">
+          <div
+            v-for="registry in registries"
+            :key="registry.id"
+            class="border border-base-300 rounded-lg p-3 flex flex-col gap-2"
+            :data-test="`registry-card-${registry.id}`"
+          >
+            <div class="flex items-start justify-between gap-2">
+              <div class="font-semibold min-w-0 [overflow-wrap:anywhere]">{{ registry.name }}</div>
+
+              <!-- Kebab (⋮) menu — custom registries only; official is read-only -->
+              <div v-if="isCustomRegistry(registry)" class="dropdown dropdown-end shrink-0">
+                <div
+                  tabindex="0"
+                  role="button"
+                  class="btn btn-ghost btn-xs btn-square"
+                  :data-test="`registry-kebab-${registry.id}`"
+                  :aria-label="`Manage ${registry.name}`"
+                >
+                  <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M12 8a2 2 0 100-4 2 2 0 000 4zm0 2a2 2 0 100 4 2 2 0 000-4zm0 6a2 2 0 100 4 2 2 0 000-4z" />
+                  </svg>
+                </div>
+                <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-10 w-32 p-1 shadow-lg border border-base-300">
+                  <li>
+                    <button type="button" :data-test="`registry-edit-${registry.id}`" @click="openEditRegistry(registry)">Edit</button>
+                  </li>
+                  <li>
+                    <button type="button" class="text-error" :data-test="`registry-delete-${registry.id}`" @click="openDeleteRegistry(registry)">Delete</button>
+                  </li>
+                </ul>
+              </div>
+            </div>
+
+            <!-- Neutral provenance badge (Official / Custom) + Built-in tag -->
+            <div class="flex flex-wrap gap-1 items-center">
+              <span
+                class="badge badge-sm"
+                :class="isCustomRegistry(registry) ? 'badge-ghost' : 'badge-outline'"
+                :data-test="`registry-provenance-${registry.id}`"
+              >{{ isCustomRegistry(registry) ? 'Custom' : 'Official' }}</span>
+              <span
+                v-if="!isCustomRegistry(registry)"
+                class="badge badge-sm badge-ghost"
+                :data-test="`registry-builtin-${registry.id}`"
+              >Built-in</span>
+            </div>
+
+            <div v-if="registry.url" class="text-xs text-base-content/60 truncate" :title="registry.url">{{ registry.url }}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <!-- Registry Selector & Search -->
     <div class="card bg-base-100 shadow-md">
       <div class="card-body">
@@ -55,7 +129,7 @@
                       @change="toggleRegistry(registry.id)"
                       :data-test="`registry-option-${registry.id}`"
                     />
-                    <span class="text-sm">{{ registry.name }}<span v-if="isCustomRegistry(registry)" class="opacity-60"> — unverified</span></span>
+                    <span class="text-sm">{{ registry.name }}<span v-if="isCustomRegistry(registry)" class="opacity-60"> — custom</span></span>
                   </label>
                 </li>
               </ul>
@@ -312,18 +386,35 @@
       </form>
     </dialog>
 
-    <!-- Add Registry Source dialog (MCP-866/MCP-867) -->
+    <!-- Add / Edit Registry Source dialog (MCP-866 add, MCP-1073 edit) -->
     <dialog :open="showAddRegistry" class="modal" data-test="registry-add-source-dialog">
       <div class="modal-box">
-        <h3 class="font-bold text-lg">Add a registry</h3>
+        <h3 class="font-bold text-lg">{{ isEditMode ? 'Edit registry' : 'Add a registry' }}</h3>
         <p class="text-sm text-base-content/70 mt-1">
-          Add a custom <code>modelcontextprotocol/registry</code> v0.1 source by its HTTPS URL.
-          Added registries are marked
-          <span class="badge badge-warning badge-xs align-middle">third-party · unverified</span>;
-          their servers are always quarantined.
+          <template v-if="isEditMode">
+            Update this custom <code>modelcontextprotocol/registry</code> source. Its id is fixed.
+          </template>
+          <template v-else>
+            Add a custom <code>modelcontextprotocol/registry</code> v0.1 source by its HTTPS URL.
+            It is shown as a <span class="badge badge-ghost badge-xs align-middle">Custom</span> source.
+          </template>
         </p>
 
-        <form @submit.prevent="submitAddRegistry" class="mt-4 space-y-3" data-test="registry-add-form">
+        <form @submit.prevent="submitRegistryDialog" class="mt-4 space-y-3" data-test="registry-add-form">
+          <!-- Read-only id (edit mode only) -->
+          <div v-if="isEditMode" class="form-control">
+            <label class="label">
+              <span class="label-text font-semibold">Registry ID</span>
+            </label>
+            <input
+              :value="editRegistryId"
+              type="text"
+              data-test="registry-edit-id"
+              class="input input-bordered w-full opacity-70"
+              readonly
+            />
+          </div>
+
           <div class="form-control">
             <label class="label">
               <span class="label-text font-semibold">Registry URL</span>
@@ -339,7 +430,7 @@
             />
           </div>
 
-          <div class="form-control">
+          <div v-if="!isEditMode" class="form-control">
             <label class="label">
               <span class="label-text font-semibold">Protocol</span>
             </label>
@@ -381,7 +472,7 @@
               :disabled="!addRegistryUrl.trim() || addingRegistry"
             >
               <span v-if="addingRegistry" class="loading loading-spinner loading-xs"></span>
-              <span v-else>Add Registry</span>
+              <span v-else>{{ isEditMode ? 'Save changes' : 'Add Registry' }}</span>
             </button>
           </div>
         </form>
@@ -391,48 +482,36 @@
       </form>
     </dialog>
 
-    <!-- One-time third-party registry warning (MCP-867) -->
-    <dialog :open="showThirdPartyWarning" class="modal" data-test="registry-third-party-warning">
+    <!-- Delete custom registry confirmation (MCP-1073, destructive) -->
+    <dialog :open="showDeleteRegistry" class="modal" data-test="registry-delete-dialog">
       <div class="modal-box">
-        <h3 class="font-bold text-lg text-warning flex items-center gap-2">
-          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-          </svg>
-          Adding a third-party registry
-        </h3>
-        <div class="text-sm py-3 space-y-2">
-          <p>
-            You're about to add a registry that is <strong>not</strong> shipped with MCPProxy.
-            Custom registries are <strong>unverified</strong> — MCPProxy cannot vouch for the
-            servers they list.
-          </p>
-          <p>
-            For your safety, every server you add from a custom registry is
-            <strong>always quarantined</strong> and can never skip security review.
-            Only add registries operated by parties you trust.
-          </p>
+        <h3 class="font-bold text-lg">Remove "{{ deleteRegistryTarget?.name }}"?</h3>
+        <p class="text-sm py-2 text-base-content/80">
+          Servers you already added stay; only the source is removed.
+        </p>
+
+        <div v-if="deleteRegistryError" class="alert alert-error text-sm" data-test="registry-delete-error">
+          <span>{{ deleteRegistryError }}</span>
         </div>
+
         <div class="modal-action">
-          <button
-            type="button"
-            class="btn btn-ghost"
-            data-test="registry-third-party-cancel"
-            @click="cancelThirdPartyWarning"
-          >
+          <button type="button" class="btn btn-ghost" data-test="registry-delete-cancel" @click="closeDeleteRegistry">
             Cancel
           </button>
           <button
             type="button"
-            class="btn btn-warning"
-            data-test="registry-third-party-acknowledge"
-            @click="acknowledgeThirdPartyWarning"
+            class="btn btn-error"
+            data-test="registry-delete-confirm"
+            :disabled="deletingRegistry"
+            @click="confirmDeleteRegistry"
           >
-            I understand, continue
+            <span v-if="deletingRegistry" class="loading loading-spinner loading-xs"></span>
+            <span v-else>Remove</span>
           </button>
         </div>
       </div>
       <form method="dialog" class="modal-backdrop">
-        <button @click="cancelThirdPartyWarning">close</button>
+        <button @click="closeDeleteRegistry">close</button>
       </form>
     </dialog>
 
@@ -459,11 +538,6 @@ import type { Hint } from '@/components/CollapsibleHintsPanel.vue'
 import type { Registry, RepositoryServer, RequiredInput } from '@/types'
 import { REGISTRY_PROVENANCE_CUSTOM } from '@/types'
 
-// localStorage key recording that the user has acknowledged the one-time
-// third-party registry warning (MCP-867). Once acknowledged, subsequent custom
-// adds skip the warning.
-const THIRD_PARTY_ACK_KEY = 'mcpproxy-thirdparty-registry-ack'
-
 // State
 const registries = ref<Registry[]>([])
 const selectedRegistries = ref<string[]>([])
@@ -485,14 +559,22 @@ const promptServer = ref<RepositoryServer | null>(null)
 const promptInputs = ref<RequiredInput[]>([])
 const promptValues = ref<Record<string, string>>({})
 
-// Add-registry-source state (MCP-866/MCP-867)
+// Add / edit registry-source dialog state (MCP-866 add, MCP-1073 edit).
+// editRegistryId is empty in add mode and the registry id in edit mode.
 const showAddRegistry = ref(false)
+const editRegistryId = ref<string | null>(null)
 const addRegistryUrl = ref('')
 const addRegistryProtocol = ref('modelcontextprotocol/registry')
 const addRegistryName = ref('')
 const addRegistryError = ref<string | null>(null)
 const addingRegistry = ref(false)
-const showThirdPartyWarning = ref(false)
+const isEditMode = computed(() => editRegistryId.value !== null)
+
+// Delete-custom-registry confirmation state (MCP-1073)
+const showDeleteRegistry = ref(false)
+const deleteRegistryTarget = ref<Registry | null>(null)
+const deleteRegistryError = ref<string | null>(null)
+const deletingRegistry = ref(false)
 
 let searchDebounceTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -786,73 +868,58 @@ function closePrompt() {
   promptValues.value = {}
 }
 
-// --- Add registry source (MCP-866/MCP-867) ---
+// --- Add / edit / delete registry source (MCP-866 add, MCP-1073 edit+delete) ---
 
+// Open the dialog in add mode (blank, editRegistryId = null).
 function openAddRegistry() {
+  editRegistryId.value = null
   addRegistryUrl.value = ''
   addRegistryProtocol.value = 'modelcontextprotocol/registry'
   addRegistryName.value = ''
   addRegistryError.value = null
-  showThirdPartyWarning.value = false
+  showAddRegistry.value = true
+}
+
+// Open the dialog in edit mode, pre-filled from a custom registry (MCP-1073).
+// The id is fixed and shown read-only; only name/url are editable.
+function openEditRegistry(registry: Registry) {
+  editRegistryId.value = registry.id
+  addRegistryUrl.value = registry.url || registry.servers_url || ''
+  addRegistryName.value = registry.name || ''
+  addRegistryError.value = null
   showAddRegistry.value = true
 }
 
 function closeAddRegistry() {
   if (addingRegistry.value) return
   showAddRegistry.value = false
-  showThirdPartyWarning.value = false
+  editRegistryId.value = null
 }
 
-function hasAcknowledgedThirdParty(): boolean {
-  try {
-    return localStorage.getItem(THIRD_PARTY_ACK_KEY) === 'true'
-  } catch {
-    return false
-  }
-}
-
-// Form submit: gate the first-ever custom add behind the one-time third-party
-// warning. Every user-added source is custom/unverified server-side, so the
-// warning applies to all adds — but only until the user acknowledges it once.
-function submitAddRegistry() {
-  if (!addRegistryUrl.value.trim() || addingRegistry.value) return
-  addRegistryError.value = null
-
-  if (!hasAcknowledgedThirdParty()) {
-    showThirdPartyWarning.value = true
-    return
-  }
-  doAddRegistry()
-}
-
-function cancelThirdPartyWarning() {
-  showThirdPartyWarning.value = false
-}
-
-function acknowledgeThirdPartyWarning() {
-  try {
-    localStorage.setItem(THIRD_PARTY_ACK_KEY, 'true')
-  } catch {
-    // Non-fatal: if storage is unavailable the warning simply re-appears next time.
-  }
-  showThirdPartyWarning.value = false
-  doAddRegistry()
-}
-
-// Map the backend's stable error codes to actionable messages.
-function addRegistryErrorMessage(code: string | undefined, fallback: string | undefined): string {
+// Map the backend's stable error codes to actionable messages. Shared across
+// add / edit / delete since all three surface the same code set.
+function registryErrorMessage(code: string | undefined, fallback: string | undefined, verb: string): string {
   switch (code) {
     case 'invalid_registry_url':
       return fallback || 'That URL is not a valid HTTPS registry endpoint.'
     case 'registries_locked':
-      return 'Adding registries is locked by an administrator on this instance.'
+      return `${verb} registries is locked by an administrator on this instance.`
     case 'registry_shadows_builtin':
-      return 'That id/host collides with a built-in registry. Try a different id.'
+      return 'That id/host collides with a built-in registry.'
+    case 'registry_not_found':
+      return 'That registry no longer exists. It may have already been removed.'
     case 'duplicate_registry':
       return 'A registry with that id is already configured.'
     default:
-      return fallback || 'Failed to add registry.'
+      return fallback || `Failed to ${verb.toLowerCase()} registry.`
   }
+}
+
+// Single submit path for both add and edit modes.
+function submitRegistryDialog() {
+  if (!addRegistryUrl.value.trim() || addingRegistry.value) return
+  if (isEditMode.value) doEditRegistry()
+  else doAddRegistry()
 }
 
 async function doAddRegistry() {
@@ -868,24 +935,95 @@ async function doAddRegistry() {
     if (result.success) {
       const added = result.registry
       showAddRegistry.value = false
-      // Refresh the list so the new (custom/unverified) entry appears with its
-      // provenance, then select it for immediate browsing.
+      // Refresh the list so the new custom entry appears, then select it for
+      // immediate browsing.
       await loadRegistries()
       if (added?.id) {
-        // Add the new registry to the multiselect (don't clobber existing picks)
-        // and browse it immediately.
         if (!selectedRegistries.value.includes(added.id)) selectedRegistries.value.push(added.id)
         handleRegistryChange()
       }
-      showToast(`Added registry "${added?.name || added?.id || addRegistryUrl.value}" — third-party · unverified.`)
+      showToast(`Added registry "${added?.name || added?.id || addRegistryUrl.value}".`)
       return
     }
 
-    addRegistryError.value = addRegistryErrorMessage(result.code, result.error)
+    addRegistryError.value = registryErrorMessage(result.code, result.error, 'Adding')
   } catch (err) {
     addRegistryError.value = 'Failed to add registry: ' + (err as Error).message
   } finally {
     addingRegistry.value = false
+  }
+}
+
+async function doEditRegistry() {
+  const id = editRegistryId.value
+  if (!id) return
+  addingRegistry.value = true
+  addRegistryError.value = null
+
+  try {
+    const result = await api.editRegistrySource(id, {
+      name: addRegistryName.value.trim() || undefined,
+      url: addRegistryUrl.value.trim() || undefined
+    })
+
+    if (result.success) {
+      showAddRegistry.value = false
+      editRegistryId.value = null
+      await loadRegistries()
+      const updated = result.registry
+      showToast(`Updated registry "${updated?.name || updated?.id || id}".`)
+      return
+    }
+
+    addRegistryError.value = registryErrorMessage(result.code, result.error, 'Editing')
+  } catch (err) {
+    addRegistryError.value = 'Failed to edit registry: ' + (err as Error).message
+  } finally {
+    addingRegistry.value = false
+  }
+}
+
+// Delete-custom-registry confirmation flow (MCP-1073). The kebab Delete only
+// opens the modal; the API call happens on explicit confirm.
+function openDeleteRegistry(registry: Registry) {
+  deleteRegistryTarget.value = registry
+  deleteRegistryError.value = null
+  showDeleteRegistry.value = true
+}
+
+function closeDeleteRegistry() {
+  if (deletingRegistry.value) return
+  showDeleteRegistry.value = false
+  deleteRegistryTarget.value = null
+}
+
+async function confirmDeleteRegistry() {
+  const target = deleteRegistryTarget.value
+  if (!target) return
+  deletingRegistry.value = true
+  deleteRegistryError.value = null
+
+  try {
+    const result = await api.removeRegistrySource(target.id)
+    if (result.success) {
+      // Drop it from any active selection so the search filter stays consistent.
+      const i = selectedRegistries.value.indexOf(target.id)
+      if (i !== -1) {
+        selectedRegistries.value.splice(i, 1)
+        handleRegistryChange()
+      }
+      showDeleteRegistry.value = false
+      deleteRegistryTarget.value = null
+      await loadRegistries()
+      showToast(`Removed registry "${target.name || target.id}".`)
+      return
+    }
+
+    deleteRegistryError.value = registryErrorMessage(result.code, result.error, 'Removing')
+  } catch (err) {
+    deleteRegistryError.value = 'Failed to remove registry: ' + (err as Error).message
+  } finally {
+    deletingRegistry.value = false
   }
 }
 

--- a/frontend/tests/unit/registry-edit-remove-source.spec.ts
+++ b/frontend/tests/unit/registry-edit-remove-source.spec.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import api from '@/services/api'
+
+// MCP-1073: custom registries can be edited (PUT /api/v1/registries/{id}) and
+// removed (DELETE /api/v1/registries/{id}). Both mirror addRegistrySource's
+// structured-error pattern, surfacing the stable `code`
+// (registry_not_found | registry_shadows_builtin | invalid_registry_url |
+// registries_locked) so the UI can render an actionable message.
+
+describe('api.editRegistrySource', () => {
+  beforeEach(() => {
+    api.setAPIKey('test-key')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    api.clearAPIKey()
+  })
+
+  it('PUTs only the supplied fields and returns the updated registry summary', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        success: true,
+        data: {
+          registry: {
+            id: 'acme',
+            name: 'Acme Renamed',
+            url: 'https://acme.example/registry',
+            servers_url: 'https://acme.example/registry/v0.1/servers',
+            protocol: 'modelcontextprotocol/registry',
+            provenance: 'custom',
+            trusted: false
+          }
+        },
+        request_id: 'req-1'
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await api.editRegistrySource('acme', { name: 'Acme Renamed' })
+
+    expect(result.success).toBe(true)
+    expect(result.registry?.name).toBe('Acme Renamed')
+
+    const [calledUrl, calledInit] = fetchMock.mock.calls[0]
+    expect(calledUrl).toBe('/api/v1/registries/acme')
+    expect(calledInit.method).toBe('PUT')
+    expect((calledInit.headers as Record<string, string>)['X-API-Key']).toBe('test-key')
+    // Only non-empty fields are sent; empty = unchanged (backend contract).
+    expect(JSON.parse(calledInit.body)).toEqual({ name: 'Acme Renamed' })
+  })
+
+  it('percent-encodes the id and sends url/servers_url when supplied', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, data: { registry: { id: 'a/b', name: 'AB' } } })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await api.editRegistrySource('a/b', {
+      url: 'https://acme.example/v2',
+      serversUrl: 'https://acme.example/v2/servers'
+    })
+
+    const [calledUrl, calledInit] = fetchMock.mock.calls[0]
+    expect(calledUrl).toBe('/api/v1/registries/a%2Fb')
+    expect(JSON.parse(calledInit.body)).toEqual({
+      url: 'https://acme.example/v2',
+      servers_url: 'https://acme.example/v2/servers'
+    })
+  })
+
+  it('surfaces registry_shadows_builtin / registry_not_found as a structured error', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 409,
+      statusText: 'Conflict',
+      json: async () => ({ success: false, error: 'collides with a built-in registry', code: 'registry_shadows_builtin' })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await api.editRegistrySource('official', { name: 'x' })
+    expect(result.success).toBe(false)
+    expect(result.code).toBe('registry_shadows_builtin')
+  })
+})
+
+describe('api.removeRegistrySource', () => {
+  beforeEach(() => {
+    api.setAPIKey('test-key')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    api.clearAPIKey()
+  })
+
+  it('DELETEs the (encoded) id and reports success', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, data: { registry: { id: 'acme', name: 'Acme' } } })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await api.removeRegistrySource('acme')
+
+    expect(result.success).toBe(true)
+    const [calledUrl, calledInit] = fetchMock.mock.calls[0]
+    expect(calledUrl).toBe('/api/v1/registries/acme')
+    expect(calledInit.method).toBe('DELETE')
+  })
+
+  it('surfaces registries_locked as a structured error', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+      json: async () => ({ success: false, error: 'locked', code: 'registries_locked' })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await api.removeRegistrySource('acme')
+    expect(result.success).toBe(false)
+    expect(result.code).toBe('registries_locked')
+  })
+
+  it('surfaces registry_shadows_builtin when trying to remove a built-in', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 409,
+      statusText: 'Conflict',
+      json: async () => ({ success: false, error: 'cannot remove built-in', code: 'registry_shadows_builtin' })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await api.removeRegistrySource('official')
+    expect(result.success).toBe(false)
+    expect(result.code).toBe('registry_shadows_builtin')
+  })
+})

--- a/frontend/tests/unit/repositories-add-registry.spec.ts
+++ b/frontend/tests/unit/repositories-add-registry.spec.ts
@@ -4,16 +4,19 @@ import { createPinia, setActivePinia } from 'pinia'
 import Repositories from '@/views/Repositories.vue'
 import api from '@/services/api'
 
-// MCP-867: the Repositories view gains an add-registry affordance, provenance
-// surfacing, and a one-time third-party warning. These tests lock the gating
-// (warning shown before the first custom add; skipped after acknowledgement)
-// and the provenance badge selection.
+// MCP-867 + MCP-1073: the Repositories view exposes an add-registry affordance
+// and surfaces provenance neutrally. MCP-1073 removed the alarming one-time
+// third-party warning gate and the "always quarantined" copy — adding a custom
+// source now goes straight through, and trust is surfaced as a neutral
+// Official/Custom badge.
 
 vi.mock('@/services/api', () => ({
   default: {
     listRegistries: vi.fn(),
     searchRegistryServers: vi.fn(),
     addRegistrySource: vi.fn(),
+    editRegistrySource: vi.fn(),
+    removeRegistrySource: vi.fn(),
     addServerFromRegistry: vi.fn(),
   },
 }))
@@ -34,7 +37,7 @@ const officialRegistry = {
   name: 'Official MCP Registry',
   description: 'The official registry',
   url: 'https://registry.modelcontextprotocol.io/',
-  provenance: 'official/trusted',
+  provenance: 'official',
   trusted: true,
 }
 
@@ -43,11 +46,11 @@ const customRegistry = {
   name: 'Acme Registry',
   description: 'A custom source',
   url: 'https://acme.example/registry',
-  provenance: 'custom/unverified',
+  provenance: 'custom',
   trusted: false,
 }
 
-describe('Repositories — add registry + provenance + third-party warning', () => {
+describe('Repositories — add registry + neutral provenance (MCP-867/MCP-1073)', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     localStorage.clear()
@@ -68,11 +71,7 @@ describe('Repositories — add registry + provenance + third-party warning', () 
     expect(wrapper.find('[data-test="registry-add-source-button"]').exists()).toBe(true)
   })
 
-  it('flags a custom registry as unverified in the multiselect and an official one without that suffix', async () => {
-    // R4: provenance banner removed; trust surfaced inline in the registry
-    // multiselect (R1) — the option label carries "— unverified" for
-    // third-party registries. R1: it is a multiselect (checkboxes), not a
-    // single <select>.
+  it('surfaces trust neutrally: custom flagged "custom" in the multiselect, official without it; no alarming banner', async () => {
     const wrapper = mountView()
     await flushPromises()
 
@@ -80,12 +79,13 @@ describe('Repositories — add registry + provenance + third-party warning', () 
     const officialOpt = wrapper.find('[data-test="registry-option-official"]')
     expect(acmeOpt.exists()).toBe(true)
     expect(officialOpt.exists()).toBe(true)
-    expect((acmeOpt.element as HTMLElement).closest('label')?.textContent).toContain('unverified')
-    expect((officialOpt.element as HTMLElement).closest('label')?.textContent).not.toContain('unverified')
+    expect((acmeOpt.element as HTMLElement).closest('label')?.textContent).toContain('custom')
+    expect((officialOpt.element as HTMLElement).closest('label')?.textContent).not.toContain('custom')
 
-    // The old prominent banner / quarantine-note block is gone.
-    expect(wrapper.find('[data-test="registry-provenance-badge-custom"]').exists()).toBe(false)
-    expect(wrapper.find('[data-test="registry-custom-quarantine-note"]').exists()).toBe(false)
+    // No alarming copy anywhere, and the old warning gate is gone.
+    expect(wrapper.find('[data-test="registry-third-party-warning"]').exists()).toBe(false)
+    expect(wrapper.html().toLowerCase()).not.toContain('unverified')
+    expect(wrapper.html().toLowerCase()).not.toContain('always quarantined')
   })
 
   it('multiselect: toggling a registry searches it; selecting a second searches across both (R1)', async () => {
@@ -103,56 +103,31 @@ describe('Repositories — add registry + provenance + third-party warning', () 
     expect(searched).toContain('acme')
   })
 
-  it('shows the one-time third-party warning before the first add and does NOT call the API yet', async () => {
-    const wrapper = mountView()
-    await flushPromises()
-
-    await wrapper.find('[data-test="registry-add-source-button"]').trigger('click')
-    await wrapper.find('[data-test="registry-add-url-input"]').setValue('https://acme.example/registry')
-    await wrapper.find('[data-test="registry-add-form"]').trigger('submit')
-    await flushPromises()
-
-    // Warning is shown; the add request has not gone out.
-    expect((wrapper.find('[data-test="registry-third-party-warning"]').element as HTMLDialogElement).hasAttribute('open')).toBe(true)
-    expect(api.addRegistrySource).not.toHaveBeenCalled()
-  })
-
-  it('proceeds with the add after acknowledging, and persists acknowledgement so the warning is skipped next time', async () => {
+  it('adds a custom source directly — no warning gate, no acknowledgement persisted', async () => {
     ;(api.addRegistrySource as any).mockResolvedValue({
       success: true,
-      registry: { id: 'acme', name: 'Acme Registry', provenance: 'custom/unverified', trusted: false },
+      registry: { id: 'acme', name: 'Acme Registry', provenance: 'custom', trusted: false },
     })
 
     const wrapper = mountView()
     await flushPromises()
 
-    // First add → warning → acknowledge → API called once.
     await wrapper.find('[data-test="registry-add-source-button"]').trigger('click')
     await wrapper.find('[data-test="registry-add-url-input"]').setValue('https://acme.example/registry')
     await wrapper.find('[data-test="registry-add-form"]').trigger('submit')
     await flushPromises()
-    await wrapper.find('[data-test="registry-third-party-acknowledge"]').trigger('click')
-    await flushPromises()
 
+    // The add goes straight through; no warning dialog, no localStorage ack.
     expect(api.addRegistrySource).toHaveBeenCalledTimes(1)
     expect(api.addRegistrySource).toHaveBeenCalledWith('https://acme.example/registry', {
       protocol: 'modelcontextprotocol/registry',
       name: undefined,
     })
-    expect(localStorage.getItem('mcpproxy-thirdparty-registry-ack')).toBe('true')
-
-    // Second add → no warning, API called directly.
-    await wrapper.find('[data-test="registry-add-source-button"]').trigger('click')
-    await wrapper.find('[data-test="registry-add-url-input"]').setValue('https://other.example/registry')
-    await wrapper.find('[data-test="registry-add-form"]').trigger('submit')
-    await flushPromises()
-
-    expect((wrapper.find('[data-test="registry-third-party-warning"]').element as HTMLDialogElement).hasAttribute('open')).toBe(false)
-    expect(api.addRegistrySource).toHaveBeenCalledTimes(2)
+    expect(localStorage.getItem('mcpproxy-thirdparty-registry-ack')).toBe(null)
+    expect(wrapper.find('[data-test="registry-third-party-warning"]').exists()).toBe(false)
   })
 
   it('surfaces a friendly message for a locked-registries error', async () => {
-    localStorage.setItem('mcpproxy-thirdparty-registry-ack', 'true')
     ;(api.addRegistrySource as any).mockResolvedValue({
       success: false,
       code: 'registries_locked',

--- a/frontend/tests/unit/repositories-manage-registries.spec.ts
+++ b/frontend/tests/unit/repositories-manage-registries.spec.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import Repositories from '@/views/Repositories.vue'
+import api from '@/services/api'
+
+// MCP-1073: the Repositories view manages registry *sources* as cards.
+// - Custom registries get a kebab (⋮) menu with Edit + Delete.
+// - Official (built-in) registries are read-only: no kebab, a neutral
+//   "Built-in" tag, and a neutral Official/Custom badge (no alarming copy).
+// - Edit reuses the Add-Registry dialog, pre-filled, with a read-only id.
+// - Delete shows a destructive confirmation modal before calling the API.
+
+vi.mock('@/services/api', () => ({
+  default: {
+    listRegistries: vi.fn(),
+    searchRegistryServers: vi.fn(),
+    addRegistrySource: vi.fn(),
+    editRegistrySource: vi.fn(),
+    removeRegistrySource: vi.fn(),
+    addServerFromRegistry: vi.fn(),
+  },
+}))
+
+const globalStubs = {
+  CollapsibleHintsPanel: { template: '<div />' },
+}
+
+function mountView() {
+  return mount(Repositories, {
+    global: { plugins: [createPinia()], stubs: globalStubs },
+  })
+}
+
+const officialRegistry = {
+  id: 'official',
+  name: 'Official MCP Registry',
+  description: 'The official registry',
+  url: 'https://registry.modelcontextprotocol.io/',
+  provenance: 'official',
+  trusted: true,
+}
+
+const customRegistry = {
+  id: 'acme',
+  name: 'Acme Registry',
+  description: 'A custom source',
+  url: 'https://acme.example/registry',
+  servers_url: 'https://acme.example/registry/v0.1/servers',
+  provenance: 'custom',
+  trusted: false,
+}
+
+describe('Repositories — manage registry sources (MCP-1073)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+    ;(api.listRegistries as any).mockResolvedValue({
+      success: true,
+      data: { registries: [officialRegistry, customRegistry], total: 2 },
+    })
+    ;(api.searchRegistryServers as any).mockResolvedValue({
+      success: true,
+      data: { registry_id: 'official', servers: [], total: 0 },
+    })
+    ;(api.editRegistrySource as any).mockReset()
+    ;(api.removeRegistrySource as any).mockReset()
+  })
+
+  it('renders a manageable card per registry with a neutral Official/Custom badge', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="registry-card-official"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="registry-card-acme"]').exists()).toBe(true)
+
+    // Neutral badge — no alarming words anywhere on the official card.
+    const officialCard = wrapper.find('[data-test="registry-card-official"]')
+    expect(officialCard.text()).toContain('Official')
+    expect(officialCard.text().toLowerCase()).not.toContain('quarantine')
+    expect(officialCard.text().toLowerCase()).not.toContain('unverified')
+
+    const customCard = wrapper.find('[data-test="registry-card-acme"]')
+    expect(customCard.text()).toContain('Custom')
+  })
+
+  it('shows no alarming warning banner or one-time third-party warning gate', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    // The old third-party warning dialog and custom-quarantine note are gone.
+    expect(wrapper.find('[data-test="registry-third-party-warning"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="registry-custom-quarantine-note"]').exists()).toBe(false)
+    expect(wrapper.html().toLowerCase()).not.toContain('always quarantined')
+    expect(wrapper.html().toLowerCase()).not.toContain('can never skip')
+  })
+
+  it('exposes a kebab Edit/Delete only on custom registries; official is read-only', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="registry-kebab-acme"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="registry-edit-acme"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="registry-delete-acme"]').exists()).toBe(true)
+
+    // Official: no kebab, no edit/delete, has a "Built-in" tag.
+    expect(wrapper.find('[data-test="registry-kebab-official"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="registry-edit-official"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="registry-delete-official"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="registry-card-official"]').text()).toContain('Built-in')
+  })
+
+  it('Edit opens the dialog pre-filled with a read-only id and PUTs the changes', async () => {
+    ;(api.editRegistrySource as any).mockResolvedValue({
+      success: true,
+      registry: { id: 'acme', name: 'Acme Renamed', provenance: 'custom', trusted: false },
+    })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.find('[data-test="registry-edit-acme"]').trigger('click')
+    await flushPromises()
+
+    // Dialog open + pre-filled.
+    expect((wrapper.find('[data-test="registry-add-source-dialog"]').element as HTMLDialogElement).hasAttribute('open')).toBe(true)
+    const urlInput = wrapper.find('[data-test="registry-add-url-input"]').element as HTMLInputElement
+    const nameInput = wrapper.find('[data-test="registry-add-name-input"]').element as HTMLInputElement
+    expect(urlInput.value).toBe('https://acme.example/registry')
+    expect(nameInput.value).toBe('Acme Registry')
+
+    // The id is shown read-only in edit mode.
+    const idInput = wrapper.find('[data-test="registry-edit-id"]')
+    expect(idInput.exists()).toBe(true)
+    expect((idInput.element as HTMLInputElement).readOnly).toBe(true)
+
+    // Change the name and submit → PUT, not POST.
+    await wrapper.find('[data-test="registry-add-name-input"]').setValue('Acme Renamed')
+    await wrapper.find('[data-test="registry-add-form"]').trigger('submit')
+    await flushPromises()
+
+    expect(api.editRegistrySource).toHaveBeenCalledTimes(1)
+    expect(api.addRegistrySource).not.toHaveBeenCalled()
+    const [id, opts] = (api.editRegistrySource as any).mock.calls[0]
+    expect(id).toBe('acme')
+    expect(opts.name).toBe('Acme Renamed')
+  })
+
+  it('Delete shows a destructive confirmation modal and only calls the API on confirm', async () => {
+    ;(api.removeRegistrySource as any).mockResolvedValue({ success: true })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.find('[data-test="registry-delete-acme"]').trigger('click')
+    await flushPromises()
+
+    const confirm = wrapper.find('[data-test="registry-delete-dialog"]')
+    expect(confirm.exists()).toBe(true)
+    expect((confirm.element as HTMLDialogElement).hasAttribute('open')).toBe(true)
+    expect(api.removeRegistrySource).not.toHaveBeenCalled()
+
+    await wrapper.find('[data-test="registry-delete-confirm"]').trigger('click')
+    await flushPromises()
+
+    expect(api.removeRegistrySource).toHaveBeenCalledWith('acme')
+  })
+})


### PR DESCRIPTION
## What (MCP-1073, v0.37.0 blocker)

Frontend Web UI registry management, now unblocked by the backend edit/remove endpoints (PUT #594 / DELETE #592).

### Remove alarming copy
- Delete the one-time third-party warning gate, the "always quarantined … can never skip security review. Only add registries operated by parties you trust" copy, and the "third-party · unverified" badge.
- Provenance is surfaced as a **neutral Official / Custom badge** (MCP-1072 made provenance informational only). Multiselect suffix softened `— unverified` → `— custom`.

### Edit + Delete on custom registries
- New **Registries** management section: each configured source renders as a card.
- **Official** cards are read-only with a neutral **Built-in** tag (no kebab).
- **Custom** cards carry a **kebab (⋮)** menu:
  - **Edit** → reuses the Add-Registry dialog, pre-filled, **id read-only** → `PUT /api/v1/registries/{id}`.
  - **Delete** → destructive **confirmation modal** → `DELETE /api/v1/registries/{id}` ("Servers you already added stay; only the source is removed").
- `api.ts`: new `editRegistrySource` (PUT) + `removeRegistrySource` (DELETE) clients mirroring `addRegistrySource`'s structured-error contract (`registry_not_found` | `registry_shadows_builtin` | `invalid_registry_url` | `registries_locked`).

### Docs
- `docs/registries.md` updated to describe the new neutral, edit/delete Web UI surface (ENG-9).

## Verification
- **TDD**: new failing specs written first, then implemented.
- `vitest run` → **114 pass** (incl. new `registry-edit-remove-source.spec.ts` api-client tests and `repositories-manage-registries.spec.ts` component tests; rewrote `repositories-add-registry.spec.ts` for the no-warning-gate behavior).
- `make build` (frontend `//go:embed`) green.
- **Playwright CRUD sweep** against a fresh `--data-dir` instance: add custom registry → edit (rename, **persisted across reload**) → delete (confirm dialog → gone), official cards read-only, no warning banner. Report kept local per repo policy.
- Backend contract spot-checked via curl: PUT renames, PUT on `official` → 409 `registry_shadows_builtin`, DELETE → 200.

Related MCP-1073