### PR TITLE
feat(macos): registry edit/remove + drop warnings; official read-only (MCP-1074)

### DIFF
--- a/native/macos/MCPProxy/MCPProxy/API/APIClient.swift
+++ b/native/macos/MCPProxy/MCPProxy/API/APIClient.swift
@@ -691,10 +691,10 @@ actor APIClient {
     }
 
     /// Add a user-supplied registry source via `POST /api/v1/registries`. The
-    /// server always tags an added source custom/unverified (provenance is NOT
-    /// part of the request), so every server later discovered through it lands
-    /// quarantined. Returns a structured result carrying the stable error
-    /// `code` instead of throwing, mirroring the Web UI's `addRegistrySource`.
+    /// server always tags an added source "custom" (provenance is NOT part of
+    /// the request); provenance is informational only (MCP-1072) and servers
+    /// follow the global quarantine default. Returns a structured result carrying
+    /// the stable error `code` instead of throwing, mirroring the Web UI.
     func addRegistrySource(
         url: String,
         protocol proto: String? = nil,
@@ -709,6 +709,70 @@ actor APIClient {
         do {
             let bodyData = try JSONSerialization.data(withJSONObject: body)
             let (data, response) = try await rawRequest(path: "/api/v1/registries", method: "POST", body: bodyData)
+            let decoder = JSONDecoder()
+
+            if (200...299).contains(response.statusCode),
+               let wrapper = try? decoder.decode(APIResponse<AddRegistrySourceData>.self, from: data),
+               wrapper.success {
+                return .ok(wrapper.data?.registry)
+            }
+
+            let errBody = try? decoder.decode(RegistryAddErrorBody.self, from: data)
+            return .failure(
+                code: errBody?.code,
+                error: errBody?.error ?? "HTTP \(response.statusCode): \(HTTPURLResponse.localizedString(forStatusCode: response.statusCode))"
+            )
+        } catch {
+            return .failure(code: nil, error: error.localizedDescription)
+        }
+    }
+
+    /// Edit a user-added custom registry via `PUT /api/v1/registries/{id}`
+    /// (MCP-1072). All fields are optional — an empty field leaves the existing
+    /// value unchanged; the id is immutable. Returns a structured result carrying
+    /// the stable error `code` (e.g. `registry_not_found`, `invalid_registry_url`,
+    /// `registry_shadows_builtin`, `registries_locked`) instead of throwing.
+    func editRegistrySource(
+        id: String,
+        url: String? = nil,
+        name: String? = nil,
+        serversURL: String? = nil
+    ) async -> AddRegistrySourceResult {
+        var body: [String: Any] = [:]
+        if let url, !url.isEmpty { body["url"] = url }
+        if let name, !name.isEmpty { body["name"] = name }
+        if let serversURL, !serversURL.isEmpty { body["servers_url"] = serversURL }
+
+        do {
+            let bodyData = try JSONSerialization.data(withJSONObject: body)
+            let (data, response) = try await rawRequest(
+                path: "/api/v1/registries/\(id.uriComponentEncoded)", method: "PUT", body: bodyData)
+            let decoder = JSONDecoder()
+
+            if (200...299).contains(response.statusCode),
+               let wrapper = try? decoder.decode(APIResponse<AddRegistrySourceData>.self, from: data),
+               wrapper.success {
+                return .ok(wrapper.data?.registry)
+            }
+
+            let errBody = try? decoder.decode(RegistryAddErrorBody.self, from: data)
+            return .failure(
+                code: errBody?.code,
+                error: errBody?.error ?? "HTTP \(response.statusCode): \(HTTPURLResponse.localizedString(forStatusCode: response.statusCode))"
+            )
+        } catch {
+            return .failure(code: nil, error: error.localizedDescription)
+        }
+    }
+
+    /// Remove a user-added custom registry via `DELETE /api/v1/registries/{id}`
+    /// (MCP-1057). Built-in registries cannot be removed (the backend returns
+    /// `registry_not_found` / a locked error). Returns a structured result
+    /// carrying the stable error `code` instead of throwing.
+    func removeRegistrySource(id: String) async -> AddRegistrySourceResult {
+        do {
+            let (data, response) = try await rawRequest(
+                path: "/api/v1/registries/\(id.uriComponentEncoded)", method: "DELETE")
             let decoder = JSONDecoder()
 
             if (200...299).contains(response.statusCode),

--- a/native/macos/MCPProxy/MCPProxy/API/RegistryModels.swift
+++ b/native/macos/MCPProxy/MCPProxy/API/RegistryModels.swift
@@ -4,15 +4,19 @@ import Foundation
 //
 // macOS-tray mirror of the MCP-867 Web UI registry surface. Models the
 // `GET /api/v1/registries` list (with provenance/trust) and the
-// `POST /api/v1/registries` add-source flow (with stable error codes), plus the
-// one-time third-party-registry warning acknowledgement.
+// add/edit/remove-source flows (`POST`/`PUT`/`DELETE /api/v1/registries[/{id}]`,
+// with stable error codes). Provenance is informational only (MCP-1072).
 
-/// Trust-tag constants mirroring `config.RegistryProvenance*` on the Go side
-/// (and `REGISTRY_PROVENANCE_*` in the Web UI). Trust is derived server-side
-/// from membership in the shipped default set — never self-asserted.
+/// Provenance constants mirroring `config.RegistryProvenance*` on the Go side
+/// (MCP-1072 simplified these to two plain values). Provenance is informational
+/// only — it no longer forces quarantine — and is derived server-side from
+/// membership in the shipped default set, never self-asserted.
 enum RegistryProvenance {
-    static let official = "official/trusted"
-    static let custom = "custom/unverified"
+    static let official = "official"
+    static let custom = "custom"
+    /// Legacy strings persisted before MCP-1072; still accepted on read.
+    static let legacyOfficial = "official/trusted"
+    static let legacyCustom = "custom/unverified"
 }
 
 /// A registry as listed by `GET /api/v1/registries`. Mirrors `contracts.Registry`.
@@ -25,10 +29,10 @@ struct Registry: Codable, Identifiable, Equatable {
     let url: String?
     let serversURL: String?
     let `protocol`: String?
-    /// "official/trusted" for built-in defaults, "custom/unverified" for
-    /// user-added sources.
+    /// "official" for built-in defaults, "custom" for user-added sources
+    /// (legacy "official/trusted" / "custom/unverified" still accepted on read).
     let provenance: String?
-    /// Convenience boolean mirror of `provenance == "official/trusted"`.
+    /// Convenience boolean mirror of "is this an official, shipped registry".
     let trusted: Bool?
 
     enum CodingKeys: String, CodingKey {
@@ -38,12 +42,19 @@ struct Registry: Codable, Identifiable, Equatable {
         case provenance, trusted
     }
 
-    /// A registry is "custom/unverified" (third-party) when its provenance says
-    /// so, or — defensively — when `trusted` is explicitly false. Anything else
-    /// (including older payloads without the field) is treated as
-    /// official/trusted. Mirrors the Web UI's `isCustomRegistry`.
+    /// A registry is "custom" (user-added) when its provenance says so — for
+    /// both the new 2-value model and the legacy string — or, defensively, when
+    /// `trusted` is explicitly false. Anything else (including older payloads
+    /// without the field) is treated as official. Mirrors the Web UI's
+    /// `isCustomRegistry`.
     var isCustom: Bool {
-        provenance == RegistryProvenance.custom || trusted == false
+        if trusted == false { return true }
+        switch provenance {
+        case RegistryProvenance.custom, RegistryProvenance.legacyCustom:
+            return true
+        default:
+            return false
+        }
     }
 
     /// Resolve the full `Registry` that a search result's `registry` field
@@ -130,31 +141,11 @@ struct AddRegistrySourceResult: Equatable {
             return "That id/host collides with a built-in registry. Try a different id."
         case "duplicate_registry":
             return "A registry with that id is already configured."
+        case "registry_not_found":
+            return "That registry no longer exists — it may have already been removed."
         default:
             return fallback ?? "Failed to add registry."
         }
-    }
-}
-
-/// Persists the one-time acknowledgement of the third-party-registry warning
-/// (MCP-867 parity). Backed by UserDefaults so the warning only shows until the
-/// user acknowledges it once. `defaults` is injectable for testing.
-struct ThirdPartyRegistryAck {
-    /// Key mirrors the Web UI's localStorage key for cross-surface consistency.
-    static let key = "mcpproxy-thirdparty-registry-ack"
-
-    let defaults: UserDefaults
-
-    init(defaults: UserDefaults = .standard) {
-        self.defaults = defaults
-    }
-
-    var hasAcknowledged: Bool {
-        defaults.bool(forKey: Self.key)
-    }
-
-    func acknowledge() {
-        defaults.set(true, forKey: Self.key)
     }
 }
 

--- a/native/macos/MCPProxy/MCPProxy/Views/RegistriesView.swift
+++ b/native/macos/MCPProxy/MCPProxy/Views/RegistriesView.swift
@@ -1,15 +1,38 @@
 // RegistriesView.swift
 // MCPProxy
 //
-// macOS-tray mirror of the MCP-867 Web UI registry surface (MCP-902):
-//   - lists configured registries with provenance/trust badges
+// macOS-tray registry management surface (MCP-902 / MCP-1074):
+//   - lists configured registries with a neutral Official / Custom badge
 //   - an "Add Registry" affordance (POST /api/v1/registries)
-//   - a one-time third-party warning gating the first custom add
+//   - per-custom-registry Edit (PUT /api/v1/registries/{id}) and
+//     Remove (DELETE /api/v1/registries/{id}) via an ellipsis + context menu
+//   - browse + add servers across registries (ServerBrowseView)
 //
-// Servers discovered through a custom (third-party) registry are always
-// quarantined and can never skip security review; the UI surfaces that.
+// Provenance is informational only (MCP-1072): servers added from any registry
+// follow the global quarantine default, so there is no third-party warning.
 
 import SwiftUI
+
+// MARK: - Neutral provenance badge (reused by the browse info popup, MCP-1074)
+
+/// A small, neutral 2-value provenance badge: "Official" (built-in) or
+/// "Custom" (user-added). Replaces the old alarming "third-party · unverified"
+/// styling now that provenance is informational only (MCP-1072).
+struct RegistryProvenanceBadge: View {
+    let isCustom: Bool
+    @Environment(\.fontScale) var fontScale
+
+    var body: some View {
+        Text(isCustom ? "Custom" : "Official")
+            .font(.scaled(.caption2, scale: fontScale).weight(.medium))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background((isCustom ? Color.secondary : Color.accentColor).opacity(0.16))
+            .foregroundStyle(isCustom ? Color.secondary : Color.accentColor)
+            .clipShape(Capsule())
+            .accessibilityIdentifier(isCustom ? "registry-badge-custom" : "registry-badge-official")
+    }
+}
 
 // MARK: - Registries View
 
@@ -20,10 +43,24 @@ struct RegistriesView: View {
     @State private var registries: [Registry] = []
     @State private var isLoading = false
     @State private var loadError: String?
-    @State private var showAddRegistry = false
     @State private var successMessage: String?
 
+    /// Drives the add/edit sheet. `editing == nil` => add a new registry;
+    /// otherwise edit the carried (custom) registry. `.sheet(item:)` keeps the
+    /// pre-filled state fresh per presentation.
+    @State private var activeSheet: RegistrySheet?
+    /// The custom registry awaiting a Remove confirmation, if any.
+    @State private var pendingRemoval: Registry?
+
     private var apiClient: APIClient? { appState.apiClient }
+
+    private var customRegistries: [Registry] { registries.filter(\.isCustom) }
+
+    /// Custom (editable) registries first, then official (read-only) ones —
+    /// a management view leads with the rows the user can act on.
+    private var sortedRegistries: [Registry] {
+        registries.filter(\.isCustom) + registries.filter { !$0.isCustom }
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -32,7 +69,7 @@ struct RegistriesView: View {
             // Prominent "Add Registry" button bar (mirrors ServersView).
             HStack {
                 Button {
-                    showAddRegistry = true
+                    activeSheet = RegistrySheet(editing: nil)
                 } label: {
                     Label("Add Registry", systemImage: "plus.circle.fill")
                 }
@@ -52,17 +89,39 @@ struct RegistriesView: View {
                 banner(icon: "exclamationmark.triangle.fill", tint: .orange, text: err)
             }
 
+            configuredList
+
+            Divider()
+
             // Browse + add servers across one or more registries (R1 parity).
-            // The configured-registries list lives in the browse multiselect and
-            // the per-result registry badge → info popup (MCP-1050); there is no
-            // longer a bottom "Configured registries" description panel.
             ServerBrowseView(appState: appState, registries: registries)
         }
-        .sheet(isPresented: $showAddRegistry) {
-            AddRegistryView(appState: appState, isPresented: $showAddRegistry) { added in
-                successMessage = "Added registry \u{201C}\(added.name.isEmpty ? added.id : added.name)\u{201D} — third-party \u{00B7} unverified."
+        .sheet(item: $activeSheet) { sheet in
+            AddRegistryView(appState: appState, editing: sheet.editing) { result in
+                let verb = sheet.editing == nil ? "Added" : "Updated"
+                let label = result.name.isEmpty ? result.id : result.name
+                successMessage = "\(verb) registry \u{201C}\(label)\u{201D}."
+                loadError = nil
                 Task { await load() }
             }
+        }
+        .confirmationDialog(
+            "Remove \u{201C}\(pendingRemoval?.name ?? "")\u{201D}?",
+            isPresented: Binding(
+                get: { pendingRemoval != nil },
+                set: { if !$0 { pendingRemoval = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            if let reg = pendingRemoval {
+                Button("Remove", role: .destructive) {
+                    Task { await remove(reg) }
+                }
+                .accessibilityIdentifier("registry-remove-confirm")
+            }
+            Button("Cancel", role: .cancel) { pendingRemoval = nil }
+        } message: {
+            Text("This removes the registry source from MCPProxy. Servers you have already added stay installed.")
         }
         .task { await load() }
     }
@@ -92,6 +151,112 @@ struct RegistriesView: View {
         }
         .padding()
         .accessibilityIdentifier("registries-header")
+    }
+
+    // MARK: Configured registries list
+
+    @ViewBuilder
+    private var configuredList: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text("Configured registries")
+                    .font(.scaled(.subheadline, scale: fontScale).weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+            .padding(.horizontal)
+            .padding(.top, 8)
+            .padding(.bottom, 4)
+
+            if registries.isEmpty {
+                Text(isLoading ? "Loading…" : "No registries configured.")
+                    .font(.scaled(.caption, scale: fontScale))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal)
+                    .padding(.bottom, 8)
+                    .accessibilityIdentifier("registries-list-empty")
+            } else {
+                ScrollView {
+                    VStack(spacing: 0) {
+                        ForEach(sortedRegistries) { reg in
+                            registryRow(reg)
+                            if reg.id != sortedRegistries.last?.id { Divider() }
+                        }
+                    }
+                }
+                .frame(maxHeight: 360)
+                .accessibilityIdentifier("registries-list")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func registryRow(_ reg: Registry) -> some View {
+        HStack(spacing: 10) {
+            // Built-in indicator for official registries (MCP-1074).
+            Image(systemName: reg.isCustom ? "globe" : "checkmark.seal.fill")
+                .foregroundStyle(reg.isCustom ? Color.secondary : Color.accentColor)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(reg.name.isEmpty ? reg.id : reg.name)
+                        .font(.scaled(.body, scale: fontScale).weight(.medium))
+                    RegistryProvenanceBadge(isCustom: reg.isCustom)
+                }
+                if let url = reg.serversURL ?? reg.url, !url.isEmpty {
+                    Text(url)
+                        .font(.scaledMonospaced(.caption2, scale: fontScale))
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+
+            Spacer()
+
+            // Custom registries are editable/removable; official ones are
+            // read-only (no menu).
+            if reg.isCustom {
+                Menu {
+                    rowActions(reg)
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                        .foregroundStyle(.secondary)
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .fixedSize()
+                .help("Edit or remove this registry")
+                .accessibilityIdentifier("registry-row-menu-\(reg.id)")
+            }
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 6)
+        .contentShape(Rectangle())
+        // Right-click parity with the ellipsis menu (custom registries only).
+        .contextMenu {
+            if reg.isCustom { rowActions(reg) }
+        }
+        .accessibilityIdentifier("registry-row-\(reg.id)")
+    }
+
+    /// Edit / Remove actions shared by the ellipsis menu and the context menu.
+    @ViewBuilder
+    private func rowActions(_ reg: Registry) -> some View {
+        Button {
+            activeSheet = RegistrySheet(editing: reg)
+        } label: {
+            Label("Edit Registry\u{2026}", systemImage: "pencil")
+        }
+        .accessibilityIdentifier("registry-edit-\(reg.id)")
+
+        Button(role: .destructive) {
+            pendingRemoval = reg
+        } label: {
+            Label("Remove Registry\u{2026}", systemImage: "trash")
+        }
+        .accessibilityIdentifier("registry-remove-\(reg.id)")
     }
 
     // MARK: Content
@@ -125,28 +290,65 @@ struct RegistriesView: View {
             loadError = error.localizedDescription
         }
     }
+
+    private func remove(_ reg: Registry) async {
+        guard let client = apiClient else {
+            loadError = "Not connected to MCPProxy core"
+            return
+        }
+        pendingRemoval = nil
+        let result = await client.removeRegistrySource(id: reg.id)
+        if result.success {
+            let label = reg.name.isEmpty ? reg.id : reg.name
+            successMessage = "Removed registry \u{201C}\(label)\u{201D}."
+            loadError = nil
+            await load()
+        } else {
+            loadError = result.userMessage
+        }
+    }
 }
 
-// MARK: - Add Registry Sheet
+/// Identifiable wrapper for the add/edit sheet (`.sheet(item:)`).
+struct RegistrySheet: Identifiable {
+    let id = UUID()
+    /// nil => add a new registry; otherwise the custom registry being edited.
+    let editing: Registry?
+}
+
+// MARK: - Add / Edit Registry Sheet
 
 struct AddRegistryView: View {
     @ObservedObject var appState: AppState
-    @Binding var isPresented: Bool
-    let onAdded: (RegistrySummary) -> Void
+    /// nil => add mode; non-nil => edit the carried custom registry (id immutable).
+    let editing: Registry?
+    /// Called with the added/updated registry summary on success.
+    let onCompleted: (RegistrySummary) -> Void
+
+    @Environment(\.dismiss) private var dismiss
     @Environment(\.fontScale) var fontScale
 
-    @State private var url = ""
-    @State private var name = ""
+    @State private var url: String
+    @State private var name: String
+    @State private var submitError: String?
+    @State private var isSubmitting = false
+
     /// Only the official protocol is offered (mirrors the Web UI's single
     /// option); the field exists so the contract stays explicit.
     private let registryProtocol = "modelcontextprotocol/registry"
 
-    @State private var addError: String?
-    @State private var isAdding = false
-    @State private var showThirdPartyWarning = false
+    init(appState: AppState, editing: Registry? = nil, onCompleted: @escaping (RegistrySummary) -> Void) {
+        self.appState = appState
+        self.editing = editing
+        self.onCompleted = onCompleted
+        _url = State(initialValue: editing?.serversURL ?? editing?.url ?? "")
+        _name = State(initialValue: editing?.name ?? "")
+    }
 
     private var apiClient: APIClient? { appState.apiClient }
-    private let ack = ThirdPartyRegistryAck()
+    private var isEditing: Bool { editing != nil }
+    private var title: String { isEditing ? "Edit Registry" : "Add a Registry" }
+    private var submitTitle: String { isEditing ? "Save Changes" : "Add Registry" }
 
     private var isValid: Bool {
         !url.trimmingCharacters(in: .whitespaces).isEmpty
@@ -155,11 +357,11 @@ struct AddRegistryView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
-                Text("Add a Registry")
+                Text(title)
                     .font(.scaled(.title2, scale: fontScale).bold())
                 Spacer()
                 Button {
-                    if !isAdding { isPresented = false }
+                    if !isSubmitting { dismiss() }
                 } label: {
                     Image(systemName: "xmark.circle.fill")
                         .foregroundStyle(.secondary)
@@ -172,9 +374,21 @@ struct AddRegistryView: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
-                    Text("Add a custom **modelcontextprotocol/registry** v0.1 source by its HTTPS URL. Added registries are marked **third-party \u{00B7} unverified**; their servers are always quarantined.")
+                    Text(isEditing
+                         ? "Update this custom **modelcontextprotocol/registry** source. The registry id is fixed; you can change its name or URL."
+                         : "Add a custom **modelcontextprotocol/registry** v0.1 source by its HTTPS URL.")
                         .font(.scaled(.caption, scale: fontScale))
                         .foregroundStyle(.secondary)
+
+                    if let editing {
+                        formField(label: "Registry ID") {
+                            Text(editing.id)
+                                .font(.scaledMonospaced(.body, scale: fontScale))
+                                .foregroundStyle(.secondary)
+                                .textSelection(.enabled)
+                                .accessibilityIdentifier("registry-edit-id")
+                        }
+                    }
 
                     formField(label: "Registry URL (required)") {
                         TextField("https://registry.example.com/", text: $url)
@@ -194,7 +408,7 @@ struct AddRegistryView: View {
                             .accessibilityIdentifier("registry-add-name-input")
                     }
 
-                    if let err = addError {
+                    if let err = submitError {
                         HStack(alignment: .top, spacing: 8) {
                             Image(systemName: "exclamationmark.triangle.fill")
                                 .foregroundStyle(.red)
@@ -218,37 +432,26 @@ struct AddRegistryView: View {
             HStack {
                 Spacer()
                 Button("Cancel") {
-                    if !isAdding { isPresented = false }
+                    if !isSubmitting { dismiss() }
                 }
                 .buttonStyle(.bordered)
 
                 Button {
-                    submit()
+                    Task { await submit() }
                 } label: {
-                    if isAdding {
+                    if isSubmitting {
                         ProgressView().controlSize(.small)
                     } else {
-                        Text("Add Registry")
+                        Text(submitTitle)
                     }
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(!isValid || isAdding)
+                .disabled(!isValid || isSubmitting)
                 .accessibilityIdentifier("registry-add-submit")
             }
             .padding()
         }
-        .frame(width: 520, height: 420)
-        // One-time third-party warning (MCP-867 parity). Gates the first custom
-        // add until the user acknowledges it once.
-        .alert("Adding a third-party registry", isPresented: $showThirdPartyWarning) {
-            Button("Cancel", role: .cancel) {}
-            Button("I understand, continue") {
-                ack.acknowledge()
-                Task { await doAdd() }
-            }
-        } message: {
-            Text("You're about to add a registry that is not shipped with MCPProxy. Custom registries are unverified — MCPProxy cannot vouch for the servers they list.\n\nFor your safety, every server you add from a custom registry is always quarantined and can never skip security review. Only add registries operated by parties you trust.")
-        }
+        .frame(width: 520, height: 440)
     }
 
     @ViewBuilder
@@ -261,39 +464,34 @@ struct AddRegistryView: View {
         }
     }
 
-    /// Gate the first-ever custom add behind the one-time warning; every
-    /// user-added source is custom/unverified server-side, so the warning
-    /// applies to all adds until acknowledged once.
-    private func submit() {
-        guard isValid, !isAdding else { return }
-        addError = nil
-        if ack.hasAcknowledged {
-            Task { await doAdd() }
-        } else {
-            showThirdPartyWarning = true
-        }
-    }
-
-    private func doAdd() async {
+    /// Submit the add (POST) or edit (PUT) directly — provenance is
+    /// informational only now, so there is no third-party warning to gate on.
+    private func submit() async {
+        guard isValid, !isSubmitting else { return }
         guard let client = apiClient else {
-            addError = "Not connected to MCPProxy core"
+            submitError = "Not connected to MCPProxy core"
             return
         }
-        isAdding = true
-        addError = nil
-        defer { isAdding = false }
+        isSubmitting = true
+        submitError = nil
+        defer { isSubmitting = false }
 
-        let result = await client.addRegistrySource(
-            url: url.trimmingCharacters(in: .whitespaces),
-            protocol: registryProtocol,
-            name: name.trimmingCharacters(in: .whitespaces).isEmpty ? nil : name.trimmingCharacters(in: .whitespaces)
-        )
+        let trimmedURL = url.trimmingCharacters(in: .whitespaces)
+        let trimmedName = name.trimmingCharacters(in: .whitespaces)
+        let nameOrNil = trimmedName.isEmpty ? nil : trimmedName
+
+        let result: AddRegistrySourceResult
+        if let editing {
+            result = await client.editRegistrySource(id: editing.id, url: trimmedURL, name: nameOrNil)
+        } else {
+            result = await client.addRegistrySource(url: trimmedURL, protocol: registryProtocol, name: nameOrNil)
+        }
 
         if result.success, let registry = result.registry {
-            isPresented = false
-            onAdded(registry)
+            onCompleted(registry)
+            dismiss()
             return
         }
-        addError = result.userMessage
+        submitError = result.userMessage
     }
 }

--- a/native/macos/MCPProxy/MCPProxy/Views/ServerBrowseView.swift
+++ b/native/macos/MCPProxy/MCPProxy/Views/ServerBrowseView.swift
@@ -6,7 +6,7 @@
 // searches, and sees a merged, registry-attributed result list. Registries
 // that need an API key / are unreachable are surfaced as a non-fatal notice so
 // the registries that DID return still render. Each result can be added
-// (servers from custom registries land quarantined server-side).
+// (new servers follow the global quarantine default — MCP-1072).
 
 import SwiftUI
 
@@ -88,7 +88,7 @@ struct ServerBrowseView: View {
             HStack(spacing: 8) {
                 Text(displayName)
                     .font(.scaled(.title3, scale: fontScale).bold())
-                if let reg = ctx.registry { provenanceBadge(reg) }
+                if let reg = ctx.registry { RegistryProvenanceBadge(isCustom: reg.isCustom) }
                 Spacer()
                 Button {
                     registryInfo = nil
@@ -121,13 +121,13 @@ struct ServerBrowseView: View {
                     }
                 }
 
-                if reg.isCustom {
-                    Text("Servers added from this third-party registry are always quarantined and cannot skip security review.")
-                        .font(.scaled(.caption, scale: fontScale))
-                        .foregroundStyle(.orange)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .accessibilityIdentifier("registry-info-quarantine-note")
-                }
+                Text(reg.isCustom
+                     ? "A custom registry you added. Servers you install follow your global security settings."
+                     : "A built-in registry shipped with MCPProxy.")
+                    .font(.scaled(.caption, scale: fontScale))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("registry-info-provenance-note")
             } else {
                 Text("No additional details are available for this registry.")
                     .font(.scaled(.subheadline, scale: fontScale))
@@ -139,28 +139,6 @@ struct ServerBrowseView: View {
         .padding()
         .frame(width: 420, height: 220)
         .accessibilityIdentifier("registry-info-popup")
-    }
-
-    @ViewBuilder
-    private func provenanceBadge(_ registry: Registry) -> some View {
-        if registry.isCustom {
-            badge(text: "Third-party \u{00B7} unverified", tint: .orange)
-                .accessibilityIdentifier("registry-info-badge-custom")
-        } else {
-            badge(text: "Official \u{00B7} trusted", tint: .green)
-                .accessibilityIdentifier("registry-info-badge-official")
-        }
-    }
-
-    @ViewBuilder
-    private func badge(text: String, tint: Color) -> some View {
-        Text(text)
-            .font(.scaled(.caption2, scale: fontScale).weight(.medium))
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(tint.opacity(0.18))
-            .foregroundStyle(tint)
-            .clipShape(Capsule())
     }
 
     // MARK: Filter bar (multiselect + search)
@@ -179,7 +157,7 @@ struct ServerBrowseView: View {
                         toggle(registry.id)
                     } label: {
                         Label(
-                            registry.name + (registry.isCustom ? " — unverified" : ""),
+                            registry.name,
                             systemImage: selectedIDs.contains(registry.id) ? "checkmark.square.fill" : "square"
                         )
                     }

--- a/native/macos/MCPProxy/MCPProxyTests/RegistryModelsTests.swift
+++ b/native/macos/MCPProxy/MCPProxyTests/RegistryModelsTests.swift
@@ -15,23 +15,45 @@ final class RegistryModelsTests: XCTestCase {
     // MARK: - Provenance / trust derivation (mirrors Web UI isCustomRegistry)
 
     func testRegistryProvenanceConstants() {
-        XCTAssertEqual(RegistryProvenance.official, "official/trusted")
-        XCTAssertEqual(RegistryProvenance.custom, "custom/unverified")
+        // MCP-1074: provenance simplified to the 2-value model.
+        XCTAssertEqual(RegistryProvenance.official, "official")
+        XCTAssertEqual(RegistryProvenance.custom, "custom")
     }
 
     func testOfficialRegistryIsNotCustom() throws {
+        // New 2-value model: provenance "official".
         let json = """
         {"id": "official", "name": "Official MCP Registry",
-         "provenance": "official/trusted", "trusted": true}
+         "provenance": "official", "trusted": true}
         """
         let reg = try decode(Registry.self, from: json)
         XCTAssertFalse(reg.isCustom)
     }
 
     func testCustomProvenanceIsCustom() throws {
+        // New 2-value model: provenance "custom".
         let json = """
         {"id": "acme", "name": "Acme Corp",
-         "provenance": "custom/unverified", "trusted": false}
+         "provenance": "custom", "trusted": false}
+        """
+        let reg = try decode(Registry.self, from: json)
+        XCTAssertTrue(reg.isCustom)
+    }
+
+    func testCustomProvenanceAloneIsCustom() throws {
+        // Defensive: provenance "custom" with no trusted flag still reads custom.
+        let json = """
+        {"id": "acme", "name": "Acme Corp", "provenance": "custom"}
+        """
+        let reg = try decode(Registry.self, from: json)
+        XCTAssertTrue(reg.isCustom)
+    }
+
+    func testLegacyCustomProvenanceStillReadsCustom() throws {
+        // Backward-compat: a legacy "custom/unverified" payload (pre-MCP-1072)
+        // must still read as custom.
+        let json = """
+        {"id": "acme", "name": "Acme Corp", "provenance": "custom/unverified"}
         """
         let reg = try decode(Registry.self, from: json)
         XCTAssertTrue(reg.isCustom)
@@ -128,6 +150,14 @@ final class RegistryModelsTests: XCTestCase {
         )
     }
 
+    func testErrorMessageRegistryNotFound() {
+        // MCP-1074: edit/remove can fail with registry_not_found.
+        XCTAssertEqual(
+            AddRegistrySourceResult.message(code: "registry_not_found", fallback: nil),
+            "That registry no longer exists — it may have already been removed."
+        )
+    }
+
     func testErrorMessageUnknownFallsBack() {
         XCTAssertEqual(
             AddRegistrySourceResult.message(code: nil, fallback: "boom"),
@@ -173,23 +203,5 @@ final class RegistryModelsTests: XCTestCase {
     func testLookupReturnsNilWhenNotFound() throws {
         let regs = try sampleRegistries()
         XCTAssertNil(Registry.lookup("nonexistent", in: regs))
-    }
-
-    // MARK: - One-time third-party warning ack persistence (mirrors localStorage)
-
-    func testThirdPartyAckPersistence() throws {
-        let suiteName = "test-thirdparty-ack-\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-
-        let ack = ThirdPartyRegistryAck(defaults: defaults)
-        XCTAssertFalse(ack.hasAcknowledged, "fresh defaults should not be acknowledged")
-
-        ack.acknowledge()
-        XCTAssertTrue(ack.hasAcknowledged, "acknowledge() must persist")
-
-        // A new instance over the same defaults sees the persisted ack.
-        let ack2 = ThirdPartyRegistryAck(defaults: defaults)
-        XCTAssertTrue(ack2.hasAcknowledged)
     }
 }


### PR DESCRIPTION
## Summary (MCP-1074 — v0.37.0 blocker)

macOS tray registry surface, updated for the MCP-1072 provenance simplification (provenance is now **informational only** — servers follow the global quarantine default).

### Warnings removed
- Dropped the third-party warning alert/text in `RegistriesView` and the "always quarantined / cannot skip security review" note in `ServerBrowseView`'s registry-info popup.
- Replaced the alarming `Third-party · unverified` / `Official · trusted` styling with a neutral **Official / Custom** badge (`RegistryProvenanceBadge`, reused by the browse info popup).
- Removed the obsolete one-time third-party warning + `ThirdPartyRegistryAck`.

### Edit + Remove (macOS HIG)
- New **Configured registries** management list in `RegistriesView` (custom rows first, so the actionable ones lead).
- Each **custom** row has a trailing **ellipsis menu** (`ellipsis.circle`) **and** a right-click **`.contextMenu`**, both offering:
  - **Edit Registry…** → a `.sheet` reusing `AddRegistryView` in edit mode (pre-filled name/url, id immutable) → `PUT /api/v1/registries/{id}`.
  - **Remove Registry…** (`role: .destructive`) → a `.confirmationDialog` naming the registry → `DELETE /api/v1/registries/{id}`.
- **Official/built-in** registries are **read-only** (no menu) with a `checkmark.seal` indicator.
- New `APIClient.editRegistrySource` / `removeRegistrySource`; provenance model moved to the 2-value `official`/`custom` scheme (legacy `official/trusted` | `custom/unverified` still accepted on read).

### Verification
- `swift build -c release` green; `MCPProxyTests/RegistryModelsTests` 19/19 pass (new tests for the 2-value + legacy provenance and the `registry_not_found` edit-error mapping). Remaining full-suite failures (SSEParser/Models/AutoStart/MergePatch) are pre-existing and unrelated — they fail identically on `origin/main`.
- ui-test (dev tray attached to the live core): verified no warning text, official rows read-only with `Official` badge + seal, custom rows show the ellipsis menu → **Edit Registry… / Remove Registry…**, the edit sheet opens pre-filled (immutable id), and the client issues the correct `PUT` (the live core's older build lacks the route, so it surfaced the mapped error — confirming the request path + error handling).
- New-backend round-trip proven against a worktree-built core: `POST`→`PUT` (rename + new url, provenance `custom`)→`GET`→`DELETE`→`GET` all return 200 / behave correctly.

Related MCP-1074