### PR TITLE
feat(quarantine): baseline-approve pending tools on server unquarantine (MCP-2100)

### DIFF
--- a/docs/features/security-quarantine.md
+++ b/docs/features/security-quarantine.md
@@ -55,6 +55,11 @@ When a server is unquarantined (approved):
 1. The server connects to discover its tools
 2. Tools are **indexed and become searchable**
 3. Tool calls are allowed to execute normally
+4. Any **pending** (newly-discovered, never-reviewed) tool-approval records for
+   the server are **auto-promoted to approved** — approving a server means you
+   trust its current tool snapshot (baseline trust). Tools whose description or
+   schema later **changes** (`changed`, i.e. rug-pull) are *not* affected and
+   stay blocked until you re-approve them explicitly.
 
 ### Security Analysis
 

--- a/internal/runtime/lifecycle.go
+++ b/internal/runtime/lifecycle.go
@@ -1164,6 +1164,21 @@ func (r *Runtime) QuarantineServer(serverName string, quarantined bool) error {
 		return fmt.Errorf("failed to reload configuration: %w", err)
 	}
 
+	// On unquarantine/approval, baseline-trust the server's CURRENT tool
+	// snapshot: promote its pending (never-reviewed) tool records to approved.
+	// Tool-level quarantine then guards only status=changed (rug-pull) records.
+	// (Spec 032, MCP-2100; trust model confirmed in MCP-2081.) Done before the
+	// re-index in HandleUpstreamServerChange so the newly-trusted tools become
+	// immediately searchable. Best-effort: a promotion failure must not abort
+	// the unquarantine the user already requested and that is already persisted.
+	if !quarantined {
+		if err := r.approveBaselineToolsForServer(serverName); err != nil {
+			r.logger.Warn("Failed to baseline-approve tools on server unquarantine",
+				zap.String("server", serverName),
+				zap.Error(err))
+		}
+	}
+
 	r.emitServersChanged("quarantine_toggle", map[string]any{
 		"server":      serverName,
 		"quarantined": quarantined,

--- a/internal/runtime/tool_quarantine.go
+++ b/internal/runtime/tool_quarantine.go
@@ -962,6 +962,54 @@ func (r *Runtime) collectKnownToolNames(serverName string) ([]string, error) {
 	return out, nil
 }
 
+// approveBaselineToolsForServer promotes a server's pending tool-approval
+// records to approved as baseline trust when the server itself is
+// approved/unquarantined.
+//
+// Trust model (Spec 032, MCP-2081/MCP-2100, request_confirmation 7cfce731):
+// approving/unquarantining a server == trusting its CURRENT tool snapshot. So
+// pending (newly-discovered, never-reviewed) tools inherit that baseline trust
+// automatically. Tool-level quarantine is then reserved for status=changed
+// (rug-pull) records only.
+//
+// CRITICAL: this promotes status=pending ONLY. status=changed records are left
+// untouched so that re-approving a server later never silently clears a genuine
+// rug-pull flag (preserves Spec 032's rug-pull guarantee). This is precisely why
+// it does NOT reuse ApproveAllTools, which promotes both pending AND changed.
+func (r *Runtime) approveBaselineToolsForServer(serverName string) error {
+	if r.storageManager == nil {
+		return nil
+	}
+
+	records, err := r.storageManager.ListToolApprovals(serverName)
+	if err != nil {
+		return err
+	}
+
+	var pendingTools []string
+	for _, record := range records {
+		if record.Status == storage.ToolApprovalStatusPending {
+			pendingTools = append(pendingTools, record.ToolName)
+		}
+	}
+
+	if len(pendingTools) == 0 {
+		return nil
+	}
+
+	// ApproveTools sets ApprovedHash=CurrentHash, runs enforceInvariant
+	// (pending→approved is permitted), and emits activity + a single SSE event.
+	if err := r.ApproveTools(serverName, pendingTools, "system:server-approval-baseline"); err != nil {
+		return err
+	}
+
+	r.logger.Info("Baseline-approved pending tools on server approval",
+		zap.String("server", serverName),
+		zap.Int("count", len(pendingTools)))
+
+	return nil
+}
+
 // ApproveAllTools approves all pending/changed tools for a server.
 func (r *Runtime) ApproveAllTools(serverName string, approvedBy string) (int, error) {
 	if r.storageManager == nil {

--- a/internal/runtime/tool_quarantine_baseline_test.go
+++ b/internal/runtime/tool_quarantine_baseline_test.go
@@ -1,0 +1,162 @@
+package runtime
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
+)
+
+// TestApproveBaselineToolsForServer_PromotesPendingOnly verifies the core
+// baseline-trust rule (Spec 032, MCP-2100): when a server is approved, its
+// pending (never-reviewed) tool records inherit baseline trust and are promoted
+// to approved.
+func TestApproveBaselineToolsForServer_PromotesPendingOnly(t *testing.T) {
+	rt := setupQuarantineRuntime(t, nil, []*config.ServerConfig{
+		{Name: "github", Enabled: true, Quarantined: true},
+	})
+
+	// Seed two pending tools (the state after first discovery under quarantine).
+	tools := []*config.ToolMetadata{
+		{ServerName: "github", Name: "create_issue", Description: "Creates issues", ParamsJSON: `{}`},
+		{ServerName: "github", Name: "list_repos", Description: "Lists repos", ParamsJSON: `{}`},
+	}
+	result, err := rt.checkToolApprovals("github", tools)
+	require.NoError(t, err)
+	require.Equal(t, 2, result.PendingCount, "precondition: both tools pending")
+
+	// Approve the server's baseline tool snapshot.
+	require.NoError(t, rt.approveBaselineToolsForServer("github"))
+
+	records, err := rt.storageManager.ListToolApprovals("github")
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+	for _, rec := range records {
+		assert.Equal(t, storage.ToolApprovalStatusApproved, rec.Status,
+			"tool %s must be approved after baseline approval", rec.ToolName)
+		assert.Equal(t, "system:server-approval-baseline", rec.ApprovedBy)
+		assert.Equal(t, rec.CurrentHash, rec.ApprovedHash,
+			"approved hash must equal current hash (baseline trusts current snapshot)")
+	}
+
+	// Re-checking discovery must now block nothing.
+	result, err = rt.checkToolApprovals("github", tools)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(result.BlockedTools))
+	assert.Equal(t, 0, result.PendingCount)
+}
+
+// TestApproveBaselineToolsForServer_LeavesChangedUntouched is the critical
+// correctness constraint: baseline approval must promote pending ONLY, never
+// status=changed (rug pull). Re-approving a server later must not silently
+// clear a genuine rug-pull flag (preserves Spec 032's guarantee).
+func TestApproveBaselineToolsForServer_LeavesChangedUntouched(t *testing.T) {
+	rt := setupQuarantineRuntime(t, nil, []*config.ServerConfig{
+		{Name: "github", Enabled: true, Quarantined: true},
+	})
+
+	// One pending tool (should be promoted).
+	require.NoError(t, rt.storageManager.SaveToolApproval(&storage.ToolApprovalRecord{
+		ServerName:         "github",
+		ToolName:           "create_issue",
+		CurrentHash:        "hash-pending",
+		Status:             storage.ToolApprovalStatusPending,
+		CurrentDescription: "Creates issues",
+		CurrentSchema:      `{}`,
+	}))
+
+	// One changed (rug-pull) tool (must remain changed).
+	require.NoError(t, rt.storageManager.SaveToolApproval(&storage.ToolApprovalRecord{
+		ServerName:          "github",
+		ToolName:            "list_repos",
+		ApprovedHash:        "hash-approved-old",
+		CurrentHash:         "hash-changed-new",
+		Status:              storage.ToolApprovalStatusChanged,
+		CurrentDescription:  "MALICIOUS: exfiltrate secrets",
+		PreviousDescription: "Lists repos",
+		CurrentSchema:       `{}`,
+	}))
+
+	require.NoError(t, rt.approveBaselineToolsForServer("github"))
+
+	pending, err := rt.storageManager.GetToolApproval("github", "create_issue")
+	require.NoError(t, err)
+	assert.Equal(t, storage.ToolApprovalStatusApproved, pending.Status,
+		"pending tool must be promoted to approved")
+
+	changed, err := rt.storageManager.GetToolApproval("github", "list_repos")
+	require.NoError(t, err)
+	assert.Equal(t, storage.ToolApprovalStatusChanged, changed.Status,
+		"changed (rug-pull) tool must NOT be silently cleared by baseline approval")
+	assert.Equal(t, "hash-approved-old", changed.ApprovedHash,
+		"changed tool's approved hash must be left untouched")
+}
+
+// TestQuarantineServer_Unquarantine_BaselineApprovesPending exercises the
+// end-to-end path the user actually triggers: unquarantining a server promotes
+// its pending tools to approved (baseline trust) while leaving changed records
+// blocked.
+func TestQuarantineServer_Unquarantine_BaselineApprovesPending(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "mcp_config.json")
+
+	cfg := config.DefaultConfig()
+	cfg.Listen = "127.0.0.1:0"
+	cfg.DataDir = tmpDir
+	cfg.Servers = []*config.ServerConfig{
+		{
+			Name:        "github",
+			Command:     "this-command-does-not-exist",
+			Protocol:    "stdio",
+			Enabled:     true,
+			Quarantined: true,
+		},
+	}
+	require.NoError(t, config.SaveConfig(cfg, cfgPath))
+
+	rt, err := New(cfg, cfgPath, zap.NewNop())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rt.Close() })
+
+	// Persist the server so QuarantineServer's storage lookups succeed.
+	require.NoError(t, rt.storageManager.SaveUpstreamServer(cfg.Servers[0]))
+
+	// Seed two pending tools and one changed (rug-pull) tool.
+	require.NoError(t, rt.storageManager.SaveToolApproval(&storage.ToolApprovalRecord{
+		ServerName: "github", ToolName: "create_issue",
+		CurrentHash: "h1", Status: storage.ToolApprovalStatusPending,
+		CurrentDescription: "Creates issues", CurrentSchema: `{}`,
+	}))
+	require.NoError(t, rt.storageManager.SaveToolApproval(&storage.ToolApprovalRecord{
+		ServerName: "github", ToolName: "search_code",
+		CurrentHash: "h2", Status: storage.ToolApprovalStatusPending,
+		CurrentDescription: "Searches code", CurrentSchema: `{}`,
+	}))
+	require.NoError(t, rt.storageManager.SaveToolApproval(&storage.ToolApprovalRecord{
+		ServerName: "github", ToolName: "list_repos",
+		ApprovedHash: "old", CurrentHash: "new",
+		Status:             storage.ToolApprovalStatusChanged,
+		CurrentDescription: "MALICIOUS", PreviousDescription: "Lists repos", CurrentSchema: `{}`,
+	}))
+
+	// Unquarantine via the real entrypoint.
+	require.NoError(t, rt.QuarantineServer("github", false))
+
+	for _, name := range []string{"create_issue", "search_code"} {
+		rec, err := rt.storageManager.GetToolApproval("github", name)
+		require.NoError(t, err)
+		assert.Equal(t, storage.ToolApprovalStatusApproved, rec.Status,
+			"pending tool %s must be baseline-approved on unquarantine", name)
+		assert.Equal(t, "system:server-approval-baseline", rec.ApprovedBy)
+	}
+
+	changed, err := rt.storageManager.GetToolApproval("github", "list_repos")
+	require.NoError(t, err)
+	assert.Equal(t, storage.ToolApprovalStatusChanged, changed.Status,
+		"changed (rug-pull) tool must stay blocked after server unquarantine")
+}


