### PR TITLE
test(runtime): deflake Windows 5m package timeout in internal/runtime (MCP-2493)

### DIFF
--- a/internal/runtime/tool_quarantine_invariant_test.go
+++ b/internal/runtime/tool_quarantine_invariant_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,6 +14,26 @@ import (
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
 )
+
+// skipQuarantinePropertyTestOnWindows skips the rapid-based property tests below
+// on Windows. Each rapid.Check iteration creates and tears down a full
+// BBolt-backed Runtime in a temp dir; with hundreds of iterations under `-race`
+// these tests run for several minutes. On Windows the slower file IO/timers push
+// them past the 5m package timeout of the Unit Tests (windows-latest) job, which
+// runs `go test -race -timeout 5m ./...` without `-short`, producing flaky
+// "panic: test timed out after 5m0s" reds in internal/runtime (MCP-2493).
+//
+// The invariants these tests assert (tool-approval hash + storage state machine)
+// are platform-independent, so full coverage on Linux/macOS — plus the dedicated
+// heavy-runtime CI job — is sufficient. This mirrors the existing Windows skip in
+// apply_config_restart_test.go.
+func skipQuarantinePropertyTestOnWindows(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("heavy rapid property test exceeds the 5m Windows -race package timeout (MCP-2493); " +
+			"platform-independent invariants are fully covered on Linux/macOS and the heavy-runtime CI job")
+	}
+}
 
 // =============================================================================
 // Unit tests for assertToolApprovalInvariant
@@ -356,6 +377,7 @@ func TestRapidQuarantineStateMachine(t *testing.T) {
 	if testing.Short() {
 		t.Skip("heavy property test (~270s under -race); runs in the stress-tests CI job")
 	}
+	skipQuarantinePropertyTestOnWindows(t)
 	rapid.Check(t, func(t *rapid.T) {
 		// Set up runtime with quarantine enabled
 		tempDir, err := os.MkdirTemp("", "quarantine-rapid-*")
@@ -504,6 +526,7 @@ func TestRapidInvariant_ChangedNeverAutoApproved(t *testing.T) {
 	if testing.Short() {
 		t.Skip("heavy property test (~70s under -race); runs in the stress-tests CI job")
 	}
+	skipQuarantinePropertyTestOnWindows(t)
 	rapid.Check(t, func(t *rapid.T) {
 		tempDir, err := os.MkdirTemp("", "quarantine-changed-*")
 		if err != nil {
@@ -585,6 +608,7 @@ func TestRapidInvariant_ChangedNeverAutoApproved(t *testing.T) {
 // TestRapidInvariant_PendingNeverAutoApproved is a focused property test that
 // verifies pending tools never auto-approve when quarantine is enabled.
 func TestRapidInvariant_PendingNeverAutoApproved(t *testing.T) {
+	skipQuarantinePropertyTestOnWindows(t)
 	rapid.Check(t, func(t *rapid.T) {
 		tempDir, err := os.MkdirTemp("", "quarantine-pending-*")
 		if err != nil {


### PR DESCRIPTION
## Problem (MCP-2493)

The `Unit Tests (windows-latest, 1.25)` job intermittently fails with:

```
panic: test timed out after 5m0s
FAIL github.com/smart-mcp-proxy/mcpproxy-go/internal/runtime 300s
```

It flaked on PRs #675, #685, and #684's first run — always unrelated to the PR's change (including Vue-only PRs). Not a required check (only `Unit Tests (ubuntu …)` is required), so it does not block merges, but it produces repeated false reds.

## Root cause

`.github/workflows/unit-tests.yml` runs the Windows job as:

```
go test -v -race -timeout 5m ... ./...
```

— **without `-short`**. The `internal/runtime` package contains three heavy [`rapid`](https://pkg.go.dev/pgregory.net/rapid)-based property tests that each create and tear down hundreds of BBolt-backed `Runtime`s per `rapid.Check` run:

- `TestRapidQuarantineStateMachine` (~270s under `-race` per its own skip note)
- `TestRapidInvariant_ChangedNeverAutoApproved` (~70s under `-race`)
- `TestRapidInvariant_PendingNeverAutoApproved` (no guard at all)

Two of them already carry `testing.Short()` skip guards, but those never fire because the job omits `-short`. On Windows the slower file IO/timers push the package total past the 5m timeout → the package-wide panic. On Linux/macOS the same tests fit within the default 10m and pass (which is why only Windows flakes).

## Fix (scoped to the offending tests, per the issue)

Add a documented Windows-only skip helper (`skipQuarantinePropertyTestOnWindows`) and call it from the three tests. This mirrors the existing precedent in `apply_config_restart_test.go:150` (`runtime.GOOS == "windows"`).

- The invariants asserted (tool-approval hash + storage state machine) are **platform-independent**, so Linux/macOS coverage plus the dedicated heavy-runtime job in `e2e-tests.yml` (`-timeout 20m`) is sufficient.
- The global/package test timeout is **left untouched** (per the issue's "don't blanket-bump" guidance).
- `testing.Short()` guards are kept as-is.

Test-only change; no production code touched. Stays entirely in the `internal/` lane.

> Note for the Release/CI lane: `unit-tests.yml` claims-by-omission to run the fast path but never passes `-short`, while `e2e-tests.yml` line 99 does. Wiring `-short` into `unit-tests.yml` would be the deeper alignment, but that's a CI-config change outside this backend lane and not required to fix the flake — flagging it for follow-up.

## Verification

```
$ gofmt -l internal/runtime/tool_quarantine_invariant_test.go   # clean
$ GOOS=windows go vet ./internal/runtime/                        # exit 0 (skip path compiles for Windows)
$ golangci-lint run --config .github/.golangci.yml internal/runtime/   # 0 issues
$ go test -race -v -run 'TestRapidQuarantineStateMachine|TestRapidInvariant_ChangedNeverAutoApproved|TestRapidInvariant_PendingNeverAutoApproved' ./internal/runtime/
--- PASS: TestRapidQuarantineStateMachine (22.39s)
--- PASS: TestRapidInvariant_ChangedNeverAutoApproved (19.93s)
--- PASS: TestRapidInvariant_PendingNeverAutoApproved (22.43s)
ok  github.com/smart-mcp-proxy/mcpproxy-go/internal/runtime  66.333s
```

The non-Windows path is unchanged (tests still run and pass); Windows now skips the three heavy tests, eliminating the 5m package panic.

Related #MCP-2493