### PR TITLE
fix(scanner): ramparts scan fails closed on garbled tools.json or scan error

### DIFF
--- a/docker/scanners/ramparts/entrypoint.sh
+++ b/docker/scanners/ramparts/entrypoint.sh
@@ -62,10 +62,12 @@ if [ ! -s "$REPORT" ]; then
 fi
 
 # Validate $REPORT is a GENUINE Ramparts report, not an error payload. A real
-# report carries a top-level "security_issues" object and a "yara_results"
-# array (mirrors the engine's isRampartsOutput() probe). An error/garbled JSON
-# lacks these; without this gate it would parse as 0 findings = a spurious clean
-# scan (fail-open). python3 is already in the image for the replay shim.
+# report carries a top-level "security_issues" OBJECT (with the tool/prompt/
+# resource issue arrays) and a "yara_results" ARRAY. We TYPE-check, not just
+# presence-check: an error payload such as {"security_issues":"scan failed"}
+# has the key present but the wrong type and must fail CLOSED — a presence-only
+# gate would wave it through as a spurious clean scan (MCP-2443 re-review).
+# python3 is already in the image for the replay shim.
 if ! python3 - "$REPORT" <<'PY'
 import json, sys
 try:
@@ -75,9 +77,10 @@ except (OSError, ValueError) as exc:
     print(f"report is not valid JSON: {exc}", file=sys.stderr)
     sys.exit(1)
 if (not isinstance(data, dict)
-        or data.get("security_issues") is None
+        or not isinstance(data.get("security_issues"), dict)
         or not isinstance(data.get("yara_results"), list)):
-    print("report lacks security_issues/yara_results (error payload or wrong shape)", file=sys.stderr)
+    print("report is not a Ramparts report: security_issues must be an object "
+          "and yara_results an array (error payload or wrong shape)", file=sys.stderr)
     sys.exit(1)
 sys.exit(0)
 PY

--- a/docker/scanners/ramparts/entrypoint.sh
+++ b/docker/scanners/ramparts/entrypoint.sh
@@ -24,19 +24,69 @@
 # them at /scan and WORKDIR is /scan (see Dockerfile).
 set -u
 
-REPORT=/scan/report/results.json
+# Overridable so the test harness (entrypoint_test.sh) can run without Docker.
+REPORT_DIR="${REPORT_DIR:-/scan/report}"
+REPLAY="${MCP_REPLAY:-/usr/local/bin/mcp-replay.py}"
+REPORT="$REPORT_DIR/results.json"
+RAMPARTS_STDERR="$REPORT_DIR/ramparts.stderr"
+
+# fail_closed marks the scan as FAILED. The Go scanner runner ignores the
+# container exit code (docker.go RunScanner returns nil for a non-zero exit),
+# so a non-zero exit alone is NOT enough — it reads whatever report file exists.
+# We therefore DELETE the report so the engine finds no output and records the
+# scanner as failed instead of parsing a stale/error payload as a clean scan
+# (MCP-2443: defeat the fail-open).
+fail_closed() {
+  echo "ramparts scan FAILED (fail-closed): $1" >&2
+  echo "ramparts exit code: ${rc:-unknown}" >&2
+  if [ -f "$RAMPARTS_STDERR" ]; then
+    echo "--- ramparts stderr ---" >&2
+    cat "$RAMPARTS_STDERR" >&2 2>/dev/null || true
+  fi
+  rm -f "$REPORT"
+  exit 1
+}
 
 # `scan`'s --format accepts json|raw|table|text (no sarif) and has no --output
 # flag, so emit native JSON to stdout and capture it. MCPProxy's engine parses
 # the Ramparts JSON shape ({security_issues{...}, yara_results[]}) directly.
-# A non-zero exit from findings/offline-LLM is expected and tolerated by the
-# engine as long as a report was produced, so don't let `set -e` abort here.
-ramparts scan "stdio:python3:/usr/local/bin/mcp-replay.py" \
+# Ramparts may exit non-zero to signal findings/offline-LLM, so capture the code
+# rather than abort; the gate below is the report's shape, not the bare exit.
+ramparts scan "stdio:python3:$REPLAY" \
   --format json \
