### PR TITLE
fix(test): make e2e API-key extraction robust to NUL/ANSI log bytes (MCP-2404)

### DIFF
--- a/scripts/test-api-e2e.sh
+++ b/scripts/test-api-e2e.sh
@@ -113,9 +113,14 @@ log_fail() {
 }
 
 # Extract API key from server logs
+# Optional $1 overrides the log path (used by scripts/test-extract-api-key.sh).
+# -a forces grep to treat the log as text: the server log can contain NUL bytes
+# (and ANSI color codes), which otherwise make grep report "Binary file ... matches"
+# instead of the match, corrupting API_KEY. See MCP-2404.
 extract_api_key() {
-    if [ -f "/tmp/mcpproxy_e2e.log" ]; then
-        API_KEY=$(grep -o '"api_key": "[^"]*"' "/tmp/mcpproxy_e2e.log" | sed 's/.*"api_key": "\([^"]*\)".*/\1/' | head -1)
+    local log_file="${1:-/tmp/mcpproxy_e2e.log}"
+    if [ -f "$log_file" ]; then
+        API_KEY=$(grep -ao '"api_key": "[^"]*"' "$log_file" | sed 's/.*"api_key": "\([^"]*\)".*/\1/' | head -1)
         if [ ! -z "$API_KEY" ]; then
             echo "Extracted API key: ${API_KEY:0:8}..."
         fi

--- a/scripts/test-extract-api-key.sh
+++ b/scripts/test-extract-api-key.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#
+# Unit test for extract_api_key() in scripts/test-api-e2e.sh (MCP-2404).
+#
+# The server log can contain NUL bytes and ANSI color codes. Without `grep -a`,
+# grep treats the log as binary and emits "Binary file ... matches" instead of
+# the match, so API_KEY becomes garbage and every authed curl is rejected.
+#
+# This test extracts the *real* extract_api_key() function from test-api-e2e.sh
+# (so it stays in lockstep with the code under test) and runs it against a
+# fixture log that mixes ANSI escapes, a NUL byte, and the api_key line.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="$SCRIPT_DIR/test-api-e2e.sh"
+
+if [ ! -f "$TARGET" ]; then
+    echo "FAIL: cannot find $TARGET"
+    exit 1
+fi
+
+# Pull just the extract_api_key() function out of the real script and load it,
+# without executing the rest of the (top-level) integration script.
+FUNC_SRC="$(awk '/^extract_api_key\(\) \{/,/^\}/' "$TARGET")"
+if [ -z "$FUNC_SRC" ]; then
+    echo "FAIL: could not extract extract_api_key() from $TARGET"
+    exit 1
+fi
+eval "$FUNC_SRC"
+
+EXPECTED_KEY="4197c426deadbeef0123456789abcdef"
+FIXTURE="$(mktemp -t mcpproxy_e2e_fixture.XXXXXX)"
+trap 'rm -f "$FIXTURE"' EXIT
+
+# Build a fixture log that reproduces the real-world failure: ANSI color codes
+# plus an embedded NUL byte, then the api_key line.
+{
+    printf '\033[0;34m2026-06-14T12:00:00\033[0m starting server\n'
+    printf 'some binary noise: \x00\x00 end\n'
+    printf '{"level":"info","api_key": "%s","listen":"127.0.0.1:8081"}\n' "$EXPECTED_KEY"
+} > "$FIXTURE"
+
+# Sanity check: the fixture really does contain a NUL byte (the trigger).
+if ! grep -qa $'\x00' "$FIXTURE"; then
+    echo "FAIL: fixture is missing the NUL byte that triggers the bug"
+    exit 1
+fi
+
+API_KEY=""
+extract_api_key "$FIXTURE" > /dev/null
+
+if [ "$API_KEY" = "$EXPECTED_KEY" ]; then
+    echo "PASS: extract_api_key() returned the key from a NUL/ANSI log ($EXPECTED_KEY)"
+    exit 0
+else
+    echo "FAIL: expected '$EXPECTED_KEY' but got '$API_KEY'"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
Local QA harness fix (not a product bug). `./scripts/test-api-e2e.sh` deterministically exits 1 at startup on local macOS — 30× "server not ready yet" with `Extracted API key: Binary f...` — so no tests run.

## Root cause
`extract_api_key()` used `grep -o '"api_key": "[^"]*"'` over `/tmp/mcpproxy_e2e.log`. The server log can contain a NUL byte (and ANSI color codes), so `grep` treats the file as binary and emits `Binary file … matches` instead of the match. That string becomes `$API_KEY` → every authed curl is rejected → `wait_for_server` times out → exit 1. CI uses a different log path, so it slips through there.

## Fix
- Add `-a` to the `grep` so it always treats the log as text.
- Parameterize the log path (optional `$1`, defaults to the existing hardcoded path) so the function is unit-testable; all existing no-arg callers are unaffected.
- Add `scripts/test-extract-api-key.sh`, which extracts the **real** `extract_api_key()` from `test-api-e2e.sh` and asserts it recovers the key from a fixture log containing ANSI escapes + a NUL byte.

## Verification (TDD)
- RED — against the unfixed `grep`: `FAIL: ... got 'Binary file /…/mcpproxy_e2e_fixture… matches'` (reproduces the exact symptom).
- GREEN — against the fix: `PASS: extract_api_key() returned the key from a NUL/ANSI log`.
- `bash -n` clean on both files; `shellcheck` clean on the new test.

No Go / CLI / REST / MCP / config / docs surface is touched.

Related MCP-2404