### PR TITLE
feat(diagnostics): classify OAuth login-required (MCP-1820)

### DIFF
--- a/docs/errors/MCPX_OAUTH_LOGIN_REQUIRED.md
+++ b/docs/errors/MCPX_OAUTH_LOGIN_REQUIRED.md
@@ -1,0 +1,43 @@
+---
+id: MCPX_OAUTH_LOGIN_REQUIRED
+title: MCPX_OAUTH_LOGIN_REQUIRED
+sidebar_label: LOGIN_REQUIRED
+description: The server requires an OAuth sign-in before it can connect (first-time login).
+---
+
+# `MCPX_OAUTH_LOGIN_REQUIRED`
+
+**Severity:** warn
+**Domain:** OAuth
+
+## What happened
+
+The server is configured for OAuth but has no usable token yet, so mcpproxy
+deferred the browser sign-in to you (via the tray menu, web UI, or CLI) instead
+of blocking the connection. This is an **expected setup step, not a fault** — the
+server is reported as *degraded* (amber), not *unhealthy* (red), and the only
+suggested action is to sign in.
+
+## Common causes
+
+- A newly added OAuth server that you have not signed in to yet.
+- mcpproxy started headless (daemon/tray mode) and deferred the interactive
+  browser flow until you trigger it.
+
+## How to fix
+
+### Sign in
+
+```bash
+mcpproxy auth login --server=<server-name>
+```
+
+Or click **Sign in** on the server's web UI page, or use the tray menu. The
+server moves to healthy once a token is obtained.
+
+## Related
+
+- [`MCPX_OAUTH_REAUTH_REQUIRED`](MCPX_OAUTH_REAUTH_REQUIRED.md) — a previously
+  working token broke (red, not amber)
+- [`MCPX_OAUTH_REFRESH_EXPIRED`](MCPX_OAUTH_REFRESH_EXPIRED.md) — refresh token expired
+- [OAuth Authentication](../features/oauth-authentication.md)

--- a/docs/errors/MCPX_OAUTH_REAUTH_REQUIRED.md
+++ b/docs/errors/MCPX_OAUTH_REAUTH_REQUIRED.md
@@ -1,0 +1,45 @@
+---
+id: MCPX_OAUTH_REAUTH_REQUIRED
+title: MCPX_OAUTH_REAUTH_REQUIRED
+sidebar_label: REAUTH_REQUIRED
+description: A previously working OAuth token is no longer valid; sign in again.
+---
+
+# `MCPX_OAUTH_REAUTH_REQUIRED`
+
+**Severity:** error
+**Domain:** OAuth
+
+## What happened
+
+mcpproxy had a stored OAuth token for this server, but it stopped working — for
+example the server returned an error while the token was presented, so mcpproxy
+cleared the broken token and now needs you to sign in again. Unlike
+[`MCPX_OAUTH_LOGIN_REQUIRED`](MCPX_OAUTH_LOGIN_REQUIRED.md), the server *was*
+working, so this is reported as **unhealthy** (red): it is a regression you
+should act on, not a routine first-time setup step.
+
+## Common causes
+
+- The provider returned a 5xx/auth error while the stored token was in use, so
+  the token was discarded as likely invalid.
+- The token was revoked, rotated, or otherwise invalidated provider-side.
+
+## How to fix
+
+### Sign in again
+
+```bash
+mcpproxy auth login --server=<server-name>
+```
+
+Or click **Sign in again** on the server's web UI page, or use the tray menu.
+
+If re-login keeps failing, the OAuth client itself may be misconfigured — see
+[`MCPX_OAUTH_REFRESH_403`](MCPX_OAUTH_REFRESH_403.md) for client-validation steps.
+
+## Related
+
+- [`MCPX_OAUTH_LOGIN_REQUIRED`](MCPX_OAUTH_LOGIN_REQUIRED.md) — first-time sign-in (amber)
+- [`MCPX_OAUTH_REFRESH_403`](MCPX_OAUTH_REFRESH_403.md) — provider rejected refresh
+- [OAuth Authentication](../features/oauth-authentication.md)

