### PR TITLE
fix(runtime): serve indexed tools when StateView per-server cache is empty (MCP-2083)

### DIFF
--- a/internal/runtime/get_server_tools_fallback_test.go
+++ b/internal/runtime/get_server_tools_fallback_test.go
@@ -1,0 +1,119 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/runtime/stateview"
+)
+
+// seedStateViewServer registers a server in the supervisor StateView with the
+// given tool set, simulating a connected server whose StateView per-server tool
+// cache holds exactly `tools` (possibly empty).
+func seedStateViewServer(t *testing.T, rt *Runtime, name string, connected bool, tools []stateview.ToolInfo) {
+	t.Helper()
+	sv := rt.supervisor.StateView()
+	if sv == nil {
+		t.Fatal("StateView not available on test runtime")
+	}
+	sv.UpdateServer(name, func(status *stateview.ServerStatus) {
+		status.Connected = connected
+		status.State = "ready"
+		status.Tools = tools
+		status.ToolCount = len(tools)
+	})
+}
+
+// TestGetServerTools_FallsBackToIndexWhenStateViewEmpty reproduces MCP-2083:
+// after approving (unquarantining) a server, the per-server StateView tool list
+// is transiently cleared by the disconnect/reconnect cycle, but the durable
+// search index still holds the server's tools. GetServerTools must never serve
+// an empty list when the index has tools for a known server.
+func TestGetServerTools_FallsBackToIndexWhenStateViewEmpty(t *testing.T) {
+	rt := newTestRuntime(t)
+
+	const server = "com.googleapis.sqladmin/mcp"
+	// Index holds 2 tools (analogue of the 15 indexed after approval).
+	if err := rt.indexManager.BatchIndexTools([]*config.ToolMetadata{
+		{ServerName: server, Name: "list_instances", Description: "List instances", ParamsJSON: `{"type":"object"}`},
+		{ServerName: server, Name: "get_instance", Description: "Get instance"},
+	}); err != nil {
+		t.Fatalf("failed to seed index: %v", err)
+	}
+
+	// StateView has the server present and connected, but with an empty tool list
+	// (the bug state right after the unquarantine reconnect).
+	seedStateViewServer(t, rt, server, true, nil)
+
+	tools, err := rt.GetServerTools(server)
+	if err != nil {
+		t.Fatalf("GetServerTools returned error: %v", err)
+	}
+	if len(tools) != 2 {
+		t.Fatalf("expected fallback to index (2 tools), got %d: %#v", len(tools), tools)
+	}
+
+	got := map[string]bool{}
+	for _, tool := range tools {
+		name, _ := tool["name"].(string)
+		got[name] = true
+		if sn, _ := tool["server_name"].(string); sn != server {
+			t.Fatalf("expected server_name %q, got %q", server, sn)
+		}
+	}
+	for _, want := range []string{"list_instances", "get_instance"} {
+		if !got[want] {
+			t.Fatalf("missing tool %q in fallback result: %#v", want, got)
+		}
+	}
+}
+
+// TestGetServerTools_PrefersStateViewWhenPopulated guards against the fallback
+// overriding a populated StateView: when StateView already has tools, the index
+// is not consulted (StateView is the freshest source).
+func TestGetServerTools_PrefersStateViewWhenPopulated(t *testing.T) {
+	rt := newTestRuntime(t)
+
+	const server = "srv"
+	if err := rt.indexManager.BatchIndexTools([]*config.ToolMetadata{
+		{ServerName: server, Name: "stale_indexed_tool", Description: "stale"},
+	}); err != nil {
+		t.Fatalf("failed to seed index: %v", err)
+	}
+
+	seedStateViewServer(t, rt, server, true, []stateview.ToolInfo{
+		{Name: "live_a", Description: "A"},
+		{Name: "live_b", Description: "B"},
+	})
+
+	tools, err := rt.GetServerTools(server)
+	if err != nil {
+		t.Fatalf("GetServerTools returned error: %v", err)
+	}
+	if len(tools) != 2 {
+		t.Fatalf("expected StateView tools (2), got %d: %#v", len(tools), tools)
+	}
+	for _, tool := range tools {
+		if name, _ := tool["name"].(string); name == "stale_indexed_tool" {
+			t.Fatalf("fallback incorrectly overrode a populated StateView with stale index data")
+		}
+	}
+}
+
+// TestGetServerTools_EmptyStateViewAndIndexReturnsEmpty ensures a genuinely
+// empty server (no StateView tools, no index tools) still reports empty — the
+// fallback must not invent tools.
+func TestGetServerTools_EmptyStateViewAndIndexReturnsEmpty(t *testing.T) {
+	rt := newTestRuntime(t)
+
+	const server = "empty-srv"
+	seedStateViewServer(t, rt, server, true, nil)
+
+	tools, err := rt.GetServerTools(server)
+	if err != nil {
+		t.Fatalf("GetServerTools returned error: %v", err)
+	}
+	if len(tools) != 0 {
+		t.Fatalf("expected empty result for a server with no tools, got %d: %#v", len(tools), tools)
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -2111,6 +2111,49 @@ func (r *Runtime) GetServerTools(serverName string) ([]map[string]interface{}, e
 		tools = append(tools, toolMap)
 	}
 
+	// Defensive fallback (MCP-2083): the per-server StateView tool list is volatile
+	// derived state — it is cleared on disconnect (supervisor clears Tools on a
+	// connection-down event) and only repopulated asynchronously by background
+	// discovery. Approving a quarantined server triggers a disconnect/reconnect
+	// cycle, and in the field this can leave StateView holding zero tools even
+	// though the durable search index already indexed the server's tools. Serving
+	// that empty snapshot makes the Tools tab show "No tools available" for a
+	// connected server that demonstrably has tools. When StateView reports no tools
+	// for a server, fall back to the authoritative search index so we never serve
+	// an empty list when indexed tools exist.
+	if len(tools) == 0 && r.indexManager != nil {
+		if indexed, err := r.indexManager.GetToolsByServer(serverName); err == nil && len(indexed) > 0 {
+			tools = make([]map[string]interface{}, 0, len(indexed))
+			for _, tool := range indexed {
+				// Index stores the full tool name; normalize to the bare tool name
+				// (no "server:" prefix) to match the StateView/approval-record
+				// convention used by the enrichment layer.
+				name := tool.Name
+				if idx := strings.Index(name, ":"); idx != -1 {
+					name = name[idx+1:]
+				}
+				toolMap := map[string]interface{}{
+					"name":        name,
+					"description": tool.Description,
+					"server_name": serverName,
+				}
+				if tool.ParamsJSON != "" {
+					var inputSchema map[string]interface{}
+					if err := json.Unmarshal([]byte(tool.ParamsJSON), &inputSchema); err == nil {
+						toolMap["inputSchema"] = inputSchema
+					}
+				}
+				if tool.Annotations != nil {
+					toolMap["annotations"] = tool.Annotations
+				}
+				tools = append(tools, toolMap)
+			}
+			r.logger.Debug("GetServerTools: StateView empty, served tools from search index fallback",
+				zap.String("server", serverName),
+				zap.Int("tool_count", len(tools)))
+		}
+	}
+
 	return tools, nil
 }
 


### PR DESCRIPTION
## Problem (MCP-2083)

Approving a quarantined remote server (repro: `com.googleapis.sqladmin/mcp`, 15 tools) flips it Enabled/Online but the **Tools tab then shows "Tools: 0 / No tools available"** — unquarantining appears to drop the per-server tool list.

## Root cause (verified against `/tmp/sqladmin-scanner-logs.txt`)

The Tools tab is served by `GET /api/v1/servers/{id}/tools` → `handleGetServerTools` → `mgmtSvc.GetServerTools()` → **`Runtime.GetServerTools()`, which reads solely from the volatile per-server StateView snapshot.**

On approve, `QuarantineServer(false)` reloads config and the server **disconnects then reconnects** (logs: 3× "Disconnecting" then "Successfully connected" at 09:09:03). The supervisor clears `status.Tools = nil` on the connection-down event (`supervisor.go:961`) and the reconnect handler deliberately does **not** repopulate it ("background indexing will handle it", `supervisor.go:945`). Re-discovery does re-index the tools (logs: "added: 15 … Successfully indexed … count: 15") — i.e. **the durable search index correctly holds 15 tools** — but the StateView per-server cache can remain empty, and `GetServerTools` serves that empty snapshot. The index and upstream both report 15; only StateView is stale.

## Fix

Defensive fallback in `Runtime.GetServerTools` (`internal/runtime/runtime.go`): when StateView reports **zero** tools for a known server, serve the server's tools from the authoritative search index (`indexManager.GetToolsByServer`), normalizing names to the bare tool name so the httpapi enrichment layer still attaches approval status. A populated StateView is still preferred (freshest source); a genuinely empty server still reports empty. This is defense-in-depth at the serving layer and is robust to the exact disconnect/reconnect StateView ordering.

## Tests (TDD)

New `internal/runtime/get_server_tools_fallback_test.go`:
- `TestGetServerTools_FallsBackToIndexWhenStateViewEmpty` — reproduces the bug (StateView empty + index populated → was 0, now serves index). **Confirmed failing before the fix.**
- `TestGetServerTools_PrefersStateViewWhenPopulated` — guards against overriding a live StateView with stale index data.
- `TestGetServerTools_EmptyStateViewAndIndexReturnsEmpty` — a truly empty server still reports empty.

## Verification

- `go build ./...` ✅
- `go test ./internal/runtime/... -race` ✅ (incl. the `TestCalculateToolApprovalHash_Stability` canary)
- `go test ./internal/management/... ./internal/httpapi/...` ✅
- `./scripts/run-linter.sh` ✅ 0 issues

## Scope / coupling

This resolves the user-visible empty-Tools-tab symptom independently. In this repro the 15 tools are no longer blocked after unquarantine (`enforceQuarantine` becomes false → indexed, blocked: 0), so the serving fallback is sufficient. The trust-model change (auto-approve pending baseline on server-approve) belongs to the cross-linked **Ticket A** and is intentionally out of scope here.

No user-facing/doc/API/config contract change (the endpoint contract is unchanged — just more correct), so no docs diff.

Related MCP-2083