### PR TITLE
test(qa-gate): verify required-safe skip on a non-native PR (MCP-1219)

### DIFF
--- a/docs/qa-merge-gate.md
+++ b/docs/qa-merge-gate.md
@@ -94,3 +94,5 @@ requires QATester to:
 failures (AutoStart UserDefaults first-run, SSE-parser edge cases, a
 JSONEncoder behavior canary) so the gate is green today. Green those and remove
 the `--skip` flags to widen coverage.
+
+<!-- qa-gate required-safe verification: non-native PR check (MCP-1219). -->


### PR DESCRIPTION
**Throwaway verification PR for MCP-1219.** Touches only `docs/` — no `native/macos/**` or settings paths — so it exercises the non-native path of the required-safe `native-tests.yml`.

Expected: `detect-native-changes` runs, `swift-test` + `settings-parity` are **skipped** and report green, and they do **not** block this PR. Once confirmed, the two contexts are safe to add to `main` branch protection. Will be closed after verification.