### PR TITLE
fix(frontend): encode '/' in server-detail route + prefer registry title (MCP-1112, #598)

### DIFF
--- a/frontend/src/components/ServerCard.vue
+++ b/frontend/src/components/ServerCard.vue
@@ -4,7 +4,7 @@
       <!-- Header -->
       <div class="flex justify-between items-start mb-4">
         <div class="flex-1 min-w-0 mr-2">
-          <h3 class="card-title text-lg truncate">{{ server.name }}</h3>
+          <h3 class="card-title text-lg truncate" :title="server.name" data-test="server-card-title">{{ displayName }}</h3>
           <p class="text-sm text-base-content/70 truncate">
             {{ server.protocol }} • {{ server.url || server.command || 'No endpoint' }}
           </p>
@@ -128,7 +128,7 @@
         </svg>
         <span class="text-xs flex-1">{{ toolQuarantineSummary }}</span>
         <router-link
-          :to="`/servers/${server.name}?tab=tools`"
+          :to="serverDetailPath(server.name, 'tools')"
           class="btn btn-xs btn-warning"
         >
           Review
@@ -180,7 +180,7 @@
 
         <router-link
           v-if="healthAction === 'view_logs'"
-          :to="`/servers/${server.name}?tab=logs`"
+          :to="serverDetailPath(server.name, 'logs')"
           class="btn btn-sm btn-primary"
         >
           View Logs
@@ -196,7 +196,7 @@
 
         <router-link
           v-if="healthAction === 'configure'"
-          :to="`/servers/${server.name}?tab=config`"
+          :to="serverDetailPath(server.name, 'config')"
           class="btn btn-sm btn-primary"
         >
           Configure
@@ -231,7 +231,7 @@
           </div>
           <router-link
             v-else
-            :to="`/servers/${server.name}?tab=security`"
+            :to="serverDetailPath(server.name, 'security')"
             class="btn btn-sm btn-outline btn-ghost"
             title="Security Scan"
           >
@@ -243,8 +243,9 @@
         </template>
 
         <router-link
-          :to="`/servers/${server.name}`"
+          :to="serverDetailPath(server.name)"
           class="btn btn-sm btn-outline"
+          data-test="server-detail-link"
         >
           Details
         </router-link>
@@ -286,7 +287,7 @@
           </button>
           <router-link
             v-if="approveDialogMode === 'no_scan'"
-            :to="`/servers/${server.name}?tab=security`"
+            :to="serverDetailPath(server.name, 'security')"
             class="btn btn-primary"
             @click="showApproveConfirmation = false"
           >
@@ -342,12 +343,17 @@ import type { Server } from '@/types'
 import { useServersStore } from '@/stores/servers'
 import { useSystemStore } from '@/stores/system'
 import { useSecurityScannerStatus } from '@/composables/useSecurityScannerStatus'
+import { serverDetailPath, serverDisplayName } from '@/utils/serverRoute'
 
 interface Props {
   server: Server
 }
 
 const props = defineProps<Props>()
+
+// MCP-1112: title-preferring display label. The '/'-safe detail links call
+// serverDetailPath() directly in the template.
+const displayName = computed(() => serverDisplayName(props.server))
 
 const serversStore = useServersStore()
 const systemStore = useSystemStore()

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -142,6 +142,11 @@ export interface ServerIsolationDefaults {
 
 export interface Server {
   name: string
+  // Human-friendly display label from the source registry (MCP-1112). When
+  // present it is preferred over `name` for display; `name` stays the stable
+  // identifier used for routing and API calls (it may be a reverse-DNS id such
+  // as "io.github.owner/repo").
+  title?: string
   url?: string
   command?: string
   args?: string[]

--- a/frontend/src/utils/serverRoute.ts
+++ b/frontend/src/utils/serverRoute.ts
@@ -1,0 +1,19 @@
+// MCP-1112 (#598): official-registry server names contain '/'
+// (e.g. "io.github.owner/repo"). The server-detail route is a single
+// `:serverName` segment, so the name MUST be percent-encoded — otherwise the
+// '/' splits the path into two segments and the request falls through to the
+// catch-all 404. vue-router decodes the param back to the original name when it
+// is read via `route.params.serverName` / the component prop, so callers read
+// the plain name without any manual decode.
+export function serverDetailPath(name: string, tab?: string): string {
+  const base = `/servers/${encodeURIComponent(name)}`
+  return tab ? `${base}?tab=${encodeURIComponent(tab)}` : base
+}
+
+// serverDisplayName prefers the registry-provided human-friendly `title` over
+// the raw reverse-DNS `name` identifier (e.g. "io.github.owner/repo"). The
+// `name` remains the stable key used for API calls and routing; only the
+// rendered label changes.
+export function serverDisplayName(server: { name: string; title?: string }): string {
+  return server.title?.trim() || server.name
+}

--- a/frontend/src/views/Activity.vue
+++ b/frontend/src/views/Activity.vue
@@ -364,7 +364,7 @@
                 <td>
                   <router-link
                     v-if="activity.server_name"
-                    :to="`/servers/${activity.server_name}`"
+                    :to="serverDetailPath(activity.server_name)"
                     class="link link-hover font-medium"
                     @click.stop
                   >
@@ -526,7 +526,7 @@
               </div>
               <div v-if="selectedActivity.server_name" class="flex gap-2">
                 <span class="text-sm text-base-content/60 w-24 shrink-0">Server:</span>
-                <router-link :to="`/servers/${selectedActivity.server_name}`" class="link link-primary text-sm">
+                <router-link :to="serverDetailPath(selectedActivity.server_name)" class="link link-primary text-sm">
                   {{ selectedActivity.server_name }}
                 </router-link>
               </div>
@@ -688,6 +688,7 @@
 </template>
 
 <script setup lang="ts">
+import { serverDetailPath } from '@/utils/serverRoute'
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { useSystemStore } from '@/stores/system'

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -50,7 +50,7 @@
         <div class="text-sm space-y-1 mt-1">
           <div v-for="server in serversNeedingAttention.slice(0, 3)" :key="server.name" class="flex items-center gap-2">
             <span :class="server.health?.level === 'unhealthy' ? 'text-error' : 'text-warning'">●</span>
-            <router-link :to="`/servers/${server.name}`" class="font-medium link link-hover">{{ server.name }}</router-link>
+            <router-link :to="serverDetailPath(server.name)" class="font-medium link link-hover">{{ server.name }}</router-link>
             <span class="opacity-70">{{ server.health?.summary }}</span>
             <button
               v-if="server.health?.action === 'login'"
@@ -82,7 +82,7 @@
             </router-link>
             <router-link
               v-if="server.health?.action === 'configure'"
-              :to="`/servers/${server.name}?tab=config`"
+              :to="serverDetailPath(server.name, 'config')"
               class="btn btn-xs btn-primary"
             >
               Configure
@@ -111,7 +111,7 @@
         <div class="text-sm space-y-1 mt-1">
           <div v-for="entry in serversWithPendingTools.slice(0, 5)" :key="entry.serverName" class="flex items-center gap-2">
             <span class="text-warning">&#9679;</span>
-            <router-link :to="`/servers/${entry.serverName}`" class="font-medium link link-hover">{{ entry.serverName }}</router-link>
+            <router-link :to="serverDetailPath(entry.serverName)" class="font-medium link link-hover">{{ entry.serverName }}</router-link>
             <span class="opacity-70">{{ entry.count }} tool{{ entry.count !== 1 ? 's' : '' }} pending</span>
           </div>
           <div v-if="serversWithPendingTools.length > 5" class="text-xs opacity-60">
@@ -421,6 +421,7 @@
 </template>
 
 <script setup lang="ts">
+import { serverDetailPath } from '@/utils/serverRoute'
 import { computed, ref, watch, onMounted, onUnmounted, defineAsyncComponent } from 'vue'
 import { useServersStore } from '@/stores/servers'
 import { useSystemStore } from '@/stores/system'

--- a/frontend/src/views/Search.vue
+++ b/frontend/src/views/Search.vue
@@ -168,7 +168,7 @@
                   View Details
                 </button>
                 <router-link
-                  :to="`/servers/${result.tool.server_name}`"
+                  :to="serverDetailPath(result.tool.server_name)"
                   class="btn btn-sm btn-outline"
                 >
                   Server Info
@@ -251,7 +251,7 @@
 
         <div class="modal-action">
           <router-link
-            :to="`/servers/${selectedTool.tool.server_name}`"
+            :to="serverDetailPath(selectedTool.tool.server_name)"
             class="btn btn-outline"
             @click="selectedTool = null"
           >
@@ -268,6 +268,7 @@
 </template>
 
 <script setup lang="ts">
+import { serverDetailPath } from '@/utils/serverRoute'
 import { ref, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import type { SearchResult } from '@/types'

--- a/frontend/src/views/ServerDetail.vue
+++ b/frontend/src/views/ServerDetail.vue
@@ -42,10 +42,10 @@
           <div class="breadcrumbs text-sm mb-2">
             <ul>
               <li><router-link to="/servers">Servers</router-link></li>
-              <li>{{ server.name }}</li>
+              <li>{{ displayName }}</li>
             </ul>
           </div>
-          <h1 class="text-3xl font-bold">{{ server.name }}</h1>
+          <h1 class="text-3xl font-bold" :title="server.name">{{ displayName }}</h1>
           <p class="text-base-content/70 mt-1">{{ server.protocol }} • {{ server.url || server.command || 'No endpoint' }}</p>
         </div>
 
@@ -1195,8 +1195,12 @@ import type { Hint } from '@/components/CollapsibleHintsPanel.vue'
 import type { Server, Tool, ToolApproval, SecurityScanReport } from '@/types'
 import api from '@/services/api'
 import { useSecurityScannerStatus } from '@/composables/useSecurityScannerStatus'
+import { serverDisplayName } from '@/utils/serverRoute'
 
 interface Props {
+  // MCP-1112: vue-router decodes the percent-encoded ':serverName' param, so
+  // this is the plain server name (which may contain '/', e.g.
+  // "io.github.owner/repo") and matches the stored config `name` directly.
   serverName: string
 }
 
@@ -1235,6 +1239,13 @@ const error = ref<string | null>(null)
 const server = computed<Server | null>(() => {
   return serversStore.servers.find(s => s.name === props.serverName) || null
 })
+
+// MCP-1112: prefer the registry-provided human-friendly title over the raw
+// reverse-DNS `name` identifier for display. Falls back to the name (or the
+// route param before the server loads).
+const displayName = computed(() =>
+  server.value ? serverDisplayName(server.value) : props.serverName
+)
 
 // mutateStoreServer applies fn to the live store object for this view's
 // server. Lets optimistic updates land where the rest of the app will

--- a/frontend/src/views/Tools.vue
+++ b/frontend/src/views/Tools.vue
@@ -300,7 +300,7 @@
                 </td>
                 <td>
                   <router-link
-                    :to="`/servers/${tool.server_name}`"
+                    :to="serverDetailPath(tool.server_name)"
                     class="link link-primary text-sm font-medium"
                     @click.stop
                   >
@@ -372,7 +372,7 @@
               <code class="text-base bg-base-200 px-2 py-1 rounded">{{ selectedTool.name }}</code>
             </h3>
             <div class="flex items-center gap-2 mt-2">
-              <router-link :to="`/servers/${selectedTool.server_name}`" class="link link-primary text-sm">
+              <router-link :to="serverDetailPath(selectedTool.server_name)" class="link link-primary text-sm">
                 {{ selectedTool.server_name }}
               </router-link>
               <span class="badge badge-sm" :class="getRiskBadgeClass(selectedTool)">{{ getRiskLabel(selectedTool) }}</span>
@@ -444,6 +444,7 @@
 </template>
 
 <script setup lang="ts">
+import { serverDetailPath } from '@/utils/serverRoute'
 import { ref, computed, onMounted, watch } from 'vue'
 import CollapsibleHintsPanel from '@/components/CollapsibleHintsPanel.vue'
 import type { Hint } from '@/components/CollapsibleHintsPanel.vue'

--- a/frontend/tests/unit/server-detail-route.spec.ts
+++ b/frontend/tests/unit/server-detail-route.spec.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createRouter, createWebHistory } from 'vue-router'
+import ServerCard from '@/components/ServerCard.vue'
+import { serverDetailPath } from '@/utils/serverRoute'
+
+// MCP-1112 (#598): official-registry server names contain '/'
+// (e.g. "io.github.owner/repo"). An unencoded `/servers/<namespace>/<name>`
+// path splits into two segments and falls through to the catch-all 404, so the
+// '/' MUST be percent-encoded. vue-router decodes the param back on read.
+
+const SLASH_NAME = 'io.github.owner/repo'
+
+describe('serverDetailPath (MCP-1112)', () => {
+  it('percent-encodes a "/"-containing server name into a single path segment', () => {
+    expect(serverDetailPath(SLASH_NAME)).toBe('/servers/io.github.owner%2Frepo')
+  })
+
+  it('appends a tab query without encoding the "?"/"="', () => {
+    expect(serverDetailPath(SLASH_NAME, 'tools')).toBe(
+      '/servers/io.github.owner%2Frepo?tab=tools'
+    )
+  })
+
+  it('leaves a plain name untouched (no "/" to encode)', () => {
+    expect(serverDetailPath('github')).toBe('/servers/github')
+    expect(serverDetailPath('github', 'logs')).toBe('/servers/github?tab=logs')
+  })
+})
+
+describe('server-detail route round-trip (MCP-1112)', () => {
+  it('decodes the encoded "/" back into the serverName param', async () => {
+    const router = createRouter({
+      history: createWebHistory(),
+      routes: [
+        { path: '/servers/:serverName', name: 'server-detail', component: { template: '<div/>' } },
+        { path: '/:pathMatch(.*)*', name: 'not-found', component: { template: '<div>404</div>' } },
+      ],
+    })
+    await router.push(serverDetailPath(SLASH_NAME))
+    await router.isReady()
+    // It must match server-detail (NOT the catch-all 404)...
+    expect(router.currentRoute.value.name).toBe('server-detail')
+    // ...and the param must be decoded back to the original name.
+    expect(router.currentRoute.value.params.serverName).toBe(SLASH_NAME)
+  })
+})
+
+describe('ServerCard slash-name links + title preference (MCP-1112)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  function mountCard(server: Record<string, unknown>) {
+    const router = createRouter({
+      history: createWebHistory(),
+      routes: [{ path: '/', component: { template: '<div>Home</div>' } }],
+    })
+    return mount(ServerCard, {
+      props: { server },
+      global: { plugins: [createPinia(), router] },
+    })
+  }
+
+  it('renders the server-detail link with the "/" percent-encoded', () => {
+    const wrapper = mountCard({
+      name: SLASH_NAME,
+      protocol: 'stdio',
+      enabled: true,
+      connected: true,
+      tool_count: 3,
+    })
+    const detailLink = wrapper.find('[data-test="server-detail-link"]')
+    expect(detailLink.exists()).toBe(true)
+    const href = detailLink.attributes('href') || ''
+    expect(href).toContain('io.github.owner%2Frepo')
+    expect(href).not.toContain('io.github.owner/repo')
+
+    // Belt-and-suspenders: NO server-detail link anywhere on the card may
+    // leave the '/' unencoded (it would split the path and 404).
+    const allDetailHrefs = wrapper
+      .findAll('a')
+      .map((a) => a.attributes('href') || '')
+      .filter((h) => h.startsWith('/servers/'))
+    expect(allDetailHrefs.length).toBeGreaterThan(0)
+    for (const h of allDetailHrefs) {
+      expect(h).not.toContain('io.github.owner/repo')
+    }
+  })
+
+  it('prefers the registry-provided title over the raw reverse-DNS name', () => {
+    const wrapper = mountCard({
+      name: SLASH_NAME,
+      title: 'Owner Repo',
+      protocol: 'stdio',
+      enabled: true,
+      connected: true,
+      tool_count: 0,
+    })
+    expect(wrapper.find('[data-test="server-card-title"]').text()).toBe('Owner Repo')
+  })
+
+  it('falls back to the name when no title is present', () => {
+    const wrapper = mountCard({
+      name: 'github',
+      protocol: 'stdio',
+      enabled: true,
+      connected: true,
+      tool_count: 0,
+    })
+    expect(wrapper.find('[data-test="server-card-title"]').text()).toBe('github')
+  })
+})


### PR DESCRIPTION
## Summary
Frontend fix for official-registry server names that contain a `/` (reverse-DNS ids such as `io.github.owner/repo`). **Related #598** (child of MCP-1090).

An unencoded `/servers/<namespace>/<name>` path splits into two segments and falls through the SPA catch-all to the **404 (NotFound)** view instead of matching the single-segment `/servers/:serverName` route.

## Changes (`frontend/src/`)
- **New `utils/serverRoute.ts`:**
  - `serverDetailPath(name, tab?)` — `encodeURIComponent`s the name into one path segment (`%2F`). vue-router decodes the param back on read, so components keep reading the plain name (no manual decode needed — proven by the round-trip test).
  - `serverDisplayName(server)` — prefers the registry-provided `title` over the raw reverse-DNS `name`.
- Wired `serverDetailPath()` through **every** server-detail link: `ServerCard`, `Dashboard`, `Tools`, `Activity`, `Search`. (`Security`, `AdminServers`, `UserServers` already encoded.)
- `ServerCard` heading and `ServerDetail` header/breadcrumb now use `serverDisplayName()`; the raw `name` stays as the hover `title`, in the config details, and as the routing/API identifier.
- Added optional `title` to the `Server` type.

## Test (Required, per spec 075)
`tests/unit/server-detail-route.spec.ts` (vitest + `@vue/test-utils`, **`data-test` selectors**), exercising a `/`-containing name:
- `serverDetailPath` encoding (with/without tab; plain names untouched).
- **Real vue-router round-trip**: the encoded path matches `server-detail` (not the catch-all 404) and the param decodes back to `io.github.owner/repo`.
- `ServerCard` renders the detail link with `%2F`, prefers `title`, falls back to `name`.

## Verification
- `npx vitest run` → **121/121 pass** (7 new). `vue-tsc --noEmit` clean. `make build` green.
- **Real-browser smoke** (Playwright, embedded UI) with a `/`-named server: `href = /ui/servers/io.github.owner%2Frepo`; clicking lands on **ServerDetail**, not "Page Not Found".

## Note for reviewers
The `title` half is **forward-compatible**: today the backend `/api/v1/servers` does not return a `title` (no `Title` on `config.ServerConfig`), so the UI falls back to `name`. Persisting/exposing the registry `title` is backend lane under the **MCP-1090** parent. This PR makes the frontend ready to use it the moment it appears.

Frontend changes require a Go rebuild (`make build`) since the UI is `//go:embed`-ed.