### PR TITLE
docs(qa-gate): fix activation command -f strict=false → -F (HTTP 422) (MCP-1227)

### DIFF
--- a/docs/qa-merge-gate.md
+++ b/docs/qa-merge-gate.md
@@ -56,7 +56,7 @@ Add the three new contexts (keeps `enforce_admins: false`):
 
 ```bash
 gh api -X PATCH repos/:owner/:repo/branches/main/protection/required_status_checks \
-  -f strict=false \
+  -F strict=false \
   -f 'contexts[]=Lint' \
   -f 'contexts[]=Unit Tests (ubuntu-latest, 1.25)' \
   -f 'contexts[]=Build (ubuntu-latest)' \


### PR DESCRIPTION
## Summary
One-char docs fix in `docs/qa-merge-gate.md` activation block.

`gh api -f` always sends values as **strings**, so `-f strict=false` fails the branch-protection PATCH with **HTTP 422** (`For 'properties/strict', "false" is not a boolean`). The boolean must use uppercase `-F strict=false` for typed JSON. The `contexts[]` entries correctly stay on `-f` (they are strings).

Discovered while executing MCP-1225 — qa-gate activation succeeded after switching to `-F`.

## Scope
Docs-only. No code paths touched. `swift-test` / `settings-parity` / `qa-gate` are not relevant to a docs change; admin-mergeable (`enforce_admins: false`).

Refs: MCP-1227, MCP-1225