### PR TITLE
fix(ci): point Server Edition test job at internal/serveredition (not deleted internal/teams)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -204,7 +204,7 @@ jobs:
         run: go build -tags server ./cmd/mcpproxy
 
       - name: Test server edition packages
-        run: go test -race -tags server ./internal/teams/... ./internal/config/...
+        run: go test -race -tags server ./internal/serveredition/... ./internal/config/...
 
   build:
     name: Build


### PR DESCRIPTION
## Problem
The `Server Edition` CI job (added in #631) runs:
```
go test -race -tags server ./internal/teams/... ./internal/config/...
```
But the Teams→Server Edition rename (#603) moved that code to `internal/serveredition/`, and #679 removed the last stale `internal/teams/` file. The job now fails:
```
pattern ./internal/teams/...: lstat ./internal/teams/: no such file or directory
```
Worse: before #679 it was silently testing the stale, near-empty `internal/teams/` path — **never the real `internal/serveredition/` packages** (the multi-user/auth/broker/workspace code). So the job gave false confidence.

## Fix
Test `./internal/serveredition/...` instead. **One-line workflow change.**

## Verification (local, exact CI command)
`go test -race -tags server ./internal/serveredition/... ./internal/config/...` → all 8 packages `ok` (serveredition + api + auth + broker + multiuser + users + workspace + config).

Follow-up to #679 (MCP-2455). Unblocks the Server Edition check on all open PRs once they pick up this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)