### PR TITLE
fix(connect): merge onboarding connected_client_ids into wizard client list (MCP-2952)

### DIFF
--- a/frontend/src/components/ConnectModal.vue
+++ b/frontend/src/components/ConnectModal.vue
@@ -22,7 +22,7 @@
       <!-- Client list -->
       <div v-else class="space-y-2">
         <div
-          v-for="client in clients"
+          v-for="client in mergedClients"
           :key="client.id"
           class="flex items-center justify-between p-3 rounded-lg border border-base-300 hover:bg-base-200/50 transition-colors"
         >
@@ -91,6 +91,7 @@
 import { ref, reactive, computed, watch } from 'vue'
 import api from '@/services/api'
 import { useSystemStore } from '@/stores/system'
+import { useOnboardingStore } from '@/stores/onboarding'
 import type { ClientStatus } from '@/types'
 
 interface Props {
@@ -104,6 +105,7 @@ interface Emits {
 const props = defineProps<Props>()
 const emit = defineEmits<Emits>()
 const systemStore = useSystemStore()
+const onboarding = useOnboardingStore()
 
 const clients = ref<ClientStatus[]>([])
 const error = ref<string | null>(null)
@@ -114,10 +116,22 @@ const loading = reactive({
   clients: {} as Record<string, boolean>,
 })
 
+// MCP-2952: `GET /api/v1/connect` is stat-only (#706/MCP-2829) and reports
+// connected=false for every client. Merge the content-resolved
+// connected_client_ids (fetched on open via onboarding.fetchState) so already
+// connected clients render Disconnect instead of a fresh Connect button.
+// Derived (not mutated) so refreshes stay correct.
+const mergedClients = computed<ClientStatus[]>(() => {
+  const connectedIds = new Set(onboarding.connectedClientIds)
+  return clients.value.map(c =>
+    c.connected || !connectedIds.has(c.id) ? c : { ...c, connected: true }
+  )
+})
+
 const connectableClients = computed(() =>
   // Bridge clients (e.g. Claude Desktop) can be connected even without an
   // existing config file — Connect creates it.
-  clients.value.filter(c => c.supported && (c.exists || c.bridge) && !c.connected)
+  mergedClients.value.filter(c => c.supported && (c.exists || c.bridge) && !c.connected)
 )
 
 const allConnected = computed(() =>
@@ -226,10 +240,13 @@ function close() {
   emit('close')
 }
 
-// Fetch client list when modal opens
+// Fetch client list when modal opens. Also refresh the onboarding state so
+// connected_client_ids is current — this is the wizard-scoped, #706-safe path
+// that already content-resolves connections (MCP-2952).
 watch(() => props.show, (newVal) => {
   if (newVal) {
     fetchClients()
+    void onboarding.fetchState()
     resultMessage.value = ''
   }
 })

--- a/frontend/src/components/OnboardingWizard.vue
+++ b/frontend/src/components/OnboardingWizard.vue
@@ -657,18 +657,30 @@ const modalSizing = computed(() => ({
 // --- Client sort: detected → pinned trio → others -----------------------
 const PINNED_TRIO: readonly string[] = ['claude-code', 'codex', 'gemini']
 
+// MCP-2952: the `GET /api/v1/connect` listing is stat-only (#706/MCP-2829) and
+// always reports connected=false. Merge the content-resolved
+// connected_client_ids the wizard already fetched via onboarding.fetchState()
+// so connected clients render the Connected badge instead of a Connect button.
+// Derived (not mutated) so polling refreshes stay correct.
+const mergedClients = computed<ClientStatus[]>(() => {
+  const connectedIds = new Set(onboarding.connectedClientIds)
+  return clients.value.map(c =>
+    c.connected || !connectedIds.has(c.id) ? c : { ...c, connected: true }
+  )
+})
+
 const detectedClients = computed(() =>
-  clients.value.filter(c => c.exists)
+  mergedClients.value.filter(c => c.exists)
 )
 const pinnedClients = computed(() =>
   PINNED_TRIO
-    .map(id => clients.value.find(c => c.id === id))
+    .map(id => mergedClients.value.find(c => c.id === id))
     .filter((c): c is ClientStatus => !!c && !c.exists)
 )
 const moreClients = computed(() => {
   const detectedIds = new Set(detectedClients.value.map(c => c.id))
   const pinnedIds = new Set(pinnedClients.value.map(c => c.id))
-  return clients.value.filter(c => !detectedIds.has(c.id) && !pinnedIds.has(c.id))
+  return mergedClients.value.filter(c => !detectedIds.has(c.id) && !pinnedIds.has(c.id))
 })
 
 const serverCountLabel = computed(() => {

--- a/frontend/src/stores/onboarding.ts
+++ b/frontend/src/stores/onboarding.ts
@@ -40,6 +40,13 @@ export const useOnboardingStore = defineStore('onboarding', () => {
   const mcpClientsSeenEver = computed<string[]>(() => state.value?.mcp_clients_seen_ever ?? [])
   const incompleteTabCount = computed(() => state.value?.incomplete_tab_count ?? 0)
 
+  // MCP-2952 — content-resolved IDs of clients currently wired to MCPProxy.
+  // GetAllStatus()/`GET /api/v1/connect` is stat-only (#706/MCP-2829) and
+  // reports connected=false for every client, so the Connect wizard merges
+  // these IDs (already fetched with the onboarding state) to mark connected
+  // clients without triggering new content reads.
+  const connectedClientIds = computed<string[]>(() => state.value?.connected_client_ids ?? [])
+
   // v1 visibleSteps kept for back-compat with any remaining caller. The v2
   // wizard renders a fixed three-tab surface and ignores this value.
   const visibleSteps = computed<Array<'connect' | 'server'>>(() => {
@@ -161,6 +168,7 @@ export const useOnboardingStore = defineStore('onboarding', () => {
     firstMCPClientEver,
     mcpClientsSeenEver,
     incompleteTabCount,
+    connectedClientIds,
     visibleSteps,
     fetchState,
     mark,

--- a/frontend/tests/unit/connect-modal.spec.ts
+++ b/frontend/tests/unit/connect-modal.spec.ts
@@ -9,6 +9,7 @@ vi.mock('@/services/api', () => ({
     getConnectStatus: vi.fn(),
     connectClient: vi.fn(),
     disconnectClient: vi.fn(),
+    getOnboardingState: vi.fn(),
   },
 }))
 
@@ -21,6 +22,10 @@ describe('ConnectModal', () => {
     ;(api.getConnectStatus as any).mockReset()
     ;(api.connectClient as any).mockReset()
     ;(api.disconnectClient as any).mockReset()
+    ;(api.getOnboardingState as any).mockReset()
+    // Default: no content-resolved connections (most tests exercise the
+    // stat-only listing only). Individual tests override as needed.
+    ;(api.getOnboardingState as any).mockResolvedValue({ success: true, data: null })
   })
 
   it('renders an OpenCode row', async () => {
@@ -199,5 +204,68 @@ describe('ConnectModal', () => {
     await flushPromises()
 
     expect(disconnectSpy).toHaveBeenCalledWith('opencode', 'proxy-alt')
+  })
+
+  // MCP-2952: GetAllStatus() is stat-only (#706) and always reports
+  // connected=false. The wizard/modal must merge the content-resolved
+  // connected_client_ids from the onboarding state so already-connected
+  // clients render Disconnect, not a fresh Connect button.
+  it('renders Disconnect for a client present in connected_client_ids despite connected=false', async () => {
+    ;(api.getConnectStatus as any).mockResolvedValue({
+      success: true,
+      data: [
+        {
+          id: 'codex',
+          name: 'Codex CLI',
+          config_path: '/Users/test/.codex/config.toml',
+          exists: true,
+          connected: false, // stat-only listing never sets this
+          supported: true,
+          icon: 'codex',
+        },
+        {
+          id: 'cursor',
+          name: 'Cursor',
+          config_path: '/Users/test/.cursor/mcp.json',
+          exists: true,
+          connected: false, // genuinely not connected
+          supported: true,
+          icon: 'cursor',
+        },
+      ],
+    })
+    ;(api.getOnboardingState as any).mockResolvedValue({
+      success: true,
+      data: {
+        has_connected_client: true,
+        has_configured_server: false,
+        connected_client_count: 1,
+        connected_client_ids: ['codex'],
+        configured_server_count: 0,
+        state: { engaged: false },
+        should_show_wizard: true,
+        first_mcp_client_ever: false,
+        mcp_clients_seen_ever: [],
+        incomplete_tab_count: 0,
+      },
+    })
+
+    const wrapper = mount(ConnectModal, {
+      props: { show: false },
+      global: { plugins: [pinia] },
+    })
+
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    // codex resolved as connected -> Disconnect button.
+    const codexRow = wrapper.find('button.btn-ghost.text-error')
+    expect(codexRow.exists()).toBe(true)
+    expect(codexRow.text()).toContain('Disconnect')
+
+    // cursor is genuinely not connected -> Connect button still offered.
+    const connectButtons = wrapper.findAll('button.btn-primary.btn-xs')
+    expect(connectButtons.length).toBe(1)
+    expect(connectButtons[0].text()).toContain('Connect')
   })
 })

--- a/frontend/tests/unit/onboarding-wizard-connected-merge.spec.ts
+++ b/frontend/tests/unit/onboarding-wizard-connected-merge.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import OnboardingWizard from '@/components/OnboardingWizard.vue'
+import api from '@/services/api'
+
+// MCP-2952: GetAllStatus() is stat-only (#706/MCP-2829) and always reports
+// connected=false for every installed client. The wizard already fetches the
+// onboarding state (which carries content-resolved connected_client_ids) and
+// must merge those IDs into the per-client list so connected clients render a
+// "Connected" badge instead of a fresh Connect button.
+
+vi.mock('@/services/api', () => ({
+  default: {
+    getConnectStatus: vi.fn(),
+    getOnboardingState: vi.fn(),
+    getActivities: vi.fn(),
+    getConfig: vi.fn(),
+    getDockerStatus: vi.fn(),
+    getCanonicalConfigPaths: vi.fn(),
+    connectClient: vi.fn(),
+  },
+}))
+
+function onboardingState(connectedIds: string[]) {
+  return {
+    success: true,
+    data: {
+      has_connected_client: connectedIds.length > 0,
+      has_configured_server: true,
+      connected_client_count: connectedIds.length,
+      connected_client_ids: connectedIds,
+      configured_server_count: 1,
+      state: { engaged: false },
+      should_show_wizard: true,
+      first_mcp_client_ever: false,
+      mcp_clients_seen_ever: [],
+      incomplete_tab_count: 0,
+    },
+  }
+}
+
+describe('OnboardingWizard connected_client_ids merge', () => {
+  let pinia: any
+
+  beforeEach(() => {
+    pinia = createPinia()
+    setActivePinia(pinia)
+    vi.clearAllMocks()
+    // Safe defaults for the wizard's open lifecycle.
+    ;(api.getActivities as any).mockResolvedValue({ success: true, data: { activities: [] } })
+    ;(api.getConfig as any).mockResolvedValue({ success: true, data: {} })
+    ;(api.getDockerStatus as any).mockResolvedValue({ success: true, data: { available: false } })
+    ;(api.getCanonicalConfigPaths as any).mockResolvedValue({ success: true, data: { paths: [] } })
+  })
+
+  it('renders Connected for a stat-only client present in connected_client_ids, Connect for the rest', async () => {
+    ;(api.getConnectStatus as any).mockResolvedValue({
+      success: true,
+      data: [
+        {
+          id: 'codex',
+          name: 'Codex CLI',
+          config_path: '/Users/test/.codex/config.toml',
+          exists: true,
+          connected: false, // stat-only listing never sets this
+          supported: true,
+          icon: 'codex',
+        },
+        {
+          id: 'cursor',
+          name: 'Cursor',
+          config_path: '/Users/test/.cursor/mcp.json',
+          exists: true,
+          connected: false, // genuinely not connected
+          supported: true,
+          icon: 'cursor',
+        },
+      ],
+    })
+    ;(api.getOnboardingState as any).mockResolvedValue(onboardingState(['codex']))
+
+    const wrapper = mount(OnboardingWizard, {
+      props: { show: false },
+      global: { plugins: [pinia] },
+    })
+
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    // Ensure the Clients tab is active (initial tab depends on onboarding
+    // predicates; the merge under test lives on the Clients panel).
+    await wrapper.find('[data-test="tab-clients"]').trigger('click')
+    await flushPromises()
+
+    // codex resolved as connected -> Connected badge, no Connect button.
+    const codexRow = wrapper.find('[data-test="client-row-codex"]')
+    expect(codexRow.exists()).toBe(true)
+    expect(codexRow.text()).toContain('Connected')
+    expect(wrapper.find('[data-test="connect-codex"]').exists()).toBe(false)
+
+    // cursor genuinely not connected -> Connect button still offered.
+    const cursorRow = wrapper.find('[data-test="client-row-cursor"]')
+    expect(cursorRow.exists()).toBe(true)
+    expect(wrapper.find('[data-test="connect-cursor"]').exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
## What

Fixes the MCP-2951 Connect-wizard regression **frontend-only**, consuming data the wizard already fetches. No backend change, no new config reads, no dependency on the stalled per-client-route PR #711.

## Root cause

`GetAllStatus()` / `GET /api/v1/connect` was made **stat-only** in #706 (MCP-2829) to kill the macOS App-Data prompt storm. It now leaves `connected=false` for every installed client. The wizard/modal badge rides entirely on `c.connected`, so every connected client renders the blue **Connect** button.

## Fix

The wizard already calls `onboarding.fetchState()` before `fetchClients()`. That response carries content-resolved **`connected_client_ids: string[]`**. We simply merge those IDs into the per-client list — **zero new content reads** (those reads already happen on wizard-open today).

- `stores/onboarding.ts`: expose `connectedClientIds` computed.
- `OnboardingWizard.vue`: derive `mergedClients` = each client connected when `c.connected || connectedIds.has(c.id)`; base detected/pinned/more lists on it (derived, not mutated, so polling refreshes stay correct).
- `ConnectModal.vue`: fetch onboarding state on open (wizard-scoped, #706-safe) and apply the same merge.

## Regression guard

The **passively-polled** Dashboard listing stays stat-only — content resolution was **not** added to `GET /api/v1/connect`, so the #706 macOS prompt storm does not return.

## Tests

- `connect-modal.spec.ts`: client with `connected=false` + `connected_client_ids=['codex']` renders **Disconnect** for codex; genuinely-unconnected `cursor` still renders **Connect**.
- `onboarding-wizard-connected-merge.spec.ts`: same assertion on the wizard Clients panel.
- Full vitest suite: 215 passed. `vue-tsc` type-check clean. `make build` green (frontend re-embedded).

## Out of scope

Per-client `access_state=denied` + remediation (MCP-2951 AC4) needs the per-client `GET /api/v1/connect/{client}` route from PR #711 (not on `origin/main`). `connected_client_ids` cannot distinguish "denied" from "not connected". Tracked separately once #711 lands.

Related #696. Paperclip: MCP-2952 (parent MCP-2951).