### PR TITLE
feat(macos): calm OAuth Sign-in affordance for login-required servers (MCP-1822)

### DIFF
--- a/native/macos/MCPProxy/MCPProxy/API/Models.swift
+++ b/native/macos/MCPProxy/MCPProxy/API/Models.swift
@@ -112,7 +112,7 @@ enum HealthAction: String, Codable, CaseIterable {
     /// Human-readable button label.
     var label: String {
         switch self {
-        case .login:      return "Log In"
+        case .login:      return "Sign In"
         case .restart:    return "Restart"
         case .enable:     return "Enable"
         case .approve:    return "Approve"
@@ -358,10 +358,21 @@ struct ServerStatus: Codable, Identifiable, Equatable {
         quarantine?.totalPending ?? 0
     }
 
+    /// True when this server is in the OAuth login-required state — an actionable,
+    /// calm "sign in" condition, not a hard error. Driven by the stable
+    /// `health.action == "login"` contract (MCP-1819 T3) so it stays correct
+    /// regardless of how the backend classifies `health.level` for this state.
+    var isLoginRequired: Bool {
+        health?.action == HealthAction.login.rawValue
+    }
+
     /// Centralized SwiftUI health color for this server, used across all views.
     var statusColor: Color {
         if !enabled { return .gray }
         if quarantined { return .orange }
+        // OAuth login-required reads as a calm, actionable sign-in state (accent),
+        // never a red error — even while the backend still reports level=unhealthy.
+        if isLoginRequired { return .accentColor }
         switch health?.level {
         case "healthy": return .green
         case "degraded": return .yellow
@@ -374,6 +385,7 @@ struct ServerStatus: Codable, Identifiable, Equatable {
     var statusNSColor: NSColor {
         if !enabled { return .systemGray }
         if quarantined { return .systemOrange }
+        if isLoginRequired { return .controlAccentColor }
         switch health?.level {
         case "healthy": return .systemGreen
         case "degraded": return .systemYellow

--- a/native/macos/MCPProxy/MCPProxy/Menu/TrayMenu.swift
+++ b/native/macos/MCPProxy/MCPProxy/Menu/TrayMenu.swift
@@ -244,9 +244,9 @@ struct TrayMenu: View {
             }
         }
 
-        // OAuth Login (shown when action is "login")
-        if server.health?.action == "login" {
-            Button("Log In") {
+        // OAuth Sign-in (shown when action is "login")
+        if server.isLoginRequired {
+            Button("Sign In") {
                 Task {
                     try? await apiClient?.loginServer(server.id)
                 }
@@ -352,6 +352,10 @@ struct TrayMenu: View {
     private func serverStatusColor(for server: ServerStatus) -> Color {
         if server.quarantined {
             return .orange
+        }
+        // OAuth login-required is a calm, actionable sign-in state, not a red error.
+        if server.isLoginRequired {
+            return .accentColor
         }
         if let health = server.health {
             switch health.level {

--- a/native/macos/MCPProxy/MCPProxy/Views/ServerDetailView.swift
+++ b/native/macos/MCPProxy/MCPProxy/Views/ServerDetailView.swift
@@ -93,6 +93,11 @@ struct ServerDetailView: View {
         VStack(alignment: .leading, spacing: 0) {
             serverHeader
             Divider()
+
+            if server.isLoginRequired {
+                signInBanner
+            }
+
             tabBar
             Divider()
 
@@ -142,14 +147,17 @@ struct ServerDetailView: View {
             Spacer()
 
             // Action buttons
-            if server.health?.action == "login" {
-                Button("Log In") {
+            if server.isLoginRequired {
+                Button {
                     Task { await performAction { try await apiClient?.loginServer(server.id) }
-                        actionMessage = "Login initiated for \(server.name)"
+                        actionMessage = "Sign-in started for \(server.name)"
                     }
+                } label: {
+                    Label("Sign In", systemImage: "person.badge.key")
                 }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.small)
+                .help("Sign in to this server with OAuth")
             }
 
             if server.quarantined {
@@ -225,6 +233,41 @@ struct ServerDetailView: View {
             .help("Restart server")
         }
         .padding()
+    }
+
+    // MARK: - Sign-in Banner
+
+    /// Calm, prominent OAuth sign-in callout shown when `health.action == "login"`.
+    /// Mirrors the Web UI's tone: this is an expected, actionable state — not an error.
+    @ViewBuilder
+    private var signInBanner: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "person.badge.key")
+                .font(.title3)
+                .foregroundStyle(Color.accentColor)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Sign-in required")
+                    .font(.scaled(.subheadline, scale: fontScale).bold())
+                Text("This server uses OAuth. Sign in to connect — this is expected, not an error.")
+                    .font(.scaled(.caption, scale: fontScale))
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 8)
+            Button {
+                Task { await performAction { try await apiClient?.loginServer(server.id) }
+                    actionMessage = "Sign-in started for \(server.name)"
+                }
+            } label: {
+                Label("Sign In", systemImage: "person.badge.key")
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.accentColor.opacity(0.10))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Sign-in required for \(server.name). This server uses OAuth.")
     }
 
     // MARK: - Tab Bar

--- a/native/macos/MCPProxy/MCPProxy/Views/ServersView.swift
+++ b/native/macos/MCPProxy/MCPProxy/Views/ServersView.swift
@@ -504,13 +504,13 @@ struct ServerTableView: NSViewRepresentable {
             restart.representedObject = server
             menu.addItem(restart)
 
-            // Log In (if auth needed)
-            if server.health?.action == "login" {
+            // Sign In (if OAuth auth needed) — calm, actionable, not an error
+            if server.isLoginRequired {
                 menu.addItem(.separator())
-                let login = NSMenuItem(title: "Log In", action: #selector(ctxLoginServer(_:)), keyEquivalent: "")
+                let login = NSMenuItem(title: "Sign In", action: #selector(ctxLoginServer(_:)), keyEquivalent: "")
                 login.target = self
                 login.representedObject = server
-                login.image = NSImage(systemSymbolName: "person.badge.key", accessibilityDescription: "login")
+                login.image = NSImage(systemSymbolName: "person.badge.key", accessibilityDescription: "sign in")
                 menu.addItem(login)
             }
 

--- a/native/macos/MCPProxy/MCPProxyTests/ModelsTests.swift
+++ b/native/macos/MCPProxy/MCPProxyTests/ModelsTests.swift
@@ -1,4 +1,6 @@
 import XCTest
+import SwiftUI
+import AppKit
 @testable import MCPProxy
 
 final class ModelsTests: XCTestCase {
@@ -8,6 +10,59 @@ final class ModelsTests: XCTestCase {
     private func decode<T: Decodable>(_ type: T.Type, from jsonString: String) throws -> T {
         let data = jsonString.data(using: .utf8)!
         return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    /// Build a minimal ServerStatus with a given health.action/level and admin flags,
+    /// for exercising the OAuth sign-in presentation logic (MCP-1822).
+    private func makeServer(
+        action: String?,
+        level: String = "unhealthy",
+        enabled: Bool = true,
+        quarantined: Bool = false,
+        connected: Bool = false
+    ) throws -> ServerStatus {
+        let actionField = action.map { "\"action\": \"\($0)\"," } ?? ""
+        let json = """
+        {
+            "id": "s", "name": "s", "protocol": "http",
+            "enabled": \(enabled), "connected": \(connected), "quarantined": \(quarantined),
+            "tool_count": 0,
+            "health": { "level": "\(level)", "admin_state": "enabled", "summary": "x", \(actionField) "detail": null }
+        }
+        """
+        return try decode(ServerStatus.self, from: json)
+    }
+
+    // MARK: - OAuth Sign-in State (MCP-1822)
+
+    func testIsLoginRequiredTrueForLoginAction() throws {
+        XCTAssertTrue(try makeServer(action: "login").isLoginRequired)
+    }
+
+    func testIsLoginRequiredFalseForOtherOrMissingAction() throws {
+        XCTAssertFalse(try makeServer(action: "restart").isLoginRequired)
+        XCTAssertFalse(try makeServer(action: nil).isLoginRequired)
+    }
+
+    func testLoginRequiredRendersCalmAccentNotRed() throws {
+        // Even while the backend still reports level=unhealthy, the sign-in state
+        // must read calmly (accent), never as a red error.
+        let s = try makeServer(action: "login", level: "unhealthy")
+        XCTAssertEqual(s.statusColor, Color.accentColor)
+        XCTAssertNotEqual(s.statusColor, Color.red)
+        XCTAssertNotEqual(s.statusNSColor, NSColor.systemRed)
+    }
+
+    func testUnhealthyWithoutLoginStaysRed() throws {
+        XCTAssertEqual(try makeServer(action: nil, level: "unhealthy").statusColor, Color.red)
+    }
+
+    func testDisabledTakesPrecedenceOverLogin() throws {
+        XCTAssertEqual(try makeServer(action: "login", enabled: false).statusColor, Color.gray)
+    }
+
+    func testQuarantineTakesPrecedenceOverLogin() throws {
+        XCTAssertEqual(try makeServer(action: "login", quarantined: true).statusColor, Color.orange)
     }
 
     // MARK: - HealthStatus
@@ -145,7 +200,7 @@ final class ModelsTests: XCTestCase {
     // MARK: - HealthAction Enum
 
     func testHealthActionLabels() {
-        XCTAssertEqual(HealthAction.login.label, "Log In")
+        XCTAssertEqual(HealthAction.login.label, "Sign In")
         XCTAssertEqual(HealthAction.restart.label, "Restart")
         XCTAssertEqual(HealthAction.enable.label, "Enable")
         XCTAssertEqual(HealthAction.approve.label, "Approve")


### PR DESCRIPTION
## T3 — macOS tray: Sign-in affordance parity for OAuth login-required

Part of epic **MCP-1819** (*OAuth login-required = actionable Sign-in state, not MCPX_UNKNOWN_UNCLASSIFIED*). Sibling tasks: T1 backend (MCP-1820), T2 frontend (MCP-1821).

### Problem
A server in the OAuth login-required state rendered on the native tray as a **red hard error** (red status dot from `level==unhealthy`, error framing) with the login action buried — instead of a calm, actionable "Sign in" state like the Web UI.

### Fix (native-only)
Keyed entirely off the **stable `health.action == "login"`** contract (already emitted today), so it is robust to whatever T1 finalizes for `health.level` / the diagnostics code — no cross-task coupling on unfinished contract details.

- **Models**: new `ServerStatus.isLoginRequired`; `statusColor`/`statusNSColor` return the calm **accent** (never red) for login-required even while `level==unhealthy`. `disabled` (gray) and `quarantined` (orange) precedence preserved.
- **ServerDetailView**: a prominent, calm **"Sign-in required"** callout (accent-tinted, `person.badge.key`, copy: *"This server uses OAuth. Sign in to connect — this is expected, not an error."*) + header **Sign In** button.
- **TrayMenu**: server-row dot calm for login-required; submenu **Sign In**.
- **ServersView**: context-menu **Sign In**.
- **Terminology parity**: `HealthAction.login.label` `"Log In"` → `"Sign In"`.

### Tests
- 6 new GUI-free `XCTest` cases: `isLoginRequired` true/false, calm-accent-not-red (with `level==unhealthy`), red-regression for non-login unhealthy, disabled/quarantine precedence; updated label assertion.
- `swift test`: **266 tests**, only the **7 pre-existing** unrelated env failures (AutoStart UserDefaults leakage, MergePatch JSONEncoder, SSE parser) — identical on `origin/main` baseline (260/7). **Zero new failures.**
- `scripts/check-settings-parity.py`: green.

### Verification note
Logic is fully unit-covered. Interactive `mcpproxy-ui-test` screenshot verification of the calm callout requires staging a live OAuth server mid-login — best exercised by the QA gate (which can stage OAuth) since the dev-tray Screen-Recording TCC limitation white-captures local screenshots.

🤖 Generated with Paperclip