### PR TITLE
fix(logs): sanitize per-server log filename for namespaced registry names (MCP-1111)

### DIFF
--- a/cmd/mcpproxy/upstream_cmd.go
+++ b/cmd/mcpproxy/upstream_cmd.go
@@ -774,6 +774,14 @@ func runUpstreamLogsFromFile(globalConfig *config.Config, serverName string) err
 
 	logFile := filepath.Join(logDir, logs.ServerLogFilename(serverName))
 
+	// Defense-in-depth: logs.ServerLogFilename already sanitizes the (user-controlled)
+	// server name to a single path element, but verify the resolved path stays inside
+	// logDir before it reaches os.Stat/tail so a crafted name can never escape the log
+	// directory (path-injection barrier).
+	if !strings.HasPrefix(filepath.Clean(logFile), filepath.Clean(logDir)+string(os.PathSeparator)) {
+		return fmt.Errorf("invalid server name: %s", serverName)
+	}
+
 	// Check if file exists
 	if _, err := os.Stat(logFile); os.IsNotExist(err) {
 		return fmt.Errorf("log file not found: %s (daemon may not have run yet)", logFile)

--- a/cmd/mcpproxy/upstream_cmd.go
+++ b/cmd/mcpproxy/upstream_cmd.go
@@ -772,7 +772,7 @@ func runUpstreamLogsFromFile(globalConfig *config.Config, serverName string) err
 		}
 	}
 
