### PR TITLE
fix(secureenv): trim whitespace before proxy credential redaction (MCP-2776)

### DIFF
--- a/internal/secureenv/manager.go
+++ b/internal/secureenv/manager.go
@@ -342,6 +342,10 @@ func anyProxyKeyPresent(present map[string]struct{}, group []string) bool {
 // proxy host/port so the proxy remains functional. Non-URL values (e.g. the
 // host list in NO_PROXY) and unparseable values are returned unchanged.
 func redactProxyCredentials(value string) string {
+	// Surrounding whitespace would make url.Parse error (leading space) or
+	// otherwise fall through, forwarding a credentialed value verbatim. Trim it
+	// first; whitespace is never meaningful in a proxy URL.
+	value = strings.TrimSpace(value)
 	if value == "" {
 		return value
 	}

--- a/internal/secureenv/proxy_forward_test.go
+++ b/internal/secureenv/proxy_forward_test.go
@@ -36,6 +36,11 @@ func TestRedactProxyCredentials(t *testing.T) {
 		{"schemeless user only", "user@proxy.example.com:3128", "proxy.example.com:3128"},
 		{"schemeless no userinfo", "proxy.example.com:8080", "proxy.example.com:8080"},
 		{"schemeless at-in-path not stripped", "proxy.example.com:8080/path@x", "proxy.example.com:8080/path@x"},
+		// Whitespace-wrapped credentialed URLs would otherwise make url.Parse
+		// error and fall through, forwarding creds verbatim (PR #704 non-blocking
+		// review note). Surrounding whitespace is trimmed before redaction.
+		{"whitespace-wrapped scheme creds", "  http://user:pass@proxy.example.com:8080  ", "http://proxy.example.com:8080"},
+		{"whitespace-wrapped schemeless creds", "\tuser:pass@proxy.example.com:8080\n", "proxy.example.com:8080"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up to #704 (MCP-2769). The reviewer left a non-blocking note: `redactProxyCredentials` doesn't trim surrounding whitespace, so a credentialed value with leading/trailing spaces (`  http://user:pass@proxy  `) makes `url.Parse` error and fall through, forwarding the value **with credentials intact** — a residual gap in the redaction guarantee.

## Fix

`strings.TrimSpace(value)` at function entry, before any parsing. Whitespace is never meaningful in a proxy URL, so trimming is safe and the forwarded value is the clean redacted form.

## Tests

Added table cases to `TestRedactProxyCredentials`:
- `"  http://user:pass@proxy.example.com:8080  "` → `http://proxy.example.com:8080`
- `"\tuser:pass@proxy.example.com:8080\n"` (schemeless) → `proxy.example.com:8080`

## Verification

```
go test ./internal/secureenv/... -race    # ok
golangci-lint v2.5.0 --config .github/.golangci.yml ./internal/secureenv/...   # 0 issues
go build ./...   # ok
```

Related #704