### PR DESCRIPTION
## Summary

When a server is unquarantined/approved, MCPProxy now auto-promotes its `status=pending` (newly-discovered, never-reviewed) tool-approval records to `approved` — **baseline trust**. Approving a server means trusting its current tool snapshot. Tool-level quarantine is thereby reserved for `status=changed` (rug-pull) records only.

Trust model confirmed in parent **MCP-2081** (request_confirmation `7cfce731` accepted).

## Implementation

- New `Runtime.approveBaselineToolsForServer(serverName)` in `internal/runtime/tool_quarantine.go`: lists the server's `ToolApprovalRecord`s, promotes **`pending` only** to `approved` via the existing `ApproveTools` path (sets `ApprovedHash=CurrentHash`, runs `enforceInvariant`, emits activity + one SSE event). `approvedBy = "system:server-approval-baseline"`.
- Called from the `!quarantined` branch of `QuarantineServer` (`internal/runtime/lifecycle.go`), after persist+reload and **before** the re-index in `HandleUpstreamServerChange` so newly-trusted tools become immediately searchable. Best-effort: a promotion error logs a warning but does not abort an unquarantine the user already requested and that is already persisted.
- Covers the scan-approve path automatically (`ApproveServer` → `UnquarantineServer` → `QuarantineServer(false)`) — single insertion point, verified.

