### PR TITLE
feat(macos): discovery-first Registries view with Discover/Manage tabs (MCP-1078)

### DIFF
--- a/native/macos/MCPProxy/MCPProxy/Views/RegistriesView.swift
+++ b/native/macos/MCPProxy/MCPProxy/Views/RegistriesView.swift
@@ -52,6 +52,12 @@ struct RegistriesView: View {
     /// The custom registry awaiting a Remove confirmation, if any.
     @State private var pendingRemoval: Registry?
 
+    /// Discovery-first layout (MCP-1078): a segmented control splits server
+    /// discovery (default) from registry management so search controls sit on
+    /// top and the results region is the dominant area, while the configured-
+    /// registries management list no longer competes with results for space.
+    @State private var tab: RegistryTab = .discover
+
     private var apiClient: APIClient? { appState.apiClient }
 
     private var customRegistries: [Registry] { registries.filter(\.isCustom) }
@@ -66,22 +72,22 @@ struct RegistriesView: View {
         VStack(alignment: .leading, spacing: 0) {
             header
 
-            // Prominent "Add Registry" button bar (mirrors ServersView).
-            HStack {
-                Button {
-                    activeSheet = RegistrySheet(editing: nil)
-                } label: {
-                    Label("Add Registry", systemImage: "plus.circle.fill")
+            // Discovery-first segmented control (MCP-1078): "Discover servers"
+            // is the default; "Manage registries" holds the add/edit/remove UI.
+            Picker("", selection: $tab) {
+                ForEach(RegistryTab.allCases) { t in
+                    Text(t.title).tag(t)
                 }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.large)
-                .accessibilityIdentifier("registry-add-source-button")
             }
+            .pickerStyle(.segmented)
+            .labelsHidden()
             .padding(.horizontal)
-            .padding(.vertical, 8)
+            .padding(.bottom, 8)
+            .accessibilityIdentifier("registries-tab-picker")
 
-            Divider()
-
+            // Banners apply to both tabs: load errors affect discovery (no
+            // registries to search) and management; add/edit/remove successes
+            // surface here too.
             if let success = successMessage {
                 banner(icon: "checkmark.circle.fill", tint: .green, text: success)
             }
@@ -89,12 +95,16 @@ struct RegistriesView: View {
                 banner(icon: "exclamationmark.triangle.fill", tint: .orange, text: err)
             }
 
-            configuredList
-
             Divider()
 
-            // Browse + add servers across one or more registries (R1 parity).
-            ServerBrowseView(appState: appState, registries: registries)
+            switch tab {
+            case .discover:
+                // Search controls on top, results fill all remaining space.
+                ServerBrowseView(appState: appState, registries: registries)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            case .manage:
+                manageTab
+            }
         }
         .sheet(item: $activeSheet) { sheet in
             AddRegistryView(appState: appState, editing: sheet.editing) { result in
@@ -124,6 +134,34 @@ struct RegistriesView: View {
             Text("This removes the registry source from MCPProxy. Servers you have already added stay installed.")
         }
         .task { await load() }
+    }
+
+    // MARK: Manage tab
+
+    /// Registry management: the prominent "Add Registry" affordance plus the
+    /// configured-registries list with per-custom-registry edit/remove. Lives
+    /// only on this tab so it no longer competes with search results (MCP-1078).
+    @ViewBuilder
+    private var manageTab: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Prominent "Add Registry" button bar (mirrors ServersView).
+            HStack {
+                Button {
+                    activeSheet = RegistrySheet(editing: nil)
+                } label: {
+                    Label("Add Registry", systemImage: "plus.circle.fill")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .accessibilityIdentifier("registry-add-source-button")
+                Spacer()
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+
+            configuredList
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
     // MARK: Header
@@ -184,7 +222,7 @@ struct RegistriesView: View {
                         }
                     }
                 }
-                .frame(maxHeight: 360)
+                .frame(maxHeight: .infinity)
                 .accessibilityIdentifier("registries-list")
             }
         }
@@ -305,6 +343,22 @@ struct RegistriesView: View {
             await load()
         } else {
             loadError = result.userMessage
+        }
+    }
+}
+
+/// The two faces of the Registries pane (MCP-1078): discovery-first server
+/// browse (default) and registry management.
+enum RegistryTab: String, CaseIterable, Identifiable {
+    case discover
+    case manage
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .discover: return "Discover servers"
+        case .manage: return "Manage registries"
         }
     }
 }

--- a/native/macos/MCPProxy/MCPProxy/Views/ServerBrowseView.swift
+++ b/native/macos/MCPProxy/MCPProxy/Views/ServerBrowseView.swift
@@ -73,6 +73,9 @@ struct ServerBrowseView: View {
 
             resultsArea
         }
