### PR TITLE
fix(import): sanitize server names before the import filter check

### DIFF
--- a/internal/configimport/import.go
+++ b/internal/configimport/import.go
@@ -73,33 +73,50 @@ func Import(content []byte, opts *ImportOptions) (*ImportResult, error) {
 
 	// Step 4: Process each parsed server
 	for _, parsed := range parsedServers {
-		foundServers[parsed.Name] = true
+		originalName := parsed.Name
 
-		// Check filter
-		if filterSet != nil && !filterSet[parsed.Name] {
+		// Resolve the effective (sanitized) name BEFORE filtering and dedup.
+		// The Web UI's two-step flow surfaces the sanitized name in the preview,
+		// so its server_names filter carries the sanitized name; the CLI's
+		// --server flag carries the raw source name verbatim. We must match
+		// either and track both, otherwise a name that needs sanitizing (e.g.
+		// "Figma Desktop" -> "Figma_Desktop") gets silently dropped on whichever
+		// path doesn't happen to match.
+		effectiveName, _ := SanitizeServerName(originalName)
+		nameUnsanitizable := effectiveName == ""
+		if nameUnsanitizable {
+			effectiveName = originalName
+		}
+
+		foundServers[originalName] = true
+		foundServers[effectiveName] = true
+
+		// Check filter against either the raw source name (CLI --server) or the
+		// sanitized name the Web UI selected from the preview.
+		if filterSet != nil && !filterSet[originalName] && !filterSet[effectiveName] {
 			result.Skipped = append(result.Skipped, SkippedServer{
-				Name:   parsed.Name,
+				Name:   effectiveName,
 				Reason: "filtered_out",
 			})
 			continue
 		}
 
-		// Validate server name
-		if err := ValidServerName(parsed.Name); err != nil {
-			// Try to sanitize
-			sanitized, _ := SanitizeServerName(parsed.Name)
-			if sanitized == "" {
-				result.Failed = append(result.Failed, FailedServer{
-					Name:    parsed.Name,
-					Error:   "invalid_name",
-					Details: err.Error(),
-				})
-				continue
-			}
-			// Use sanitized name with warning
-			result.Warnings = append(result.Warnings, fmt.Sprintf("server '%s' renamed to '%s' due to invalid characters", parsed.Name, sanitized))
-			parsed.Name = sanitized
+		// Now that we know this server was selected, fail it if its name could
+		// not be sanitized into anything valid.
+		if nameUnsanitizable {
+			result.Failed = append(result.Failed, FailedServer{
+				Name:    originalName,
+				Error:   "invalid_name",
+				Details: ValidServerName(originalName).Error(),
+			})
+			continue
 		}
+
+		// Emit a rename warning when sanitization changed the name.
+		if effectiveName != originalName {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("server '%s' renamed to '%s' due to invalid characters", originalName, effectiveName))
+		}
+		parsed.Name = effectiveName
 
 		// Check for duplicates
 		if existingSet[parsed.Name] {
@@ -122,7 +139,7 @@ func Import(content []byte, opts *ImportOptions) (*ImportResult, error) {
 		imported := &ImportedServer{
 			Server:        serverConfig,
 			SourceFormat:  parsed.SourceFormat,
-			OriginalName:  parsed.Name,
+			OriginalName:  originalName,
 			FieldsSkipped: skipped,
 			Warnings:      warnings,
 		}

--- a/internal/configimport/import_test.go
+++ b/internal/configimport/import_test.go
@@ -1,6 +1,7 @@
 package configimport
 
 import (
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -315,5 +316,87 @@ func TestImport_DuplicateWithinSameImport(t *testing.T) {
 	// Both should be imported since they have different names
 	if result.Summary.Imported != 2 {
 		t.Errorf("Summary.Imported = %d, want 2", result.Summary.Imported)
+	}
+}
+
+// TestImport_FilterMatchesSanitizedName reproduces the two-step preview -> import
+// flow used by the Web UI for a server whose name needs sanitizing (a space).
+// The preview surfaces the sanitized name ("Figma_Desktop"), so the actual
+// import call carries that sanitized name in ServerNames. The filter must match
+// it; previously it compared against the un-sanitized "Figma Desktop" and the
+// server was silently dropped ("0 servers added").
+func TestImport_FilterMatchesSanitizedName(t *testing.T) {
+	now := time.Date(2026, 1, 17, 12, 0, 0, 0, time.UTC)
+	content := []byte(`{
+		"mcpServers": {
+			"Figma Desktop": {
+				"url": "http://127.0.0.1:3845/mcp"
+			}
+		}
+	}`)
+
+	// Step 1: preview (no filter) — this is what the UI shows as "Will import 1".
+	preview, err := Import(content, &ImportOptions{Now: now})
+	if err != nil {
+		t.Fatalf("preview Import() error = %v", err)
+	}
+	if preview.Summary.Imported != 1 {
+		t.Fatalf("preview Summary.Imported = %d, want 1", preview.Summary.Imported)
+	}
+	previewedName := preview.Imported[0].Server.Name
+	if previewedName != "Figma_Desktop" {
+		t.Fatalf("previewed server name = %q, want %q", previewedName, "Figma_Desktop")
+	}
+
+	// OriginalName must carry the raw source name (the httpapi rename map keys
+	// off it), not the sanitized name.
+	if got := preview.Imported[0].OriginalName; got != "Figma Desktop" {
+		t.Errorf("preview OriginalName = %q, want %q", got, "Figma Desktop")
+	}
+
+	// Step 2a: Web UI path — filter by the sanitized name the UI selected.
+	// Step 2b: CLI path — filter by the raw source name passed to `--server`.
+	// Both must import the server.
+	for _, tc := range []struct {
+		name   string
+		filter string
+	}{
+		{"webui_sanitized_name", previewedName}, // "Figma_Desktop"
+		{"cli_raw_name", "Figma Desktop"},       // verbatim --server value
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := Import(content, &ImportOptions{
+				ServerNames: []string{tc.filter},
+				Now:         now,
+			})
+			if err != nil {
+				t.Fatalf("Import() error = %v", err)
+			}
+
+			if result.Summary.Imported != 1 {
+				t.Errorf("Summary.Imported = %d, want 1 (regression: server dropped despite filter match on %q)", result.Summary.Imported, tc.filter)
+			}
+			if result.Summary.Skipped != 0 {
+				t.Errorf("Summary.Skipped = %d, want 0", result.Summary.Skipped)
+			}
+			// No spurious "requested server not found" warning.
+			for _, w := range result.Warnings {
+				if w == fmt.Sprintf("requested server '%s' not found in config", tc.filter) {
+					t.Errorf("unexpected not-found warning for filter %q", tc.filter)
+				}
+			}
+			if len(result.Imported) != 1 {
+				t.Fatalf("len(Imported) = %d, want 1", len(result.Imported))
+			}
+			if result.Imported[0].Server.Name != "Figma_Desktop" {
+				t.Errorf("imported server name = %q, want %q", result.Imported[0].Server.Name, "Figma_Desktop")
+			}
+			if result.Imported[0].OriginalName != "Figma Desktop" {
+				t.Errorf("imported OriginalName = %q, want %q", result.Imported[0].OriginalName, "Figma Desktop")
+			}
+			if result.Imported[0].Server.URL != "http://127.0.0.1:3845/mcp" {
+				t.Errorf("imported server URL = %q, want the Figma URL", result.Imported[0].Server.URL)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Problem

The two-step config-import flow in the Web UI (preview, then import the selected servers) silently imports **zero** servers when a server name needs sanitizing — e.g. a name containing a space like `Figma Desktop`:

```json
{ "mcpServers": { "Figma Desktop": { "url": "http://127.0.0.1:3845/mcp" } } }
```

The preview says "Will import 1 server", but after clicking Import the UI shows a success toast reading **"0 servers imported"**.

## Root cause

Server names are validated against `^[a-zA-Z0-9_-]+$` and sanitized on import (`Figma Desktop` → `Figma_Desktop`). In `configimport.Import`:

1. The **preview** call (no `server_names` filter) sanitizes the name and surfaces `Figma_Desktop` to the client, which pre-selects it.
2. The **import** call sends `server_names: ["Figma_Desktop"]`, but the filter check ran against the *un-sanitized* parsed name (`Figma Desktop`) **before** sanitization, so `filterSet["Figma_Desktop"]` never matched. The server was reported `filtered_out` and `Summary.Imported` came back `0`.

## Fix

Resolve the effective (sanitized) name **before** the filter, dedup, and found-server tracking. Match the filter against **either** the raw source name (the CLI `--server` flag passes it verbatim) **or** the sanitized name (the Web UI selects it from the preview), and track both names so the "requested server not found" warning stays correct on both paths. `ImportedServer.OriginalName` keeps pointing at the true source name so the httpapi rename map continues to resolve.

## Test

Adds `TestImport_FilterMatchesSanitizedName`, which reproduces the two-step flow for a space-containing name and asserts the server is imported via **both** the Web UI (sanitized-name) and CLI (raw-name) filter paths, with no spurious not-found warning and `OriginalName` preserved.

## Repro before the fix

Import the Figma config above through the UI → "0 servers imported" despite a green toast. After the fix it imports 1 server (quarantined, as expected).