### PR TITLE
ci(release): restore prerelease guard on retry update-homebrew/publish-linux-repos (MCP-3020)

### DIFF
--- a/.github/workflows/retry-sign-release.yml
+++ b/.github/workflows/retry-sign-release.yml
@@ -399,7 +399,7 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     environment: production
-    if: github.repository == 'smart-mcp-proxy/mcpproxy-go'
+    if: github.repository == 'smart-mcp-proxy/mcpproxy-go' && !contains(inputs.tag, '-')
 
     steps:
       - name: Checkout tap repository
@@ -585,7 +585,7 @@ jobs:
   # Publish signed apt/yum repositories to Cloudflare R2 (mirrors release.yml)
   publish-linux-repos:
     needs: [release]
-    if: github.repository == 'smart-mcp-proxy/mcpproxy-go'
+    if: github.repository == 'smart-mcp-proxy/mcpproxy-go' && !contains(inputs.tag, '-')
     runs-on: ubuntu-latest
     environment: production
 


### PR DESCRIPTION
## Problem

`retry-sign-release.yml`'s newly-added `update-homebrew` and `publish-linux-repos` jobs (PR #718) only check `github.repository` but lack the stable-tag guard present in `release.yml`:

```yaml
# release.yml
if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') && github.repository == '...'
```

Running the retry workflow for an RC tag (e.g. `v1.2.0-rc.1`) would push to the **stable** Homebrew tap and apt/rpm repos.

## Fix

Add `!contains(inputs.tag, '-')` to both job `if:` conditions (using `inputs.tag` since the retry workflow is `workflow_dispatch`-only and `github.ref_name` is always the default branch there):

```diff
-    if: github.repository == 'smart-mcp-proxy/mcpproxy-go'
+    if: github.repository == 'smart-mcp-proxy/mcpproxy-go' && !contains(inputs.tag, '-')
```

Applies to both `update-homebrew` (line 402) and `publish-linux-repos` (line 588).

## Testing

CI workflow — no runtime test possible without a real RC signing scenario. Logic is a single boolean expression parity-check against `release.yml`.

Fast-follow flagged during PR #718 review. Closes MCP-3020.