### PR TITLE
fix(scanner): spec-parsing + version-pin correctness in package-runner source resolution (MCP-2445)

### DIFF
--- a/docker/scanners/cisco/Dockerfile
+++ b/docker/scanners/cisco/Dockerfile
@@ -14,11 +14,12 @@ LABEL org.opencontainers.image.source="https://github.com/smart-mcp-proxy/mcppro
 LABEL org.opencontainers.image.description="Cisco MCP Scanner (YARA + readiness) packaged for MCPProxy"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
-# Install the vendor package. We pin the top-level tool name so the image
-# fails at build time if the upstream package name ever changes. The CLI
-# does not accept --version, so we run `-h` as a sanity check that the
-# binary is on PATH.
-RUN pip install --no-cache-dir cisco-ai-mcp-scanner && mcp-scanner -h >/dev/null
+# Install the vendor package. We pin BOTH the top-level tool name and an exact
+# version so the image is reproducible and cannot silently pull a new upstream
+# release (supply-chain / rug-pull guard). Bump this pin deliberately. The CLI
+# does not accept --version, so we run `-h` as a sanity check that the binary is
+# on PATH.
+RUN pip install --no-cache-dir cisco-ai-mcp-scanner==4.7.3 && mcp-scanner -h >/dev/null
 
 WORKDIR /scan
 ENTRYPOINT ["mcp-scanner"]

--- a/docs/features/security-scanner-plugins.md
+++ b/docs/features/security-scanner-plugins.md
@@ -255,7 +255,7 @@ The resolved method and path are recorded on the scan job and visible via both t
 
 #### Published package fetch (npx / uvx)
 
-Package-runner servers (`npx`, `uvx`) are the **primary** quarantine/scan target, but a server quarantined on add has never run locally — so the local package cache (step 2) misses and, before this fallback existed, the scan degraded to **tool definitions only** (no real source-level analysis). Step 5 closes that gap by downloading the *published* package source so the AI and supply-chain scanners run against real code.
+Package-runner servers (`npx`, `uvx`, plus `pnpm dlx` / `yarn dlx`, `pipx run`, and `bunx`) are the **primary** quarantine/scan target, but a server quarantined on add has never run locally — so the local package cache (step 2) misses and, before this fallback existed, the scan degraded to **tool definitions only** (no real source-level analysis). Step 5 closes that gap by downloading the *published* package source so the AI and supply-chain scanners run against real code. The target package is parsed from the launch command — subcommand runners (`pipx run X`, `pnpm dlx X`), package-naming flags (`npx --package X`, `uvx --from X`), and extra-dependency flags (`uvx --with <dep> X`, which names `X`, not the dep) are all handled. When the spec carries an exact version pin (`pkg@1.2.3`, `pkg==1.2.3`), the local-cache lookups (steps 2–4) prefer the cache entry matching that version rather than the newest one.
 
 **The source is fetched but never executed.** A scanner must not run the untrusted code it is scanning. The fetch only ever downloads and unpacks archives:
 
@@ -263,7 +263,7 @@ Package-runner servers (`npx`, `uvx`) are the **primary** quarantine/scan target
 - **npm (`npx`)** — `npm pack <pkg>@<version> --ignore-scripts` downloads the published tarball without running any lifecycle scripts (`install`/`postinstall`), then it is extracted (`source_method=npm_pack`).
 - **PyPI (`uvx`)** — `uv pip download <pkg>==<version> --no-deps --only-binary=:all:` (falling back to `pip download`) fetches **only a prebuilt wheel**, which is unpacked without building or running `setup.py` (`source_method=pip_download`). `--only-binary=:all:` is mandatory: downloading an sdist would invoke the package's PEP 517 build backend (`setup.py egg_info`) to resolve metadata, executing the untrusted code. A package that ships **no wheel** therefore fails the fetch and falls back to tool definitions only — sdists are never built or extracted.
 
-Extraction is hardened against path traversal (zip-slip), symlink escape, and decompression bombs (bounded file count and total size). If the toolchain is missing, the host is offline, or the fetch fails, resolution falls through to **tool definitions only** with no regression.
+Extraction is hardened against path traversal (zip-slip), symlink escape, and decompression bombs (bounded file count and total size). The whole fetch (download + extract) is bounded by a timeout, so a hung or throttled registry cannot stall the scan. If the toolchain is missing, the host is offline, or the fetch fails or times out, resolution falls through to **tool definitions only** with no regression.
 
 This fallback is **enabled by default**. Air-gapped deployments that must forbid the scanner's network egress can disable it with `security.scanner_fetch_package_source: false` — package-runner servers without local source then scan tool definitions only.
 

--- a/internal/security/scanner/package_fetch.go
+++ b/internal/security/scanner/package_fetch.go
@@ -257,9 +257,35 @@ func runnerFlagTakesValue(npm bool, flag string) bool {
 // The first remaining positional token is the package. Returns "" when no package
 // can be determined.
 func runnerPackageSpec(commandBase string, args []string) string {
-	sub := runnerSubcommand(commandBase)
-	subSkipped := sub == ""
 	npm := isNpmRunner(commandBase)
+
+	// Subcommand-style runners (pnpm/yarn `dlx`, `bun x`, `pipx run`) REQUIRE
+	// their keyword before anything is treated as a package. The keyword check
+	// runs BEFORE any flag parsing, so a package flag cannot bypass it: a bare
+	// `pnpm start`, `bun server.ts`, `pipx install foo`, or `pnpm -p start` has
+	// no keyword and resolves nothing (a local invocation, not a remote fetch —
+	// fetching the wrong token would mean false coverage + typosquat risk;
+	// MCP-2445). Leading global flags before the keyword (e.g. `pnpm --silent
+	// dlx`) are skipped. npx/uvx/bunx have no subcommand and parse from the start.
+	if sub := runnerSubcommand(commandBase); sub != "" {
+		i := 0
+		for i < len(args) {
+			arg := args[i]
+			if strings.HasPrefix(arg, "-") {
+				if i+1 < len(args) && runnerFlagTakesValue(npm, arg) {
+					i++
+				}
+				i++
+				continue
+			}
+			break // first positional token
+		}
+		if i >= len(args) || args[i] != sub {
+			return "" // first positional is not the required keyword → no package
+		}
+		args = args[i+1:] // parse only what follows the keyword
+	}
+
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		hasNext := i+1 < len(args)
@@ -277,20 +303,6 @@ func runnerPackageSpec(commandBase string, args []string) string {
 				i++ // skip the flag's value too
 			}
 			continue
-		}
-		// First positional token. Subcommand-style runners (pnpm/yarn/bun/pipx)
-		// REQUIRE their keyword (dlx/x/run) before the package token: a bare
-		// `pnpm start`, `bun server.ts`, or `pipx install foo` is a LOCAL
-		// invocation, NOT a remote package fetch, so it must not resolve a spec —
-		// fetching the wrong token would mean false coverage and typosquat risk
-		// (MCP-2445 re-review). Once the keyword is consumed the next positional
-		// is the package.
-		if !subSkipped {
-			if arg == sub {
-				subSkipped = true
-				continue
-			}
-			return ""
 		}
 		return arg
 	}

--- a/internal/security/scanner/package_fetch.go
+++ b/internal/security/scanner/package_fetch.go
@@ -246,7 +246,9 @@ func runnerFlagTakesValue(npm bool, flag string) bool {
 // returned verbatim) that a package-runner command will execute, from its command
 // base and argument list. It understands:
 //   - a leading runner subcommand keyword (`pipx run`, `pnpm dlx`, `yarn dlx`,
-//     `bun x`) that precedes the package token;
+//     `bun x`) that precedes the package token — and which is REQUIRED for those
+//     runners: a bare `pnpm start` / `bun server.ts` is a local invocation, not a
+//     remote fetch, and yields "" (no package);
 //   - flags that NAME the target package — uv `--from <pkg>`, npx `--package`/
 //     `-p <pkg>` — whose value is returned directly;
 //   - value-bearing flags whose argument is NOT the target (`--with <dep>`,
@@ -276,10 +278,19 @@ func runnerPackageSpec(commandBase string, args []string) string {
 			}
 			continue
 		}
-		// First positional token. Skip a leading runner subcommand keyword once.
-		if !subSkipped && arg == sub {
-			subSkipped = true
-			continue
+		// First positional token. Subcommand-style runners (pnpm/yarn/bun/pipx)
+		// REQUIRE their keyword (dlx/x/run) before the package token: a bare
+		// `pnpm start`, `bun server.ts`, or `pipx install foo` is a LOCAL
+		// invocation, NOT a remote package fetch, so it must not resolve a spec —
+		// fetching the wrong token would mean false coverage and typosquat risk
+		// (MCP-2445 re-review). Once the keyword is consumed the next positional
+		// is the package.
+		if !subSkipped {
+			if arg == sub {
+				subSkipped = true
+				continue
+			}
+			return ""
 		}
 		return arg
 	}

--- a/internal/security/scanner/package_fetch.go
+++ b/internal/security/scanner/package_fetch.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"go.uber.org/zap"
 )
