### PR TITLE
feat(macos): calm "Sign in" affordance for OAuth login-required servers (MCP-1822)

### DIFF
--- a/native/macos/MCPProxy/MCPProxy/API/Models.swift
+++ b/native/macos/MCPProxy/MCPProxy/API/Models.swift
@@ -112,7 +112,7 @@ enum HealthAction: String, Codable, CaseIterable {
     /// Human-readable button label.
     var label: String {
         switch self {
-        case .login:      return "Log In"
+        case .login:      return "Sign in"
         case .restart:    return "Restart"
         case .enable:     return "Enable"
         case .approve:    return "Approve"
@@ -351,6 +351,15 @@ struct ServerStatus: Codable, Identifiable, Equatable {
     var hasAttentionDiagnostic: Bool {
         guard let d = diagnostic, !(d.code).isEmpty else { return false }
         return d.severity == "warn" || d.severity == "error"
+    }
+
+    /// True when the server is in the OAuth login-required state (MCP-1819/T3).
+    /// `health.action == "login"` is the stable, cross-surface contract that
+    /// CLI/REST/Web-UI/tray all key off. In this state the server needs a calm,
+    /// actionable "Sign in" affordance — NOT hard-error framing — even when the
+    /// backend also attaches an error-severity diagnostic for the failed connect.
+    var isOAuthLoginRequired: Bool {
+        health?.action == "login"
     }
 
     /// Number of tools awaiting approval (pending + changed), or 0 if quarantine stats are absent.

--- a/native/macos/MCPProxy/MCPProxy/API/Models.swift
+++ b/native/macos/MCPProxy/MCPProxy/API/Models.swift
@@ -390,6 +390,14 @@ struct ServerStatus: Codable, Identifiable, Equatable {
         default: return connected ? .systemGreen : .systemGray
         }
     }
+
+    /// AppKit tray-menu dot color (MCP-1822). The OAuth login-required state is
+    /// calm and actionable, not a failure: it gets the system accent tint rather
+    /// than the red/error `statusNSColor` that previously read as a hard error.
+    /// Genuine errors (any non-login state) keep `statusNSColor`.
+    var menuStatusNSColor: NSColor {
+        isOAuthLoginRequired ? .controlAccentColor : statusNSColor
+    }
 }
 
 // MARK: - SSE Event Envelopes

--- a/native/macos/MCPProxy/MCPProxy/MCPProxyApp.swift
+++ b/native/macos/MCPProxy/MCPProxy/MCPProxyApp.swift
@@ -620,23 +620,19 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate, NS
             for server in appState.servers {
                 let item = NSMenuItem(title: server.name, action: nil, keyEquivalent: "")
 
-                // Status icon: colored dot + auth indicator
-                let needsAuth = server.health?.action == "login"
-                let dotColor = server.statusNSColor
+                // Status icon: colored dot. The OAuth login-required state is a
+                // calm, actionable affordance (MCP-1822) — `menuStatusNSColor`
+                // gives it the system accent tint instead of the red error dot +
+                // red lock badge that previously framed sign-in as a hard failure.
+                let needsAuth = server.isOAuthLoginRequired
+                let dotColor = server.menuStatusNSColor
 
                 let iconSize = NSSize(width: 16, height: 16)
-                let icon = NSImage(size: iconSize, flipped: false) { rect in
+                let icon = NSImage(size: iconSize, flipped: false) { _ in
                     // Draw health dot
                     let dotRect = NSRect(x: 2, y: 4, width: 8, height: 8)
                     dotColor.setFill()
                     NSBezierPath(ovalIn: dotRect).fill()
-
-                    // Draw auth lock icon overlay if needed
-                    if needsAuth {
-                        let lockRect = NSRect(x: 9, y: 0, width: 7, height: 7)
-                        NSColor.systemRed.setFill()
-                        NSBezierPath(ovalIn: lockRect).fill()
-                    }
                     return true
                 }
                 item.image = icon
@@ -655,12 +651,13 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate, NS
 
                 sub.addItem(.separator())
 
-                // Auth login button — prominently first if needed
+                // OAuth sign-in — calm, actionable affordance shown first when
+                // login is required (MCP-1822), not error framing.
                 if needsAuth {
-                    let login = NSMenuItem(title: "Log In (Opens Browser)", action: #selector(loginServer(_:)), keyEquivalent: "")
+                    let login = NSMenuItem(title: "Sign in", action: #selector(loginServer(_:)), keyEquivalent: "")
                     login.target = self
                     login.representedObject = server.name
-                    login.image = NSImage(systemSymbolName: "person.badge.key", accessibilityDescription: "login")
+                    login.image = NSImage(systemSymbolName: "person.badge.key", accessibilityDescription: "sign in")
                     sub.addItem(login)
                     sub.addItem(.separator())
                 }
@@ -982,7 +979,7 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate, NS
 
     private func actionDisplayName(for action: String) -> String {
         switch action {
-        case "login": return "Login Required"
+        case "login": return "Sign in"
         case "restart": return "Restart Needed"
         case "enable": return "Disabled"
         case "approve": return "Approval Needed"

--- a/native/macos/MCPProxy/MCPProxy/Menu/TrayMenu.swift
+++ b/native/macos/MCPProxy/MCPProxy/Menu/TrayMenu.swift
@@ -153,6 +153,14 @@ struct TrayMenu: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
+                    // MCP-1819/T3 — surface the remediation verb (e.g. "Sign in")
+                    // explicitly so the actionable affordance is clear, not buried.
+                    if let label = server.health?.healthAction?.label {
+                        Spacer()
+                        Text(label)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
             }
         }
@@ -244,9 +252,10 @@ struct TrayMenu: View {
             }
         }
 
-        // OAuth Login (shown when action is "login")
+        // OAuth Sign in (shown when action is "login") — calm, actionable
+        // affordance, not error framing (MCP-1819/T3).
         if server.health?.action == "login" {
-            Button("Log In") {
+            Button("Sign in") {
                 Task {
                     try? await apiClient?.loginServer(server.id)
                 }

--- a/native/macos/MCPProxy/MCPProxy/Menu/TrayMenu.swift
+++ b/native/macos/MCPProxy/MCPProxy/Menu/TrayMenu.swift
@@ -153,9 +153,11 @@ struct TrayMenu: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
-                    // MCP-1819/T3 — surface the remediation verb (e.g. "Sign in")
-                    // explicitly so the actionable affordance is clear, not buried.
-                    if let label = server.health?.healthAction?.label {
+                    // MCP-1819/T3 — surface the "Sign in" verb explicitly for the
+                    // OAuth login-required state so the actionable affordance is
+                    // clear, not buried. Scoped to login (this issue's concern);
+                    // other attention actions keep their prior icon-only row.
+                    if server.isOAuthLoginRequired, let label = server.health?.healthAction?.label {
                         Spacer()
                         Text(label)
                             .font(.caption)
@@ -252,9 +254,9 @@ struct TrayMenu: View {
             }
         }
 
-        // OAuth Sign in (shown when action is "login") — calm, actionable
+        // OAuth Sign in (shown when login is required) — calm, actionable
         // affordance, not error framing (MCP-1819/T3).
-        if server.health?.action == "login" {
+        if server.isOAuthLoginRequired {
             Button("Sign in") {
                 Task {
                     try? await apiClient?.loginServer(server.id)

--- a/native/macos/MCPProxy/MCPProxy/State/AppState.swift
+++ b/native/macos/MCPProxy/MCPProxy/State/AppState.swift
@@ -117,15 +117,25 @@ final class AppState: ObservableObject {
     /// Spec 044 — servers that have an attached, classified diagnostic with
     /// warn/error severity. These drive the "Fix issues" menu group and the
     /// tray badge tint.
+    ///
+    /// MCP-1819/T3: OAuth login-required servers are excluded. Pre-T1 the
+    /// backend classifies that state as an error-severity
+    /// MCPX_UNKNOWN_UNCLASSIFIED diagnostic, which would otherwise read as a
+    /// "file a bug" hard error. A server that just needs sign-in is surfaced
+    /// calmly via `serversNeedingAttention` (the "Sign in" affordance) instead.
     var serversWithDiagnostic: [ServerStatus] {
-        servers.filter { $0.hasAttentionDiagnostic }
+        servers.filter { $0.hasAttentionDiagnostic && !$0.isOAuthLoginRequired }
     }
 
     /// Highest-severity diagnostic across enabled servers. Returns nil when
     /// no diagnostics are attached. Used by TrayIcon to colour the badge.
+    ///
+    /// MCP-1819/T3: OAuth login-required servers are skipped so a server that
+    /// merely needs sign-in does not tint the tray icon badge red/orange — the
+    /// calm "Needs Attention / Sign in" path owns that state instead.
     var worstDiagnosticSeverity: String? {
         var sawWarn = false
-        for srv in servers where srv.enabled {
+        for srv in servers where srv.enabled && !srv.isOAuthLoginRequired {
             guard let d = srv.diagnostic else { continue }
             if d.severity == "error" { return "error" }
             if d.severity == "warn" { sawWarn = true }

--- a/native/macos/MCPProxy/MCPProxy/Views/ServerDetailView.swift
+++ b/native/macos/MCPProxy/MCPProxy/Views/ServerDetailView.swift
@@ -143,7 +143,7 @@ struct ServerDetailView: View {
 
             // Action buttons — OAuth login-required surfaces a calm, prominent
             // "Sign in" affordance, consistent with the Web UI (MCP-1819/T3).
-            if server.health?.action == "login" {
+            if server.isOAuthLoginRequired {
                 Button("Sign in") {
                     Task { await performAction { try await apiClient?.loginServer(server.id) }
                         actionMessage = "Sign-in started for \(server.name)"

--- a/native/macos/MCPProxy/MCPProxy/Views/ServerDetailView.swift
+++ b/native/macos/MCPProxy/MCPProxy/Views/ServerDetailView.swift
@@ -141,11 +141,12 @@ struct ServerDetailView: View {
 
             Spacer()
 
-            // Action buttons
+            // Action buttons — OAuth login-required surfaces a calm, prominent
+            // "Sign in" affordance, consistent with the Web UI (MCP-1819/T3).
             if server.health?.action == "login" {
-                Button("Log In") {
+                Button("Sign in") {
                     Task { await performAction { try await apiClient?.loginServer(server.id) }
-                        actionMessage = "Login initiated for \(server.name)"
+                        actionMessage = "Sign-in started for \(server.name)"
                     }
                 }
                 .buttonStyle(.borderedProminent)

--- a/native/macos/MCPProxy/MCPProxy/Views/ServersView.swift
+++ b/native/macos/MCPProxy/MCPProxy/Views/ServersView.swift
@@ -504,13 +504,13 @@ struct ServerTableView: NSViewRepresentable {
             restart.representedObject = server
             menu.addItem(restart)
 
-            // Log In (if auth needed)
+            // Sign in (if auth needed) — calm, actionable affordance (MCP-1819/T3)
             if server.health?.action == "login" {
                 menu.addItem(.separator())
-                let login = NSMenuItem(title: "Log In", action: #selector(ctxLoginServer(_:)), keyEquivalent: "")
+                let login = NSMenuItem(title: "Sign in", action: #selector(ctxLoginServer(_:)), keyEquivalent: "")
                 login.target = self
                 login.representedObject = server
-                login.image = NSImage(systemSymbolName: "person.badge.key", accessibilityDescription: "login")
+                login.image = NSImage(systemSymbolName: "person.badge.key", accessibilityDescription: "sign in")
                 menu.addItem(login)
             }
 

--- a/native/macos/MCPProxy/MCPProxy/Views/ServersView.swift
+++ b/native/macos/MCPProxy/MCPProxy/Views/ServersView.swift
@@ -505,7 +505,7 @@ struct ServerTableView: NSViewRepresentable {
             menu.addItem(restart)
 
             // Sign in (if auth needed) — calm, actionable affordance (MCP-1819/T3)
-            if server.health?.action == "login" {
+            if server.isOAuthLoginRequired {
                 menu.addItem(.separator())
                 let login = NSMenuItem(title: "Sign in", action: #selector(ctxLoginServer(_:)), keyEquivalent: "")
                 login.target = self

--- a/native/macos/MCPProxy/MCPProxyTests/AppStateOAuthSignInTests.swift
+++ b/native/macos/MCPProxy/MCPProxyTests/AppStateOAuthSignInTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import AppKit
 @testable import MCPProxy
 
 /// Tests for MCP-1822 (T3): a server in the OAuth login-required state
@@ -130,6 +131,38 @@ final class AppStateOAuthSignInTests: XCTestCase {
         XCTAssertEqual(
             state.serversNeedingAttention.map(\.name), ["github"],
             "A sign-in-required server must remain in the calm 'Needs Attention' group"
+        )
+    }
+
+    // MARK: - menuStatusNSColor (active AppKit tray dot, MCP-1856)
+
+    /// The active AppKit tray (`MCPProxyApp.swift`) draws its server dot from
+    /// `menuStatusNSColor`. A login-required server must get the calm accent
+    /// tint, never the red `statusNSColor` error treatment, so the shipping
+    /// menu no longer renders a red error dot for the pure sign-in state.
+    func testLoginRequiredServerUsesCalmAccentDot() throws {
+        let server = try loginRequiredServer()
+        XCTAssertEqual(
+            server.menuStatusNSColor, NSColor.controlAccentColor,
+            "A login-required server's tray dot must use the calm accent tint, not statusNSColor"
+        )
+        XCTAssertNotEqual(
+            server.menuStatusNSColor, NSColor.systemRed,
+            "A login-required server's tray dot must never be the red error color"
+        )
+    }
+
+    /// A genuine (non-login) failure must keep the red `statusNSColor` tint in
+    /// the tray menu — only the sign-in state is calmed.
+    func testGenuineErrorKeepsRedDot() throws {
+        let server = try brokenServer()
+        XCTAssertEqual(
+            server.statusNSColor, NSColor.systemRed,
+            "Precondition: a broken server's health color is red"
+        )
+        XCTAssertEqual(
+            server.menuStatusNSColor, server.statusNSColor,
+            "A genuine error must keep its statusNSColor tint in the tray menu"
         )
     }
 }

--- a/native/macos/MCPProxy/MCPProxyTests/AppStateOAuthSignInTests.swift
+++ b/native/macos/MCPProxy/MCPProxyTests/AppStateOAuthSignInTests.swift
@@ -1,0 +1,135 @@
+import XCTest
+@testable import MCPProxy
+
+/// Tests for MCP-1822 (T3): a server in the OAuth login-required state
+/// (`health.action == "login"`) must surface as a calm, actionable "Sign in"
+/// affordance — never as a hard error. On the tray that means it is excluded
+/// from the red "Fix issues" diagnostic section and does not tint the tray
+/// icon badge, while still appearing in the calm "Needs Attention" group.
+final class AppStateOAuthSignInTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func decodeServer(_ jsonString: String) throws -> ServerStatus {
+        let data = jsonString.data(using: .utf8)!
+        return try JSONDecoder().decode(ServerStatus.self, from: data)
+    }
+
+    /// A server in the OAuth login-required state. Pre-T1 the backend
+    /// classifies this as an `error`-severity `MCPX_UNKNOWN_UNCLASSIFIED`
+    /// diagnostic; the tray must still treat it as a sign-in affordance, not
+    /// a hard error, regardless of the diagnostic the backend attaches.
+    private func loginRequiredServer(name: String = "github") throws -> ServerStatus {
+        try decodeServer("""
+        {
+            "id": "\(name)",
+            "name": "\(name)",
+            "protocol": "http",
+            "enabled": true,
+            "connected": false,
+            "quarantined": false,
+            "tool_count": 0,
+            "error_code": "MCPX_UNKNOWN_UNCLASSIFIED",
+            "diagnostic": {
+                "code": "MCPX_UNKNOWN_UNCLASSIFIED",
+                "severity": "error",
+                "user_message": "Server error"
+            },
+            "health": {
+                "level": "degraded",
+                "admin_state": "enabled",
+                "summary": "Sign in required",
+                "action": "login"
+            }
+        }
+        """)
+    }
+
+    /// A server with a genuine, non-OAuth failure that should still surface
+    /// as a hard error in the tray.
+    private func brokenServer(name: String = "filesystem") throws -> ServerStatus {
+        try decodeServer("""
+        {
+            "id": "\(name)",
+            "name": "\(name)",
+            "protocol": "stdio",
+            "enabled": true,
+            "connected": false,
+            "quarantined": false,
+            "tool_count": 0,
+            "error_code": "MCPX_STDIO_SPAWN_ENOENT",
+            "diagnostic": {
+                "code": "MCPX_STDIO_SPAWN_ENOENT",
+                "severity": "error",
+                "user_message": "Command not found"
+            },
+            "health": {
+                "level": "unhealthy",
+                "admin_state": "enabled",
+                "summary": "Failed to start",
+                "action": "restart"
+            }
+        }
+        """)
+    }
+
+    // MARK: - serversWithDiagnostic (Fix Issues section)
+
+    func testLoginRequiredServerExcludedFromFixIssues() throws {
+        let state = AppState()
+        state.servers = [try loginRequiredServer()]
+        XCTAssertTrue(
+            state.serversWithDiagnostic.isEmpty,
+            "A login-required server must not appear in the red 'Fix issues' diagnostic section"
+        )
+    }
+
+    func testGenuineErrorStillSurfacesInFixIssues() throws {
+        let state = AppState()
+        state.servers = [try brokenServer()]
+        XCTAssertEqual(
+            state.serversWithDiagnostic.map(\.name), ["filesystem"],
+            "A genuine non-OAuth error must still surface in 'Fix issues'"
+        )
+    }
+
+    func testMixedServersOnlySurfaceGenuineError() throws {
+        let state = AppState()
+        state.servers = [try loginRequiredServer(), try brokenServer()]
+        XCTAssertEqual(
+            state.serversWithDiagnostic.map(\.name), ["filesystem"],
+            "Only the genuinely broken server should be in 'Fix issues'; the sign-in server is calm"
+        )
+    }
+
+    // MARK: - worstDiagnosticSeverity (tray icon badge tint)
+
+    func testLoginRequiredServerDoesNotTintBadge() throws {
+        let state = AppState()
+        state.servers = [try loginRequiredServer()]
+        XCTAssertNil(
+            state.worstDiagnosticSeverity,
+            "A sign-in-required server must not tint the tray icon badge red"
+        )
+    }
+
+    func testGenuineErrorTintsBadgeRed() throws {
+        let state = AppState()
+        state.servers = [try loginRequiredServer(), try brokenServer()]
+        XCTAssertEqual(
+            state.worstDiagnosticSeverity, "error",
+            "A genuine error must still tint the badge even when a sign-in server is present"
+        )
+    }
+
+    // MARK: - serversNeedingAttention (calm Sign in path)
+
+    func testLoginRequiredServerStillNeedsAttention() throws {
+        let state = AppState()
+        state.servers = [try loginRequiredServer()]
+        XCTAssertEqual(
+            state.serversNeedingAttention.map(\.name), ["github"],
+            "A sign-in-required server must remain in the calm 'Needs Attention' group"
+        )
+    }
+}

--- a/native/macos/MCPProxy/MCPProxyTests/ModelsTests.swift
+++ b/native/macos/MCPProxy/MCPProxyTests/ModelsTests.swift
@@ -145,7 +145,7 @@ final class ModelsTests: XCTestCase {
     // MARK: - HealthAction Enum
 
     func testHealthActionLabels() {
-        XCTAssertEqual(HealthAction.login.label, "Log In")
+        XCTAssertEqual(HealthAction.login.label, "Sign in")
         XCTAssertEqual(HealthAction.restart.label, "Restart")
         XCTAssertEqual(HealthAction.enable.label, "Enable")
         XCTAssertEqual(HealthAction.approve.label, "Approve")


### PR DESCRIPTION
## What & why

Parent epic: smart-mcp-proxy/mcpproxy-go MCP-1819 — *OAuth login-required = actionable Sign-in state, not MCPX_UNKNOWN_UNCLASSIFIED*. This is **T3 (macOS tray)**.

A server in the OAuth login-required state (`health.action == "login"`) read as a **hard error** in the tray. Pre-T1 the backend classifies that state as an `error`-severity `MCPX_UNKNOWN_UNCLASSIFIED` diagnostic, so the same server appeared in the red **"Fix issues"** section (`xmark.octagon` / "file a bug") *and* tinted the tray-icon badge red — while the only login affordance was a plain "Log In" menu item.

This renders it as a **calm, actionable Sign-in state** instead.

## Changes (all in `native/macos/`)

- `ServerStatus.isOAuthLoginRequired` — keyed off the stable, cross-surface `health.action == "login"` contract (the same one CLI/REST/Web-UI/TUI use).
- `AppState.serversWithDiagnostic` and `worstDiagnosticSeverity` **exclude** login-required servers → no red "Fix issues" entry, no red badge tint for a pure sign-in state. They remain in the calm **"Needs Attention"** group, which now shows the remediation verb (**"Sign in"**) explicitly so the affordance isn't buried.
- Rename **"Log In" → "Sign in"** across the tray (`HealthAction.login.label`, server submenu, ServerDetail header button, server-list context menu), mirroring the Web UI's calm tone.

### Contract / T1 relationship
Keyed off the **already-stable** `action == "login"` contract that exists on `main`, so this is independently correct and **forward-compatible** with T1's classifier change (whether T1 stops emitting a diagnostic for OAuth-pending or emits a calmer one, the tray no longer error-frames the sign-in state).

## Tests
`swift test` — new `AppStateOAuthSignInTests` (6) + updated `ModelsTests.testHealthActionLabels` all pass:
- login-required server excluded from Fix-issues / badge tint
- login-required server retained in Needs-Attention
- genuine non-OAuth error **still** surfaces in Fix-issues and tints the badge red
- `HealthAction.login.label == "Sign in"`

Pre-existing, environment-dependent failures unrelated to this change (`AutoStartTests.testFirstRunFlagRoundTrip` — UserDefaults pollution; `MergePatchEncodingTests` and `SSEParserTests` — Foundation-version canaries) reproduce on clean `origin/main` and are not touched here.

## Verification note
A live OAuth-pending upstream cannot be staged in this environment, so visual `mcpproxy-ui-test` capture of the exact login state isn't meaningful here; behavior is covered by the unit tests above against the `AppState`/`ServerStatus` logic that drives the menu.

Related #MCP-1819