### PR TITLE
feat(httpapi): expose default MCP instructions via /api/v1/status (MCP-2176)

### DIFF
--- a/internal/httpapi/contracts_test.go
+++ b/internal/httpapi/contracts_test.go
@@ -289,6 +289,10 @@ func (m *MockServerController) GetConfig() (*config.Config, error) {
 	}, nil
 }
 
+func (m *MockServerController) DefaultInstructions() string {
+	return "test built-in default: use retrieve_tools to discover tools"
+}
+
 // Readiness method
 func (m *MockServerController) IsReady() bool { return true }
 

--- a/internal/httpapi/routing_test.go
+++ b/internal/httpapi/routing_test.go
@@ -180,3 +180,33 @@ func TestHandleGetStatus_IncludesRoutingMode(t *testing.T) {
 		assert.Equal(t, config.RoutingModeRetrieveTools, resp.Data["routing_mode"])
 	})
 }
+
+// TestHandleGetStatus_IncludesDefaultInstructions verifies the status response
+// exposes the built-in default MCP instructions so the Web UI can render them as
+// the instructions textarea placeholder without hardcoding the text (MCP-2176).
+func TestHandleGetStatus_IncludesDefaultInstructions(t *testing.T) {
+	logger := zap.NewNop().Sugar()
+	mockCtrl := &mockRoutingController{apiKey: "test-key", routingMode: ""}
+	srv := NewServer(mockCtrl, logger, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+	req.Header.Set("X-API-Key", "test-key")
+	w := httptest.NewRecorder()
+
+	srv.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Success bool                   `json:"success"`
+		Data    map[string]interface{} `json:"data"`
+	}
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	require.True(t, resp.Success)
+
+	defaultInstructions, ok := resp.Data["default_instructions"].(string)
+	require.True(t, ok, "default_instructions must be present and a string")
+	assert.NotEmpty(t, defaultInstructions)
+	assert.Contains(t, defaultInstructions, "retrieve_tools")
+}

--- a/internal/httpapi/security_test.go
+++ b/internal/httpapi/security_test.go
@@ -361,3 +361,6 @@ func (m *baseController) GetOnboardingState() (*storage.OnboardingState, error) 
 }
 func (m *baseController) SaveOnboardingState(_ *storage.OnboardingState) error { return nil }
 func (m *baseController) GetActivationFirstMCPClient() (bool, []string)        { return false, nil }