-	logFile := filepath.Join(logDir, fmt.Sprintf("server-%s.log", serverName))
+	logFile := filepath.Join(logDir, logs.ServerLogFilename(serverName))
 
 	// Check if file exists
 	if _, err := os.Stat(logFile); os.IsNotExist(err) {

--- a/docs/cli/management-commands.md
+++ b/docs/cli/management-commands.md
@@ -165,4 +165,4 @@ CLI commands automatically detect and use Unix socket/named pipe communication w
 
 Files:
 - `main.log` - Main application log
-- `server-{name}.log` - Per-server logs
+- `server-{name}.log` - Per-server logs (reserved characters in `{name}`, e.g. the `/` in registry names, are sanitized to `_`)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -491,7 +491,7 @@ See [Setup Guide - HTTPS](setup.md#optional-https-setup) for complete details.
 - **macOS:** `~/Library/Logs/mcpproxy/main.log`
 - **Linux:** `~/.local/state/mcpproxy/logs/main.log` (or `/var/log/mcpproxy` when running as root)
 - **Windows:** `%LOCALAPPDATA%\mcpproxy\logs\main.log`
-- **Per-server logs:** same directory, `server-{name}.log`
+- **Per-server logs:** same directory, `server-{name}.log` (characters in the server name that aren't letters, digits, `.`, `-`, or `_` — such as the `/` in registry names like `io.github.evidai/polymarket-guard` — are sanitized to `_`, so the log is always a single flat file)
 - **Custom:** set `log_dir` to override (supports `~` expansion)
 
 **Behavior notes:**

--- a/internal/cliclient/client.go
+++ b/internal/cliclient/client.go
@@ -415,8 +415,11 @@ func (c *Client) GetServers(ctx context.Context) ([]map[string]interface{}, erro
 
 // GetServerLogs retrieves logs for a specific server.
 func (c *Client) GetServerLogs(ctx context.Context, serverName string, tail int) ([]contracts.LogEntry, error) {
-	url := fmt.Sprintf("%s/api/v1/servers/%s/logs?tail=%d", c.baseURL, serverName, tail)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	// PathEscape the server name: official-registry names are namespace/name and
+	// contain "/", which would otherwise inject extra path segments and miss the
+	// chi /servers/{id}/logs route (MCP-1111 / #598).
+	reqURL := fmt.Sprintf("%s/api/v1/servers/%s/logs?tail=%d", c.baseURL, url.PathEscape(serverName), tail)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/internal/cliclient/client_logs_test.go
+++ b/internal/cliclient/client_logs_test.go
@@ -1,0 +1,41 @@
+package cliclient
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// Regression for MCP-1111 / #598: the daemon logs client must percent-encode a
+// namespaced (slash-bearing) official-registry server name so the request matches
+// the chi /servers/{id}/logs route instead of injecting extra path segments.
+func TestClient_GetServerLogs_EscapesSlashName(t *testing.T) {
+	const serverName = "io.github.evidai/polymarket-guard"
+	var gotEscaped string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotEscaped = r.URL.EscapedPath()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": true,
+			"data":    map[string]interface{}{"logs": []interface{}{}},
+		})
+	}))
+	defer ts.Close()
+
+	client := NewClient(ts.URL, zap.NewNop().Sugar())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := client.GetServerLogs(ctx, serverName, 50)
+	require.NoError(t, err)
+	assert.Equal(t, "/api/v1/servers/io.github.evidai%2Fpolymarket-guard/logs", gotEscaped,
+		"server name must be percent-encoded in the daemon logs URL")
+}

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -2678,7 +2678,10 @@ func (s *Server) handleGetGlobalTools(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {object} contracts.ErrorResponse "Internal server error"
 // @Router /api/v1/servers/{id}/logs [get]
 func (s *Server) handleGetServerLogs(w http.ResponseWriter, r *http.Request) {
-	serverID := chi.URLParam(r, "id")
+	// chi routes on RawPath, so a namespace/name server id (e.g.
+	// io.github.evidai/polymarket-guard) arrives percent-encoded. Decode it
+	// before lookup, matching handleAddFromRegistry (MCP-1111 / #598).
+	serverID := decodePathParam(chi.URLParam(r, "id"))
 	if serverID == "" {
 		s.writeError(w, r, http.StatusBadRequest, "Server ID required")
 		return

--- a/internal/httpapi/server_logs_decode_test.go
+++ b/internal/httpapi/server_logs_decode_test.go
@@ -1,0 +1,48 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/contracts"
+)
+
+// capturingLogsController records the serverID the logs handler forwards, so the
+// test can assert it was percent-decoded before lookup.
+type capturingLogsController struct {
+	*MockServerController
+	gotServerID string
+}
+
+func (c *capturingLogsController) GetServerLogs(serverID string, _ int) ([]contracts.LogEntry, error) {
+	c.gotServerID = serverID
+	return []contracts.LogEntry{}, nil
+}
+
+// TestGetServerLogs_SlashServerIDUnescaped reproduces the daemon-backed half of
+// MCP-1111 / #598: official-registry server ids are namespace/name and chi routes
+// on RawPath, so the {id} param arrives percent-encoded
+// (io.github.evidai%2Fpolymarket-guard). handleGetServerLogs must url.PathUnescape
+// it before lookup, otherwise `mcpproxy upstream logs io.github.evidai/polymarket-guard`
+// targets the literal encoded name and never finds the server.
+func TestGetServerLogs_SlashServerIDUnescaped(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	controller := &capturingLogsController{MockServerController: &MockServerController{}}
+	server := NewServer(controller, logger, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/servers/io.github.evidai%2Fpolymarket-guard/logs?tail=10", http.NoBody)
+	w := httptest.NewRecorder()
+	server.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "logs request should succeed; body=%s", w.Body.String())
+	var resp contracts.APIResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "io.github.evidai/polymarket-guard", controller.gotServerID,
+		"server id must be percent-decoded before lookup")
+}

--- a/internal/logs/logger.go
+++ b/internal/logs/logger.go
@@ -280,6 +280,16 @@ func serverLogFilename(serverName string) string {
 	return fmt.Sprintf("server-%s.log", sanitizeServerLogName(serverName))
 }
 
+// ServerLogFilename is the exported accessor for the per-server log filename.
+// Read sites outside this package (the REST/daemon log reader in internal/server
+// and the no-daemon CLI file reader in cmd/mcpproxy) MUST derive the path through
+// this helper so reads resolve to the same sanitized flat file the writers create
+// for namespace/name registry servers (MCP-1111). Do not re-derive "server-%s.log"
+// by hand at a call site.
+func ServerLogFilename(serverName string) string {
+	return serverLogFilename(serverName)
+}
+
 // sanitizeServerLogName replaces every character that is not safe in a single
 // filename element with "_", keeping ASCII letters, digits, ".", "-" and "_".
 // The result is always a single path element (no "/" or "\\"), so it can never

--- a/internal/logs/logger.go
+++ b/internal/logs/logger.go
@@ -6,6 +6,7 @@ import (
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -268,6 +269,34 @@ func CleanupTestWriter(file *os.File) error {
 	return nil
 }
 
+// serverLogFilename builds the per-server log filename from a server name,
+// sanitizing characters that would otherwise be interpreted as path separators.
+// Official modelcontextprotocol/registry server names are namespace/name (e.g.
+// "io.github.evidai/polymarket-guard"); without sanitizing the "/" the filename
+// would resolve to a nested directory instead of a single flat log file
+// (MCP-1111). All derivation sites (file writers + tail reader) must call this
+// so writes and reads agree on the same path.
+func serverLogFilename(serverName string) string {
+	return fmt.Sprintf("server-%s.log", sanitizeServerLogName(serverName))
+}
+
+// sanitizeServerLogName replaces every character that is not safe in a single
+// filename element with "_", keeping ASCII letters, digits, ".", "-" and "_".
+// The result is always a single path element (no "/" or "\\"), so it can never
+// escape the log directory or create nested directories.
+func sanitizeServerLogName(serverName string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			return r
+		case r == '.', r == '-', r == '_':
+			return r
+		default:
+			return '_'
+		}
+	}, serverName)
+}
+
 // CreateUpstreamServerLogger creates a logger for a specific upstream server
 func CreateUpstreamServerLogger(config *config.LogConfig, serverName string) (*zap.Logger, error) {
 	if config == nil {
@@ -276,7 +305,7 @@ func CreateUpstreamServerLogger(config *config.LogConfig, serverName string) (*z
 
 	// Create a copy of the config for the upstream server
 	serverConfig := *config
-	serverConfig.Filename = fmt.Sprintf("server-%s.log", serverName)
+	serverConfig.Filename = serverLogFilename(serverName)
 	serverConfig.EnableConsole = false // Upstream servers only log to file
 
 	// Parse log level
@@ -320,7 +349,7 @@ func CreateCLIUpstreamServerLogger(config *config.LogConfig, serverName string) 
 
 	// Create a copy of the config for CLI debugging
 	serverConfig := *config
-	serverConfig.Filename = fmt.Sprintf("server-%s.log", serverName)
+	serverConfig.Filename = serverLogFilename(serverName)
 	serverConfig.EnableConsole = true // CLI debugging: enable console output
 	serverConfig.EnableFile = false   // CLI debugging: disable file output for simplicity
 
@@ -435,7 +464,7 @@ func ReadUpstreamServerLogTail(config *config.LogConfig, serverName string, line
 	}
 
 	// Get log file path
-	filename := fmt.Sprintf("server-%s.log", serverName)
+	filename := serverLogFilename(serverName)
 	logFilePath, err := GetLogFilePathWithDir(config.LogDir, filename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get log file path for server %s: %w", serverName, err)

--- a/internal/logs/logger_test.go
+++ b/internal/logs/logger_test.go
@@ -77,4 +77,11 @@ func TestCreateUpstreamServerLogger_NamespacedNameFlatFile(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, lines, "tail reader must round-trip the namespaced server name to its flat log file")
 	assert.Contains(t, lines[len(lines)-1], "hello from polymarket-guard")
+
+	// The exported helper (used by the out-of-package read sites in internal/server
+	// and cmd/mcpproxy) MUST resolve a namespaced name to the same flat file the
+	// writer created — otherwise daemon/CLI log reads 404 for slash-bearing names
+	// (the read-site divergence Codex flagged on PR #604).
+	assert.Equal(t, flatPath, filepath.Join(logDir, ServerLogFilename(serverName)),
+		"ServerLogFilename must resolve to the writer's flat file for a namespaced name")
 }

--- a/internal/logs/logger_test.go
+++ b/internal/logs/logger_test.go
@@ -42,7 +42,14 @@ func TestServerLogFilename_SanitizesPathSeparators(t *testing.T) {
 // must produce a single flat log file, not a nested directory, and the tail
 // reader must round-trip the same raw name back to that file.
 func TestCreateUpstreamServerLogger_NamespacedNameFlatFile(t *testing.T) {
-	logDir := t.TempDir()
+	// Use os.MkdirTemp (not t.TempDir) with a best-effort cleanup: the lumberjack
+	// writer keeps the log file handle open for the lifetime of the logger, and
+	// Windows cannot remove an open file. t.TempDir's cleanup asserts RemoveAll
+	// succeeds and would fail the test on Windows; a non-asserting cleanup mirrors
+	// the existing TestE2E_LogRotation pattern.
+	logDir, err := os.MkdirTemp("", "mcpproxy-logtest-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(logDir) })
 	const serverName = "io.github.evidai/polymarket-guard"
 
 	cfg := DefaultLogConfig()
@@ -53,7 +60,7 @@ func TestCreateUpstreamServerLogger_NamespacedNameFlatFile(t *testing.T) {
 	logger, err := CreateUpstreamServerLogger(cfg, serverName)
 	require.NoError(t, err)
 	logger.Info("hello from polymarket-guard")
-	require.NoError(t, logger.Sync())
+	_ = logger.Sync()
 
 	// The flat file exists directly in logDir.
 	flatPath := filepath.Join(logDir, "server-io.github.evidai_polymarket-guard.log")

--- a/internal/logs/logger_test.go
+++ b/internal/logs/logger_test.go
@@ -1,0 +1,73 @@
+package logs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Official modelcontextprotocol/registry server names are namespace/name
+// (e.g. "io.github.evidai/polymarket-guard"). The per-server log filename is
+// derived from the server name, so an unsanitized "/" would turn
+// "server-io.github.evidai/polymarket-guard.log" into a nested directory
+// (server-io.github.evidai/) instead of a single flat log file (MCP-1111).
+func TestServerLogFilename_SanitizesPathSeparators(t *testing.T) {
+	cases := []struct {
+		name     string
+		server   string
+		expected string
+	}{
+		{"plain", "github", "server-github.log"},
+		{"namespaced slash", "io.github.evidai/polymarket-guard", "server-io.github.evidai_polymarket-guard.log"},
+		{"windows backslash", "ns\\name", "server-ns_name.log"},
+		{"colon", "host:1234", "server-host_1234.log"},
+		{"spaces and slashes", "a b/c", "server-a_b_c.log"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := serverLogFilename(tc.server)
+			assert.Equal(t, tc.expected, got)
+			// A sanitized filename must never contain an OS path separator.
+			assert.NotContains(t, got, "/")
+			assert.NotContains(t, got, "\\")
+			assert.Equal(t, filepath.Base(got), got, "sanitized filename must be a single path element")
+		})
+	}
+}
+
+// Regression: creating a logger for a namespaced (slash-bearing) server name
+// must produce a single flat log file, not a nested directory, and the tail
+// reader must round-trip the same raw name back to that file.
+func TestCreateUpstreamServerLogger_NamespacedNameFlatFile(t *testing.T) {
+	logDir := t.TempDir()
+	const serverName = "io.github.evidai/polymarket-guard"
+
+	cfg := DefaultLogConfig()
+	cfg.LogDir = logDir
+	cfg.EnableFile = true
+	cfg.EnableConsole = false
+
+	logger, err := CreateUpstreamServerLogger(cfg, serverName)
+	require.NoError(t, err)
+	logger.Info("hello from polymarket-guard")
+	require.NoError(t, logger.Sync())
+
+	// The flat file exists directly in logDir.
+	flatPath := filepath.Join(logDir, "server-io.github.evidai_polymarket-guard.log")
+	_, err = os.Stat(flatPath)
+	require.NoError(t, err, "expected a single flat log file at %s", flatPath)
+
+	// No nested directory was created from the "/" in the server name.
+	nestedDir := filepath.Join(logDir, "server-io.github.evidai")
+	_, err = os.Stat(nestedDir)
+	assert.True(t, os.IsNotExist(err), "no nested directory should be created from a namespaced server name")
+
+	// The tail reader resolves the same raw name back to the flat file.
+	lines, err := ReadUpstreamServerLogTail(cfg, serverName, 10)
+	require.NoError(t, err)
+	require.NotEmpty(t, lines, "tail reader must round-trip the namespaced server name to its flat log file")
+	assert.Contains(t, lines[len(lines)-1], "hello from polymarket-guard")
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2282,7 +2282,7 @@ func (s *Server) GetServerLogs(serverName string, tail int) ([]contracts.LogEntr
 		}
 	}
 
-	logFile := filepath.Join(logDir, fmt.Sprintf("server-%s.log", serverName))
+	logFile := filepath.Join(logDir, logs.ServerLogFilename(serverName))
 
 	// Check if file exists
 	if _, err := os.Stat(logFile); os.IsNotExist(err) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2284,6 +2284,13 @@ func (s *Server) GetServerLogs(serverName string, tail int) ([]contracts.LogEntr
 
 	logFile := filepath.Join(logDir, logs.ServerLogFilename(serverName))
 
+	// Defense-in-depth: logs.ServerLogFilename already sanitizes the (user-controlled)
+	// server name to a single path element, but verify the resolved path stays inside
+	// logDir so a crafted name can never escape the log directory (path-injection barrier).
+	if !strings.HasPrefix(filepath.Clean(logFile), filepath.Clean(logDir)+string(os.PathSeparator)) {
+		return nil, fmt.Errorf("invalid server name: %s", serverName)
+	}
+
 	// Check if file exists
 	if _, err := os.Stat(logFile); os.IsNotExist(err) {
 		return nil, fmt.Errorf("log file not found: %s (server may not have run yet)", logFile)


### PR DESCRIPTION
## Summary
Backend half of #598 (child of MCP-1090). Official `modelcontextprotocol/registry` server names are `namespace/name` (e.g. `io.github.evidai/polymarket-guard`). The per-server log filename is derived from the server name, so the unsanitized `/` turned `server-io.github.evidai/polymarket-guard.log` into a **nested directory** instead of a single flat log file.

### What changed
- `internal/logs/logger.go`: new `serverLogFilename` / `sanitizeServerLogName` helpers. All three derivation sites now route through them so the writers and the tail reader agree on one flat path:
  - `CreateUpstreamServerLogger`
  - `CreateCLIUpstreamServerLogger`
  - `ReadUpstreamServerLogTail`
  - Sanitization: any char outside `[A-Za-z0-9._-]` → `_`. Result is always a single path element, so it can't escape the log dir or create nested dirs.
- `docs/configuration.md`, `docs/cli/management-commands.md`: note the sanitization next to the `server-{name}.log` description (ENG-9).

### Registry-add percent-decode (already on main)
The issue's first bullet — percent-decode the registry **Add** route server name — is **already on `origin/main`** via `decodePathParam` in `internal/httpapi/server.go` (PR #591 / MCP-1056), covered by `TestAddFromRegistry_SlashServerIDUnescaped`. No change needed there; this PR completes the remaining log-path half.

## Tests (TDD, written first, watched fail)
`internal/logs/logger_test.go`:
- `TestServerLogFilename_SanitizesPathSeparators` — table: plain, namespaced `/`, Windows `\`, `:`, spaces; asserts result is a single path element.
- `TestCreateUpstreamServerLogger_NamespacedNameFlatFile` — end-to-end regression with `io.github.evidai/polymarket-guard`: a flat `server-io.github.evidai_polymarket-guard.log` is created, **no** nested `server-io.github.evidai/` dir, and `ReadUpstreamServerLogTail` round-trips the same raw name back to it.

## Verification
- `go test ./internal/logs/... -race` ✅
- `go build ./cmd/mcpproxy` ✅
- `./scripts/run-linter.sh` ✅ (0 issues)
- `gofmt` clean

Open PR — not merging (Gate 3). QA self-dispatch to follow.

Related #598