### PR TITLE
fix(mcp): truncate direct-mode text on a UTF-8 rune boundary

### DIFF
--- a/internal/server/mcp_routing.go
+++ b/internal/server/mcp_routing.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
@@ -22,6 +23,28 @@ const (
 	// Using double underscore to avoid conflicts with single underscores in tool names.
 	DirectModeToolSeparator = "__"
 )
+
+// safeTruncateBytes returns the largest cut length <= limit at which s can be
+// sliced without splitting a multi-byte UTF-8 rune. Direct-mode truncation uses
+// a raw byte budget (ToolResponseLimit); cutting at the raw offset can land in
+// the middle of a multi-byte character and emit invalid UTF-8 in the forwarded
+// TextContent, which downstream JSON encoders/clients reject or render as a
+// replacement char. Callers must ensure limit < len(s) (i.e. truncation is
+// actually needed) before calling.
+func safeTruncateBytes(s string, limit int) int {
+	if limit <= 0 {
+		return 0
+	}
+	if limit >= len(s) {
+		return len(s)
+	}
+	// Back up to the start of the rune that straddles the cut point.
+	cut := limit
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return cut
+}
 
 // ParseDirectToolName parses a direct mode tool name (serverName__toolName) into server and tool components.
 // Splits on the FIRST occurrence of "__" only, so tool names containing "__" are preserved.
@@ -210,7 +233,7 @@ func (p *MCPProxyServer) makeDirectModeHandler(serverName, toolName string, anno
 				case mcp.TextContent:
 					txt := tc.Text
 					if limit > 0 && len(txt) > limit {
-						txt = txt[:limit]
+						txt = txt[:safeTruncateBytes(txt, limit)]
 						truncated = true
 					}
 					tc.Text = txt

--- a/internal/server/mcp_routing_test.go
+++ b/internal/server/mcp_routing_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
@@ -741,4 +742,38 @@ func TestHandleRetrieveToolsForMode_ClosureReturnsDifferentInstructions(t *testi
 	// Code exec should mention code_execution, retrieve should mention call_tool_read
 	assert.Contains(t, codeExecInstructions, "code_execution")
 	assert.Contains(t, retrieveInstructions, "call_tool_read")
+}
+
+func TestSafeTruncateBytes(t *testing.T) {
+	tests := []struct {
+		name  string
+		s     string
+		limit int
+		want  int
+	}{
+		{"ascii cut mid-string", "hello world", 5, 5},
+		{"limit beyond length", "hi", 10, 2},
+		{"limit equals length", "hello", 5, 5},
+		{"zero limit", "hello", 0, 0},
+		{"negative limit", "hello", -1, 0},
+		// "héllo": 'é' is 2 bytes (0xC3 0xA9) at indices 1-2. A raw cut at 2
+		// would split it; safeTruncateBytes backs up to 1.
+		{"cut inside 2-byte rune backs up", "héllo", 2, 1},
+		{"cut at 2-byte rune end is kept", "héllo", 3, 3},
+		// "😀x": emoji is 4 bytes (indices 0-3). Cuts inside it back up to 0.
+		{"cut inside 4-byte rune backs up to 0", "😀x", 2, 0},
+		{"cut at emoji boundary kept", "😀x", 4, 4},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := safeTruncateBytes(tt.s, tt.limit)
+			if got != tt.want {
+				t.Fatalf("safeTruncateBytes(%q, %d) = %d, want %d", tt.s, tt.limit, got, tt.want)
+			}
+			// The truncated prefix must always be valid UTF-8.
+			if !utf8.ValidString(tt.s[:got]) {
+				t.Errorf("prefix %q is not valid UTF-8", tt.s[:got])
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Problem

Direct-mode response truncation in `internal/server/mcp_routing.go` cuts `TextContent` at a raw byte offset — `txt = txt[:limit]` where `limit` is `ToolResponseLimit`. When the cut point lands inside a multi-byte UTF-8 sequence (emoji, accented or non-Latin text), the forwarded `TextContent` contains a partial/invalid byte sequence. Downstream JSON encoders / MCP clients then reject it or render a replacement character at the truncation boundary.

The direct-mode path intentionally uses the simple `ToolResponseLimit` byte budget rather than the caching `Truncator` (per the existing comment), so this is the right place to make the cut rune-safe.

## Fix

Add `safeTruncateBytes(s, limit)` — the largest cut `<= limit` that does not split a rune (it backs up from the byte offset to the nearest `utf8.RuneStart`) — and use it in the direct-mode forward path. ASCII behaviour is unchanged (the cut stays at `limit`).

## Test

`TestSafeTruncateBytes` covers ASCII, 2-byte and 4-byte runes at and inside the boundary, and asserts every truncated prefix is valid UTF-8 via `utf8.ValidString`.