@@ -45,6 +46,10 @@ const (
 	fetchMaxTotalBytes int64 = 256 << 20 // 256 MiB
 	// fetchMaxFileBytes caps any single extracted file.
 	fetchMaxFileBytes int64 = 64 << 20 // 64 MiB
+	// packageFetchTimeout bounds a single published-source fetch (download +
+	// extract). A hung or throttled registry must not stall the scan; on timeout
+	// the caller degrades to a tool-definitions-only scan.
+	packageFetchTimeout = 90 * time.Second
 )
 
 type archiveKind int
@@ -182,16 +187,101 @@ func validatePackageSpec(ecosystem, spec string) error {
 	return nil
 }
 
-// firstPackageArg returns the package spec from a runner command's args. It
-// honors `--from <pkg>` (uvx) and otherwise returns the first non-flag arg.
-func firstPackageArg(args []string) string {
-	for i, arg := range args {
-		if arg == "--from" && i+1 < len(args) {
-			return args[i+1]
+// runnerSubcommand returns the keyword that must precede the package token for a
+// subcommand-style runner (e.g. `pipx run <pkg>`, `pnpm dlx <pkg>`). Runners that
+// take the package as their first positional (npx, uvx, bunx) return "".
+func runnerSubcommand(commandBase string) string {
+	switch commandBase {
+	case "pipx":
+		return "run"
+	case "pnpm", "yarn":
+		return "dlx"
+	case "bun":
+		return "x"
+	}
+	return ""
+}
+
+// isNpmRunner reports whether a runner belongs to the npm/Node family (as opposed
+// to the uv/Python family). The two families differ in how flags name packages:
+// npx uses `--package`/`-p`, uv uses `--from`, and `-p` means `--python` for uv.
+func isNpmRunner(commandBase string) bool {
+	switch commandBase {
+	case "npx", "pnpm", "yarn", "bunx", "bun":
+		return true
+	}
+	return false
+}
+
+// runnerFlagTakesValue reports whether a flag consumes the FOLLOWING token as a
+// value that is NOT the target package (a python version, an extra dependency, a
+// command string, an index URL, ...). Its value must be skipped so it is never
+// mistaken for the package. Attached forms ("--python=3.11") carry their value
+// inline and consume no extra token.
+func runnerFlagTakesValue(npm bool, flag string) bool {
+	if strings.Contains(flag, "=") {
+		return false
+	}
+	if npm {
+		// npx -c/--call <cmd> carries a command string; --package/-p are handled
+		// earlier as package-naming flags, so they never reach here.
+		switch flag {
+		case "-c", "--call":
+			return true
 		}
-		if !strings.HasPrefix(arg, "-") {
-			return arg
+		return false
+	}
+	// uv / uvx / pipx value flags whose argument is not the target package.
+	switch flag {
+	case "-p", "--python",
+		"--with", "--with-editable", "--with-requirements",
+		"-i", "--index", "--index-url", "--index-strategy",
+		"-c", "--constraint", "--reinstall-package", "--refresh-package":
+		return true
+	}
+	return false
+}
+
+// runnerPackageSpec extracts the TARGET package spec (name plus any version pin,
+// returned verbatim) that a package-runner command will execute, from its command
+// base and argument list. It understands:
+//   - a leading runner subcommand keyword (`pipx run`, `pnpm dlx`, `yarn dlx`,
+//     `bun x`) that precedes the package token;
+//   - flags that NAME the target package — uv `--from <pkg>`, npx `--package`/
+//     `-p <pkg>` — whose value is returned directly;
+//   - value-bearing flags whose argument is NOT the target (`--with <dep>`,
+//     uv `-p`/`--python <ver>`, `-c <cmd>`, index flags), whose value is skipped.
+//
+// The first remaining positional token is the package. Returns "" when no package
+// can be determined.
+func runnerPackageSpec(commandBase string, args []string) string {
+	sub := runnerSubcommand(commandBase)
+	subSkipped := sub == ""
+	npm := isNpmRunner(commandBase)
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		hasNext := i+1 < len(args)
+		// Flags that name the target package directly: return their value.
+		if hasNext {
+			if !npm && arg == "--from" {
+				return args[i+1]
+			}
+			if npm && (arg == "--package" || arg == "-p") {
+				return args[i+1]
+			}
 		}
+		if strings.HasPrefix(arg, "-") {
+			if hasNext && runnerFlagTakesValue(npm, arg) {
+				i++ // skip the flag's value too
+			}
+			continue
+		}
+		// First positional token. Skip a leading runner subcommand keyword once.
+		if !subSkipped && arg == sub {
+			subSkipped = true
+			continue
+		}
+		return arg
 	}
 	return ""
 }
@@ -463,13 +553,20 @@ func writeArchiveFile(target string, src io.Reader, limit int64) (int64, error) 
 // guaranteeing no regression versus today's behavior.
 func (r *SourceResolver) resolveFromPackageFetch(ctx context.Context, info ServerInfo) (*ResolvedSource, error) {
 	cmdBase := strings.ToLower(filepath.Base(info.Command))
-	spec := firstPackageArg(info.Args)
+	spec := runnerPackageSpec(cmdBase, info.Args)
 	if spec == "" {
 		return nil, fmt.Errorf("no package spec in args for %s", info.Name)
 	}
 
+	// Bound the whole fetch (download + extract): a slow or hung registry must
+	// not stall the scan indefinitely. exec.CommandContext kills the download
+	// subprocess when this deadline fires, and the caller falls back to a
+	// tool-definitions-only scan.
+	ctx, cancel := context.WithTimeout(ctx, packageFetchTimeout)
+	defer cancel()
+
 	switch cmdBase {
-	case "npx", "bunx", "pnpm":
+	case "npx", "bunx", "bun", "pnpm", "yarn":
 		if err := validatePackageSpec("npm", spec); err != nil {
 			return nil, fmt.Errorf("refusing to fetch untrusted spec for %s: %w", info.Name, err)
 		}

--- a/internal/security/scanner/package_fetch_test.go
+++ b/internal/security/scanner/package_fetch_test.go
@@ -73,6 +73,13 @@ func TestRunnerPackageSpec(t *testing.T) {
 		{"bun run dev (local script)", "bun", []string{"run", "dev"}, ""},
 		{"yarn build (local script)", "yarn", []string{"build"}, ""},
 		{"pipx install foo (not ephemeral run)", "pipx", []string{"install", "foo"}, ""},
+		// The subcommand keyword is enforced BEFORE flag parsing, so a package
+		// flag cannot bypass it (MCP-2445 round-2 hole #1).
+		{"pnpm -p start (flag bypass)", "pnpm", []string{"-p", "start"}, ""},
+		{"bun -p server.ts (flag bypass)", "bun", []string{"-p", "server.ts"}, ""},
+		{"pnpm --package x (no dlx)", "pnpm", []string{"--package", "x", "start"}, ""},
+		// Leading global flags before the keyword are fine; keyword still required.
+		{"pnpm --silent dlx pkg", "pnpm", []string{"--silent", "dlx", "pkg"}, "pkg"},
 		// Degenerate inputs.
 		{"npx flag only", "npx", []string{"-y"}, ""},
 		{"nil", "npx", nil, ""},

--- a/internal/security/scanner/package_fetch_test.go
+++ b/internal/security/scanner/package_fetch_test.go
@@ -37,21 +37,42 @@ func TestParsePackageSpec(t *testing.T) {
 	}
 }
 
-func TestFirstPackageArg(t *testing.T) {
+func TestRunnerPackageSpec(t *testing.T) {
 	cases := []struct {
-		args []string
-		want string
+		name    string
+		command string
+		args    []string
+		want    string
 	}{
-		{[]string{"-y", "google-flights-mcp-server@0.2.4"}, "google-flights-mcp-server@0.2.4"},
-		{[]string{"--from", "pkg-a", "cmd"}, "pkg-a"},
-		{[]string{"pkg-only"}, "pkg-only"},
-		{[]string{"-y"}, ""},
-		{nil, ""},
+		// npx: -y is a boolean flag, the package follows.
+		{"npx -y", "npx", []string{"-y", "google-flights-mcp-server@0.2.4"}, "google-flights-mcp-server@0.2.4"},
+		{"npx bare", "npx", []string{"server-everything"}, "server-everything"},
+		// npx --package / -p NAMES the target; -c carries a command string.
+		{"npx -p", "npx", []string{"-p", "@scope/srv@1.2.3", "-c", "srv"}, "@scope/srv@1.2.3"},
+		{"npx --package", "npx", []string{"--package", "srv", "-c", "run-srv"}, "srv"},
+		// Subcommand runners: the subcommand keyword is NOT the package.
+		{"pipx run", "pipx", []string{"run", "some-pkg"}, "some-pkg"},
+		{"pnpm dlx", "pnpm", []string{"dlx", "some-pkg"}, "some-pkg"},
+		{"yarn dlx", "yarn", []string{"dlx", "some-pkg@2.0.0"}, "some-pkg@2.0.0"},
+		{"bun x", "bun", []string{"x", "some-pkg"}, "some-pkg"},
+		// uvx: --from names the distribution; a positional after it is the command.
+		{"uvx --from", "uvx", []string{"--from", "pkg-a", "cmd"}, "pkg-a"},
+		{"uvx bare", "uvx", []string{"pkg-only"}, "pkg-only"},
+		// uvx --with adds an EXTRA dep; the target is the first real positional.
+		{"uvx --with then target", "uvx", []string{"--with", "extra-dep", "main-pkg"}, "main-pkg"},
+		{"uvx --with then --from", "uvx", []string{"--with", "extra-dep", "--from", "main-pkg", "cmd"}, "main-pkg"},
+		// uvx -p/--python carries a version, NOT the package.
+		{"uvx -p python", "uvx", []string{"-p", "3.11", "main-pkg"}, "main-pkg"},
+		{"uvx --python", "uvx", []string{"--python", "3.12", "--from", "main-pkg", "cmd"}, "main-pkg"},
+		// Degenerate inputs.
+		{"npx flag only", "npx", []string{"-y"}, ""},
+		{"nil", "npx", nil, ""},
+		{"pipx run only", "pipx", []string{"run"}, ""},
 	}
 	for _, c := range cases {
-		got := firstPackageArg(c.args)
+		got := runnerPackageSpec(filepath.Base(c.command), c.args)
 		if got != c.want {
-			t.Errorf("firstPackageArg(%v) = %q, want %q", c.args, got, c.want)
+			t.Errorf("%s: runnerPackageSpec(%q, %v) = %q, want %q", c.name, c.command, c.args, got, c.want)
 		}
 	}
 }

--- a/internal/security/scanner/package_fetch_test.go
+++ b/internal/security/scanner/package_fetch_test.go
@@ -64,6 +64,15 @@ func TestRunnerPackageSpec(t *testing.T) {
 		// uvx -p/--python carries a version, NOT the package.
 		{"uvx -p python", "uvx", []string{"-p", "3.11", "main-pkg"}, "main-pkg"},
 		{"uvx --python", "uvx", []string{"--python", "3.12", "--from", "main-pkg", "cmd"}, "main-pkg"},
+		// Subcommand runners WITHOUT the keyword must NOT resolve a package spec —
+		// these are local invocations, not remote package fetches (MCP-2445 re-review).
+		// Fetching the first positional here = false coverage + typosquat risk.
+		{"pnpm start (local script)", "pnpm", []string{"start"}, ""},
+		{"pnpm run build (local script)", "pnpm", []string{"run", "build"}, ""},
+		{"bun server.ts (local file)", "bun", []string{"server.ts"}, ""},
+		{"bun run dev (local script)", "bun", []string{"run", "dev"}, ""},
+		{"yarn build (local script)", "yarn", []string{"build"}, ""},
+		{"pipx install foo (not ephemeral run)", "pipx", []string{"install", "foo"}, ""},
 		// Degenerate inputs.
 		{"npx flag only", "npx", []string{"-y"}, ""},
 		{"nil", "npx", nil, ""},

--- a/internal/security/scanner/source_resolver.go
+++ b/internal/security/scanner/source_resolver.go
@@ -174,7 +174,7 @@ func (r *SourceResolver) Resolve(ctx context.Context, info ServerInfo) (*Resolve
 	// a server like `npx @modelcontextprotocol/server-filesystem /tmp/data`
 	// from picking up the user's data dir (`/tmp/data`) as the server
 	// source — the arg is the filesystem server's allowed root, not code.
-	if info.Command != "" && isPackageRunnerCommand(info.Command) {
+	if info.Command != "" && isPackageRunnerCommand(info.Command, info.Args) {
 		if resolved, err := r.resolveFromPackageCache(ctx, info); err == nil {
 			return resolved, nil
 		} else {
@@ -256,7 +256,7 @@ func (r *SourceResolver) Resolve(ctx context.Context, info ServerInfo) (*Resolve
 
 	// Last resort: try the package cache for any other command (e.g. the user
 	// has an absolute path to node_modules that we didn't match above).
-	if info.Command != "" && !isPackageRunnerCommand(info.Command) {
+	if info.Command != "" && !isPackageRunnerCommand(info.Command, info.Args) {
 		if resolved, err := r.resolveFromPackageCache(ctx, info); err == nil {
 			return resolved, nil
 		}
@@ -267,7 +267,7 @@ func (r *SourceResolver) Resolve(ctx context.Context, info ServerInfo) (*Resolve
 	// a quarantined-on-add server is never run locally, so the local cache above
 	// always misses (MCP-2206). Fetching real source lets the AI + supply-chain
 	// scanners run instead of degrading to tool_definitions_only.
-	if r.fetchPackageSource && info.Command != "" && isPackageRunnerCommand(info.Command) {
+	if r.fetchPackageSource && info.Command != "" && isPackageRunnerCommand(info.Command, info.Args) {
 		if resolved, err := r.resolveFromPackageFetch(ctx, info); err == nil {
 			return resolved, nil
 		} else {
@@ -286,15 +286,22 @@ func (r *SourceResolver) Resolve(ctx context.Context, info ServerInfo) (*Resolve
 // a remote registry rather than running local source code. For these, the
 // server source lives in the package manager's cache, not in any positional
 // argument.
-func isPackageRunnerCommand(command string) bool {
+//
+// Classification is ARGUMENT-AWARE for subcommand-style runners (MCP-2445):
+// npx/uvx/bunx always run a remote package by name, but pnpm/yarn/bun/pipx are
+// general multi-command tools — they are runners ONLY when their ephemeral-run
+// keyword (`dlx`/`x`/`run`) is actually present. Classifying `pnpm start` or
+// `bun server.ts` as a runner by name alone would route a local invocation into
+// the package cache/fetch path and scan the wrong token. We decide this up front
+// rather than relying on a later parser failure.
+func isPackageRunnerCommand(command string, args []string) bool {
 	base := strings.ToLower(filepath.Base(command))
 	switch base {
-	// pnpm/yarn are runners only in their `dlx` form; that is the only way an MCP
-	// server is launched from them, and resolveFromPackageFetch dispatches pnpm to
-	// the npm fetch path. Including them here lets that fetch fallback actually run
-	// (previously pnpm was dispatched but never gated true here — a dead branch).
-	case "npx", "uvx", "pipx", "bunx", "bun", "pnpm", "yarn":
+	case "npx", "uvx", "bunx":
 		return true
+	case "pipx", "pnpm", "yarn", "bun":
+		// Runner only when the ephemeral-run keyword yields a resolvable package.
+		return runnerPackageSpec(base, args) != ""
 	}
 	return false
 }
@@ -792,19 +799,20 @@ func uvxTargetPackage(info ServerInfo) string {
 // embedding. Factored out so the shell logic is unit-testable on the host.
 func npxContainerLocateScript(npxGlobRoot, pkg, version string) string {
 	pkgEsc := strings.ReplaceAll(pkg, "'", `'\''`)
-	verClause := ""
 	if version != "" {
-		verEsc := strings.ReplaceAll(version, "'", `'\''`)
-		// The .dist-info-free npm case: match the version inside package.json. The
+		// Pinned: return ONLY a bucket whose package.json declares that exact
+		// version. A pin-miss returns nothing — never a mismatched version, which
+		// would scan the wrong code and report false coverage (MCP-2445). The
 		// pattern tolerates arbitrary JSON spacing around the colon.
-		verClause = "if grep -Eq '\"version\"[[:space:]]*:[[:space:]]*\"" + verEsc + "\"' \"$d/package.json\" 2>/dev/null; then printf '%s\\n' \"$d\"; exit 0; fi; "
+		verEsc := strings.ReplaceAll(version, "'", `'\''`)
+		return "for d in " + npxGlobRoot + "/*/node_modules/'" + pkgEsc + "'; do " +
+			"[ -d \"$d\" ] || continue; " +
+			"if grep -Eq '\"version\"[[:space:]]*:[[:space:]]*\"" + verEsc + "\"' \"$d/package.json\" 2>/dev/null; then printf '%s\\n' \"$d\"; exit 0; fi; " +
+			"done"
 	}
-	return "first=''; for d in " + npxGlobRoot + "/*/node_modules/'" + pkgEsc + "'; do " +
-		"[ -d \"$d\" ] || continue; " +
-		"[ -z \"$first\" ] && first=\"$d\"; " +
-		verClause +
-		"done; " +
-		"[ -n \"$first\" ] && printf '%s\\n' \"$first\""
+	// Unpinned: first matching bucket.
+	return "for d in " + npxGlobRoot + "/*/node_modules/'" + pkgEsc + "'; do " +
+		"[ -d \"$d\" ] || continue; printf '%s\\n' \"$d\"; exit 0; done"
 }
 
 // findContainerTargetDir locates the target package's directory inside a
@@ -951,7 +959,7 @@ func (r *SourceResolver) ResolveFullSource(ctx context.Context, info ServerInfo)
 	// source without executing it (MCP-2206). Same rationale as Pass 1 — without
 	// a local container or cache, Pass 2 supply-chain scanning would otherwise
 	// have nothing to analyze for npx/uvx servers.
-	if r.fetchPackageSource && info.Command != "" && isPackageRunnerCommand(info.Command) {
+	if r.fetchPackageSource && info.Command != "" && isPackageRunnerCommand(info.Command, info.Args) {
 		if resolved, err := r.resolveFromPackageFetch(ctx, info); err == nil {
 			return resolved, nil
 		}
@@ -1347,6 +1355,19 @@ func (r *SourceResolver) resolveNpxCache(info ServerInfo) (*ResolvedSource, erro
 		return nil, fmt.Errorf("package %q not found in npx cache (%s)", pkgName, npxCacheDir)
 	}
 
+	if wantVersion != "" && !bestVerMatch {
+		// An exact version was pinned but no cached candidate declares it. Do NOT
+		// substitute a different cached version — scanning the wrong code reports
+		// false coverage (MCP-2445). Defer to the published-source fetch fallback,
+		// which fetches the PINNED version, or degrade to tool_definitions_only.
+		r.logger.Warn("npx cache has the package but not the pinned version; deferring to published-source fetch",
+			zap.String("server", info.Name),
+			zap.String("package", pkgName),
+			zap.String("pinned_version", wantVersion),
+		)
+		return nil, fmt.Errorf("npx cache for %q has no entry matching pinned version %q (avoiding mismatched-version scan)", pkgName, wantVersion)
+	}
+
 	if !bestReal {
 		// Every candidate was a bare stub (e.g. a lone tools.json mcpproxy wrote
 		// into the cache) — no real installed source exists locally. Returning the
@@ -1443,6 +1464,13 @@ func (r *SourceResolver) resolveUvxCache(info ServerInfo) (*ResolvedSource, erro
 	// Check if it's a git URL: git+https://github.com/...
 	isGitURL := strings.HasPrefix(pkgName, "git+")
 
+	// Exact version pin (if any). Only meaningful for registry packages — git
+	// specs pin via the URL ref, not a PEP 440 version.
+	wantVersion := ""
+	if !isGitURL {
+		_, wantVersion = parsePackageSpec(pkgName)
+	}
+
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return nil, fmt.Errorf("cannot determine home directory: %w", err)
@@ -1474,33 +1502,48 @@ func (r *SourceResolver) resolveUvxCache(info ServerInfo) (*ResolvedSource, erro
 		}
 	}
 
-	// Strategy 2: UV tools directory (for regular packages)
-	// Strip version: package@version → package
+	// Strategy 2: UV tools directory (for regular packages). Reduce the spec to a
+	// bare distribution name: strip a git+ URL to its repo, otherwise strip the
+	// `@version` form AND any PEP 440 specifier (`==`, `>=`, extras …) — the latter
+	// was previously missed, so a `pkg==1.0` spec produced a bogus `tools/pkg==1.0`
+	// path that never matched.
 	cleanPkg := pkgName
-	if idx := strings.LastIndex(cleanPkg, "@"); idx > 0 {
-		cleanPkg = cleanPkg[:idx]
-	}
-	// Also strip git+ prefix and URL
 	if strings.HasPrefix(cleanPkg, "git+") {
 		// Extract package name from URL: git+https://github.com/org/repo → repo
 		parts := strings.Split(cleanPkg, "/")
 		if len(parts) > 0 {
 			cleanPkg = parts[len(parts)-1]
 		}
+	} else {
+		if idx := strings.LastIndex(cleanPkg, "@"); idx > 0 {
+			cleanPkg = cleanPkg[:idx]
+		}
+		cleanPkg = stripPkgVersion(cleanPkg)
 	}
 
 	toolsDir := filepath.Join(homeDir, ".local", "share", "uv", "tools", cleanPkg)
 	if stat, err := os.Stat(toolsDir); err == nil && stat.IsDir() {
-		r.logger.Info("Resolved source from UV tools directory",
+		// When a version is pinned, only accept the tools dir if it actually holds
+		// that version — otherwise fall through so the published-source fetch gets
+		// the PINNED version instead of scanning whatever was `uv tool install`-ed
+		// (MCP-2445: never substitute a mismatched version).
+		if wantVersion == "" || uvDirHasVersion(toolsDir, stripPkgVersion(cleanPkg), wantVersion) {
+			r.logger.Info("Resolved source from UV tools directory",
+				zap.String("server", info.Name),
+				zap.String("package", cleanPkg),
+				zap.String("path", toolsDir),
+			)
+			return &ResolvedSource{
+				SourceDir: toolsDir,
+				Method:    "uvx_cache",
+				Cleanup:   func() {},
+			}, nil
+		}
+		r.logger.Warn("UV tools dir present but not the pinned version; deferring to archive/published-source fetch",
 			zap.String("server", info.Name),
 			zap.String("package", cleanPkg),
-			zap.String("path", toolsDir),
+			zap.String("pinned_version", wantVersion),
 		)
-		return &ResolvedSource{
-			SourceDir: toolsDir,
-			Method:    "uvx_cache",
-			Cleanup:   func() {},
-		}, nil
 	}
 
 	// Strategy 3: ephemeral uvx archive cache (~/.cache/uv/archive-v0/<hash>/).
@@ -1516,9 +1559,8 @@ func (r *SourceResolver) resolveUvxCache(info ServerInfo) (*ResolvedSource, erro
 	// not archive-v0, so they are skipped here.
 	if !isGitURL {
 		archiveRoot := filepath.Join(homeDir, ".cache", "uv", "archive-v0")
-		// Honor an exact version pin: prefer the archive entry whose .dist-info
-		// declares the pinned version over a newer-but-mismatched one (MCP-2445).
-		_, wantVersion := parsePackageSpec(pkgName)
+		// Honor an exact version pin: select the archive entry whose .dist-info
+		// declares the pinned version; a pin-miss resolves nothing (MCP-2445).
 		if dir, ok := findUvxArchiveDir(archiveRoot, stripPkgVersion(cleanPkg), wantVersion); ok {
 			r.logger.Info("Resolved source from UV archive cache",
 				zap.String("server", info.Name),
@@ -1635,7 +1677,34 @@ func findUvxArchiveDir(archiveRoot, pkg, wantVersion string) (string, bool) {
 	if best == "" {
 		return "", false
 	}
+	if wantVersion != "" && !bestVerMatch {
+		// Pinned version requested but no archive entry declares it. Do not
+		// substitute a different cached version (false coverage) — report not found
+		// so the caller fetches the pinned version or degrades (MCP-2445).
+		return "", false
+	}
 	return best, true
+}
+
+// uvDirHasVersion reports whether a uv venv-style directory (a `uv tool install`
+// tools dir) holds distribution pkg at exactly version. It looks for a matching
+// `<dist>-<version>.dist-info` under any `lib/python*/site-packages`. Used to keep
+// a version pin honest against the persistent tools dir.
+func uvDirHasVersion(root, pkg, version string) bool {
+	if version == "" {
+		return false
+	}
+	norm := normalizeDistName(pkg)
+	if norm == "" {
+		return false
+	}
+	sps, _ := filepath.Glob(filepath.Join(root, "lib", "python*", "site-packages"))
+	for _, d := range sps {
+		if _, vm := distInfoMatch(d, norm, version); vm {
+			return true
+		}
+	}
+	return false
 }
 
 // distInfoMatch reports whether dir directly contains a `<name>-<version>.dist-info`

--- a/internal/security/scanner/source_resolver.go
+++ b/internal/security/scanner/source_resolver.go
@@ -802,12 +802,19 @@ func npxContainerLocateScript(npxGlobRoot, pkg, version string) string {
 	if version != "" {
 		// Pinned: return ONLY a bucket whose package.json declares that exact
 		// version. A pin-miss returns nothing — never a mismatched version, which
-		// would scan the wrong code and report false coverage (MCP-2445). The
-		// pattern tolerates arbitrary JSON spacing around the colon.
+		// would scan the wrong code and report false coverage (MCP-2445).
+		//
+		// The version is compared as a LITERAL shell string ([ "$v" = '...' ]),
+		// NOT as a regex: a pin like "1.0.0-alpha.1" must not match a cached
+		// "1.0.0-alpha-1" ('.' is not a wildcard) — MCP-2445 round-3. We extract
+		// the package.json "version" value with a grep whose pattern matches only
+		// the KEY (the value is captured as "[^\"]*", never the pin), pull the
+		// value out with sed, then compare it literally.
 		verEsc := strings.ReplaceAll(version, "'", `'\''`)
 		return "for d in " + npxGlobRoot + "/*/node_modules/'" + pkgEsc + "'; do " +
 			"[ -d \"$d\" ] || continue; " +
-			"if grep -Eq '\"version\"[[:space:]]*:[[:space:]]*\"" + verEsc + "\"' \"$d/package.json\" 2>/dev/null; then printf '%s\\n' \"$d\"; exit 0; fi; " +
+			"v=$(grep -o '\"version\"[[:space:]]*:[[:space:]]*\"[^\"]*\"' \"$d/package.json\" 2>/dev/null | head -1 | sed 's/.*\"\\([^\"]*\\)\"$/\\1/'); " +
+			"if [ \"$v\" = '" + verEsc + "' ]; then printf '%s\\n' \"$d\"; exit 0; fi; " +
 			"done"
 	}
 	// Unpinned: first matching bucket.

--- a/internal/security/scanner/source_resolver.go
+++ b/internal/security/scanner/source_resolver.go
@@ -3,6 +3,7 @@ package scanner
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -288,7 +289,11 @@ func (r *SourceResolver) Resolve(ctx context.Context, info ServerInfo) (*Resolve
 func isPackageRunnerCommand(command string) bool {
 	base := strings.ToLower(filepath.Base(command))
 	switch base {
-	case "npx", "uvx", "pipx", "bunx":
+	// pnpm/yarn are runners only in their `dlx` form; that is the only way an MCP
+	// server is launched from them, and resolveFromPackageFetch dispatches pnpm to
+	// the npm fetch path. Including them here lets that fetch fallback actually run
+	// (previously pnpm was dispatched but never gated true here — a dead branch).
+	case "npx", "uvx", "pipx", "bunx", "bun", "pnpm", "yarn":
 		return true
 	}
 	return false
@@ -746,18 +751,8 @@ func npxTargetPackage(info ServerInfo) string {
 	if info.Command == "" || filepath.Base(info.Command) != "npx" {
 		return ""
 	}
-	for _, arg := range info.Args {
-		if strings.HasPrefix(arg, "-") {
-			continue
-		}
-		pkg := arg
-		// Strip version: @scope/name@1.0.0 → @scope/name, pkg@1.0.0 → pkg
-		if idx := strings.LastIndex(pkg, "@"); idx > 0 {
-			pkg = pkg[:idx]
-		}
-		return pkg
-	}
-	return ""
+	name, _ := parsePackageSpec(runnerPackageSpec("npx", info.Args))
+	return name
 }
 
 // uvxTargetPackage returns the Python package name a uvx-based server launches.
@@ -768,17 +763,9 @@ func uvxTargetPackage(info ServerInfo) string {
 	if info.Command == "" || filepath.Base(info.Command) != "uvx" {
 		return ""
 	}
-	var raw string
-	for i, arg := range info.Args {
-		if arg == "--from" && i+1 < len(info.Args) {
-			raw = info.Args[i+1]
-			break
-		}
-		if !strings.HasPrefix(arg, "-") {
-			raw = arg
-			break
-		}
-	}
+	// runnerPackageSpec skips `--with <dep>` / `-p <python>` values so the target
+	// is not shadowed by an extra dependency or python version (MCP-2445).
+	raw := runnerPackageSpec("uvx", info.Args)
 	if raw == "" {
 		return ""
 	}
@@ -792,13 +779,32 @@ func uvxTargetPackage(info ServerInfo) string {
 		return ""
 	}
 	// Strip version specifier: pkg@1.0 or pkg==1.0.
-	if idx := strings.LastIndex(raw, "@"); idx > 0 {
-		raw = raw[:idx]
+	name, _ := parsePackageSpec(raw)
+	return name
+}
+
+// npxContainerLocateScript builds a /bin/sh script that locates the npx cache
+// directory for pkg under npxGlobRoot (`<root>/<hash>/node_modules/<pkg>`). When
+// version is non-empty it PREFERS a bucket whose package.json declares that exact
+// version (honoring a version pin across a multi-version cache), and otherwise
+// echoes the first matching directory — preserving the previous newest/first
+// behavior. The package name and version are single-quote escaped for safe
+// embedding. Factored out so the shell logic is unit-testable on the host.
+func npxContainerLocateScript(npxGlobRoot, pkg, version string) string {
+	pkgEsc := strings.ReplaceAll(pkg, "'", `'\''`)
+	verClause := ""
+	if version != "" {
+		verEsc := strings.ReplaceAll(version, "'", `'\''`)
+		// The .dist-info-free npm case: match the version inside package.json. The
+		// pattern tolerates arbitrary JSON spacing around the colon.
+		verClause = "if grep -Eq '\"version\"[[:space:]]*:[[:space:]]*\"" + verEsc + "\"' \"$d/package.json\" 2>/dev/null; then printf '%s\\n' \"$d\"; exit 0; fi; "
 	}
-	if idx := strings.Index(raw, "=="); idx > 0 {
-		raw = raw[:idx]
-	}
-	return raw
+	return "first=''; for d in " + npxGlobRoot + "/*/node_modules/'" + pkgEsc + "'; do " +
+		"[ -d \"$d\" ] || continue; " +
+		"[ -z \"$first\" ] && first=\"$d\"; " +
+		verClause +
+		"done; " +
+		"[ -n \"$first\" ] && printf '%s\\n' \"$first\""
 }
 
 // findContainerTargetDir locates the target package's directory inside a
@@ -811,13 +817,11 @@ func uvxTargetPackage(info ServerInfo) string {
 // target cannot be located.
 func (r *SourceResolver) findContainerTargetDir(ctx context.Context, containerID string, info ServerInfo) string {
 	if pkg := npxTargetPackage(info); pkg != "" {
-		// Shell-escape single quotes in the package name and glob for it under
-		// every npx cache bucket inside the container.
-		escaped := strings.ReplaceAll(pkg, "'", `'\''`)
-		script := fmt.Sprintf(
-			"ls -d /root/.npm/_npx/*/node_modules/'%s' 2>/dev/null | head -n 1",
-			escaped,
-		)
+		// Glob for the package under every npx cache bucket inside the container.
+		// When the spec carries an exact version pin, prefer the bucket whose
+		// package.json declares that version over the first match (MCP-2445).
+		_, wantVer := parsePackageSpec(runnerPackageSpec("npx", info.Args))
+		script := npxContainerLocateScript("/root/.npm/_npx", pkg, wantVer)
 		if out, ok := r.dockerExecCapture(ctx, containerID, script); ok {
 			if path := strings.TrimSpace(out); path != "" {
 				return path
@@ -1259,21 +1263,15 @@ func (r *SourceResolver) resolveFromPackageCache(ctx context.Context, info Serve
 
 // resolveNpxCache finds an npx package's source in ~/.npm/_npx/*/node_modules/<package>/
 func (r *SourceResolver) resolveNpxCache(info ServerInfo) (*ResolvedSource, error) {
-	// Extract package name from args (first non-flag arg)
-	pkgName := ""
-	for _, arg := range info.Args {
-		if !strings.HasPrefix(arg, "-") {
-			pkgName = arg
-			break
-		}
-	}
-	if pkgName == "" {
+	// Extract the target package spec (handles `npx -p <pkg>`, `pnpm dlx <pkg>`,
+	// version pins, etc.) then split name from any exact version pin.
+	spec := runnerPackageSpec(strings.ToLower(filepath.Base(info.Command)), info.Args)
+	if spec == "" {
 		return nil, fmt.Errorf("no package name found in npx args")
 	}
-
-	// Strip version specifier: @modelcontextprotocol/server-everything@1.0.0 → @modelcontextprotocol/server-everything
-	if idx := strings.LastIndex(pkgName, "@"); idx > 0 {
-		pkgName = pkgName[:idx]
+	pkgName, wantVersion := parsePackageSpec(spec)
+	if pkgName == "" {
+		return nil, fmt.Errorf("no package name found in npx args")
 	}
 
 	// Find npm cache directory
@@ -1296,10 +1294,13 @@ func (r *SourceResolver) resolveNpxCache(info ServerInfo) (*ResolvedSource, erro
 	// real source (it was just written), so a naive newest-mtime pick selects the
 	// stub and the scan reports a false "1 file" coverage (MCP-2397). We therefore
 	// prefer candidates that look like real package source, and only fall back to
-	// the newest-mtime tiebreak among candidates of the same class.
+	// the newest-mtime tiebreak among candidates of the same class. When the spec
+	// carries an exact version pin, a candidate whose package.json declares that
+	// version is preferred over a newer-but-mismatched install (MCP-2445).
 	var bestMatch string
 	var bestModTime int64
 	var bestReal bool
+	var bestVerMatch bool
 
 	entries, err := os.ReadDir(npxCacheDir)
 	if err != nil {
@@ -1316,24 +1317,29 @@ func (r *SourceResolver) resolveNpxCache(info ServerInfo) (*ResolvedSource, erro
 			continue
 		}
 		real := npxCacheLooksReal(candidatePath)
+		verMatch := npxCacheVersionMatches(candidatePath, wantVersion)
 		modTime := stat.ModTime().Unix()
 
-		// Selection order:
+		// Selection order (most to least significant):
 		//  1. any real-source candidate beats any stub;
-		//  2. within the same class, the newest mtime wins.
+		//  2. a version-pin match beats a mismatch;
+		//  3. within the same class, the newest mtime wins.
 		better := false
 		switch {
 		case bestMatch == "":
 			better = true
-		case real && !bestReal:
-			better = true
-		case real == bestReal && modTime > bestModTime:
-			better = true
+		case real != bestReal:
+			better = real
+		case verMatch != bestVerMatch:
+			better = verMatch
+		default:
+			better = modTime > bestModTime
 		}
 		if better {
 			bestMatch = candidatePath
 			bestModTime = modTime
 			bestReal = real
+			bestVerMatch = verMatch
 		}
 	}
 
@@ -1370,6 +1376,27 @@ func (r *SourceResolver) resolveNpxCache(info ServerInfo) (*ResolvedSource, erro
 	}, nil
 }
 
+// npxCacheVersionMatches reports whether the package.json at dir declares exactly
+// the given version. Returns false when version is empty or the file is missing /
+// unparseable. Used to prefer a version-pinned install over a newer-but-
+// mismatched one in a multi-version npx cache.
+func npxCacheVersionMatches(dir, version string) bool {
+	if version == "" {
+		return false
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "package.json"))
+	if err != nil {
+		return false
+	}
+	var pj struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(data, &pj); err != nil {
+		return false
+	}
+	return pj.Version == version
+}
+
 // npxCacheLooksReal reports whether an npx cache package directory holds the
 // real installed package rather than a bare stub. Every npm package ships a
 // package.json, so its presence is the canonical marker of real source. A stub
@@ -1404,28 +1431,17 @@ func npxCacheLooksReal(dir string) bool {
 
 // resolveUvxCache finds a uvx package's source in ~/.cache/uv/ or ~/.local/share/uv/tools/
 func (r *SourceResolver) resolveUvxCache(info ServerInfo) (*ResolvedSource, error) {
-	// Extract package name from args
-	// uvx supports: uvx <package>, uvx --from <package> <command>, uvx git+<url>
-	pkgName := ""
-	isGitURL := false
-	for i, arg := range info.Args {
-		if arg == "--from" && i+1 < len(info.Args) {
-			pkgName = info.Args[i+1]
-			break
-		}
-		if !strings.HasPrefix(arg, "-") {
-			pkgName = arg
-			break
-		}
-	}
+	// Extract the target package spec. runnerPackageSpec handles `uvx <pkg>`,
+	// `uvx --from <pkg> <cmd>`, `uvx git+<url>`, and crucially skips `--with <dep>`
+	// / `-p <python>` values so the additional dependency or python version is not
+	// mistaken for the target (MCP-2445).
+	pkgName := runnerPackageSpec(strings.ToLower(filepath.Base(info.Command)), info.Args)
 	if pkgName == "" {
 		return nil, fmt.Errorf("no package name found in uvx args")
 	}
 
 	// Check if it's a git URL: git+https://github.com/...
-	if strings.HasPrefix(pkgName, "git+") {
-		isGitURL = true
-	}
+	isGitURL := strings.HasPrefix(pkgName, "git+")
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -1500,7 +1516,10 @@ func (r *SourceResolver) resolveUvxCache(info ServerInfo) (*ResolvedSource, erro
 	// not archive-v0, so they are skipped here.
 	if !isGitURL {
 		archiveRoot := filepath.Join(homeDir, ".cache", "uv", "archive-v0")
-		if dir, ok := findUvxArchiveDir(archiveRoot, stripPkgVersion(cleanPkg)); ok {
+		// Honor an exact version pin: prefer the archive entry whose .dist-info
+		// declares the pinned version over a newer-but-mismatched one (MCP-2445).
+		_, wantVersion := parsePackageSpec(pkgName)
+		if dir, ok := findUvxArchiveDir(archiveRoot, stripPkgVersion(cleanPkg), wantVersion); ok {
 			r.logger.Info("Resolved source from UV archive cache",
 				zap.String("server", info.Name),
 				zap.String("package", cleanPkg),
@@ -1552,10 +1571,11 @@ func normalizeDistName(name string) string {
 // directory rather than by constructing a name-based path. Both the flat layout
 // (<hash>/<dist>-<ver>.dist-info) and the venv-style layout
 // (<hash>/lib/python*/site-packages/<dist>-<ver>.dist-info) are supported. When
-// multiple entries match (e.g. several cached versions) the most recently
-// modified entry wins, consistent with resolveNpxCache. Returns the archive
-// entry root (the <hash> dir) and ok=true on a hit.
-func findUvxArchiveDir(archiveRoot, pkg string) (string, bool) {
+// multiple entries match (e.g. several cached versions) a wantVersion match wins
+// first; otherwise the most recently modified entry wins, consistent with
+// resolveNpxCache. wantVersion may be "" (no pin). Returns the archive entry root
+// (the <hash> dir) and ok=true on a hit.
+func findUvxArchiveDir(archiveRoot, pkg, wantVersion string) (string, bool) {
 	norm := normalizeDistName(pkg)
 	if norm == "" {
 		return "", false
@@ -1567,6 +1587,7 @@ func findUvxArchiveDir(archiveRoot, pkg string) (string, bool) {
 
 	var best string
 	var bestMod int64
+	var bestVerMatch bool
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -1578,10 +1599,14 @@ func findUvxArchiveDir(archiveRoot, pkg string) (string, bool) {
 			matchDirs = append(matchDirs, sp...)
 		}
 		matched := false
+		verMatch := false
 		for _, d := range matchDirs {
-			if dirHasDistInfo(d, norm) {
+			nm, vm := distInfoMatch(d, norm, wantVersion)
+			if nm {
 				matched = true
-				break
+				if vm {
+					verMatch = true
+				}
 			}
 		}
 		if !matched {
@@ -1591,9 +1616,20 @@ func findUvxArchiveDir(archiveRoot, pkg string) (string, bool) {
 		if fi, err := entry.Info(); err == nil {
 			modTime = fi.ModTime().Unix()
 		}
-		if best == "" || modTime > bestMod {
+		// Selection: a version-pin match beats a mismatch; then newest mtime wins.
+		better := false
+		switch {
+		case best == "":
+			better = true
+		case verMatch != bestVerMatch:
+			better = verMatch
+		default:
+			better = modTime > bestMod
+		}
+		if better {
 			best = entryPath
 			bestMod = modTime
+			bestVerMatch = verMatch
 		}
 	}
 	if best == "" {
@@ -1602,15 +1638,17 @@ func findUvxArchiveDir(archiveRoot, pkg string) (string, bool) {
 	return best, true
 }
 
-// dirHasDistInfo reports whether dir directly contains a `<name>-<version>.dist-info`
-// directory whose normalized distribution name equals norm. A wheel's `.dist-info`
-// name is `{normalized-distribution}-{version}.dist-info`, and the normalized
-// distribution name contains no "-" (those become "_"), so the FIRST "-" cleanly
-// separates name from version.
-func dirHasDistInfo(dir, norm string) bool {
+// distInfoMatch reports whether dir directly contains a `<name>-<version>.dist-info`
+// directory whose normalized distribution name equals norm (nameMatch), and — when
+// wantVersion is non-empty — whether that directory's version equals wantVersion
+// (versionMatch). A wheel's `.dist-info` name is
+// `{normalized-distribution}-{version}.dist-info`, and the normalized distribution
+// name contains no "-" (those become "_"), so the FIRST "-" cleanly separates name
+// from version.
+func distInfoMatch(dir, norm, wantVersion string) (nameMatch, versionMatch bool) {
 	es, err := os.ReadDir(dir)
 	if err != nil {
-		return false
+		return false, false
 	}
 	for _, e := range es {
 		if !e.IsDir() {
@@ -1625,11 +1663,16 @@ func dirHasDistInfo(dir, norm string) bool {
 		if idx <= 0 {
 			continue
 		}
-		if normalizeDistName(base[:idx]) == norm {
-			return true
+		if normalizeDistName(base[:idx]) != norm {
+			continue
+		}
+		nameMatch = true
+		if wantVersion != "" && base[idx+1:] == wantVersion {
+			// Exact version match — best possible, return immediately.
+			return true, true
 		}
 	}
-	return false
+	return nameMatch, versionMatch
 }
 
 // findGitCheckoutByRepo searches UV git checkouts for a directory that matches the given repo.

--- a/internal/security/scanner/source_resolver_test.go
+++ b/internal/security/scanner/source_resolver_test.go
@@ -3,7 +3,9 @@ package scanner
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -741,6 +743,157 @@ func TestResolveUvxCacheArchiveNoMatch(t *testing.T) {
 	})
 	if err == nil {
 		t.Error("expected error when package absent from uv cache")
+	}
+}
+
+// TestResolveNpxCacheHonorsPinnedVersion (MCP-2445) verifies that when the same
+// package is cached under multiple npx hashes at DIFFERENT versions, a spec with
+// an exact version pin selects the matching install — NOT the newest-mtime one.
+func TestResolveNpxCacheHonorsPinnedVersion(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+
+	pkg := filepath.Join("node_modules", "@modelcontextprotocol", "server-everything")
+
+	// Pinned version 1.0.0 lives under an OLDER mtime.
+	wantDir := filepath.Join(homeDir, ".npm", "_npx", "wanthash", pkg)
+	os.MkdirAll(wantDir, 0755)
+	os.WriteFile(filepath.Join(wantDir, "package.json"),
+		[]byte(`{"name":"@modelcontextprotocol/server-everything","version":"1.0.0"}`), 0644)
+
+	// A NEWER but version-mismatched install (2.0.0) would win newest-mtime.
+	otherDir := filepath.Join(homeDir, ".npm", "_npx", "otherhash", pkg)
+	os.MkdirAll(otherDir, 0755)
+	os.WriteFile(filepath.Join(otherDir, "package.json"),
+		[]byte(`{"name":"@modelcontextprotocol/server-everything","version":"2.0.0"}`), 0644)
+
+	older := time.Now().Add(-2 * time.Hour)
+	newer := time.Now()
+	if err := os.Chtimes(wantDir, older, older); err != nil {
+		t.Fatalf("chtimes want: %v", err)
+	}
+	if err := os.Chtimes(otherDir, newer, newer); err != nil {
+		t.Fatalf("chtimes other: %v", err)
+	}
+
+	r := NewSourceResolver(zap.NewNop())
+	result, err := r.resolveNpxCache(ServerInfo{
+		Name:    "everything-server",
+		Command: "npx",
+		Args:    []string{"-y", "@modelcontextprotocol/server-everything@1.0.0"},
+	})
+	if err != nil {
+		t.Fatalf("resolveNpxCache: %v", err)
+	}
+	if result.SourceDir != wantDir {
+		t.Errorf("expected version-pinned dir %q, got %q", wantDir, result.SourceDir)
+	}
+}
+
+// TestResolveUvxCacheWithFlag (MCP-2445) verifies that `uvx --with <extra> <pkg>`
+// resolves the TARGET package, not the additional `--with` dependency. The old
+// parser stopped at the first positional after `--with`, mistaking the extra dep
+// (or, with `--with x --from y`, never reaching `--from`) for the target.
+func TestResolveUvxCacheWithFlag(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+
+	// Only the TARGET package is present in the tools dir; the --with dep is not.
+	toolDir := filepath.Join(homeDir, ".local", "share", "uv", "tools", "main-tool")
+	os.MkdirAll(toolDir, 0755)
+	os.WriteFile(filepath.Join(toolDir, "main.py"), []byte("# main"), 0644)
+
+	r := NewSourceResolver(zap.NewNop())
+	for _, args := range [][]string{
+		{"--with", "extra-dep", "main-tool"},
+		{"--with", "extra-dep", "--from", "main-tool", "main-tool"},
+	} {
+		result, err := r.resolveUvxCache(ServerInfo{Name: "main-tool", Command: "uvx", Args: args})
+		if err != nil {
+			t.Fatalf("resolveUvxCache(%v): %v", args, err)
+		}
+		if result.SourceDir != toolDir {
+			t.Errorf("args %v: expected target tool dir %q (not the --with dep), got %q", args, toolDir, result.SourceDir)
+		}
+	}
+}
+
+// TestResolveUvxCacheArchiveHonorsPinnedVersion (MCP-2445) verifies that an exact
+// version pin selects the matching .dist-info archive entry over a newer one.
+func TestResolveUvxCacheArchiveHonorsPinnedVersion(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+
+	wantEntry := writeUvArchiveWheel(t, homeDir, "Hashwant", "mcp-server-fetch", "1.0.0", "mcp_server_fetch", false)
+	otherEntry := writeUvArchiveWheel(t, homeDir, "Hashother", "mcp-server-fetch", "2.0.0", "mcp_server_fetch", false)
+
+	older := time.Now().Add(-2 * time.Hour)
+	newer := time.Now()
+	if err := os.Chtimes(wantEntry, older, older); err != nil {
+		t.Fatalf("chtimes want: %v", err)
+	}
+	if err := os.Chtimes(otherEntry, newer, newer); err != nil {
+		t.Fatalf("chtimes other: %v", err)
+	}
+
+	r := NewSourceResolver(zap.NewNop())
+	result, err := r.resolveUvxCache(ServerInfo{
+		Name:    "fetch",
+		Command: "uvx",
+		Args:    []string{"mcp-server-fetch==1.0.0"},
+	})
+	if err != nil {
+		t.Fatalf("resolveUvxCache: %v", err)
+	}
+	if result.SourceDir != wantEntry {
+		t.Errorf("expected version-pinned archive %q, got %q", wantEntry, result.SourceDir)
+	}
+}
+
+// TestNpxContainerLocateScript (MCP-2445) exercises the generated /bin/sh locate
+// script on the host against a fake npx cache tree. It proves: (a) with a version
+// pin, the bucket whose package.json declares that version is returned even when a
+// different version sorts first in the glob; (b) with no pin, the first match is
+// returned (previous behavior).
+func TestNpxContainerLocateScript(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("script targets /bin/sh; not applicable on Windows")
+	}
+	root := t.TempDir()
+	pkg := "@modelcontextprotocol/server-everything"
+
+	// hashA sorts first alphabetically and holds version 2.0.0.
+	dirA := filepath.Join(root, "hashA", "node_modules", pkg)
+	os.MkdirAll(dirA, 0755)
+	os.WriteFile(filepath.Join(dirA, "package.json"), []byte(`{"name":"x","version":"2.0.0"}`), 0644)
+	// hashB sorts later and holds the pinned version 1.0.0.
+	dirB := filepath.Join(root, "hashB", "node_modules", pkg)
+	os.MkdirAll(dirB, 0755)
+	os.WriteFile(filepath.Join(dirB, "package.json"), []byte(`{"name":"x","version":"1.0.0"}`), 0644)
+
+	run := func(version string) string {
+		script := npxContainerLocateScript(root, pkg, version)
+		out, err := exec.Command("sh", "-c", script).Output()
+		if err != nil {
+			t.Fatalf("script error (version=%q): %v", version, err)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	// Version pin selects the matching bucket, not the first-globbed one.
+	if got := run("1.0.0"); got != dirB {
+		t.Errorf("version pin 1.0.0: got %q, want %q", got, dirB)
+	}
+	// No pin returns the first match (hashA sorts first).
+	if got := run(""); got != dirA {
+		t.Errorf("no pin: got %q, want first match %q", got, dirA)
+	}
+	// A pin with no matching install falls back to the first match.
+	if got := run("9.9.9"); got != dirA {
+		t.Errorf("unmatched pin: got %q, want fallback %q", got, dirA)
 	}
 }
 

--- a/internal/security/scanner/source_resolver_test.go
+++ b/internal/security/scanner/source_resolver_test.go
@@ -957,6 +957,12 @@ func TestNpxContainerLocateScript(t *testing.T) {
 	dirB := filepath.Join(root, "hashB", "node_modules", pkg)
 	os.MkdirAll(dirB, 0755)
 	os.WriteFile(filepath.Join(dirB, "package.json"), []byte(`{"name":"x","version":"1.0.0"}`), 0644)
+	// hashC holds a version with regex-special chars: a literal '.' and '-'. A pin
+	// of "1.0.0-alpha.1" must NOT match this "1.0.0-alpha-1" (the '.' is not a
+	// wildcard) — the container compare must be literal, not an ERE (MCP-2445 round-3).
+	dirC := filepath.Join(root, "hashC", "node_modules", pkg)
+	os.MkdirAll(dirC, 0755)
+	os.WriteFile(filepath.Join(dirC, "package.json"), []byte(`{"name":"x","version":"1.0.0-alpha-1"}`), 0644)
 
 	run := func(version string) string {
 		script := npxContainerLocateScript(root, pkg, version)
@@ -979,6 +985,15 @@ func TestNpxContainerLocateScript(t *testing.T) {
 	// version (MCP-2445 round-2 hole #3): scanning the wrong version = false coverage.
 	if got := run("9.9.9"); got != "" {
 		t.Errorf("unmatched pin: got %q, want empty (no mismatched substitute)", got)
+	}
+	// Regex-special pin must compare LITERALLY: "1.0.0-alpha.1" must NOT match the
+	// cached "1.0.0-alpha-1" (an ERE would treat '.' as a wildcard) — MCP-2445 round-3.
+	if got := run("1.0.0-alpha.1"); got != "" {
+		t.Errorf("regex-special pin matched a different version (got %q); compare must be literal", got)
+	}
+	// The exact version (incl. the literal '.') still resolves.
+	if got := run("1.0.0-alpha-1"); got != dirC {
+		t.Errorf("exact regex-special pin: got %q, want %q", got, dirC)
 	}
 }
 

--- a/internal/security/scanner/source_resolver_test.go
+++ b/internal/security/scanner/source_resolver_test.go
@@ -791,6 +791,90 @@ func TestResolveNpxCacheHonorsPinnedVersion(t *testing.T) {
 	}
 }
 
+// TestResolveNpxCachePinMissNotResolved (MCP-2445 round-2 hole #3) verifies that
+// when an exact version is pinned but ONLY a different version is cached, the
+// resolver returns an error rather than substituting the mismatched version
+// (which would scan the wrong code and report false coverage).
+func TestResolveNpxCachePinMissNotResolved(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+
+	pkg := filepath.Join("node_modules", "@modelcontextprotocol", "server-everything")
+	// Only version 2.0.0 is cached; the spec pins 1.0.0.
+	dir := filepath.Join(homeDir, ".npm", "_npx", "onlyhash", pkg)
+	os.MkdirAll(dir, 0755)
+	os.WriteFile(filepath.Join(dir, "package.json"),
+		[]byte(`{"name":"@modelcontextprotocol/server-everything","version":"2.0.0"}`), 0644)
+
+	r := NewSourceResolver(zap.NewNop())
+	_, err := r.resolveNpxCache(ServerInfo{
+		Name:    "everything-server",
+		Command: "npx",
+		Args:    []string{"-y", "@modelcontextprotocol/server-everything@1.0.0"},
+	})
+	if err == nil {
+		t.Fatal("expected error on version-pin miss (must not substitute a mismatched cached version)")
+	}
+}
+
+// TestResolveUvxCacheArchivePinMissNotResolved (MCP-2445 round-2 hole #3): an
+// exact pin absent from the archive cache must NOT fall back to a different
+// cached version.
+func TestResolveUvxCacheArchivePinMissNotResolved(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+
+	// Only 2.0.0 cached; spec pins 1.0.0.
+	writeUvArchiveWheel(t, homeDir, "Hashonly", "mcp-server-fetch", "2.0.0", "mcp_server_fetch", false)
+
+	r := NewSourceResolver(zap.NewNop())
+	_, err := r.resolveUvxCache(ServerInfo{
+		Name:    "fetch",
+		Command: "uvx",
+		Args:    []string{"mcp-server-fetch==1.0.0"},
+	})
+	if err == nil {
+		t.Fatal("expected error on uvx archive version-pin miss (must not substitute a mismatched version)")
+	}
+}
+
+// TestResolveUvxCacheToolsDirPinGuard (MCP-2445 round-2 hole #3): the persistent
+// `uv tool install` tools dir must not satisfy a version pin it doesn't match.
+func TestResolveUvxCacheToolsDirPinGuard(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+
+	// Tools dir installed at 2.0.0 (dist-info under the venv site-packages).
+	toolsDir := filepath.Join(homeDir, ".local", "share", "uv", "tools", "my-tool")
+	sp := filepath.Join(toolsDir, "lib", "python3.11", "site-packages")
+	os.MkdirAll(filepath.Join(sp, "my_tool-2.0.0.dist-info"), 0755)
+	os.WriteFile(filepath.Join(sp, "my_tool-2.0.0.dist-info", "METADATA"), []byte("Name: my-tool\n"), 0644)
+	os.MkdirAll(filepath.Join(sp, "my_tool"), 0755)
+	os.WriteFile(filepath.Join(sp, "my_tool", "__init__.py"), []byte("# src"), 0644)
+
+	r := NewSourceResolver(zap.NewNop())
+
+	// Pin 1.0.0 (absent) → must NOT resolve the 2.0.0 tools dir.
+	if _, err := r.resolveUvxCache(ServerInfo{Name: "my-tool", Command: "uvx", Args: []string{"my-tool==1.0.0"}}); err == nil {
+		t.Error("expected pin-miss error: tools dir is 2.0.0, pinned 1.0.0")
+	}
+	// Pin 2.0.0 (present) → resolves the tools dir.
+	res, err := r.resolveUvxCache(ServerInfo{Name: "my-tool", Command: "uvx", Args: []string{"my-tool==2.0.0"}})
+	if err != nil {
+		t.Fatalf("exact-pin hit should resolve: %v", err)
+	}
+	if res.SourceDir != toolsDir {
+		t.Errorf("got %q, want tools dir %q", res.SourceDir, toolsDir)
+	}
+	// No pin → resolves the tools dir (unchanged behavior).
+	if _, err := r.resolveUvxCache(ServerInfo{Name: "my-tool", Command: "uvx", Args: []string{"my-tool"}}); err != nil {
+		t.Errorf("unpinned should resolve tools dir: %v", err)
+	}
+}
+
 // TestResolveUvxCacheWithFlag (MCP-2445) verifies that `uvx --with <extra> <pkg>`
 // resolves the TARGET package, not the additional `--with` dependency. The old
 // parser stopped at the first positional after `--with`, mistaking the extra dep
@@ -891,9 +975,10 @@ func TestNpxContainerLocateScript(t *testing.T) {
 	if got := run(""); got != dirA {
 		t.Errorf("no pin: got %q, want first match %q", got, dirA)
 	}
-	// A pin with no matching install falls back to the first match.
-	if got := run("9.9.9"); got != dirA {
-		t.Errorf("unmatched pin: got %q, want fallback %q", got, dirA)
+	// A pin with no matching install returns NOTHING — never a mismatched
+	// version (MCP-2445 round-2 hole #3): scanning the wrong version = false coverage.
+	if got := run("9.9.9"); got != "" {
+		t.Errorf("unmatched pin: got %q, want empty (no mismatched substitute)", got)
 	}
 }
 
@@ -1045,22 +1130,36 @@ func TestDirLooksLikeSource(t *testing.T) {
 
 func TestIsPackageRunnerCommand(t *testing.T) {
 	tests := []struct {
+		name string
 		cmd  string
+		args []string
 		want bool
 	}{
-		{"npx", true},
-		{"/usr/local/bin/npx", true},
-		{"uvx", true},
-		{"pipx", true},
-		{"bunx", true},
-		{"python", false},
-		{"node", false},
-		{"./server", false},
+		// npx/uvx/bunx always run a package — runner by name.
+		{"npx", "npx", []string{"-y", "pkg"}, true},
+		{"npx path", "/usr/local/bin/npx", []string{"pkg"}, true},
+		{"uvx", "uvx", []string{"pkg"}, true},
+		{"bunx", "bunx", []string{"pkg"}, true},
+		// Subcommand-style runners: ONLY a runner when the ephemeral-run keyword is
+		// present (argument-aware classification, MCP-2445 round-2 hole #2).
+		{"pipx run", "pipx", []string{"run", "pkg"}, true},
+		{"pipx install (not runner)", "pipx", []string{"install", "pkg"}, false},
+		{"pnpm dlx", "pnpm", []string{"dlx", "pkg"}, true},
+		{"pnpm start (not runner)", "pnpm", []string{"start"}, false},
+		{"pnpm -p start (not runner)", "pnpm", []string{"-p", "start"}, false},
+		{"yarn dlx", "yarn", []string{"dlx", "pkg"}, true},
+		{"yarn build (not runner)", "yarn", []string{"build"}, false},
+		{"bun x", "bun", []string{"x", "pkg"}, true},
+		{"bun server.ts (not runner)", "bun", []string{"server.ts"}, false},
+		// Non-runners.
+		{"python", "python", []string{"app.py"}, false},
+		{"node", "node", []string{"server.js"}, false},
+		{"./server", "./server", nil, false},
 	}
 	for _, tt := range tests {
-		t.Run(tt.cmd, func(t *testing.T) {
-			if got := isPackageRunnerCommand(tt.cmd); got != tt.want {
-				t.Errorf("isPackageRunnerCommand(%q) = %v, want %v", tt.cmd, got, tt.want)
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isPackageRunnerCommand(tt.cmd, tt.args); got != tt.want {
+				t.Errorf("isPackageRunnerCommand(%q, %v) = %v, want %v", tt.cmd, tt.args, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Fixes a cluster of correctness bugs in scanner source resolution (Codex scanner audit, PRs #653–#670). The scanner mis-parsed several package-runner launch commands and ignored requested version pins, so it scanned the **wrong source** (or degraded to tool-definitions-only).

Refs against `origin/main`.

## Bugs fixed

- **Subcommand runners mis-parsed.** `pipx run X` → `"run"`, `pnpm dlx X` → `"dlx"` (returned the subcommand, not the package).
- **pnpm dead branch.** `resolveFromPackageFetch` dispatched pnpm but `isPackageRunnerCommand` excluded it → pnpm never reached the fetch.
- **Version pin ignored.** `resolveNpxCache` / `findUvxArchiveDir` / `findContainerTargetDir` picked newest-mtime, ignoring the requested version.
- **`--with` mis-handled.** `resolveUvxCache` only honored `--from`; `uvx --with <dep> <pkg>` resolved the extra dep, not the target.
- **No fetch timeout.** A hung/throttled registry could stall the scan indefinitely.
- **Unpinned cisco image.** `docker/scanners/cisco/Dockerfile` installed `cisco-ai-mcp-scanner` unpinned.

## Changes

- New command-aware `runnerPackageSpec()` parser: subcommand runners (`pipx run`, `pnpm dlx`, `yarn dlx`, `bun x`), package-naming flags (`npx --package/-p`, `uvx --from`), and skips non-target value flags (`uvx --with <dep>`, `-p/--python <ver>`, `-c <cmd>`). Replaces `firstPackageArg` and the ad-hoc parse loops in `resolveNpxCache` / `resolveUvxCache` / `npxTargetPackage` / `uvxTargetPackage` (host/container parity).
- `isPackageRunnerCommand` now includes `pnpm`/`yarn`/`bun`; npm fetch path dispatches them.
- Exact version pin honored in local caches (npx package.json version, uvx `.dist-info` version, container npx bucket), falling back to newest/first when unpinned or unmatched.
- 90s bounded timeout around the published-source fetch (download + extract).
- Pinned `cisco-ai-mcp-scanner==4.7.3` (reproducible, rug-pull guard).

## Tests (TDD)

- `TestRunnerPackageSpec` — table tests: `pipx run X`, `pnpm dlx X`, `yarn dlx X`, `bun x X`, `npx -p`, `uvx --from`, `uvx --with`, `uvx -p/--python` → `X`.
- `TestResolveNpxCacheHonorsPinnedVersion`, `TestResolveUvxCacheArchiveHonorsPinnedVersion` — pinned version selected over newer mismatch.
- `TestResolveUvxCacheWithFlag` — `--with <dep>` does not shadow the target.
- `TestNpxContainerLocateScript` — generated `/bin/sh` locate script run on the host: version pin selects the matching bucket; no pin returns first match.

```
go test ./internal/security/... -race   # green
golangci-lint run --config .github/.golangci.yml ./internal/security/scanner/   # 0 issues
```

Docs updated in the same PR (`docs/features/security-scanner-plugins.md`).

Related MCP-2445