-  > "$REPORT" 2>/scan/report/ramparts.stderr || true
+  > "$REPORT" 2>"$RAMPARTS_STDERR"
+rc=$?
 
 if [ ! -s "$REPORT" ]; then
-  echo "ramparts produced no report; stderr follows:" >&2
-  cat /scan/report/ramparts.stderr >&2 2>/dev/null || true
-  exit 1
+  fail_closed "ramparts produced no report"
+fi
+
+# Validate $REPORT is a GENUINE Ramparts report, not an error payload. A real
+# report carries a top-level "security_issues" object and a "yara_results"
+# array (mirrors the engine's isRampartsOutput() probe). An error/garbled JSON
+# lacks these; without this gate it would parse as 0 findings = a spurious clean
+# scan (fail-open). python3 is already in the image for the replay shim.
+if ! python3 - "$REPORT" <<'PY'
+import json, sys
+try:
+    with open(sys.argv[1], "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+except (OSError, ValueError) as exc:
+    print(f"report is not valid JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
+if (not isinstance(data, dict)
+        or data.get("security_issues") is None
+        or not isinstance(data.get("yara_results"), list)):
+    print("report lacks security_issues/yara_results (error payload or wrong shape)", file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+PY
+then
+  fail_closed "report is not a valid Ramparts report (error payload or wrong shape)"
+fi
+
+# A valid report with rc != 0 means Ramparts signalled findings/offline-LLM — a
+# real result we keep. (rc != 0 with no valid report already failed above.)
+if [ "$rc" -ne 0 ]; then
+  echo "ramparts exited $rc but produced a valid report (findings/offline-LLM); keeping it" >&2
 fi

--- a/docker/scanners/ramparts/entrypoint_test.sh
+++ b/docker/scanners/ramparts/entrypoint_test.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+# Tests for entrypoint.sh fail-closed behavior (MCP-2443).
+#
+# Run: sh docker/scanners/ramparts/entrypoint_test.sh
+#
+# These stub the `ramparts` binary on PATH so we can drive every report/exit
+# combination without Docker or the real scanner, and assert the entrypoint
+# fails CLOSED (non-zero exit AND no report left for the engine to read) on a
+# failed/garbled scan, while keeping a genuine report (even when Ramparts exits
+# non-zero to signal findings).
+set -u
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+ENTRYPOINT="$HERE/entrypoint.sh"
+PASS=0
+FAIL=0
+
+# Build a throwaway stub-bin dir with a `ramparts` that emits a chosen payload
+# (env REPORT_BODY) and exit code (env STUB_RC) to stdout, which the entrypoint
+# redirects into the report file.
+STUBDIR=$(mktemp -d)
+cat > "$STUBDIR/ramparts" <<'STUB'
+#!/bin/sh
+printf '%s' "$REPORT_BODY"
+exit "${STUB_RC:-0}"
+STUB
+chmod +x "$STUBDIR/ramparts"
+
+VALID='{"url":"stdio:replay","security_issues":{"tool_issues":[]},"yara_results":[]}'
+VALID_FINDING='{"url":"stdio:replay","security_issues":{"tool_issues":[{"message":"poison"}]},"yara_results":[]}'
+ERROR_PAYLOAD='{"error":"failed to connect to MCP endpoint","code":1}'
+GARBLED='{not valid json'
+
+# run_case <name> <stub_rc> <report_body> <expect_exit> <expect_report_present:yes|no>
+run_case() {
+  name=$1; rc=$2; body=$3; want_exit=$4; want_report=$5
+  rundir=$(mktemp -d)
+  REPORT_DIR="$rundir" STUB_RC="$rc" REPORT_BODY="$body" \
+    PATH="$STUBDIR:$PATH" sh "$ENTRYPOINT" >/dev/null 2>&1
+  got_exit=$?
+  if [ -s "$rundir/results.json" ]; then got_report=yes; else got_report=no; fi
+  ok=1
+  [ "$got_exit" -eq "$want_exit" ] || ok=0
+  [ "$got_report" = "$want_report" ] || ok=0
+  if [ "$ok" -eq 1 ]; then
+    PASS=$((PASS + 1)); echo "PASS $name"
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL $name: exit got=$got_exit want=$want_exit; report got=$got_report want=$want_report"
+  fi
+  rm -rf "$rundir"
+}
+
+# Acceptance: a valid report with a real finding scans and reports normally.
+run_case "valid_report_rc0_kept"           0 "$VALID"         0 yes
+run_case "valid_finding_report_rc0_kept"   0 "$VALID_FINDING" 0 yes
+# Ramparts may exit non-zero to signal findings/offline-LLM; a valid report
+# must be kept, not discarded.
+run_case "valid_report_nonzero_rc_kept"    1 "$VALID_FINDING" 0 yes
+# Acceptance: non-zero ramparts exit with an error payload -> scan failure.
+run_case "error_payload_nonzero_fails"     1 "$ERROR_PAYLOAD" 1 no
+# Error payload even on rc 0 must not be accepted as a clean report.
+run_case "error_payload_rc0_fails"         0 "$ERROR_PAYLOAD" 1 no
+# Acceptance: empty/garbled report -> scan marked failed (report removed).
+run_case "empty_report_fails"              1 ""               1 no
+run_case "garbled_report_fails"            1 "$GARBLED"       1 no
+
+rm -rf "$STUBDIR"
+echo
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/docker/scanners/ramparts/entrypoint_test.sh
+++ b/docker/scanners/ramparts/entrypoint_test.sh
@@ -30,6 +30,11 @@ VALID='{"url":"stdio:replay","security_issues":{"tool_issues":[]},"yara_results"
 VALID_FINDING='{"url":"stdio:replay","security_issues":{"tool_issues":[{"message":"poison"}]},"yara_results":[]}'
 ERROR_PAYLOAD='{"error":"failed to connect to MCP endpoint","code":1}'
 GARBLED='{not valid json'
+# Type-confusion error payloads: the expected keys are PRESENT but carry the
+# wrong type (a status string, not the real result object/array). A presence-only
+# gate would wave these through as clean (MCP-2443 re-review).
+STRING_SECISSUES='{"url":"stdio:replay","security_issues":"scan failed","yara_results":[]}'
+STRING_YARA='{"url":"stdio:replay","security_issues":{"tool_issues":[]},"yara_results":"oops"}'
 
 # run_case <name> <stub_rc> <report_body> <expect_exit> <expect_report_present:yes|no>
 run_case() {
@@ -64,6 +69,9 @@ run_case "error_payload_rc0_fails"         0 "$ERROR_PAYLOAD" 1 no
 # Acceptance: empty/garbled report -> scan marked failed (report removed).
 run_case "empty_report_fails"              1 ""               1 no
 run_case "garbled_report_fails"            1 "$GARBLED"       1 no
+# Type-confusion: keys present but wrong type must fail closed, not read clean.
+run_case "string_security_issues_fails"    0 "$STRING_SECISSUES" 1 no
+run_case "string_yara_results_fails"       0 "$STRING_YARA"      1 no
 
 rm -rf "$STUBDIR"
 echo

--- a/docker/scanners/ramparts/mcp-replay.py
+++ b/docker/scanners/ramparts/mcp-replay.py
@@ -35,21 +35,46 @@ def log(msg):
     print(f"[mcp-replay] {msg}", file=sys.stderr, flush=True)
 
 
-def load_tools():
-    """Read the captured tool definitions. Returns a list of MCP tool objects.
+class ToolsLoadError(Exception):
+    """Raised when tools.json cannot be loaded into a usable tool list.
 
-    Tolerant of a missing/empty/garbled file: an empty tool list still lets the
-    handshake complete so Ramparts emits a (clean) report instead of a connect
-    error.
+    This is the fail-CLOSED signal: rather than serve 0 tools (which makes
+    Ramparts emit a spurious "clean" report and defeats the security gate —
+    MCP-2443), the shim aborts so Ramparts sees a dead endpoint and the
+    entrypoint marks the scan as failed.
+    """
+
+
+def load_tools():
+    """Read the captured tool definitions. Returns a non-empty list of MCP
+    tool objects.
+
+    Fails CLOSED (raises ToolsLoadError) when the captured definitions are
+    missing, unreadable, empty, not valid JSON, the wrong shape, or yield zero
+    usable tools. mcpproxy only writes /scan/source/tools.json when it captured
+    at least one named tool (Service.exportToolDefinitions), so any of these
+    conditions means a broken/garbled input — NOT a legitimate clean scan.
     """
     try:
         with open(TOOLS_PATH, "r", encoding="utf-8") as fh:
-            data = json.load(fh)
-    except (OSError, ValueError) as exc:
-        log(f"could not read {TOOLS_PATH}: {exc}; serving 0 tools")
-        return []
+            raw_bytes = fh.read()
+    except OSError as exc:
+        raise ToolsLoadError(f"could not read {TOOLS_PATH}: {exc}")
 
-    raw = data.get("tools", []) if isinstance(data, dict) else []
+    if not raw_bytes.strip():
+        raise ToolsLoadError(f"{TOOLS_PATH} is empty")
+
+    try:
+        data = json.loads(raw_bytes)
+    except ValueError as exc:
+        raise ToolsLoadError(f"{TOOLS_PATH} is not valid JSON: {exc}")
+
+    if not isinstance(data, dict):
+        raise ToolsLoadError(f"{TOOLS_PATH} root is {type(data).__name__}, expected an object")
+    raw = data.get("tools")
+    if not isinstance(raw, list):
+        raise ToolsLoadError(f"{TOOLS_PATH} has no \"tools\" array (got {type(raw).__name__})")
+
     tools = []
     for entry in raw:
         if not isinstance(entry, dict) or not entry.get("name"):
@@ -64,6 +89,9 @@ def load_tools():
         if entry.get("annotations"):
             tool["annotations"] = entry["annotations"]
         tools.append(tool)
+
+    if not tools:
+        raise ToolsLoadError(f"{TOOLS_PATH} yielded 0 usable tools (none had a name)")
     return tools
 
 
@@ -111,7 +139,14 @@ def handle(msg, tools):
 
 
 def main():
-    tools = load_tools()
+    try:
+        tools = load_tools()
+    except ToolsLoadError as exc:
+        # Fail CLOSED: abort before the handshake so Ramparts cannot complete a
+        # scan and report it clean. Exit code 2 distinguishes a load failure
+        # from a normal exit; the entrypoint propagates this as a scan failure.
+        log(f"FATAL: {exc}; aborting (fail-closed)")
+        return 2
     log(f"serving {len(tools)} captured tool definition(s) from {TOOLS_PATH}")
     for line in sys.stdin:
         line = line.strip()

--- a/docker/scanners/ramparts/mcp-replay_test.py
+++ b/docker/scanners/ramparts/mcp-replay_test.py
@@ -111,13 +111,75 @@ def test_unknown_method_returns_jsonrpc_error():
     assert resp is not None and resp["error"]["code"] == -32601, resp
 
 
-def test_missing_tools_file_serves_empty_list():
-    # Point at a path that does not exist; handshake must still complete.
-    env = dict(os.environ, RAMPARTS_REPLAY_TOOLS="/nonexistent/tools.json")
-    stdin = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}) + "\n"
-    proc = subprocess.run([sys.executable, SHIM], input=stdin, capture_output=True, text=True, env=env, timeout=15)
+def run_shim_raw(stdin, tools_bytes=None, no_file=False):
+    """Run the shim against a raw tools.json byte payload (or no file at all)
+    and return (decoded_stdout_frames, stderr, returncode)."""
+    if no_file:
+        env = dict(os.environ, RAMPARTS_REPLAY_TOOLS="/nonexistent/tools.json")
+        proc = subprocess.run([sys.executable, SHIM], input=stdin, capture_output=True, text=True, env=env, timeout=15)
+    else:
+        with tempfile.NamedTemporaryFile("wb", suffix=".json", delete=False) as fh:
+            fh.write(tools_bytes if tools_bytes is not None else b"")
+            tools_path = fh.name
+        try:
+            env = dict(os.environ, RAMPARTS_REPLAY_TOOLS=tools_path)
+            proc = subprocess.run([sys.executable, SHIM], input=stdin, capture_output=True, text=True, env=env, timeout=15)
+        finally:
+            os.unlink(tools_path)
     out = [json.loads(ln) for ln in proc.stdout.splitlines() if ln.strip()]
-    assert by_id(out, 1)["result"]["tools"] == [], out
+    return out, proc.stderr, proc.returncode
+
+
+HANDSHAKE = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}) + "\n"
+
+
+def test_missing_tools_file_fails_closed():
+    # A missing tools.json is a pipeline failure, not a clean zero-tool server:
+    # the shim must exit non-zero and serve NO frames so Ramparts cannot emit a
+    # spurious "clean" report (fail CLOSED — MCP-2443).
+    out, stderr, rc = run_shim_raw(HANDSHAKE, no_file=True)
+    assert rc != 0, f"missing file must exit non-zero, got rc={rc}"
+    assert out == [], f"must serve no frames on fail-closed, got {out}"
+    assert "tools.json" in stderr, stderr
+
+
+def test_empty_file_fails_closed():
+    out, stderr, rc = run_shim_raw(HANDSHAKE, tools_bytes=b"")
+    assert rc != 0, f"empty file must exit non-zero, got rc={rc}"
+    assert out == [], out
+
+
+def test_garbled_json_fails_closed():
+    out, _stderr, rc = run_shim_raw(HANDSHAKE, tools_bytes=b"{not json at all")
+    assert rc != 0, f"garbled json must exit non-zero, got rc={rc}"
+    assert out == [], out
+
+
+def test_wrong_shape_fails_closed():
+    # Valid JSON but not the expected {"tools": [...]} document.
+    for payload in (b'[]', b'{"error": "boom"}', b'{"tools": "notalist"}', b'"a string"'):
+        out, _stderr, rc = run_shim_raw(HANDSHAKE, tools_bytes=payload)
+        assert rc != 0, f"wrong-shape {payload!r} must exit non-zero, got rc={rc}"
+        assert out == [], f"{payload!r} -> {out}"
+
+
+def test_empty_tool_list_fails_closed():
+    # {"tools": []} (or a list whose entries are all malformed) yields zero
+    # usable tools — nothing to scan, so fail closed rather than report clean.
+    for payload in (b'{"tools": []}', b'{"tools": [{"description": "no name"}]}'):
+        out, _stderr, rc = run_shim_raw(HANDSHAKE, tools_bytes=payload)
+        assert rc != 0, f"zero usable tools {payload!r} must exit non-zero, got rc={rc}"
+        assert out == [], f"{payload!r} -> {out}"
+
+
+def test_partial_garble_with_real_tool_still_scans():
+    # A list with one malformed entry but at least one real tool must scan
+    # normally (don't fail the whole scan over a single bad entry).
+    payload = json.dumps({"tools": [{"description": "no name"}, {"name": "real_tool"}]}).encode()
+    out, _stderr, rc = run_shim_raw(HANDSHAKE, tools_bytes=payload)
+    assert rc == 0, f"a real tool present must scan (rc=0), got rc={rc}"
+    tools = by_id(out, 1)["result"]["tools"]
+    assert {t["name"] for t in tools} == {"real_tool"}, tools
 
 
 def main():

--- a/docs/features/scanner-images.md
+++ b/docs/features/scanner-images.md
@@ -98,6 +98,22 @@ JSON output (`{security_issues, yara_results}`) is parsed directly by
 `internal/security/scanner/engine.go`. LLM-backed analysis stays out of scope,
 so the scanner runs fully offline (`NetworkReq: false`).
 
+**Fail-closed (MCP-2443).** The scanner must never report a broken run as a
+clean scan. Because the Go runner ignores the container's exit code, the
+entrypoint enforces this by **deleting the report** on any failure so the
+engine records the scanner as *failed* rather than parsing a stale/error
+payload as zero findings:
+
+- `mcp-replay.py` aborts (non-zero exit, serves no tools) when
+  `/scan/source/tools.json` is missing, empty, not valid JSON, the wrong shape,
+  or yields zero usable tools — instead of replaying an empty tool list that
+  would make Ramparts emit a spurious clean report.
+- `entrypoint.sh` validates that the captured output is a genuine Ramparts
+  report (a top-level `security_issues` object and `yara_results` array, the
+  same shape `isRampartsOutput()` probes). An error payload, garbled JSON, or
+  empty output marks the scan failed. A non-zero Ramparts exit accompanied by a
+  *valid* report is kept (Ramparts signals findings/offline-LLM that way).
+
 ## Background image pull UX
 
 MCPProxy pulls these images lazily:


### PR DESCRIPTION
## Problem (MCP-2443, [SEC] HIGH)

The Ramparts docker scanner **failed OPEN**: a broken/garbled input or a ramparts failure was reported as a *clean, zero-finding* scan, silently defeating the security gate.

Two root causes:
1. `mcp-replay.py` returned `[]` tools when `/scan/source/tools.json` was missing / empty / garbled / wrong-shape → Ramparts completed a handshake against an empty tool list and emitted a "clean" report.
2. `entrypoint.sh` masked the ramparts exit code (`|| true`) and accepted any non-empty file (`[ -s REPORT ]`) as success → a failed scan that wrote a non-empty **error** JSON was treated as a successful report.

Compounding it: the Go runner **ignores the container exit code** (`docker.go` `RunScanner` returns `nil` for a non-zero exit) and marks a scan failed only when *no readable report exists*. So `exit 1` alone is not enough — the engine reads whatever report file is present.

## Fix — fail CLOSED

- **`mcp-replay.py`**: `load_tools()` now raises `ToolsLoadError` and the shim exits non-zero **serving no frames** when `tools.json` is unreadable / empty / invalid JSON / wrong-shape / yields zero usable tools. Ramparts then sees a dead endpoint instead of an empty tool list. A partially-garbled file with ≥1 real tool still scans.
- **`entrypoint.sh`**: captures the ramparts exit code, then validates the output is a **genuine Ramparts report** (top-level `security_issues` object + `yara_results` array — the same shape `isRampartsOutput()` probes). On any failure it **deletes the report** so the engine finds no output and records the scanner as *failed*, instead of parsing a stale/error payload as 0 findings. A non-zero ramparts exit **with a valid report** is kept (findings/offline-LLM signal that way — discarding it would lose real detections).

## Acceptance

| Criterion | Covered by |
|---|---|
| Garbled/empty `tools.json` → non-zero exit, scan failed (not clean) | `mcp-replay_test.py`: `test_{empty_file,garbled_json,wrong_shape,empty_tool_list,missing_tools_file}_fails_closed` |
| Non-zero ramparts exit / error payload → propagated as scan failure | `entrypoint_test.sh`: `error_payload_nonzero_fails`, `error_payload_rc0_fails`, `empty_report_fails`, `garbled_report_fails` |
| Valid `tools.json` with a real finding still scans + reports | `mcp-replay_test.py`: `test_partial_garble_with_real_tool_still_scans`; `entrypoint_test.sh`: `valid_*_kept` |

## Verification (local)

```
$ python3 docker/scanners/ramparts/mcp-replay_test.py   →  11/11 passed
$ sh docker/scanners/ramparts/entrypoint_test.sh        →  7 passed, 0 failed
$ shellcheck docker/scanners/ramparts/entrypoint*.sh    →  clean (exit 0)
```

Docs updated: `docs/features/scanner-images.md` (fail-closed section).

## Notes
- No Go changes; behavior is enforced in the scanner container assets. The Dockerfile `COPY`s only `entrypoint.sh`/`mcp-replay.py`, so the new `*_test.sh`/`*_test.py` files don't enter the image.
- Follow-up (Release lane): wire `mcp-replay_test.py` + `entrypoint_test.sh` into `scanner-images.yml` CI (they currently run locally only).

Related MCP-2443