--- a/docs/errors/README.md
+++ b/docs/errors/README.md
@@ -46,6 +46,8 @@ Run `mcpproxy doctor list-codes` for the machine-readable list.
 
 ## OAuth
 
+- [`MCPX_OAUTH_LOGIN_REQUIRED`](MCPX_OAUTH_LOGIN_REQUIRED.md) — first-time sign-in needed (amber)
+- [`MCPX_OAUTH_REAUTH_REQUIRED`](MCPX_OAUTH_REAUTH_REQUIRED.md) — stored token broke, sign in again (red)
 - [`MCPX_OAUTH_REFRESH_EXPIRED`](MCPX_OAUTH_REFRESH_EXPIRED.md) — refresh token expired
 - [`MCPX_OAUTH_REFRESH_403`](MCPX_OAUTH_REFRESH_403.md) — provider rejected refresh
 - [`MCPX_OAUTH_DISCOVERY_FAILED`](MCPX_OAUTH_DISCOVERY_FAILED.md) — `.well-known` discovery failed

--- a/internal/diagnostics/classifier.go
+++ b/internal/diagnostics/classifier.go
@@ -63,6 +63,19 @@ func Classify(err error, hints ClassifierHints) Code {
 func classifyOAuth(err error, _ ClassifierHints) Code {
 	msg := strings.ToLower(err.Error())
 	switch {
+	// Re-auth (a previously-working stored token broke) is matched BEFORE the
+	// login-required backstop because "re-login available" contains the
+	// "login available" substring; the order of these two cases is load-bearing.
+	case strings.Contains(msg, "re-login available"),
+		strings.Contains(msg, "re-authentication required"),
+		strings.Contains(msg, "server error with stored token"):
+		return OAuthReauthRequired
+	// First-time sign-in deferred to the user (ErrOAuthPending text). These are
+	// actionable user-states, not faults — keep them out of UNKNOWN.
+	case strings.Contains(msg, "oauth authentication required"),
+		strings.Contains(msg, "login available"),
+		strings.Contains(msg, "mcpproxy auth login"):
+		return OAuthLoginRequired
 	case strings.Contains(msg, "refresh_token") && strings.Contains(msg, "expired"),
 		strings.Contains(msg, "refresh token has expired"),
 		strings.Contains(msg, "refresh token is expired"):

--- a/internal/diagnostics/classifier_test.go
+++ b/internal/diagnostics/classifier_test.go
@@ -170,6 +170,56 @@ func TestClassify_NetworkOffline(t *testing.T) {
 	}
 }
 
+// codedStub is a minimal typed error carrying an explicit Code, used to verify
+// the classifier's typed fast-path for the new OAuth login/re-auth states.
+type codedStub struct {
+	msg  string
+	code Code
+}
+
+func (e codedStub) Error() string { return e.msg }
+func (e codedStub) Code() Code    { return e.code }
+
+func TestClassify_OAuth_LoginRequired_Typed(t *testing.T) {
+	err := codedStub{msg: "OAuth authentication required for slack", code: OAuthLoginRequired}
+	got := Classify(err, ClassifierHints{Transport: "http"})
+	if got != OAuthLoginRequired {
+		t.Errorf("Classify(login typed) = %q, want %q", got, OAuthLoginRequired)
+	}
+}
+
+func TestClassify_OAuth_LoginRequired_String(t *testing.T) {
+	cases := []string{
+		"OAuth authentication required for slack - use 'mcpproxy auth login --server=slack' or tray menu",
+		"OAuth authentication required for github: login available via Web UI, system tray menu, or 'mcpproxy auth login' CLI command",
+	}
+	for _, msg := range cases {
+		err := errors.New(msg)
+		got := Classify(err, ClassifierHints{Transport: "http"})
+		if got != OAuthLoginRequired {
+			t.Errorf("Classify(%q) = %q, want %q", msg, got, OAuthLoginRequired)
+		}
+	}
+}
+
+func TestClassify_OAuth_ReauthRequired_Typed(t *testing.T) {
+	err := codedStub{msg: "stored token broke", code: OAuthReauthRequired}
+	got := Classify(err, ClassifierHints{Transport: "http"})
+	if got != OAuthReauthRequired {
+		t.Errorf("Classify(reauth typed) = %q, want %q", got, OAuthReauthRequired)
+	}
+}
+
+func TestClassify_OAuth_ReauthRequired_String(t *testing.T) {
+	// The re-auth message contains "login available" as a substring of
+	// "re-login available"; the classifier must prefer the re-auth code.
+	err := errors.New("OAuth authentication required for slack: server error with stored token - re-login available via Web UI, system tray menu, or 'mcpproxy auth login' CLI command")
+	got := Classify(err, ClassifierHints{Transport: "http"})
+	if got != OAuthReauthRequired {
+		t.Errorf("Classify(reauth string) = %q, want %q", got, OAuthReauthRequired)
+	}
+}
+
 func TestClassify_Fallback(t *testing.T) {
 	err := errors.New("something we don't know about")
 	got := Classify(err, ClassifierHints{})

--- a/internal/diagnostics/codes.go
+++ b/internal/diagnostics/codes.go
@@ -17,7 +17,15 @@ const (
 )
 
 // OAUTH domain — OAuth 2.1 / PKCE flow failures.
+//
+// OAuthLoginRequired and OAuthReauthRequired are actionable user-states, NOT
+// faults: they describe a server waiting for the user to sign in, so they must
+// never drive a "file a bug" CTA. Login-required is the first-time sign-in
+// (amber/degraded); re-auth-required is a previously-working token that broke
+// (red/unhealthy). See MCP-1820.
 const (
+	OAuthLoginRequired    Code = "MCPX_OAUTH_LOGIN_REQUIRED"
+	OAuthReauthRequired   Code = "MCPX_OAUTH_REAUTH_REQUIRED"
 	OAuthRefreshExpired   Code = "MCPX_OAUTH_REFRESH_EXPIRED"
 	OAuthRefresh403       Code = "MCPX_OAUTH_REFRESH_403"
 	OAuthDiscoveryFailed  Code = "MCPX_OAUTH_DISCOVERY_FAILED"

--- a/internal/diagnostics/registry.go
+++ b/internal/diagnostics/registry.go
@@ -97,6 +97,26 @@ func seedSTDIO() {
 
 func seedOAUTH() {
 	register(CatalogEntry{
+		Code:        OAuthLoginRequired,
+		Severity:    SeverityWarn, // amber: an expected setup step, not a fault
+		UserMessage: "This server needs you to sign in before it can connect.",
+		FixSteps: []FixStep{
+			{Type: FixStepButton, Label: "Sign in", FixerKey: "oauth_reauth"},
+			{Type: FixStepLink, Label: "How OAuth sign-in works", URL: docsURL(OAuthLoginRequired)},
+		},
+		DocsURL: docsURL(OAuthLoginRequired),
+	})
+	register(CatalogEntry{
+		Code:        OAuthReauthRequired,
+		Severity:    SeverityError, // red: a previously-working token broke
+		UserMessage: "Your stored sign-in for this server is no longer valid; please sign in again.",
+		FixSteps: []FixStep{
+			{Type: FixStepButton, Label: "Sign in again", FixerKey: "oauth_reauth", Destructive: true},
+			{Type: FixStepLink, Label: "Why re-authentication is needed", URL: docsURL(OAuthReauthRequired)},
+		},
+		DocsURL: docsURL(OAuthReauthRequired),
+	})
+	register(CatalogEntry{
 		Code:        OAuthRefreshExpired,
 		Severity:    SeverityError,
 		UserMessage: "The OAuth refresh token has expired; you need to log in again.",

--- a/internal/health/calculator.go
+++ b/internal/health/calculator.go
@@ -131,32 +131,32 @@ func CalculateHealth(input HealthCalculatorInput, cfg *HealthCalculatorConfig) *
 	switch state {
 	case "error":
 		// For OAuth-required servers with OAuth-related errors, suggest login instead of restart
+		level := LevelUnhealthy
 		action := ActionRestart
 		summary := formatErrorSummary(input.LastError)
 		if input.OAuthRequired && isOAuthRelatedError(input.LastError) {
-			action = ActionLogin
-			summary = "Authentication required"
+			level, action, summary = oauthAttentionState(input.LastError)
 		}
 		return &contracts.HealthStatus{
-			Level:      LevelUnhealthy,
+			Level:      level,
 			AdminState: StateEnabled,
 			Summary:    summary,
 			Detail:     input.LastError,
 			Action:     action,
 		}
 	case "disconnected":
+		level := LevelUnhealthy
 		summary := "Disconnected"
 		action := ActionRestart
 		if input.LastError != "" {
 			summary = formatErrorSummary(input.LastError)
 			// For OAuth-required servers with OAuth-related errors, suggest login
 			if input.OAuthRequired && isOAuthRelatedError(input.LastError) {
-				action = ActionLogin
-				summary = "Authentication required"
+				level, action, summary = oauthAttentionState(input.LastError)
 			}
 		}
 		return &contracts.HealthStatus{
-			Level:      LevelUnhealthy,
+			Level:      level,
 			AdminState: StateEnabled,
 			Summary:    summary,
 			Detail:     input.LastError,
@@ -414,6 +414,66 @@ func isOAuthRelatedError(err string) bool {
 		"access_denied",
 	}
 	for _, pattern := range oauthPatterns {
+		if stringutil.ContainsIgnoreCase(err, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// oauthAttentionState maps an OAuth-related error into the health level, action,
+// and summary the user should see. A first-time sign-in (ErrOAuthPending) is an
+// expected setup step, so it surfaces as degraded/amber with "Sign-in required".
+// A previously-working token that broke (re-auth) stays unhealthy/red because it
+// is a regression from a working state. Both suggest the login action. MCP-1820.
+//
+// Callers MUST gate this behind isOAuthRelatedError so genuine connection
+// failures (which mcp-go wraps in "authentication strategies failed" noise) are
+// not downgraded to amber.
+func oauthAttentionState(lastError string) (level, action, summary string) {
+	// Only a first-time deferred sign-in (ErrOAuthPending) is amber. Re-auth and
+	// every other genuine OAuth error (revoked token, invalid_grant, …) stays red
+	// because the server was — or should have been — working.
+	if isOAuthLoginRequiredError(lastError) {
+		return LevelDegraded, ActionLogin, "Sign-in required"
+	}
+	return LevelUnhealthy, ActionLogin, "Authentication required"
+}
+
+// isOAuthLoginRequiredError reports whether an OAuth-related error is a
+// first-time deferred sign-in (ErrOAuthPending). The user has never signed in,
+// so it is an expected setup step (amber) rather than a broken state (red).
+// Re-auth ("stored token broke") is explicitly excluded so it stays red. The
+// markers mirror diagnostics.classifyOAuth's login backstops. MCP-1820.
+func isOAuthLoginRequiredError(err string) bool {
+	if isOAuthReauthError(err) {
+		return false
+	}
+	loginPatterns := []string{
+		"oauth authentication required",
+		"login available",
+		"mcpproxy auth login",
+	}
+	for _, pattern := range loginPatterns {
+		if stringutil.ContainsIgnoreCase(err, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// isOAuthReauthError reports whether an OAuth-related error indicates that a
+// previously-working stored token broke and must be refreshed by signing in
+// again (as opposed to a first-time sign-in). Matched against the ErrOAuthPending
+// "stored token" / "re-login available" message text. MCP-1820.
+func isOAuthReauthError(err string) bool {
+	reauthPatterns := []string{
+		"re-login available",
+		"re-authentication required",
+		"server error with stored token",
+		"stored token may be invalid",
+	}
+	for _, pattern := range reauthPatterns {
 		if stringutil.ContainsIgnoreCase(err, pattern) {
 			return true
 		}

--- a/internal/health/calculator_test.go
+++ b/internal/health/calculator_test.go
@@ -196,6 +196,50 @@ func TestCalculateHealth_OAuthNone(t *testing.T) {
 	assert.Equal(t, ActionLogin, result.Action)
 }
 
+// TestCalculateHealth_OAuthLoginRequired verifies that a server awaiting a
+// first-time OAuth sign-in (ErrOAuthPending deferred for tray/CLI) is reported
+// as degraded/amber with a login action — NOT unhealthy/red (MCP-1820).
+func TestCalculateHealth_OAuthLoginRequired(t *testing.T) {
+	loginErrors := []string{
+		"OAuth authentication required for slack - use 'mcpproxy auth login --server=slack' or tray menu",
+		"OAuth authentication required for github: login available via Web UI, system tray menu, or 'mcpproxy auth login' CLI command",
+	}
+	for _, state := range []string{"error", "disconnected"} {
+		for _, lastErr := range loginErrors {
+			input := HealthCalculatorInput{
+				Name:          "test-server",
+				Enabled:       true,
+				State:         state,
+				OAuthRequired: true,
+				LastError:     lastErr,
+			}
+			result := CalculateHealth(input, nil)
+			assert.Equal(t, LevelDegraded, result.Level, "state=%s err=%q", state, lastErr)
+			assert.Equal(t, "Sign-in required", result.Summary, "state=%s err=%q", state, lastErr)
+			assert.Equal(t, ActionLogin, result.Action, "state=%s err=%q", state, lastErr)
+		}
+	}
+}
+
+// TestCalculateHealth_OAuthReauthRequired verifies that a server whose stored
+// token broke (re-auth needed) stays unhealthy/red with a login action — it was
+// working before, so this is a regression the user should treat as red (MCP-1820).
+func TestCalculateHealth_OAuthReauthRequired(t *testing.T) {
+	reauthErr := "OAuth authentication required for slack: server error with stored token - re-login available via Web UI, system tray menu, or 'mcpproxy auth login' CLI command"
+	for _, state := range []string{"error", "disconnected"} {
+		input := HealthCalculatorInput{
+			Name:          "test-server",
+			Enabled:       true,
+			State:         state,
+			OAuthRequired: true,
+			LastError:     reauthErr,
+		}
+		result := CalculateHealth(input, nil)
+		assert.Equal(t, LevelUnhealthy, result.Level, "state=%s", state)
+		assert.Equal(t, ActionLogin, result.Action, "state=%s", state)
+	}
+}
+
 func TestCalculateHealth_UserLoggedOut(t *testing.T) {
 	input := HealthCalculatorInput{
 		Name:          "test-server",

--- a/internal/upstream/core/connection_oauth.go
+++ b/internal/upstream/core/connection_oauth.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/contracts"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/diagnostics"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/oauth"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/transport"
 
@@ -50,6 +51,22 @@ func (e *ErrOAuthPending) Error() string {
 		return fmt.Sprintf("OAuth authentication required for %s: %s", e.ServerName, e.Message)
 	}
 	return fmt.Sprintf("OAuth authentication required for %s - use 'mcpproxy auth login --server=%s' or tray menu", e.ServerName, e.ServerName)
+}
+
+// Code attributes a stable diagnostic code so diagnostics.Classify's typed
+// fast-path resolves this to an actionable OAuth user-state instead of
+// MCPX_UNKNOWN_UNCLASSIFIED. A first-time sign-in maps to OAuthLoginRequired;
+// the "stored token broke" variant (connection_oauth.go server-5xx path) maps
+// to OAuthReauthRequired. The distinction is carried in the message text so the
+// stringified error classifies the same way downstream (e.g. health). MCP-1820.
+func (e *ErrOAuthPending) Code() diagnostics.Code {
+	lower := strings.ToLower(e.Error())
+	if strings.Contains(lower, "re-login available") ||
+		strings.Contains(lower, "re-authentication required") ||
+		strings.Contains(lower, "server error with stored token") {
+		return diagnostics.OAuthReauthRequired
+	}
+	return diagnostics.OAuthLoginRequired
 }
 
 // IsOAuthPending checks if an error is an ErrOAuthPending
@@ -873,8 +890,8 @@ func (c *Client) isOAuthError(err error) bool {
 		"OAuth authentication failed",
 		"oauth timeout",
 		"oauth error",
-		"no valid token available",  // Transport layer token check
-		"authorization required",     // Generic authorization needed
+		"no valid token available", // Transport layer token check
+		"authorization required",   // Generic authorization needed
 	}
 
 	for _, oauthErr := range oauthErrors {

--- a/internal/upstream/core/oauth_error_test.go
+++ b/internal/upstream/core/oauth_error_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/diagnostics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -151,6 +152,41 @@ func TestErrOAuthPending_Error(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.err.Error()
 			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// TestErrOAuthPending_Code verifies the typed diagnostic code attribution so
+// diagnostics.Classify's fast-path resolves these to actionable OAuth states
+// instead of MCPX_UNKNOWN_UNCLASSIFIED (MCP-1820).
+func TestErrOAuthPending_Code(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      *ErrOAuthPending
+		expected diagnostics.Code
+	}{
+		{
+			name:     "default message → login required",
+			err:      &ErrOAuthPending{ServerName: "github"},
+			expected: diagnostics.OAuthLoginRequired,
+		},
+		{
+			name:     "login-available message → login required",
+			err:      &ErrOAuthPending{ServerName: "slack", Message: "login available via Web UI, system tray menu, or 'mcpproxy auth login' CLI command"},
+			expected: diagnostics.OAuthLoginRequired,
+		},
+		{
+			name:     "stored-token-broke message → re-auth required",
+			err:      &ErrOAuthPending{ServerName: "slack", Message: "server error with stored token - re-login available via Web UI, system tray menu, or 'mcpproxy auth login' CLI command"},
+			expected: diagnostics.OAuthReauthRequired,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.err.Code())
+			// Must also resolve through the public classifier fast-path.
+			assert.Equal(t, tt.expected, diagnostics.Classify(tt.err, diagnostics.ClassifierHints{}))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Foundation task **MCP-1820** under epic MCP-1819. Makes OAuth "needs sign-in" classify correctly instead of falling through to `MCPX_UNKNOWN_UNCLASSIFIED` (which drives a misleading "file a bug" CTA), and stops the health calculator from painting an expected first-time login as unhealthy/red.

## Changes

- **`internal/diagnostics/codes.go`** — add `MCPX_OAUTH_LOGIN_REQUIRED` and `MCPX_OAUTH_REAUTH_REQUIRED` (OAUTH domain), documented as actionable user-states (NOT faults).
- **`internal/diagnostics/registry.go`** — catalog entries with login-oriented fix steps (Sign in / Sign in again), never file-a-bug. Login = `warn`, re-auth = `error`.
- **`internal/diagnostics/classifier.go`** — `classifyOAuth` string backstops: `"oauth authentication required"`, `"login available"`, `"mcpproxy auth login"` → login; `"re-login available"`, `"re-authentication required"`, `"server error with stored token"` → re-auth. **Re-auth is matched first** because `"re-login available"` contains `"login available"`.
- **`internal/upstream/core/connection_oauth.go`** — `ErrOAuthPending.Code()` typed fast-path: default/login-available message → `OAuthLoginRequired`; the stored-token-broke (server-5xx) message → `OAuthReauthRequired`.
- **`internal/health/calculator.go`** — error/disconnected branches: first-time sign-in → `degraded`/amber + `login` + `"Sign-in required"`; re-auth and other genuine OAuth errors (revoked / `invalid_grant`) stay `unhealthy`/red. Connection-failure precedence in `isOAuthRelatedError` preserved (offline servers still suggest restart).
- **`docs/errors/`** — pages for both new codes + catalog index entries.

## Tests (TDD)

- `internal/diagnostics/classifier_test.go` — both codes, typed fast-path + string backstop (incl. the re-login/login substring-ordering case).
- `internal/upstream/core/oauth_error_test.go` — `ErrOAuthPending.Code()` + end-to-end `diagnostics.Classify`.
- `internal/health/calculator_test.go` — login → degraded+login+"Sign-in required"; re-auth → unhealthy+login (both `error` and `disconnected` states).

## Verification

- `go build ./...` — clean
- `go test -race ./internal/diagnostics/... ./internal/health/... ./internal/upstream/... ./internal/runtime/...` — all green
- `./scripts/run-linter.sh` — 0 issues

Related #MCP-1820