+        // Results fill all remaining vertical space so discovery is the
+        // dominant region of the pane (MCP-1078).
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .accessibilityIdentifier("server-browse")
         .sheet(item: $registryInfo) { ctx in
             registryInfoSheet(ctx)
@@ -197,12 +200,13 @@ struct ServerBrowseView: View {
     private var resultsArea: some View {
         if isSearching {
             VStack { Spacer(); ProgressView("Searching…"); Spacer() }
-                .frame(maxWidth: .infinity, minHeight: 120)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if let err = searchError {
             Label(err, systemImage: "xmark.octagon.fill")
                 .foregroundStyle(.red)
                 .font(.scaled(.callout, scale: fontScale))
                 .padding()
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                 .accessibilityIdentifier("browse-error")
         } else if results.isEmpty {
             Text(selectedIDs.isEmpty ? "Pick one or more registries, then search."
@@ -210,6 +214,7 @@ struct ServerBrowseView: View {
                 .foregroundStyle(.secondary)
                 .font(.scaled(.callout, scale: fontScale))
                 .padding(.horizontal)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                 .accessibilityIdentifier("browse-empty")
         } else {
             HStack {
@@ -230,6 +235,7 @@ struct ServerBrowseView: View {
                 .padding(.horizontal)
                 .padding(.bottom, 8)
             }
+            .frame(maxHeight: .infinity)
         }
     }
 


### PR DESCRIPTION
## What & why (MCP-1078)

Restructures the macOS tray **Registries** pane to be discovery-first. Previously the title + Add Registry + the full *Configured registries* list sat on top and the registry filter + search field + Search button + results were crammed into a thin strip at the bottom, so search controls were buried and results had almost no room.

This implements **design A** from the issue: a segmented control at the top of the pane.

- **Discover servers** (default tab): hosts `ServerBrowseView` only. The multiselect + search field + Search button stay pinned on top; the results list now fills all remaining vertical space (`frame(maxHeight: .infinity)`). No management list competing for space.
- **Manage registries**: the *Add Registry* affordance + the configured-registries list with the MCP-1074 per-custom-registry ⋮ Edit/Remove menu. Official registries remain read-only (no menu). The list expands to fill the tab instead of the old fixed 360 pt cap.

## Changes
- `Views/RegistriesView.swift`: new `RegistryTab` enum (`discover` | `manage`), segmented `Picker`, `switch` over the tab, extracted `manageTab`; banners shown for both tabs; `configuredList` cap `360` → `maxHeight: .infinity`.
- `Views/ServerBrowseView.swift`: outer container and results `ScrollView` now fill remaining vertical space so discovery is the dominant region; empty/error states anchor to the top.

Sheets (add/edit), the remove confirmation dialog, and `RegistryProvenanceBadge` are unchanged.

## Verification
- ✅ **Builds clean**: `swiftc … -O` of the full tray module (arm64, macOS 13) exits 0; binary produced. No new warnings from these files.
- ✅ **Runs**: deployed to `/tmp/MCPProxy.app`, launches and runs against the live core, no crash.
- ⚠️ **ui-test visual capture blocked (known gotcha).** `mcpproxy-ui-test screenshot_window` returns a blank/white PNG and native `screencapture -l <winID>` fails with *"could not create image from window"*. Root cause: replacing the dev binary invalidates the **Screen Recording** TCC grant for `/tmp/MCPProxy.app` (macOS keys it to binary identity); this is the same Screen-Recording blank-screenshot gotcha the issue references (PR #583). It requires an **interactive** grant (System Settings → Privacy & Security → Screen Recording) that can't be performed headlessly.

**To complete the mandatory visual check** (for a reviewer/maintainer with the capture permission):
```
cd native/macos/MCPProxy && SDK=$(xcrun --sdk macosx --show-sdk-path)
swiftc -target arm64-apple-macosx13.0 -sdk "$SDK" -module-name MCPProxy -emit-executable -O \
  -o /tmp/MCPProxy-new $(find MCPProxy -name "*.swift" -not -path "*/Tests/*" | sort | tr '\n' ' ')
cp /tmp/MCPProxy-new /tmp/MCPProxy.app/Contents/MacOS/MCPProxy && open /tmp/MCPProxy.app
# Grant Screen Recording to /tmp/MCPProxy.app, then via mcpproxy-ui-test:
#  - Discover tab: search controls on top, results fill the pane
#  - Manage tab: registries list + Add + ⋮ Edit/Remove; official read-only
```

Related #1078
