### PR TITLE
feat(teams): TokenExchanger — RFC 8693 + Entra OBO (spec 074, MCP-1037)

### DIFF
--- a/internal/teams/broker/token_exchanger.go
+++ b/internal/teams/broker/token_exchanger.go
@@ -1,0 +1,233 @@
+//go:build server
+
+package broker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+)
+
+// RFC 8693 / Microsoft Entra OAuth grant-type and token-type URNs (FR-007/FR-008).
+const (
+	grantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange"
+	grantTypeJWTBearer     = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+	tokenTypeAccessToken   = "urn:ietf:params:oauth:token-type:access_token"
+	entraRequestedTokenUse = "on_behalf_of"
+)
+
+// defaultExchangeTimeout bounds a single token-endpoint round trip.
+const defaultExchangeTimeout = 30 * time.Second
+
+// TokenExchanger mints upstream credentials on behalf of a user by exchanging
+// that user's stored IdP subject token (T3) at an authorization server, then
+// caches the result in the CredentialStore (FR-007/FR-008/FR-009).
+//
+// Two strategies are supported, selected by AuthBrokerConfig.Mode:
+//   - token_exchange: RFC 8693 OAuth 2.0 Token Exchange.
+//   - entra_obo:      Microsoft Entra On-Behalf-Of (jwt-bearer + on_behalf_of).
+//
+// golang.org/x/oauth2 has no native RFC 8693 support (golang/oauth2#409), so
+// the exchange request is hand-rolled.
+type TokenExchanger struct {
+	store      CredentialStore
+	httpClient *http.Client
+	logger     *zap.Logger
+}
+
+// NewTokenExchanger constructs an exchanger over the given credential store. A
+// nil httpClient gets a default client with a bounded timeout.
+func NewTokenExchanger(store CredentialStore, httpClient *http.Client, logger *zap.Logger) *TokenExchanger {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultExchangeTimeout}
+	}
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &TokenExchanger{
+		store:      store,
+		httpClient: httpClient,
+		logger:     logger.Named("token-exchanger"),
+	}
+}
+
+// tokenResponse is the success body of a token-endpoint response (RFC 8693 §2.2.1
+// and the standard OAuth token response used by Entra OBO).
+type tokenResponse struct {
+	AccessToken     string `json:"access_token"`
+	IssuedTokenType string `json:"issued_token_type"`
+	TokenType       string `json:"token_type"`
+	ExpiresIn       int64  `json:"expires_in"`
+	Scope           string `json:"scope"`
+	RefreshToken    string `json:"refresh_token"`
+}
+
+// tokenErrorResponse is the OAuth 2.0 error body (RFC 6749 §5.2). Only the
+// machine-readable error code is ever surfaced; error_description may reflect
+// caller-supplied input and is treated as untrusted (never returned to callers).
+type tokenErrorResponse struct {
+	ErrorCode        string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+// Exchange reads the user's stored IdP subject token, performs the configured
+// token exchange, caches the resulting credential under (userID, serverKey),
+// and returns it. Nothing is cached when the exchange fails.
+func (e *TokenExchanger) Exchange(ctx context.Context, userID, serverKey string, cfg *config.AuthBrokerConfig) (*UpstreamCredential, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("token exchange: nil auth_broker config")
+	}
+
+	// Subject token = the stored IdP token from T3 (keyed by userID alone).
+	subject, err := e.store.Get(userID, "")
+	if err != nil {
+		return nil, fmt.Errorf("token exchange: no IdP subject token for user: %w", err)
+	}
+	if subject.AccessToken == "" {
+		return nil, fmt.Errorf("token exchange: stored IdP subject token is empty")
+	}
+
+	form, err := buildExchangeForm(cfg, subject.AccessToken)
+	if err != nil {
+		return nil, err
+	}
+
+	cred, err := e.post(ctx, cfg, form)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache only on success (FR-009).
+	if perr := e.store.Put(userID, serverKey, cred); perr != nil {
+		return nil, fmt.Errorf("token exchange: cache credential: %w", perr)
+	}
+	return cred, nil
+}
+
+// buildExchangeForm assembles the POST body for the configured mode.
+func buildExchangeForm(cfg *config.AuthBrokerConfig, subjectToken string) (url.Values, error) {
+	form := url.Values{}
+	scope := strings.Join(cfg.Scopes, " ")
+
+	switch cfg.Mode {
+	case config.AuthBrokerModeTokenExchange:
+		form.Set("grant_type", grantTypeTokenExchange)
+		form.Set("subject_token", subjectToken)
+		form.Set("subject_token_type", tokenTypeAccessToken)
+		form.Set("requested_token_type", tokenTypeAccessToken)
+		if cfg.Resource != "" {
+			form.Set("resource", cfg.Resource)
+		}
+	case config.AuthBrokerModeEntraOBO:
+		form.Set("grant_type", grantTypeJWTBearer)
+		form.Set("assertion", subjectToken)
+		form.Set("requested_token_use", entraRequestedTokenUse)
+	default:
+		return nil, fmt.Errorf("token exchange: unsupported auth_broker mode %q", cfg.Mode)
+	}
+
+	if scope != "" {
+		form.Set("scope", scope)
+	}
+	// Client authentication via client_secret_post.
+	if cfg.ClientID != "" {
+		form.Set("client_id", cfg.ClientID)
+	}
+	if cfg.ClientSecret != "" {
+		form.Set("client_secret", cfg.ClientSecret)
+	}
+	return form, nil
+}
+
+// post executes the token-endpoint round trip and maps the response onto an
+// UpstreamCredential. Errors are sanitized: only the HTTP status and OAuth
+// error code are surfaced, never the response body or request secrets.
+func (e *TokenExchanger) post(ctx context.Context, cfg *config.AuthBrokerConfig, form url.Values) (*UpstreamCredential, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.TokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("token exchange: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		// A transport error may embed the endpoint URL but not request secrets.
+		return nil, fmt.Errorf("token exchange: request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("token exchange: read response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, e.sanitizedError(resp.StatusCode, body)
+	}
+
+	var tr tokenResponse
+	if err := json.Unmarshal(body, &tr); err != nil {
+		return nil, fmt.Errorf("token exchange: malformed success response (status %d)", resp.StatusCode)
+	}
+	if tr.AccessToken == "" {
+		return nil, fmt.Errorf("token exchange: response missing access_token (status %d)", resp.StatusCode)
+	}
+
+	return credentialFromResponse(cfg, &tr), nil
+}
+
+// sanitizedError maps an authorization-server error response onto a safe error
+// that names only the HTTP status and the standard OAuth error code. The
+// error_description and raw body are deliberately dropped — they may reflect
+// caller input or secrets (FR-008/FR-009).
+func (e *TokenExchanger) sanitizedError(status int, body []byte) error {
+	var te tokenErrorResponse
+	_ = json.Unmarshal(body, &te)
+	if te.ErrorCode != "" {
+		e.logger.Warn("token exchange rejected by authorization server",
+			zap.Int("status", status),
+			zap.String("error", te.ErrorCode))
+		return fmt.Errorf("token exchange failed: status %d, error %q", status, te.ErrorCode)
+	}
+	e.logger.Warn("token exchange rejected by authorization server",
+		zap.Int("status", status))
+	return fmt.Errorf("token exchange failed: status %d", status)
+}
+
+// credentialFromResponse converts a successful token response into the stored
+// credential model, recording how it was obtained and the requested audience.
+func credentialFromResponse(cfg *config.AuthBrokerConfig, tr *tokenResponse) *UpstreamCredential {
+	now := time.Now().UTC()
+	cred := &UpstreamCredential{
+		Type:         "oauth2",
+		AccessToken:  tr.AccessToken,
+		RefreshToken: tr.RefreshToken,
+		TokenType:    tr.TokenType,
+		Audience:     cfg.Resource,
+		ObtainedVia:  cfg.Mode,
+		UpdatedAt:    now,
+	}
+	if cred.TokenType == "" {
+		cred.TokenType = "Bearer"
+	}
+	if tr.ExpiresIn > 0 {
+		cred.ExpiresAt = now.Add(time.Duration(tr.ExpiresIn) * time.Second)
+	}
+	// Prefer the granted scope from the response; fall back to the requested set.
+	if granted := strings.Fields(tr.Scope); len(granted) > 0 {
+		cred.Scopes = granted
+	} else {
+		cred.Scopes = cfg.Scopes
+	}
+	return cred
+}

--- a/internal/teams/broker/token_exchanger_test.go
+++ b/internal/teams/broker/token_exchanger_test.go
@@ -1,0 +1,261 @@
+//go:build server
+
+package broker
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+)
+
+const (
+	testUserID  = "user-42"
+	testSrvKey  = "server-key-abc"
+	testSubject = "subject-token-SECRET-do-not-leak"
+)
+
+// seedSubjectToken stores an IdP subject token for the user (serverKey == "")
+// the way T3 would, so the exchanger can read it.
+func seedSubjectToken(t *testing.T, store CredentialStore, token string) {
+	t.Helper()
+	if err := store.Put(testUserID, "", &UpstreamCredential{
+		Type:        "idp_subject_token",
+		AccessToken: token,
+	}); err != nil {
+		t.Fatalf("seed subject token: %v", err)
+	}
+}
+
+// newExchangeServer spins up a mock token endpoint. handler receives the parsed
+// POST form and writes the response.
+func newExchangeServer(t *testing.T, handler func(t *testing.T, form url.Values, w http.ResponseWriter)) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/x-www-form-urlencoded") {
+			t.Errorf("expected form content-type, got %q", ct)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		handler(t, r.PostForm, w)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func writeJSON(w http.ResponseWriter, status int, body map[string]interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func TestTokenExchanger_RFC8693HappyPath(t *testing.T) {
+	store := newTestStore(t, openTestDB(t), newTestKey(t))
+	seedSubjectToken(t, store, testSubject)
+
+	srv := newExchangeServer(t, func(t *testing.T, form url.Values, w http.ResponseWriter) {
+		t.Helper()
+		if got := form.Get("grant_type"); got != "urn:ietf:params:oauth:grant-type:token-exchange" {
+			t.Errorf("grant_type = %q", got)
+		}
+		if got := form.Get("subject_token"); got != testSubject {
+			t.Errorf("subject_token = %q", got)
+		}
+		if got := form.Get("subject_token_type"); got != "urn:ietf:params:oauth:token-type:access_token" {
+			t.Errorf("subject_token_type = %q", got)
+		}
+		if got := form.Get("resource"); got != "https://upstream.example.com" {
+			t.Errorf("resource = %q", got)
+		}
+		if got := form.Get("scope"); got != "read write" {
+			t.Errorf("scope = %q", got)
+		}
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"access_token":      "exchanged-access-token",
+			"issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+			"token_type":        "Bearer",
+			"expires_in":        3600,
+			"scope":             "read write",
+		})
+	})
+
+	cfg := &config.AuthBrokerConfig{
+		Mode:          config.AuthBrokerModeTokenExchange,
+		TokenEndpoint: srv.URL,
+		Resource:      "https://upstream.example.com",
+		Scopes:        []string{"read", "write"},
+		ClientID:      "gateway-client",
+		ClientSecret:  "gateway-secret",
+	}
+
+	ex := NewTokenExchanger(store, nil, zap.NewNop())
+	cred, err := ex.Exchange(context.Background(), testUserID, testSrvKey, cfg)
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if cred.AccessToken != "exchanged-access-token" {
+		t.Errorf("AccessToken = %q", cred.AccessToken)
+	}
+	if cred.TokenType != "Bearer" {
+		t.Errorf("TokenType = %q", cred.TokenType)
+	}
+	if cred.Audience != "https://upstream.example.com" {
+		t.Errorf("Audience = %q", cred.Audience)
+	}
+	if cred.ObtainedVia != "token_exchange" {
+		t.Errorf("ObtainedVia = %q", cred.ObtainedVia)
+	}
+	if len(cred.Scopes) != 2 || cred.Scopes[0] != "read" || cred.Scopes[1] != "write" {
+		t.Errorf("Scopes = %v", cred.Scopes)
+	}
+	// expires_in 3600 -> ExpiresAt roughly an hour out.
+	if d := time.Until(cred.ExpiresAt); d < 55*time.Minute || d > 60*time.Minute {
+		t.Errorf("ExpiresAt not ~1h out: %v (delta %v)", cred.ExpiresAt, d)
+	}
+
+	// Result must be cached under (userID, serverKey).
+	cached, err := store.Get(testUserID, testSrvKey)
+	if err != nil {
+		t.Fatalf("expected cached credential: %v", err)
+	}
+	if cached.AccessToken != "exchanged-access-token" {
+		t.Errorf("cached AccessToken = %q", cached.AccessToken)
+	}
+}
+
+func TestTokenExchanger_EntraOBOMode(t *testing.T) {
+	store := newTestStore(t, openTestDB(t), newTestKey(t))
+	seedSubjectToken(t, store, testSubject)
+
+	srv := newExchangeServer(t, func(t *testing.T, form url.Values, w http.ResponseWriter) {
+		t.Helper()
+		if got := form.Get("grant_type"); got != "urn:ietf:params:oauth:grant-type:jwt-bearer" {
+			t.Errorf("grant_type = %q", got)
+		}
+		if got := form.Get("assertion"); got != testSubject {
+			t.Errorf("assertion = %q", got)
+		}
+		if got := form.Get("requested_token_use"); got != "on_behalf_of" {
+			t.Errorf("requested_token_use = %q", got)
+		}
+		if got := form.Get("client_id"); got != "entra-client" {
+			t.Errorf("client_id = %q", got)
+		}
+		if got := form.Get("client_secret"); got != "entra-secret" {
+			t.Errorf("client_secret = %q", got)
+		}
+		if got := form.Get("scope"); got != "api://upstream/.default" {
+			t.Errorf("scope = %q", got)
+		}
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"access_token": "obo-access-token",
+			"token_type":   "Bearer",
+			"expires_in":   1800,
+			"scope":        "api://upstream/.default",
+		})
+	})
+
+	cfg := &config.AuthBrokerConfig{
+		Mode:          config.AuthBrokerModeEntraOBO,
+		TokenEndpoint: srv.URL,
+		Scopes:        []string{"api://upstream/.default"},
+		ClientID:      "entra-client",
+		ClientSecret:  "entra-secret",
+	}
+
+	ex := NewTokenExchanger(store, nil, zap.NewNop())
+	cred, err := ex.Exchange(context.Background(), testUserID, testSrvKey, cfg)
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if cred.AccessToken != "obo-access-token" {
+		t.Errorf("AccessToken = %q", cred.AccessToken)
+	}
+	if cred.ObtainedVia != "entra_obo" {
+		t.Errorf("ObtainedVia = %q", cred.ObtainedVia)
+	}
+	if d := time.Until(cred.ExpiresAt); d < 25*time.Minute || d > 30*time.Minute {
+		t.Errorf("ExpiresAt not ~30m out: %v", cred.ExpiresAt)
+	}
+}
+
+// Error responses from the AS must be sanitized: the surfaced error names the
+// OAuth error code + HTTP status but never leaks error_description (which can
+// reflect secrets) or the subject token, and nothing is cached.
+func TestTokenExchanger_ErrorSanitizedAndNotCached(t *testing.T) {
+	store := newTestStore(t, openTestDB(t), newTestKey(t))
+	seedSubjectToken(t, store, testSubject)
+
+	const leak = "this-description-leaks-a-SECRET-value"
+	srv := newExchangeServer(t, func(_ *testing.T, _ url.Values, w http.ResponseWriter) {
+		writeJSON(w, http.StatusBadRequest, map[string]interface{}{
+			"error":             "invalid_grant",
+			"error_description": leak,
+		})
+	})
+
+	cfg := &config.AuthBrokerConfig{
+		Mode:          config.AuthBrokerModeTokenExchange,
+		TokenEndpoint: srv.URL,
+		Resource:      "https://upstream.example.com",
+		ClientID:      "gateway-client",
+		ClientSecret:  "gateway-secret",
+	}
+
+	ex := NewTokenExchanger(store, nil, zap.NewNop())
+	_, err := ex.Exchange(context.Background(), testUserID, testSrvKey, cfg)
+	if err == nil {
+		t.Fatal("expected error on 400 response")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "invalid_grant") {
+		t.Errorf("error should name the OAuth error code, got %q", msg)
+	}
+	if strings.Contains(msg, leak) || strings.Contains(msg, "SECRET") {
+		t.Errorf("error leaked error_description: %q", msg)
+	}
+	if strings.Contains(msg, testSubject) {
+		t.Errorf("error leaked subject token: %q", msg)
+	}
+	// Nothing cached on failure.
+	if _, gerr := store.Get(testUserID, testSrvKey); gerr == nil {
+		t.Error("nothing should be cached after a failed exchange")
+	}
+}
+
+// A missing IdP subject token is a clean error, not a panic, and surfaces no
+// HTTP call (the endpoint is never hit because we have nothing to exchange).
+func TestTokenExchanger_MissingSubjectToken(t *testing.T) {
+	store := newTestStore(t, openTestDB(t), newTestKey(t))
+	// No subject token seeded.
+
+	called := false
+	srv := newExchangeServer(t, func(_ *testing.T, _ url.Values, w http.ResponseWriter) {
+		called = true
+		writeJSON(w, http.StatusOK, map[string]interface{}{"access_token": "x"})
+	})
+
+	cfg := &config.AuthBrokerConfig{
+		Mode:          config.AuthBrokerModeTokenExchange,
+		TokenEndpoint: srv.URL,
+	}
+	ex := NewTokenExchanger(store, nil, zap.NewNop())
+	if _, err := ex.Exchange(context.Background(), testUserID, testSrvKey, cfg); err == nil {
+		t.Fatal("expected error when subject token is missing")
+	}
+	if called {
+		t.Error("token endpoint should not be called without a subject token")
+	}
+}


