### PR TITLE
fix(scanner): scan Docker-image servers in Trivy image mode (MCP-2398)

### DIFF
--- a/docs/cli/security-commands.md
+++ b/docs/cli/security-commands.md
@@ -374,11 +374,12 @@ mcpproxy security scan my-new-server --scanners nova-proximity,trivy-mcp
 
 Before running any scanner, mcpproxy determines *what to scan*. The resolver order is:
 
-1. **Docker-isolated servers** → extract `/app` (or the server's `WorkingDir`) from the running container.
-2. **Package-runner commands** (`npx`, `uvx`, `pipx`, `bunx`) → resolve from the local package cache (`~/.npm/_npx/…`, `~/.cache/uv/…`, etc.). This path is tried **first** for package runners.
-3. **Working directory** from the server config.
-4. **Arg-scan fallback** — iterate positional command args, accept the first one that exists as a directory AND contains a source marker (`package.json`, `pyproject.toml`, `setup.py`, `Cargo.toml`, `go.mod`, etc.).
-5. **Tool definitions only** — export the server's tool schemas to a temp dir and scan those (used for HTTP/SSE servers and as a last-resort fallback).
+1. **Docker-image servers** (`command: docker`, `args: [run, …, mcp/fetch]` — also `podman` / `docker container run`) → `source_method=container_image`. The scan target is the image reference itself. Image-capable scanners (Trivy) run in image mode (`trivy image mcp/fetch`) instead of scanning an empty source tree. Trivy resolves the image via the local daemon/containerd/podman, falling back to pulling it from the remote registry, so no Docker socket mount is needed.
+2. **Docker-isolated servers** → extract `/app` (or the server's `WorkingDir`) from the running container.
+3. **Package-runner commands** (`npx`, `uvx`, `pipx`, `bunx`) → resolve from the local package cache (`~/.npm/_npx/…`, `~/.cache/uv/…`, etc.). This path is tried **first** for package runners.
+4. **Working directory** from the server config.
+5. **Arg-scan fallback** — iterate positional command args, accept the first one that exists as a directory AND contains a source marker (`package.json`, `pyproject.toml`, `setup.py`, `Cargo.toml`, `go.mod`, etc.).
+6. **Tool definitions only** — export the server's tool schemas to a temp dir and scan those (used for HTTP/SSE servers and as a last-resort fallback).
 
 The `source_method` and `source_path` are recorded on the scan job and shown in both the text and JSON report. This is how you verify a scanner is examining the right directory.
 

--- a/internal/security/scanner/engine.go
+++ b/internal/security/scanner/engine.go
@@ -50,13 +50,14 @@ func NewEngine(docker *DockerRunner, registry *Registry, dataDir string, logger 
 
 // ScanRequest describes a scan to execute
 type ScanRequest struct {
-	ServerName  string
-	SourceDir   string            // Path to server source files (for "source" input)
-	DryRun      bool              // If true, don't affect quarantine state
-	ScannerIDs  []string          // Specific scanners to use (empty = all installed)
-	Env         map[string]string // Additional environment variables
-	ScanContext *ScanContext      // Context metadata (set by service)
-	ScanPass    int               // 1 = security scan (fast), 2 = supply chain audit (background)
+	ServerName     string
+	SourceDir      string            // Path to server source files (for "source" input)
+	ContainerImage string            // Docker image reference (for "container_image" input)
+	DryRun         bool              // If true, don't affect quarantine state
+	ScannerIDs     []string          // Specific scanners to use (empty = all installed)
+	Env            map[string]string // Additional environment variables
+	ScanContext    *ScanContext      // Context metadata (set by service)
+	ScanPass       int               // 1 = security scan (fast), 2 = supply chain audit (background)
 }
 
 // ScanCallback receives scan lifecycle events
@@ -349,6 +350,32 @@ func (e *Engine) executeScan(ctx context.Context, job *ScanJob, scanners []resol
 }
 
 // runSingleScanner executes one scanner and returns its report plus execution logs
+// scannerSupportsInput reports whether the scanner declares the given input type.
+func scannerSupportsInput(s *ScannerPlugin, input string) bool {
+	for _, in := range s.Inputs {
+		if in == input {
+			return true
+		}
+	}
+	return false
+}
+
+// effectiveScannerCommand returns the command to run for a scanner. When the
+// scan target is a Docker image (req.ContainerImage set) and the scanner both
+// declares the "container_image" input and provides an ImageCommand template,
+// the image-mode command is returned with "{{IMAGE}}" substituted for the image
+// reference. Otherwise the scanner's default (source-mode) Command is returned.
+func effectiveScannerCommand(s *ScannerPlugin, req ScanRequest) []string {
+	if req.ContainerImage == "" || len(s.ImageCommand) == 0 || !scannerSupportsInput(s, "container_image") {
+		return s.Command
+	}
+	out := make([]string, len(s.ImageCommand))
+	for i, tok := range s.ImageCommand {
+		out[i] = strings.ReplaceAll(tok, "{{IMAGE}}", req.ContainerImage)
+	}
+	return out
+}
+
 func (e *Engine) runSingleScanner(ctx context.Context, s *ScannerPlugin, req ScanRequest) (*ScanReport, scannerLogs, error) {
 	// In-process scanners run directly in Go — no Docker container, no source
 	// files required. They analyze the tool definitions exported to
@@ -465,7 +492,7 @@ func (e *Engine) runSingleScanner(ctx context.Context, s *ScannerPlugin, req Sca
 	cfg := ScannerRunConfig{
 		ContainerName:          GenerateContainerName(s.ID, req.ServerName),
 		Image:                  s.EffectiveImage(),
-		Command:                s.Command,
+		Command:                effectiveScannerCommand(s, req),
 		Env:                    env,
 		SourceDir:              req.SourceDir,
 		ReportDir:              reportDir,

--- a/internal/security/scanner/image_scan_test.go
+++ b/internal/security/scanner/image_scan_test.go
@@ -1,0 +1,147 @@
+package scanner
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestDockerImageFromCommand(t *testing.T) {
+	cases := []struct {
+		name string
+		info ServerInfo
+		want string
+	}{
+		{
+			name: "simple docker run",
+			info: ServerInfo{Command: "docker", Args: []string{"run", "-i", "--rm", "mcp/fetch"}},
+			want: "mcp/fetch",
+		},
+		{
+			name: "value flags before image, command after",
+			info: ServerInfo{Command: "docker", Args: []string{"run", "--rm", "-i", "-e", "FOO=bar", "ghcr.io/x/y:tag", "serve"}},
+			want: "ghcr.io/x/y:tag",
+		},
+		{
+			name: "podman with volume",
+			info: ServerInfo{Command: "podman", Args: []string{"run", "-v", "/tmp:/data", "mcp/time"}},
+			want: "mcp/time",
+		},
+		{
+			name: "name and attached long flag",
+			info: ServerInfo{Command: "docker", Args: []string{"run", "--name", "x", "--network=host", "mcp/git"}},
+			want: "mcp/git",
+		},
+		{
+			name: "absolute docker path",
+			info: ServerInfo{Command: "/usr/local/bin/docker", Args: []string{"run", "alpine"}},
+			want: "alpine",
+		},
+		{
+			name: "attached short env flag with equals",
+			info: ServerInfo{Command: "docker", Args: []string{"run", "-e", "A=1", "-eB=2", "mcp/x"}},
+			want: "mcp/x",
+		},
+		{
+			name: "combined boolean short flags",
+			info: ServerInfo{Command: "docker", Args: []string{"run", "-it", "mcp/x"}},
+			want: "mcp/x",
+		},
+		{
+			name: "docker container run subcommand",
+			info: ServerInfo{Command: "docker", Args: []string{"container", "run", "mcp/x"}},
+			want: "mcp/x",
+		},
+		{
+			name: "not a docker command",
+			info: ServerInfo{Command: "uvx", Args: []string{"mcp-server"}},
+			want: "",
+		},
+		{
+			name: "docker but not run",
+			info: ServerInfo{Command: "docker", Args: []string{"ps"}},
+			want: "",
+		},
+		{
+			name: "no image present",
+			info: ServerInfo{Command: "docker", Args: []string{"run", "--rm"}},
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := dockerImageFromCommand(tc.info); got != tc.want {
+				t.Errorf("dockerImageFromCommand() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveDockerRunImage(t *testing.T) {
+	r := NewSourceResolver(zap.NewNop())
+	resolved, err := r.Resolve(context.Background(), ServerInfo{
+		Name:     "fetch",
+		Protocol: "stdio",
+		Command:  "docker",
+		Args:     []string{"run", "-i", "--rm", "mcp/fetch"},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	defer resolved.Cleanup()
+	if resolved.Method != "container_image" {
+		t.Errorf("Method = %q, want container_image", resolved.Method)
+	}
+	if resolved.ContainerImage != "mcp/fetch" {
+		t.Errorf("ContainerImage = %q, want mcp/fetch", resolved.ContainerImage)
+	}
+	if resolved.SourceDir != "" {
+		t.Errorf("SourceDir = %q, want empty", resolved.SourceDir)
+	}
+}
+
+func TestScannerCommandForImage(t *testing.T) {
+	trivy := &ScannerPlugin{
+		ID:           "trivy-mcp",
+		Inputs:       []string{"source", "container_image"},
+		Command:      []string{"fs", "--format", "sarif", "/scan/source"},
+		ImageCommand: []string{"image", "--format", "sarif", "{{IMAGE}}"},
+	}
+
+	// Image present + scanner supports it → image-mode command with substitution.
+	got := effectiveScannerCommand(trivy, ScanRequest{ContainerImage: "mcp/fetch"})
+	want := []string{"image", "--format", "sarif", "mcp/fetch"}
+	if !equalSlice(got, want) {
+		t.Errorf("image-mode command = %v, want %v", got, want)
+	}
+
+	// No image → fall back to default source-mode command.
+	got = effectiveScannerCommand(trivy, ScanRequest{})
+	if !equalSlice(got, trivy.Command) {
+		t.Errorf("no-image command = %v, want %v", got, trivy.Command)
+	}
+
+	// Scanner without container_image support → keep its command even if an image is present.
+	semgrep := &ScannerPlugin{
+		ID:      "semgrep-mcp",
+		Inputs:  []string{"source"},
+		Command: []string{"semgrep", "scan", "/scan/source"},
+	}
+	got = effectiveScannerCommand(semgrep, ScanRequest{ContainerImage: "mcp/fetch"})
+	if !equalSlice(got, semgrep.Command) {
+		t.Errorf("non-image scanner command = %v, want %v", got, semgrep.Command)
+	}
+}
+
+func equalSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/security/scanner/registry_bundled.go
+++ b/internal/security/scanner/registry_bundled.go
@@ -152,7 +152,12 @@ var bundledScanners = []*ScannerPlugin{
 		RequiredEnv: nil,
 		OptionalEnv: nil,
 		Command:     []string{"fs", "--format", "sarif", "/scan/source"},
-		Timeout:     "300s", // First run downloads vuln DB (~90MB)
-		NetworkReq:  true,   // Needs to download vulnerability database
+		// For Docker-image servers (`docker run mcp/fetch`) scan the image itself
+		// instead of an empty source dir. Trivy resolves the image via the local
+		// daemon/containerd/podman and falls back to pulling from the remote
+		// registry (network is enabled), so no docker socket mount is required.
+		ImageCommand: []string{"image", "--format", "sarif", "{{IMAGE}}"},
+		Timeout:      "300s", // First run downloads vuln DB (~90MB)
+		NetworkReq:   true,   // Needs to download vulnerability database
 	},
 }

--- a/internal/security/scanner/service.go
+++ b/internal/security/scanner/service.go
@@ -645,6 +645,17 @@ func (s *Service) StartScan(ctx context.Context, serverName string, dryRun bool,
 				scanCtx.SourcePath = resolved.ServerURL
 			}
 			scanCtx.ContainerID = resolved.ContainerID
+			// Docker-image servers (`docker run mcp/fetch`): the scan target is the
+			// image itself, not a source dir. Carry the reference so image-capable
+			// scanners (Trivy) run in image mode, and surface it in the context.
+			if resolved.ContainerImage != "" {
+				req.ContainerImage = resolved.ContainerImage
+				scanCtx.ContainerImage = resolved.ContainerImage
+				scanCtx.DockerIsolation = true
+				if scanCtx.SourcePath == "" {
+					scanCtx.SourcePath = resolved.ContainerImage
+				}
+			}
 			// Determine Docker isolation status
 			if resolved.Method == "docker_extract" {
 				scanCtx.DockerIsolation = true
@@ -687,9 +698,10 @@ func (s *Service) StartScan(ctx context.Context, serverName string, dryRun bool,
 			tempDir, err := os.MkdirTemp("", "mcpproxy-scan-tools-")
 			if err == nil {
 				req.SourceDir = tempDir
-				// For HTTP/URL servers, preserve the "url" source method and path
-				// (the temp dir is only for tool definitions, not the real source)
-				if scanCtx.SourceMethod != "url" {
+				// For HTTP/URL and Docker-image servers, preserve the real source
+				// method and path — the temp dir is only for tool definitions, not
+				// the real scan target (the URL / the image).
+				if scanCtx.SourceMethod != "url" && scanCtx.SourceMethod != "container_image" {
 					scanCtx.SourceMethod = "tool_definitions_only"
 					scanCtx.SourcePath = tempDir
 				}
@@ -820,6 +832,14 @@ func (s *Service) startPass2(serverName string, serverInfo *ServerInfo) {
 			scanCtx.SourcePath = resolved.ServerURL
 		}
 		scanCtx.ContainerID = resolved.ContainerID
+		// Docker-image servers: scan the image (Trivy image mode reports OS-package
+		// and bundled-dependency CVEs). No source dir to enrich or export tools into.
+		if resolved.ContainerImage != "" {
+			req.ContainerImage = resolved.ContainerImage
+			scanCtx.ContainerImage = resolved.ContainerImage
+			scanCtx.SourcePath = resolved.ContainerImage
+			scanCtx.DockerIsolation = true
+		}
 		if resolved.Method == "docker_extract" {
 			scanCtx.DockerIsolation = true
 		}
@@ -828,8 +848,9 @@ func (s *Service) startPass2(serverName string, serverInfo *ServerInfo) {
 		scanCtx.TotalFiles = resolved.TotalFiles
 		scanCtx.TotalSizeBytes = resolved.TotalSize
 
-		// Export tool definitions for Cisco scanner
-		if s.serverInfo != nil {
+		// Export tool definitions for Cisco scanner (only when there is a real
+		// source dir to write tools.json into — image-only servers have none).
+		if s.serverInfo != nil && req.SourceDir != "" {
 			s.exportToolDefinitions(serverName, req.SourceDir)
 		}
 	} else {

--- a/internal/security/scanner/source_resolver.go
+++ b/internal/security/scanner/source_resolver.go
@@ -71,14 +71,15 @@ type ServerInfo struct {
 
 // ResolvedSource contains the resolved source information for scanning
 type ResolvedSource struct {
-	SourceDir   string   // Host directory containing source files
-	ContainerID string   // Docker container ID (if applicable)
-	ServerURL   string   // URL for mcp_connection input (HTTP/SSE servers)
-	Method      string   // How source was resolved: "docker_extract", "working_dir", "local_path", "url", "manual"
-	Cleanup     func()   // Cleanup function (removes temp dirs)
-	Files       []string // List of files found in source dir (capped)
-	TotalFiles  int      // Total file count
-	TotalSize   int64    // Total size in bytes
+	SourceDir      string   // Host directory containing source files
+	ContainerID    string   // Docker container ID (if applicable)
+	ContainerImage string   // Docker image reference (for "container_image" input)
+	ServerURL      string   // URL for mcp_connection input (HTTP/SSE servers)
+	Method         string   // How source was resolved: "docker_extract", "container_image", "working_dir", "local_path", "url", "manual"
+	Cleanup        func()   // Cleanup function (removes temp dirs)
+	Files          []string // List of files found in source dir (capped)
+	TotalFiles     int      // Total file count
+	TotalSize      int64    // Total size in bytes
 }
 
 // Resolve determines the source directory for scanning a server.
@@ -98,6 +99,26 @@ func (r *SourceResolver) Resolve(ctx context.Context, info ServerInfo) (*Resolve
 			}, nil
 		}
 		return nil, fmt.Errorf("HTTP server %s has no URL configured", info.Name)
+	}
+
+	// User-managed Docker-image servers (e.g. `docker run -i --rm mcp/fetch`).
+	// These are NOT mcpproxy-managed containers (which use uvx/npx commands wrapped
+	// in `mcpproxy-<name>-*` containers and are handled below). Here the user wired
+	// `docker run <image>` directly as the server command, so there is no source
+	// tree to extract and no managed container to diff — the scan target is the
+	// image itself. Surface it so scanners that accept a "container_image" input
+	// (Trivy) can scan the image instead of falling back to an empty source dir
+	// (which produced source_method=tool_definitions_only and zero scanning).
+	if image := dockerImageFromCommand(info); image != "" {
+		r.logger.Info("Resolved source as Docker image reference",
+			zap.String("server", info.Name),
+			zap.String("image", image),
+		)
+		return &ResolvedSource{
+			ContainerImage: image,
+			Method:         "container_image",
+			Cleanup:        func() {},
+		}, nil
 	}
 
 	// Stdio servers: try Docker container first
@@ -242,6 +263,81 @@ func isPackageRunnerCommand(command string) bool {
 		return true
 	}
 	return false
+}
+
+// dockerRunValueFlags lists the `docker run` / `podman run` flags that consume
+// the following argument as their value. Used by dockerImageFromCommand to skip
+// past flag values when locating the positional image reference. Flags not in
+// this set (and not containing "=") are treated as boolean (e.g. -i, -t, --rm),
+// consuming no extra token. Attached forms ("--flag=value", "-eFOO=bar") carry
+// their value inline and are detected by the "=" check, so they need no entry.
+var dockerRunValueFlags = map[string]bool{
+	// Short forms
+	"-e": true, "-v": true, "-p": true, "-u": true, "-w": true, "-l": true, "-m": true,
+	// Long forms
+	"--env": true, "--volume": true, "--publish": true, "--name": true,
+	"--workdir": true, "--entrypoint": true, "--network": true, "--net": true,
+	"--user": true, "--label": true, "--mount": true, "--env-file": true,
+	"--add-host": true, "--device": true, "--expose": true, "--hostname": true,
+	"--memory": true, "--memory-swap": true, "--cpus": true, "--cpu-shares": true,
+	"--cpuset-cpus": true, "--platform": true, "--pull": true, "--restart": true,
+	"--log-driver": true, "--log-opt": true, "--cap-add": true, "--cap-drop": true,
+	"--security-opt": true, "--tmpfs": true, "--ulimit": true, "--gpus": true,
+	"--dns": true, "--link": true, "--volumes-from": true, "--sysctl": true,
+	"--shm-size": true, "--stop-signal": true, "--stop-timeout": true,
+	"--pid": true, "--ipc": true, "--uts": true, "--userns": true,
+	"--cgroupns": true, "--group-add": true, "--runtime": true,
+	"--health-cmd": true, "--health-interval": true, "--health-timeout": true,
+	"--health-retries": true, "--health-start-period": true,
+}
+
+// dockerImageFromCommand returns the Docker/Podman image reference for a server
+// whose command is a literal `docker run <image>` (or `podman run <image>`, or
+// `docker container run <image>`). It returns "" when the command is not a
+// docker/podman run invocation or no positional image argument can be found.
+//
+// This handles the common case where a user wires an MCP server as
+// `command: "docker", args: ["run", "-i", "--rm", "mcp/fetch"]`. Such servers
+// are not mcpproxy-managed containers, so the running-container resolver finds
+// nothing; without this the scan degraded to tool-definitions-only and Trivy
+// scanned an empty directory.
+//
+// Flag handling follows docker's CLI grammar: flags containing "=" carry their
+// value inline; flags listed in dockerRunValueFlags consume the next token;
+// every other flag (and combined short booleans like -it) consumes no value.
+// The first non-flag token after `run` is the image; anything after it belongs
+// to the containerized command and is ignored.
+func dockerImageFromCommand(info ServerInfo) string {
+	base := strings.ToLower(filepath.Base(info.Command))
+	if base != "docker" && base != "podman" {
+		return ""
+	}
+
+	args := info.Args
+	// Skip an optional "container" management subcommand: `docker container run`.
+	if len(args) > 0 && args[0] == "container" {
+		args = args[1:]
+	}
+	if len(args) == 0 || args[0] != "run" {
+		return ""
+	}
+	args = args[1:]
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if strings.HasPrefix(arg, "-") {
+			if strings.Contains(arg, "=") {
+				continue // --flag=value / -eFOO=bar — value is inline
+			}
+			if dockerRunValueFlags[arg] {
+				i++ // consume the flag's value token
+			}
+			continue
+		}
+		// First positional argument after `run` is the image reference.
+		return arg
+	}
+	return ""
 }
 
 // isSourceFile returns true if the path looks like a source-code file by
@@ -767,6 +863,21 @@ func (r *SourceResolver) ResolveFullSource(ctx context.Context, info ServerInfo)
 			}, nil
 		}
 		return nil, fmt.Errorf("HTTP server %s has no URL configured", info.Name)
+	}
+
+	// User-managed Docker-image servers: scan the image, not a source tree.
+	// Pass 2 (supply chain audit) benefits most here — Trivy image mode reports
+	// CVEs in the image's OS packages and bundled dependencies.
+	if image := dockerImageFromCommand(info); image != "" {
+		r.logger.Info("Resolved full source as Docker image reference for Pass 2",
+			zap.String("server", info.Name),
+			zap.String("image", image),
+		)
+		return &ResolvedSource{
+			ContainerImage: image,
+			Method:         "container_image",
+			Cleanup:        func() {},
+		}, nil
 	}
 
 	// Stdio servers: try Docker container first — extract FULL container

--- a/internal/security/scanner/types.go
+++ b/internal/security/scanner/types.go
@@ -63,8 +63,13 @@ type ScannerPlugin struct {
 	RequiredEnv []EnvRequirement `json:"required_env"`
 	OptionalEnv []EnvRequirement `json:"optional_env"`
 	Command     []string         `json:"command"`
-	Timeout     string           `json:"timeout"`
-	NetworkReq  bool             `json:"network_required"`
+	// ImageCommand is the command template used when the scan target is a Docker
+	// image reference rather than a source directory (input "container_image").
+	// The token "{{IMAGE}}" is replaced with the image reference at runtime.
+	// Only consulted when the scanner declares "container_image" in Inputs.
+	ImageCommand []string `json:"image_command,omitempty"`
+	Timeout      string   `json:"timeout"`
+	NetworkReq   bool     `json:"network_required"`
 	// InProcess marks a Docker-less, built-in scanner that the engine runs
 	// in-process (e.g. the tool-description TPA analyzer). Such scanners have
 	// no Docker image to pull, are always "installed", and skip the


### PR DESCRIPTION
## Problem

A server wired as a direct Docker invocation — e.g.

```json
{ "name": "fetch", "command": "docker", "args": ["run", "-i", "--rm", "mcp/fetch"] }
```

is **not** an mcpproxy-managed container. The source resolver only looks for
`mcpproxy-<name>-*` containers, found none, and fell through to
`source_method=tool_definitions_only`. Trivy then ran `fs /scan/source` against
an empty temp dir → **0 results**. Docker-image MCP servers got effectively
**zero vulnerability scanning**.

## Fix

Detect the image reference from a `docker`/`podman run` command and resolve it
as a new `container_image` source method. Scanners that declare the
`container_image` input and provide an `ImageCommand` template (Trivy) now run
in **image mode** (`trivy image <ref>`), with `{{IMAGE}}` substituted at runtime.

Trivy resolves the image via the local daemon/containerd/podman and falls back
to pulling from the remote registry (network is already enabled for Trivy), so
**no Docker socket mount is required** — registry images like `mcp/fetch` work
out of the box.

### Changes (all in `internal/security/scanner/`, backend lane)
- **source_resolver.go** — `ResolvedSource.ContainerImage` + `dockerImageFromCommand` (docker CLI arg grammar: value-flags, `--flag=value` / attached forms, combined short booleans, `docker container run`). Wired into both `Resolve` (Pass 1) and `ResolveFullSource` (Pass 2).
- **types.go / registry_bundled.go** — `ScannerPlugin.ImageCommand`; Trivy gets `image --format sarif {{IMAGE}}`.
- **engine.go** — `ScanRequest.ContainerImage` + `effectiveScannerCommand` selects image-mode vs source-mode per scanner.
- **service.go** — carry the image into the scan request, preserve the `container_image` method past the tool-definitions temp dir, and don't abort image scans even with 0 tools exported.
- **docs/cli/security-commands.md** — document the new resolution step (ENG-9).

Non-image scanners (Semgrep, Cisco) are unchanged — they keep scanning the
exported tool definitions. The Web UI already renders `source_method` and a
`container_image` badge generically, so no frontend change is required.

## Tests (TDD)
New `image_scan_test.go`:
- `TestDockerImageFromCommand` — 11 cases (docker/podman, value flags, attached `=`, combined booleans, `container run`, negatives).
- `TestResolveDockerRunImage` — `Resolve` returns `container_image` + image ref.
- `TestScannerCommandForImage` — Trivy → image command w/ substitution; no image → source command; non-image scanner unchanged.

## Verification
```
go test ./internal/security/... -race            # ok
go test ./internal/httpapi/... -race             # ok
golangci-lint run --config .github/.golangci.yml ./internal/security/scanner/...  # 0 issues
go build ./...                                    # ok
```
Note: `go build -tags server ./...` fails in `internal/teams/broker` (undefined `CredentialStore`/`UpstreamCredential`) — **pre-existing on origin/main** (PR #602 dependency), unrelated to this change and outside this lane.

Related MCP-2398