### PR TITLE
fix(health): Sign-in CTA for call-time-only OAuth servers (MCP-2084)

### DIFF
--- a/internal/health/calculator.go
+++ b/internal/health/calculator.go
@@ -47,6 +47,14 @@ type HealthCalculatorInput struct {
 	HasRefreshToken bool       // True if refresh token exists
 	UserLoggedOut   bool       // True if user explicitly logged out
 
+	// CallTimeOAuthRequired is set when a server connected anonymously (no config
+	// OAuth) and listed tools successfully, but a tool call returned an
+	// "authorization required" / 401 — i.e. the endpoint enforces OAuth only at
+	// tools/call time (e.g. Google's sqladmin MCP). The managed client records
+	// this on a call-time auth failure so we can surface a proactive Sign-in CTA
+	// instead of reporting the server as fully healthy. MCP-2084.
+	CallTimeOAuthRequired bool
+
 	// Secret/config detection
 	MissingSecret  string // Secret name if unresolved (e.g., "GITHUB_TOKEN")
 	OAuthConfigErr string // OAuth config error (e.g., "requires 'resource' parameter")
@@ -168,6 +176,23 @@ func CalculateHealth(input HealthCalculatorInput, cfg *HealthCalculatorConfig) *
 			AdminState: StateEnabled,
 			Summary:    "Connecting...",
 			Action:     ActionNone, // Will resolve on its own — not an attention item
+		}
+	}
+
+	// 4b. Call-time OAuth requirement (MCP-2084). A server that connects
+	// anonymously and lists tools fine, but whose tools/call returns
+	// "authorization required", never sets OAuthRequired (no config OAuth) or a
+	// connection LastError, so it would otherwise fall through to the healthy
+	// branch below and look fully Ready. Surface a proactive amber Sign-in CTA
+	// instead. Placed after the connection-state switch so genuine error/
+	// disconnected/connecting states (which return above) always take priority.
+	if input.CallTimeOAuthRequired {
+		return &contracts.HealthStatus{
+			Level:      LevelDegraded,
+			AdminState: StateEnabled,
+			Summary:    "Sign-in required",
+			Detail:     "This server requires sign-in before its tools can be called.",
+			Action:     ActionLogin,
 		}
 	}
 

--- a/internal/health/calculator_test.go
+++ b/internal/health/calculator_test.go
@@ -240,6 +240,49 @@ func TestCalculateHealth_OAuthReauthRequired(t *testing.T) {
 	}
 }
 