+func (m *baseController) DefaultInstructions() string {
+	return "test built-in default: use retrieve_tools to discover tools"
+}

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -109,6 +109,10 @@ type ServerController interface {
 	ValidateConfig(cfg *config.Config) ([]config.ValidationError, error)
 	ApplyConfig(cfg *config.Config, cfgPath string) (*internalRuntime.ConfigApplyResult, error)
 	GetConfig() (*config.Config, error)
+	// DefaultInstructions returns the built-in default MCP instructions text
+	// (independent of any user-configured custom value), so /api/v1/status can
+	// surface it to the Web UI as the instructions placeholder (MCP-2176).
+	DefaultInstructions() string
 
 	// Token statistics
 	GetTokenSavings() (*contracts.ServerTokenMetrics, error)
@@ -912,6 +916,11 @@ func (s *Server) handleGetStatus(w http.ResponseWriter, _ *http.Request) {
 		"status":         s.controller.GetStatus(),
 		"routing_mode":   routingMode,
 		"timestamp":      time.Now().Unix(),
+		// MCP-2176: built-in default MCP instructions. The Web UI renders this
+		// as the instructions textarea placeholder so the displayed default
+		// never drifts from the backend's resolveInstructions("") value. Always
+		// the built-in default, never the user's current custom value.
+		"default_instructions": s.controller.DefaultInstructions(),
 	}
 
 	// Spec 044 (FR-018): expose process-level env_kind + env_markers so the

--- a/internal/server/mcp_instructions_test.go
+++ b/internal/server/mcp_instructions_test.go
@@ -17,6 +17,15 @@ func TestResolveInstructions_Custom(t *testing.T) {
 	assert.Equal(t, custom, result)
 }
 
+// TestServer_DefaultInstructions verifies the controller exposes the built-in
+// default (not a user's custom value) so /api/v1/status can surface it to the
+// Web UI placeholder without drift (MCP-2176).
+func TestServer_DefaultInstructions(t *testing.T) {
+	s := &Server{}
+	assert.Equal(t, defaultInstructions, s.DefaultInstructions())
+	assert.Contains(t, s.DefaultInstructions(), "retrieve_tools")
+}
+
 func TestDefaultInstructions_ContainsKeyTerms(t *testing.T) {
 	assert.Contains(t, defaultInstructions, "retrieve_tools")
 	assert.Contains(t, defaultInstructions, "search_servers")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2205,6 +2205,15 @@ func (s *Server) GetConfig() (*config.Config, error) {
 	return s.runtime.GetConfig()
 }
 
+// DefaultInstructions returns the built-in default MCP instructions text,
+// independent of any user-configured custom value. It backs the
+// /api/v1/status `default_instructions` field so the Web UI can render the
+// built-in default as the instructions placeholder without hardcoding the
+// text (MCP-2176). This mirrors resolveInstructions("").
+func (s *Server) DefaultInstructions() string {
+	return defaultInstructions
+}
+
 // ValidateConfig validates a configuration
 func (s *Server) ValidateConfig(cfg *config.Config) ([]config.ValidationError, error) {
 	return s.runtime.ValidateConfig(cfg)


### PR DESCRIPTION
## Summary
Backend half of **MCP-2175** (Web UI `instructions` textarea, frontend PR #651). Exposes the resolved built-in MCP `instructions` default via `/api/v1/status` so the frontend renders it as the textarea placeholder **without hardcoding the default text** (drift risk — explicit issue requirement).

## What changed
- **`internal/httpapi/server.go`**
  - Added `DefaultInstructions() string` to the `ServerController` interface.
  - `handleGetStatus` now sets `response["default_instructions"] = s.controller.DefaultInstructions()`.
- **`internal/server/server.go`**
  - Implemented `(*Server).DefaultInstructions()` returning the built-in `defaultInstructions` const (mirrors `resolveInstructions("")`).

The value is always the **built-in default**, never the user's current custom value, so the placeholder shows "what you'd get if you clear the box".

### Why a controller method (not a direct import)
`defaultInstructions`/`resolveInstructions` are unexported in package `server`, and `internal/server` already imports `internal/httpapi` — so a reverse import would create a cycle. The controller interface (already used by the handler) is the clean seam.

## Tests (TDD)
- `internal/httpapi/routing_test.go` — `TestHandleGetStatus_IncludesDefaultInstructions`: asserts the status response includes a non-empty `default_instructions` containing `retrieve_tools`.
- `internal/server/mcp_instructions_test.go` — `TestServer_DefaultInstructions`: asserts the controller method returns the built-in default.
- Test mocks (`baseController`, `MockServerController`) gain the new method.

## Verification
- `go build ./...` (personal edition) ✅
- `./scripts/run-linter.sh` → **0 issues** ✅
- `go test ./internal/httpapi/... -race` ✅ and `go test ./internal/server/` ✅ (E2E need the built `./mcpproxy` binary)
- `./scripts/test-api-e2e.sh` → **65/65 passed** ✅
- Live curl `/api/v1/status` → `default_instructions` present (865 chars, contains `retrieve_tools`, real built-in text) ✅

## Docs / OAS
`/api/v1/status` response data is a generic `object` (no schema change required); no annotated contract changed, so no OAS regeneration needed.

## Handshake with frontend
Frontend PR #651 already consumes `default_instructions` and degrades gracefully when absent. Once this lands, the real default appears as the placeholder (route-mocked Playwright `placeholder-default.spec.ts`).

Related #651, MCP-2176, MCP-2175

> Note: server-edition build (`-tags server`) is red on `origin/main` due to pre-existing `internal/teams/broker` (spec-074 credential store) — unrelated to this PR; personal edition builds clean.