### PR DESCRIPTION
## Summary

Spec 074 **T4** — the `TokenExchanger` that mints per-user upstream credentials for the server-edition token broker (`internal/teams/broker/`). Builds on T1 (`CredentialStore`, #587) and T2 (`auth_broker` config, #588), both merged.

`golang.org/x/oauth2` has no native RFC 8693 support ([golang/oauth2#409](https://github.com/golang/oauth2/issues/409)), so the exchange POST is hand-rolled.

## What it does

- **`mode=token_exchange`** (RFC 8693): `grant_type=urn:ietf:params:oauth:grant-type:token-exchange`, `subject_token` + `subject_token_type`, `resource` (RFC 8707) + `scope`.
- **`mode=entra_obo`** (Microsoft Entra On-Behalf-Of): `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer`, `assertion`, `requested_token_use=on_behalf_of`, `client_secret_post`.
- Subject token = the stored IdP token from T3 (`CredentialStore.Get(userID, "")`). Response parsed → access token + expiry + scopes, cached via `store.Put(userID, serverKey, …)`.
- **Error sanitization**: authorization-server failures surface only the HTTP status + standard OAuth `error` code — never `error_description`, the raw body, or request secrets. **Nothing is cached on failure.**

FR-007, FR-008, FR-009.

## Tests (TDD)

Against an `httptest` mock token endpoint:
- RFC 8693 happy path (param assertions + audience/scope propagation + caching)
- Entra OBO mode
- Sanitized error mapping (asserts no `error_description`/secret/subject-token leak, nothing cached)
- Missing subject token (clean error, endpoint never hit)

## Verification

- `go test -tags server -race ./internal/teams/broker/` ✅
- `go build -tags server ./cmd/mcpproxy` + `go build ./cmd/mcpproxy` ✅
- `golangci-lint run --build-tags server ./internal/teams/broker/...` → 0 issues ✅

No user-facing surface yet (the `auth_broker` config schema shipped in T2); wiring into the request path is T5. No docs diff required.

Related: spec 074 (MCP-1033). Blockers MCP-1034 / MCP-1035 merged.