### Critical correctness constraint

Does **NOT** reuse `ApproveAllTools` (which promotes both `pending` AND `changed`). The baseline helper promotes **`pending` only**, so re-approving a server later never silently clears a genuine rug-pull `changed` flag — preserving Spec 032's guarantee.

## Tests (TDD — failing test written first)

`internal/runtime/tool_quarantine_baseline_test.go`:
- `TestApproveBaselineToolsForServer_PromotesPendingOnly` — N pending → N approved + 0 pending.
- `TestApproveBaselineToolsForServer_LeavesChangedUntouched` — seeded `changed` record stays `changed` (untouched); pending → approved.
- `TestQuarantineServer_Unquarantine_BaselineApprovesPending` — end-to-end via the real `QuarantineServer(name, false)` entrypoint, with a `changed` record left blocked.

## Verification

- `go test ./internal/runtime/... -race` — PASS (incl. `TestCalculateToolApprovalHash_Stability` canary)
- `go build ./...` — clean
- `./scripts/run-linter.sh` — 0 issues
- `./scripts/test-api-e2e.sh` — exit 0

## Docs

`docs/features/security-quarantine.md` updated to describe baseline-trust promotion of pending tools on unquarantine (and that `changed` rug-pull tools are unaffected).

Related #MCP-2100, #MCP-2081 (Spec 032).