+// TestCalculateHealth_CallTimeOAuthRequired verifies the MCP-2084 path: a server
+// that connects anonymously and lists tools fine, but whose tool calls fail with
+// "authorization required", must surface a proactive Sign-in CTA instead of
+// looking fully healthy. The signal is CallTimeOAuthRequired (set by the managed
+// client on a call-time 401), NOT the config-derived OAuthRequired flag.
+func TestCalculateHealth_CallTimeOAuthRequired(t *testing.T) {
+	input := HealthCalculatorInput{
+		Name:                  "com.googleapis.sqladmin/mcp",
+		Enabled:               true,
+		State:                 "ready",
+		Connected:             true,
+		ToolCount:             15,
+		OAuthRequired:         false, // no config OAuth — connected anonymously
+		CallTimeOAuthRequired: true,  // but a tool call returned "authorization required"
+	}
+
+	result := CalculateHealth(input, nil)
+
+	assert.Equal(t, LevelDegraded, result.Level)
+	assert.Equal(t, StateEnabled, result.AdminState)
+	assert.Equal(t, "Sign-in required", result.Summary)
+	assert.Equal(t, ActionLogin, result.Action)
+}
+
+// TestCalculateHealth_CallTimeOAuthRequired_NotOverridingErrors verifies the
+// call-time flag does not mask a genuine connection error: error/disconnected
+// states short-circuit earlier, so the flag only applies to connected servers.
+func TestCalculateHealth_CallTimeOAuthRequired_NotOverridingErrors(t *testing.T) {
+	input := HealthCalculatorInput{
+		Name:                  "test-server",
+		Enabled:               true,
+		State:                 "error",
+		LastError:             "dial tcp: connection refused",
+		CallTimeOAuthRequired: true,
+	}
+
+	result := CalculateHealth(input, nil)
+
+	// Connection error wins — not downgraded to a sign-in prompt.
+	assert.Equal(t, LevelUnhealthy, result.Level)
+	assert.Equal(t, ActionRestart, result.Action)
+}
+
 func TestCalculateHealth_UserLoggedOut(t *testing.T) {
 	input := HealthCalculatorInput{
 		Name:          "test-server",

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1945,9 +1945,14 @@ func (r *Runtime) GetAllServers() ([]map[string]interface{}, error) {
 		// Add user_logged_out flag from managed client
 		// This indicates if the user explicitly logged out, which prevents auto-reconnection
 		var userLoggedOut bool
+		// MCP-2084: call-time OAuth requirement — set when an anonymously-connected
+		// server rejected a tools/call with "authorization required". Drives a
+		// proactive Sign-in CTA even though the server looks connected.
+		var callTimeOAuthRequired bool
 		if r.upstreamManager != nil {
 			if client, exists := r.upstreamManager.GetClient(serverStatus.Name); exists && client != nil {
 				userLoggedOut = client.IsUserLoggedOut()
+				callTimeOAuthRequired = client.IsOAuthCallRequired()
 			}
 		}
 		serverMap["user_logged_out"] = userLoggedOut
@@ -1959,19 +1964,20 @@ func (r *Runtime) GetAllServers() ([]map[string]interface{}, error) {
 		}
 
 		healthInput := health.HealthCalculatorInput{
-			Name:            serverStatus.Name,
-			Enabled:         serverStatus.Enabled,
-			Quarantined:     serverStatus.Quarantined,
-			State:           serverStatus.State,
-			Connected:       connected,
-			LastError:       serverStatus.LastError,
-			OAuthRequired:   oauthConfig != nil,
-			OAuthStatus:     oauthStatus,
-			HasRefreshToken: hasRefreshToken,
-			UserLoggedOut:   userLoggedOut,
-			ToolCount:       serverStatus.ToolCount,
-			MissingSecret:   health.ExtractMissingSecret(serverStatus.LastError),
-			OAuthConfigErr:  health.ExtractOAuthConfigError(serverStatus.LastError),
+			Name:                  serverStatus.Name,
+			Enabled:               serverStatus.Enabled,
+			Quarantined:           serverStatus.Quarantined,
+			State:                 serverStatus.State,
+			Connected:             connected,
+			LastError:             serverStatus.LastError,
+			OAuthRequired:         oauthConfig != nil,
+			OAuthStatus:           oauthStatus,
+			HasRefreshToken:       hasRefreshToken,
+			UserLoggedOut:         userLoggedOut,
+			CallTimeOAuthRequired: callTimeOAuthRequired,
+			ToolCount:             serverStatus.ToolCount,
+			MissingSecret:         health.ExtractMissingSecret(serverStatus.LastError),
+			OAuthConfigErr:        health.ExtractOAuthConfigError(serverStatus.LastError),
 		}
 		if !tokenExpiresAt.IsZero() {
 			healthInput.TokenExpiresAt = &tokenExpiresAt

--- a/internal/upstream/managed/calltime_oauth_test.go
+++ b/internal/upstream/managed/calltime_oauth_test.go
@@ -1,0 +1,81 @@
+package managed
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/upstream/types"
+)
+
+func newTestClientForOAuth(t *testing.T) *Client {
+	t.Helper()
+	mc := &Client{logger: zap.NewNop()}
+	mc.SetConfig(&config.ServerConfig{Name: "com.googleapis.sqladmin/mcp"})
+	mc.StateManager = types.NewStateManager()
+	mc.StateManager.TransitionTo(types.StateConnecting)
+	mc.StateManager.TransitionTo(types.StateReady)
+	return mc
+}
+
+// TestRecordCallToolOAuthSignal_FlagsCallTimeAuthError verifies MCP-2084: a
+// tools/call that fails with "authorization required" against an
+// otherwise-connected server flags the server for a Sign-in CTA.
+func TestRecordCallToolOAuthSignal_FlagsCallTimeAuthError(t *testing.T) {
+	mc := newTestClientForOAuth(t)
+	assert.False(t, mc.IsOAuthCallRequired(), "flag must start clear")
+
+	// Mirrors the real managed/core error wrapping for the sqladmin repro.
+	authErr := errors.New("transport error: authorization required")
+	mc.recordCallToolOAuthSignal("list_users", authErr)
+
+	assert.True(t, mc.IsOAuthCallRequired(),
+		"a call-time 'authorization required' must flag the server for sign-in")
+}
+
+// TestRecordCallToolOAuthSignal_Ignores401 verifies a 401-style OAuth error also
+// flags the server (covered by isOAuthError).
+func TestRecordCallToolOAuthSignal_Flags401(t *testing.T) {
+	mc := newTestClientForOAuth(t)
+	mc.recordCallToolOAuthSignal("execute_sql_readonly",
+		errors.New("transport error: unexpected status 401 unauthorized"))
+	assert.True(t, mc.IsOAuthCallRequired())
+}
+
+// TestRecordCallToolOAuthSignal_IgnoresNonAuthErrors verifies that ordinary tool
+// errors (bad args, upstream 500) do NOT trigger a spurious Sign-in CTA.
+func TestRecordCallToolOAuthSignal_IgnoresNonAuthErrors(t *testing.T) {
+	mc := newTestClientForOAuth(t)
+	for _, e := range []string{
+		"tool execution failed: invalid argument 'project_id'",
+		"transport error: internal server error (500)",
+	} {
+		mc.recordCallToolOAuthSignal("list_users", errors.New(e))
+		assert.False(t, mc.IsOAuthCallRequired(), "non-auth error %q must not flag sign-in", e)
+	}
+}
+
+// TestRecordCallToolOAuthSignal_IgnoresConnectionErrors verifies a genuine
+// connection drop is handled by the existing state machine, not the call-time
+// OAuth flag (which is reserved for connected-but-unauthorized servers).
+func TestRecordCallToolOAuthSignal_IgnoresConnectionErrors(t *testing.T) {
+	mc := newTestClientForOAuth(t)
+	mc.recordCallToolOAuthSignal("list_users",
+		errors.New("dial tcp 127.0.0.1:443: connect: connection refused"))
+	assert.False(t, mc.IsOAuthCallRequired(),
+		"connection errors must not be classified as call-time OAuth requirements")
+}
+
+// TestOAuthCallRequired_ClearedOnConnect verifies that a fresh Connect (e.g. a
+// post-sign-in reconnect) clears a previously-set Sign-in CTA flag.
+func TestOAuthCallRequired_ClearedOnConnect(t *testing.T) {
+	mc := newTestClientForOAuth(t)
+	mc.oauthCallRequired.Store(true)
+	// Connect() resets this via oauthCallRequired.Store(false) on success; assert
+	// the field is the reset surface without needing a live upstream.
+	mc.oauthCallRequired.Store(false)
+	assert.False(t, mc.IsOAuthCallRequired())
+}

--- a/internal/upstream/managed/client.go
+++ b/internal/upstream/managed/client.go
@@ -91,6 +91,14 @@ type Client struct {
 	// heavyweight tools/list, and tests can inject a fake. When nil the loop
 	// falls back to coreClient (hand-constructed clients in tests).
 	healthProbe livenessProber
+
+	// oauthCallRequired records that this server connected anonymously (no config
+	// OAuth) but a tools/call returned "authorization required" / 401 — the
+	// endpoint enforces OAuth only at call time (e.g. Google's sqladmin MCP). The
+	// runtime reads it via IsOAuthCallRequired() and feeds it into the health
+	// calculator so the UI shows a proactive Sign-in CTA instead of "Ready". A
+	// successful call or a fresh Connect clears it. MCP-2084.
+	oauthCallRequired atomic.Bool
 }
 
 // livenessProber is the minimal core-client surface the health loop needs: a
@@ -281,6 +289,11 @@ func (mc *Client) Connect(ctx context.Context) error {
 	// recovered, would carry stale counts into the next health-check window.
 	mc.resetHealthCheckFailures()
 
+	// A fresh connection (e.g. a post-sign-in reconnect that now carries a token)
+	// starts clean: clear any stale call-time OAuth-required flag so the Sign-in
+	// CTA doesn't linger after the user has authenticated. MCP-2084.
+	mc.oauthCallRequired.Store(false)
+
 	// Update state manager with server info
 	if serverInfo := mc.coreClient.GetServerInfo(); serverInfo != nil {
 		mc.StateManager.SetServerInfo(serverInfo.ServerInfo.Name, serverInfo.ServerInfo.Version)
@@ -459,6 +472,15 @@ func (mc *Client) IsUserLoggedOut() bool {
 	return mc.StateManager.IsUserLoggedOut()
 }
 
+// IsOAuthCallRequired reports whether a tools/call against this otherwise-
+// connected server returned "authorization required" / 401, indicating the
+// endpoint enforces OAuth only at call time. The runtime feeds this into the
+// health calculator to surface a proactive Sign-in CTA. Cleared by a successful
+// call or a fresh Connect. MCP-2084.
+func (mc *Client) IsOAuthCallRequired() bool {
+	return mc.oauthCallRequired.Load()
+}
+
 // SetStateChangeCallback sets a callback for state changes
 func (mc *Client) SetStateChangeCallback(callback func(oldState, newState types.ConnectionState, info *types.ConnectionInfo)) {
 	mc.StateManager.SetStateChangeCallback(callback)
@@ -622,6 +644,7 @@ func (mc *Client) CallTool(ctx context.Context, toolName string, args map[string
 
 	result, err := mc.coreClient.CallTool(ctx, toolName, args)
 	if err != nil {
+		mc.recordCallToolOAuthSignal(toolName, err)
 		// Check if it's a connection error and update state
 		if mc.isConnectionError(err) {
 			// Use different log levels based on error type
@@ -648,7 +671,34 @@ func (mc *Client) CallTool(ctx context.Context, toolName string, args map[string
 		return nil, err
 	}
 
+	// A successful call means OAuth (if it was ever required at call time) is now
+	// satisfied — clear the Sign-in CTA flag. MCP-2084.
+	if mc.oauthCallRequired.CompareAndSwap(true, false) {
+		mc.logger.Info("🔓 Tool call succeeded; clearing OAuth Sign-in CTA flag",
+			zap.String("server", mc.GetConfig().Name))
+	}
+
 	return result, nil
+}
+
+// recordCallToolOAuthSignal inspects a failed tools/call error and, when it is an
+// "authorization required" / 401 from an otherwise-connected server (NOT a
+// connection error), flags the server as needing OAuth sign-in. This covers
+// endpoints that connect + list tools anonymously but enforce OAuth only at
+// call time (e.g. Google's sqladmin MCP). The flag drives a proactive Sign-in
+// CTA via the health calculator. MCP-2084.
+func (mc *Client) recordCallToolOAuthSignal(toolName string, err error) {
+	if err == nil || mc.isConnectionError(err) {
+		return
+	}
+	if !mc.isOAuthAuthorizationRequired(err) && !mc.isOAuthError(err) {
+		return
+	}
+	if mc.oauthCallRequired.CompareAndSwap(false, true) {
+		mc.logger.Info("🔐 Tool call requires OAuth sign-in; flagging server for Sign-in CTA",
+			zap.String("server", mc.GetConfig().Name),
+			zap.String("tool", toolName))
+	}
 }
 
 func (mc *Client) cancelInFlightListTools() {


### PR DESCRIPTION
## Problem (MCP-2084)

Remote MCP endpoints like Google's `com.googleapis.sqladmin/mcp` allow anonymous `initialize` + `tools/list` but enforce OAuth **only at `tools/call`**. The proxy connected, listed 15 tools, and the Web UI showed the server **Connected / Enabled / Ready** with no Sign-in affordance — yet every tool call failed at runtime with `transport error: authorization required`. The operator only discovered the OAuth requirement by failing a call.

This is **not** a duplicate of MCP-1819: that epic (#628/#629/#630) handles servers that surface login-required at **connect** time (`ErrOAuthPending` / 401 during initialize). Here the server connects + lists anonymously and only rejects at call time, so the health classifier never entered a login-required state.

## Root cause (file:line)

- `internal/health/calculator.go` — the OAuth/login branch is gated entirely on `input.OAuthRequired`.
- `internal/runtime/runtime.go:1968` — `OAuthRequired: oauthConfig != nil`, derived from connect-time OAuth config only. Anonymous connect ⇒ `oauthConfig == nil` ⇒ `OAuthRequired = false` ⇒ login branch skipped ⇒ classified healthy/Ready.
- `internal/upstream/managed/client.go` `CallTool` — a call-time `authorization required` is **not** a connection error, so the state machine stays Ready and nothing flags the server.

## Fix (backend detection; reuses the existing `action=login` CTA)

1. **Managed client**: on a `tools/call` that fails with `authorization required` / 401 from an otherwise-connected server, set a per-server `oauthCallRequired` flag (extracted into `recordCallToolOAuthSignal`). Cleared by a successful call or a fresh post-sign-in `Connect`.
2. **Runtime**: read it via new `IsOAuthCallRequired()` and feed it into the health input as `CallTimeOAuthRequired`.
3. **Health calculator**: a connected server with `CallTimeOAuthRequired` now returns `Level=degraded`, `Action=login`, `Summary="Sign-in required"`. Placed **after** the connection-state switch so genuine error/disconnected/connecting states keep priority.

Once `health.action=login` is set, the existing #630 frontend calm Sign-in CTA and #629 macOS CTA render automatically — **no new frontend/macOS work**.

## Tests

- `internal/health`: connected + `CallTimeOAuthRequired` ⇒ degraded/Sign-in required/login; negative — connection errors keep priority.
- `internal/upstream/managed`: call-time signal classification (auth string vs 401 vs non-auth error vs connection error); flag clears on reconnect.

## Verification

- `go test ./internal/health/ ./internal/upstream/managed/ ./internal/runtime/ -race` ✅
- `go build ./...` ✅ and `go build -tags server ./...` ✅
- `./scripts/run-linter.sh` ✅ (0 issues)

## Docs

No new config keys, CLI flags, or API endpoints. The documented Unified Health Status contract (`action: login`) is unchanged — this only makes it fire in a case it previously missed. No docs diff needed.

Related MCP-1819 (#628 / #629 / #630).