### PR TITLE
fix(docker): direct-exec resolved docker binary for isolated spawn (#696 follow-up)

### DIFF
--- a/internal/shellwrap/shellwrap.go
+++ b/internal/shellwrap/shellwrap.go
@@ -217,15 +217,27 @@ func ResolveDockerPath(logger *zap.Logger) (string, error) {
 	dockerPathMu.Lock()
 	defer dockerPathMu.Unlock()
 
-	// Honor cache: keep successful resolutions forever; treat failures as
-	// retryable after dockerPathNegativeTTL.
-	if dockerPathHasResult {
-		if dockerPathErr == nil {
-			return dockerPath, nil
+	// Honor cache: keep successful resolutions forever.
+	if dockerPathHasResult && dockerPathErr == nil {
+		return dockerPath, nil
+	}
+
+	// A cached negative within its TTL would normally short-circuit here. But
+	// the well-known-path probe is a pure os.Stat — never sandbox- or
+	// login-shell-restricted — so a negative cached because only the restricted
+	// login-shell leg failed must NOT permanently shadow a docker binary that is
+	// sitting at a well-known path right now (the spawn-vs-status divergence in
+	// MCP-2744). Re-run the cheap probe before honoring a live negative; on
+	// success, upgrade the cache to a permanent success and return it.
+	if dockerPathHasResult && dockerPathErr != nil &&
+		!dockerPathExpires.IsZero() && time.Now().Before(dockerPathExpires) {
+		if p := probeWellKnownDocker(logger); p != "" {
+			dockerPath = p
+			dockerPathErr = nil
+			dockerPathExpires = time.Time{}
+			return p, nil
 		}
-		if !dockerPathExpires.IsZero() && time.Now().Before(dockerPathExpires) {
-			return dockerPath, dockerPathErr
-		}
+		return dockerPath, dockerPathErr
 	}
 
 	path, err := resolveDockerPathUncached(logger)

--- a/internal/shellwrap/shellwrap_test.go
+++ b/internal/shellwrap/shellwrap_test.go
@@ -219,6 +219,51 @@ func TestResolveDockerPath_NegativeTTLRetry(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
+// TestResolveDockerPath_StatProbeOverridesLiveNegative is the MCP-2744
+// regression guard: a still-LIVE cached negative (within its TTL, NOT expired)
+// must never shadow a docker binary that is sitting at a well-known path right
+// now. The well-known-path probe is a pure os.Stat — it is never sandbox- or
+// login-shell-restricted — so the first resolution failing only because the
+// restricted login-shell leg failed must not poison discovery for the whole
+// TTL window. Distinct from TestResolveDockerPath_NegativeTTLRetry, which
+// relies on TTL expiry; here the TTL stays at its default so the negative is
+// still "live" on the second call.
+func TestResolveDockerPath_StatProbeOverridesLiveNegative(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-only fixture")
+	}
+	resetDockerPathCacheForTest()
+	t.Cleanup(resetDockerPathCacheForTest)
+
+	// Leave dockerPathNegativeTTL at its default (60s) so the cached negative is
+	// still valid on the second call — we prove the os.Stat probe overrides it.
+
+	// FIRST call fails everywhere: no PATH docker, no well-known docker, the
+	// login shell emits nothing.
+	prevPaths := wellKnownDockerPathsFn
+	wellKnownDockerPathsFn = func() []string { return nil }
+	t.Cleanup(func() { wellKnownDockerPathsFn = prevPaths })
+
+	t.Setenv("PATH", t.TempDir())
+	shellDir := t.TempDir()
+	fakeShell := writeFakeShell(t, shellDir, "")
+	t.Setenv("SHELL", fakeShell)
+
+	_, err := ResolveDockerPath(nil)
+	require.Error(t, err, "first call should cache a negative (docker absent everywhere)")
+
+	// Docker Desktop's bundle binary now appears at a well-known path. The cheap
+	// os.Stat probe must override the still-live cached negative on the very
+	// next call — no TTL expiry required.
+	dockerDir := t.TempDir()
+	want := writeFakeDocker(t, dockerDir)
+	wellKnownDockerPathsFn = func() []string { return []string{want} }
+
+	got, err := ResolveDockerPath(nil)
+	require.NoError(t, err, "a live negative must not shadow a now-present well-known docker")
+	assert.Equal(t, want, got)
+}
+
 // TestResolveDockerPath_WellKnownPathFallback simulates a PKG-installer
 // context: docker is missing from $PATH and the login shell emits nothing,
 // but Docker Desktop installed a binary at a well-known path. The fallback


### PR DESCRIPTION
## Summary

Docker-isolated upstream servers still failed to start with `command not found: docker` when the `docker` CLI is not on the spawn PATH (Docker Desktop installed without the optional CLI-tools step), **even after PR #697**. #697 resolved the absolute path but still routed the spawn through `$SHELL -l -c "<docker> run …"`, where the login shell re-derives `$PATH` from rc files and can drop the bundle dir. The absolute path was only a token inside the `-c` string, so the bug persisted while `upstream_servers list` reported a healthy `docker_path` (same resolver, different time/path → "status available, spawn not found").

Related #696. Branched from `origin/main` (contains #697 / `79849e0c`).

## Changes

**A — direct-exec the resolved docker binary (primary).** On successful resolution, `setupDockerIsolation` now returns the resolved absolute docker binary as the exec command with the raw docker argv (no login-shell wrap), mirroring the management path's `newDockerCmd` (`exec.CommandContext(dockerBin, …)`). It returns a `shellWrapped` flag so callers select the matching cidfile helper. Login-shell wrap of bare `docker` is kept **only** on the resolution-failure fallback. The spawn env already carries the enhanced PATH (`BuildSecureEnvironment`, `EnhancePath=true`), and exec'ing an absolute path needs no PATH at all.
- New `insertCidfileIntoDockerArgs` inserts `--cidfile <file>` right after the `run` token in the argv slice — platform-agnostic, sidestepping the `-c` vs `/c` shell quirk. Both call sites (`connection_stdio.go`, `connection_launcher.go`) branch on `shellWrapped`.

**B — negative-cache cannot shadow a live os.Stat probe.** `ResolveDockerPath` re-runs the cheap, sandbox-immune well-known `os.Stat` probe before honoring a still-live cached negative, so a failure cached when only the restricted login-shell leg failed can never permanently shadow a docker binary sitting at a well-known path.

## Tests (TDD — written first, watched fail, then implemented)

- `TestSetupDockerIsolationExecsResolvedBinaryDirectly` (new, the regression that failed today): asserts `finalCommand == <resolved>`, `args[0] == "run"`, no shell `-c` indirection.
- Updated `TestSetupDockerIsolationUsesResolvedAbsolutePath`, `…CidfileInsertionWithAbsolutePath`, `…FallsBackToBareDocker`, `TestInsertCidfileWindowsCmdFormat` for the args-based cidfile + direct-exec shape; added `TestInsertCidfileIntoDockerArgs`.
- `TestResolveDockerPath_StatProbeOverridesLiveNegative` (new) — a still-live negative must not shadow a now-present well-known docker.

## Verification

```
go test ./internal/upstream/... ./internal/shellwrap/... -race   # ok
go build ./cmd/mcpproxy                                          # ok
golangci-lint run --config .github/.golangci.yml ./internal/upstream/core/... ./internal/shellwrap/...  # 0 issues (v2)
```

Docs: `docs/docker-isolation.md` troubleshooting section updated to describe direct-exec (ENG-9).

> Generated with mcpproxy cockpit — engineer agent. Human merges at the pre-merge gate.