### PR TITLE
feat(064): codify Reviewer-Liveness Contract in execution-policy schema

### DIFF
--- a/specs/064-glass-cockpit/agent-instructions/README.md
+++ b/specs/064-glass-cockpit/agent-instructions/README.md
@@ -13,7 +13,10 @@ These are the **canonical source** for the rewritten agent brains. They evolve t
 - **Gate 3 (pre-merge)** — agents open PRs, never merge; the human merges on GitHub (branch protection enforced).
 
 ## Behavioral contract
-The required behaviors (and their probe tests) are pinned in [`../contracts/agent-instructions-contract.md`](../contracts/agent-instructions-contract.md). The execution-policy JSON shape is in [`../contracts/execution-policy.schema.json`](../contracts/execution-policy.schema.json).
+The required behaviors (and their probe tests) are pinned in [`../contracts/agent-instructions-contract.md`](../contracts/agent-instructions-contract.md). The execution-policy JSON shape is in [`../contracts/execution-policy.schema.json`](../contracts/execution-policy.schema.json) (validated by `../contracts/execution_policy_test.go`).
+
+### Reviewer-Liveness Contract (FR-014a)
+A `review` stage MAY carry an optional `liveness` block describing **health-based, model-diverse reviewer failover**: an ordered fallback `roster`, an SLA (`slaMinutes`, default 120 = 2h), and a per-head re-trigger budget (`maxFallbacksPerHead` default 1, `maxHops` default 2 → `escalateTo` the CEO). It codifies the MCP-3066 shell backstop (`~/.mcpproxy-gatekeeper/bin/ensure-pr-gates.sh`: `classify_stall` + `route_fallback`), which **remains the source of truth**; the schema mirrors it. A *substantive* `request_changes` on the current head is a mandatory fence and is never routed around, so it is not a permitted `failoverStallModes` value. When `liveness` is omitted, a review stage runs a single reviewer with no failover (existing policies are unchanged). See the worked [`../contracts/reviewer-liveness.example.json`](../contracts/reviewer-liveness.example.json) for the contract values and their rationale.
 
 ## Roster mapping (live company `16edd8ed-…`)
 | Agent | adapterType | Instruction file | Activate for dry-run? |

--- a/specs/064-glass-cockpit/contracts/execution-policy.schema.json
+++ b/specs/064-glass-cockpit/contracts/execution-policy.schema.json
@@ -2,9 +2,77 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://mcpproxy.app/specs/064-glass-cockpit/execution-policy.schema.json",
   "title": "Glass Cockpit executionPolicy (attached to a Paperclip issue)",
-  "description": "The gate configuration the cockpit attaches to issues. Mirrors Paperclip's IssueExecutionStage model (stage types: review|approval). Gate 2 (per-spec design) and Gate 3 (pre-merge) are 'approval' stages with a user participant; the adversarial review (FR-011) is a 'review' stage with the Critic agent participant placed before the user gate.",
+  "description": "The gate configuration the cockpit attaches to issues. Mirrors Paperclip's IssueExecutionStage model (stage types: review|approval). Gate 2 (per-spec design) and Gate 3 (pre-merge) are 'approval' stages with a user participant; the adversarial review (FR-011) is a 'review' stage with the Critic agent participant placed before the user gate. A 'review' stage MAY additionally carry a 'liveness' block (the Reviewer-Liveness Contract, FR-014a) describing health-based, model-diverse reviewer failover; see $defs/reviewerLiveness.",
   "type": "object",
   "required": ["mode", "stages"],
+  "$defs": {
+    "participant": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": { "type": "string", "enum": ["user", "agent"] },
+        "userId": { "type": "string", "description": "Required when type=user (the board)." },
+        "agentId": { "type": "string", "description": "Required when type=agent (e.g. the Gemini Critic)." },
+        "modelFamily": {
+          "type": "string",
+          "description": "Optional provider/model family of an agent participant (e.g. 'openai', 'moonshot', 'gemini', 'glm'). Used by the Reviewer-Liveness Contract to enforce the same-family exclusion: a fallback reviewer must not share the primary reviewer's family (FR-011 model diversity)."
+        }
+      }
+    },
+    "reviewerLiveness": {
+      "type": "object",
+      "description": "Reviewer-Liveness Contract — health-based, model-diverse reviewer failover for a 'review' stage (FR-014a). Codifies the MCP-3066 shell backstop (~/.mcpproxy-gatekeeper/bin/ensure-pr-gates.sh: classify_stall + route_fallback) as a first-class contract. The shipped scripts remain the source of truth; values here mirror them. When this block is omitted, the stage runs a single reviewer (participants[0]) with no failover, so pre-existing policies validate and behave unchanged.",
+      "required": ["roster"],
+      "additionalProperties": false,
+      "properties": {
+        "slaMinutes": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 120,
+          "description": "T — minutes the primary reviewer may be silent on the CURRENT head before the stage is classed a silent stall (classify_stall mode1) and a fallback becomes eligible. Default 120 (2h), matching the shell backstop SLA."
+        },
+        "maxFallbacksPerHead": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 1,
+          "description": "N — at most this many fallback hops are triggered per head SHA; the budget resets when the PR head moves. Default 1, mirroring the per-head marker state/fallback-<pr>-<sha>."
+        },
+        "maxHops": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 2,
+          "description": "Cumulative fallback hops across the roster before escalating to escalateTo. Default 2, mirroring the hop ledger state/fallback-<pr>.hops -> escalate_ceo."
+        },
+        "escalateTo": {
+          "$ref": "#/$defs/participant",
+          "description": "Who receives the escalation issue once maxHops is exhausted (the shell backstop's escalate_ceo; normally the CEO agent)."
+        },
+        "failoverStallModes": {
+          "type": "array",
+          "uniqueItems": true,
+          "default": ["silent", "stale_ci_pending"],
+          "description": "Which classify_stall outcomes make a fallback eligible. 'silent' = no verdict past the SLA on a green head (mode1); 'stale_ci_pending' = a request_changes whose only reason is pending/not-green CI on a now-green head (mode2). 'substantive' is intentionally NOT a permitted value: a substantive request_changes on the current head is a mandatory fence (mode3) and is NEVER routed around.",
+          "items": { "type": "string", "enum": ["silent", "stale_ci_pending"] }
+        },
+        "roster": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Ordered, model-diverse fallback chain tried in sequence when the primary reviewer (the stage's participants[0]) stalls. Reviewers sharing the primary's modelFamily MUST be excluded (the backstop drops the gpt-5.5 'Critic' because the primary CodexReviewer is also gpt-5.5). The same-family exclusion is a cross-entity invariant enforced by the contract test, not by this schema.",
+          "items": {
+            "type": "object",
+            "required": ["agentId", "modelFamily"],
+            "additionalProperties": false,
+            "properties": {
+              "agentId": { "type": "string", "description": "Paperclip agent id of the fallback reviewer." },
+              "name": { "type": "string", "description": "Human-readable reviewer name, e.g. 'KimiReviewer'." },
+              "model": { "type": "string", "description": "Concrete model id, e.g. 'kimi-k2', 'gemini-2.5', 'glm-4.7'." },
+              "modelFamily": { "type": "string", "description": "Provider/model family for the same-family exclusion (e.g. 'moonshot', 'gemini', 'glm')." }
+            }
+          }
+        }
+      }
+    }
+  },
   "properties": {
     "mode": {
       "type": "string",
@@ -29,15 +97,11 @@
           "participants": {
             "type": "array",
             "minItems": 1,
-            "items": {
-              "type": "object",
-              "required": ["type"],
-              "properties": {
-                "type": { "type": "string", "enum": ["user", "agent"] },
-                "userId": { "type": "string", "description": "Required when type=user (the board)." },
-                "agentId": { "type": "string", "description": "Required when type=agent (e.g. the Gemini Critic)." }
-              }
-            }
+            "items": { "$ref": "#/$defs/participant" }
+          },
+          "liveness": {
+            "$ref": "#/$defs/reviewerLiveness",
+            "description": "Optional Reviewer-Liveness Contract; meaningful only on a 'review' stage. See $defs/reviewerLiveness."
           }
         }
       }
@@ -54,6 +118,29 @@
     {
       "mode": "normal",
       "stages": [
+        { "type": "approval", "label": "Pre-merge", "participants": [ { "type": "user", "userId": "local-board" } ] }
+      ]
+    },
+    {
+      "mode": "normal",
+      "stages": [
+        {
+          "type": "review",
+          "label": "Adversarial review with liveness failover",
+          "participants": [ { "type": "agent", "agentId": "5b94562c", "modelFamily": "openai" } ],
+          "liveness": {
+            "slaMinutes": 120,
+            "maxFallbacksPerHead": 1,
+            "maxHops": 2,
+            "escalateTo": { "type": "agent", "agentId": "2dbf9388" },
+            "failoverStallModes": ["silent", "stale_ci_pending"],
+            "roster": [
+              { "agentId": "fdaa1d4c", "name": "KimiReviewer", "model": "kimi-k2", "modelFamily": "moonshot" },
+              { "agentId": "d89dd1db", "name": "GeminiCritic", "model": "gemini-2.5", "modelFamily": "gemini" },
+              { "agentId": "caf2df03", "name": "GLMReviewer", "model": "glm-4.7", "modelFamily": "glm" }
+            ]
+          }
+        },
         { "type": "approval", "label": "Pre-merge", "participants": [ { "type": "user", "userId": "local-board" } ] }
       ]
     }

--- a/specs/064-glass-cockpit/contracts/execution_policy_test.go
+++ b/specs/064-glass-cockpit/contracts/execution_policy_test.go
@@ -1,0 +1,287 @@
+// Package contracts validates the Glass Cockpit executionPolicy JSON Schema
+// (specs/064-glass-cockpit/contracts/execution-policy.schema.json).
+//
+// The schema fixes the shape of the gate configuration the cockpit attaches to
+// Paperclip issues. This test enforces two things plain JSON Schema cannot, in
+// the style of specs/065-evaluation-foundation/datasets/corpus_test.go:
+//
+//  1. Back-compat: every execution policy that validated before the
+//     Reviewer-Liveness Contract was added (i.e. a review/approval stage with no
+//     `liveness` block) still validates unchanged.
+//  2. The Reviewer-Liveness Contract (FR-014a, mirroring the MCP-3066 shell
+//     backstop ~/.mcpproxy-gatekeeper/bin/ensure-pr-gates.sh): a review stage MAY
+//     carry a `liveness` block with a model-diverse fallback roster, an SLA, and
+//     a per-head re-trigger budget; the same-family exclusion (a roster reviewer
+//     must not share the primary reviewer's modelFamily) is a cross-entity
+//     invariant checked here in Go.
+package contracts
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+const (
+	schemaFile  = "execution-policy.schema.json"
+	exampleFile = "reviewer-liveness.example.json"
+)
+
+// Contract values codified from MCP-3066 (the shell backstop is the source of
+// truth). Documented with rationale in reviewer-liveness.example.json.
+const (
+	wantSLAMinutes          = 120 // T: 2h silence on the current head => silent stall (mode1).
+	wantMaxFallbacksPerHead = 1   // N: one fallback hop per head SHA (resets when the head moves).
+	wantMaxHops             = 2   // <=2 cumulative hops, then escalate to the CEO.
+)
+
+func compileSchema(t *testing.T) *jsonschema.Schema {
+	t.Helper()
+	raw, err := os.ReadFile(schemaFile)
+	if err != nil {
+		t.Fatalf("read %s: %v", schemaFile, err)
+	}
+	doc, err := jsonschema.UnmarshalJSON(strings.NewReader(string(raw)))
+	if err != nil {
+		t.Fatalf("parse schema: %v", err)
+	}
+	c := jsonschema.NewCompiler()
+	if err := c.AddResource(schemaFile, doc); err != nil {
+		t.Fatalf("add schema resource: %v", err)
+	}
+	sch, err := c.Compile(schemaFile)
+	if err != nil {
+		t.Fatalf("compile schema: %v", err)
+	}
+	return sch
+}
+
+func mustInstance(t *testing.T, jsonStr string) any {
+	t.Helper()
+	inst, err := jsonschema.UnmarshalJSON(strings.NewReader(jsonStr))
+	if err != nil {
+		t.Fatalf("parse instance: %v", err)
+	}
+	return inst
+}
+
+// TestSchema_BackCompat: policies with no liveness block (every policy that
+// existed before this change) MUST still validate. The schema also ships
+// `examples`; all of them must validate.
+func TestSchema_BackCompat(t *testing.T) {
+	sch := compileSchema(t)
+
+	legacy := []string{
+		// Design gate: review (Critic) then user approval, no liveness.
+		`{"mode":"normal","stages":[
+			{"type":"review","label":"Adversarial review","participants":[{"type":"agent","agentId":"a"}]},
+			{"type":"approval","label":"Per-spec design sign-off","participants":[{"type":"user","userId":"local-board"}]}
+		]}`,
+		// Pre-merge gate only.
+		`{"mode":"normal","stages":[
+			{"type":"approval","label":"Pre-merge","participants":[{"type":"user","userId":"local-board"}]}
+		]}`,
+	}
+	for i, p := range legacy {
+		if err := sch.Validate(mustInstance(t, p)); err != nil {
+			t.Errorf("legacy policy %d must validate (back-compat): %v", i, err)
+		}
+	}
+
+	// Every example embedded in the schema must validate against the schema.
+	raw, err := os.ReadFile(schemaFile)
+	if err != nil {
+		t.Fatalf("read schema: %v", err)
+	}
+	var schemaDoc struct {
+		Examples []json.RawMessage `json:"examples"`
+	}
+	if err := json.Unmarshal(raw, &schemaDoc); err != nil {
+		t.Fatalf("decode schema examples: %v", err)
+	}
+	if len(schemaDoc.Examples) == 0 {
+		t.Fatal("schema must ship at least one example")
+	}
+	for i, ex := range schemaDoc.Examples {
+		if err := sch.Validate(mustInstance(t, string(ex))); err != nil {
+			t.Errorf("schema example %d does not validate: %v", i, err)
+		}
+	}
+}
+
+// TestSchema_LivenessRosterAccepted: a review stage carrying a full
+// Reviewer-Liveness Contract validates.
+func TestSchema_LivenessRosterAccepted(t *testing.T) {
+	sch := compileSchema(t)
+	valid := `{"mode":"normal","stages":[
+		{"type":"review","label":"Adversarial review","participants":[{"type":"agent","agentId":"codex","modelFamily":"openai"}],
+		 "liveness":{
+			"slaMinutes":120,
+			"maxFallbacksPerHead":1,
+			"maxHops":2,
+			"escalateTo":{"type":"agent","agentId":"ceo"},
+			"failoverStallModes":["silent","stale_ci_pending"],
+			"roster":[
+				{"agentId":"kimi","name":"KimiReviewer","model":"kimi-k2","modelFamily":"moonshot"},
+				{"agentId":"gemini","name":"GeminiCritic","model":"gemini-2.5","modelFamily":"gemini"},
+				{"agentId":"glm","name":"GLMReviewer","model":"glm-4.7","modelFamily":"glm"}
+			]
+		 }},
+		{"type":"approval","label":"Per-spec design sign-off","participants":[{"type":"user","userId":"local-board"}]}
+	]}`
+	if err := sch.Validate(mustInstance(t, valid)); err != nil {
+		t.Fatalf("valid liveness policy must validate: %v", err)
+	}
+}
+
+// TestSchema_LivenessRejectsMalformed: the schema must reject malformed liveness
+// blocks. Before the contract existed these passed silently (additionalProperties
+// was open), so this is the red->green guard for the schema change.
+func TestSchema_LivenessRejectsMalformed(t *testing.T) {
+	sch := compileSchema(t)
+	bad := map[string]string{
+		"roster entry missing modelFamily": `{"mode":"normal","stages":[
+			{"type":"review","participants":[{"type":"agent","agentId":"codex","modelFamily":"openai"}],
+			 "liveness":{"roster":[{"agentId":"kimi","name":"KimiReviewer"}]}}
+		]}`,
+		"empty roster": `{"mode":"normal","stages":[
+			{"type":"review","participants":[{"type":"agent","agentId":"codex","modelFamily":"openai"}],
+			 "liveness":{"roster":[]}}
+		]}`,
+		"liveness without roster": `{"mode":"normal","stages":[
+			{"type":"review","participants":[{"type":"agent","agentId":"codex","modelFamily":"openai"}],
+			 "liveness":{"slaMinutes":120}}
+		]}`,
+		"unknown stall mode": `{"mode":"normal","stages":[
+			{"type":"review","participants":[{"type":"agent","agentId":"codex","modelFamily":"openai"}],
+			 "liveness":{"failoverStallModes":["substantive"],"roster":[{"agentId":"kimi","modelFamily":"moonshot"}]}}
+		]}`,
+		"negative slaMinutes": `{"mode":"normal","stages":[
+			{"type":"review","participants":[{"type":"agent","agentId":"codex","modelFamily":"openai"}],
+			 "liveness":{"slaMinutes":0,"roster":[{"agentId":"kimi","modelFamily":"moonshot"}]}}
+		]}`,
+	}
+	for name, p := range bad {
+		if err := sch.Validate(mustInstance(t, p)); err == nil {
+			t.Errorf("%s: schema must reject this policy but it validated", name)
+		}
+	}
+}
+
+// reviewerLiveness mirrors the contract block for the cross-entity invariant
+// checks that JSON Schema cannot express.
+type participant struct {
+	Type        string `json:"type"`
+	UserID      string `json:"userId"`
+	AgentID     string `json:"agentId"`
+	ModelFamily string `json:"modelFamily"`
+}
+
+type rosterEntry struct {
+	AgentID     string `json:"agentId"`
+	Name        string `json:"name"`
+	Model       string `json:"model"`
+	ModelFamily string `json:"modelFamily"`
+}
+
+type reviewerLiveness struct {
+	SLAMinutes          int           `json:"slaMinutes"`
+	MaxFallbacksPerHead int           `json:"maxFallbacksPerHead"`
+	MaxHops             int           `json:"maxHops"`
+	EscalateTo          participant   `json:"escalateTo"`
+	FailoverStallModes  []string      `json:"failoverStallModes"`
+	Roster              []rosterEntry `json:"roster"`
+}
+
+type stage struct {
+	Type         string            `json:"type"`
+	Participants []participant     `json:"participants"`
+	Liveness     *reviewerLiveness `json:"liveness"`
+}
+
+type policy struct {
+	Mode   string  `json:"mode"`
+	Stages []stage `json:"stages"`
+}
+
+// TestExampleFile_SchemaAndContractValues: the committed canonical example
+// validates against the schema, carries the MCP-3066 contract values, and obeys
+// the same-family exclusion invariant (no roster reviewer shares the primary
+// reviewer's modelFamily — the shell backstop drops the gpt-5.5 Critic because
+// the primary CodexReviewer is also gpt-5.5).
+func TestExampleFile_SchemaAndContractValues(t *testing.T) {
+	sch := compileSchema(t)
+
+	raw, err := os.ReadFile(exampleFile)
+	if err != nil {
+		t.Fatalf("read %s: %v", exampleFile, err)
+	}
+	if err := sch.Validate(mustInstance(t, string(raw))); err != nil {
+		t.Fatalf("%s fails schema contract: %v", exampleFile, err)
+	}
+
+	var p policy
+	if err := json.Unmarshal(raw, &p); err != nil {
+		t.Fatalf("decode %s: %v", exampleFile, err)
+	}
+
+	var live *reviewerLiveness
+	var primary participant
+	for _, s := range p.Stages {
+		if s.Liveness != nil {
+			live = s.Liveness
+			if len(s.Participants) > 0 {
+				primary = s.Participants[0]
+			}
+			break
+		}
+	}
+	if live == nil {
+		t.Fatal("example must contain a review stage with a liveness block")
+	}
+
+	if live.SLAMinutes != wantSLAMinutes {
+		t.Errorf("slaMinutes = %d, want %d (MCP-3066 SLA T=2h)", live.SLAMinutes, wantSLAMinutes)
+	}
+	if live.MaxFallbacksPerHead != wantMaxFallbacksPerHead {
+		t.Errorf("maxFallbacksPerHead = %d, want %d (<=1 fallback/head)", live.MaxFallbacksPerHead, wantMaxFallbacksPerHead)
+	}
+	if live.MaxHops != wantMaxHops {
+		t.Errorf("maxHops = %d, want %d (<=2 hops then escalate to CEO)", live.MaxHops, wantMaxHops)
+	}
+	if len(live.Roster) == 0 {
+		t.Fatal("roster must be non-empty")
+	}
+
+	// Same-family exclusion (FR-011 model diversity): no roster reviewer may
+	// share the primary reviewer's model family, and roster families must be
+	// distinct from one another.
+	if primary.ModelFamily == "" {
+		t.Fatal("primary reviewer must declare a modelFamily so the same-family exclusion is checkable")
+	}
+	seen := map[string]bool{primary.ModelFamily: true}
+	for _, r := range live.Roster {
+		if r.ModelFamily == "" {
+			t.Errorf("roster entry %q missing modelFamily", r.AgentID)
+			continue
+		}
+		if r.ModelFamily == primary.ModelFamily {
+			t.Errorf("roster reviewer %q shares the primary reviewer's family %q (same-family exclusion violated)", r.AgentID, primary.ModelFamily)
+		}
+		if seen[r.ModelFamily] {
+			t.Errorf("roster reviewer %q duplicates family %q (roster must be model-diverse)", r.AgentID, r.ModelFamily)
+		}
+		seen[r.ModelFamily] = true
+	}
+
+	// substantive request_changes is a mandatory fence: it must never be a
+	// failover-eligible stall mode (mode3 in the shell backstop).
+	for _, m := range live.FailoverStallModes {
+		if m == "substantive" {
+			t.Error("failoverStallModes must not include 'substantive' — a substantive request_changes is a mandatory fence (mode3)")
+		}
+	}
+}

--- a/specs/064-glass-cockpit/contracts/reviewer-liveness.example.json
+++ b/specs/064-glass-cockpit/contracts/reviewer-liveness.example.json
@@ -1,0 +1,45 @@
+{
+  "$comment": "Canonical executionPolicy showing the Reviewer-Liveness Contract (FR-014a). Validated by execution_policy_test.go. Values mirror the MCP-3066 shell backstop (~/.mcpproxy-gatekeeper/bin/ensure-pr-gates.sh), which remains the source of truth. Agent ids are the documented cockpit roster: CodexReviewer 5b94562c (openai/gpt-5.5, the primary), KimiReviewer fdaa1d4c (moonshot), GeminiCritic d89dd1db (gemini), GLMReviewer caf2df03 (glm), CEO 2dbf9388 (escalation target). The gpt-5.5 'Critic' (4439bdfe) is deliberately absent from the roster: it shares CodexReviewer's openai family, so the same-family exclusion drops it.",
+  "$rationale": {
+    "slaMinutes": "T=120 (2h). A primary reviewer silent on the current head for longer than 2h with a green head is a silent stall (classify_stall mode1); only then is a fallback eligible.",
+    "maxFallbacksPerHead": "N=1. At most one fallback hop per head SHA, mirroring the per-head marker state/fallback-<pr>-<sha>; the budget resets when the PR head moves so a pushed fix re-arms failover.",
+    "maxHops": "2. Up to two cumulative roster hops (hop ledger state/fallback-<pr>.hops) before escalating to the CEO (escalate_ceo).",
+    "failoverStallModes": "silent + stale_ci_pending only. A substantive request_changes on the current head is a mandatory fence (mode3) and is never routed around, so 'substantive' is not a permitted failover mode.",
+    "roster": "Model-diverse, ordered: KimiReviewer (moonshot) -> GeminiCritic (gemini) -> GLMReviewer (glm). Each family differs from the primary openai family and from one another (FR-011 model diversity)."
+  },
+  "mode": "normal",
+  "stages": [
+    {
+      "id": "adversarial-review",
+      "type": "review",
+      "label": "Adversarial review (Critic) with liveness failover",
+      "participants": [
+        { "type": "agent", "agentId": "5b94562c", "modelFamily": "openai" }
+      ],
+      "liveness": {
+        "slaMinutes": 120,
+        "maxFallbacksPerHead": 1,
+        "maxHops": 2,
+        "escalateTo": { "type": "agent", "agentId": "2dbf9388" },
+        "failoverStallModes": ["silent", "stale_ci_pending"],
+        "roster": [
+          { "agentId": "fdaa1d4c", "name": "KimiReviewer", "model": "kimi-k2", "modelFamily": "moonshot" },
+          { "agentId": "d89dd1db", "name": "GeminiCritic", "model": "gemini-2.5", "modelFamily": "gemini" },
+          { "agentId": "caf2df03", "name": "GLMReviewer", "model": "glm-4.7", "modelFamily": "glm" }
+        ]
+      }
+    },
+    {
+      "id": "design-gate",
+      "type": "approval",
+      "label": "Per-spec design sign-off (Gate 2)",
+      "participants": [ { "type": "user", "userId": "local-board" } ]
+    },
+    {
+      "id": "pre-merge-gate",
+      "type": "approval",
+      "label": "Pre-merge (Gate 3)",
+      "participants": [ { "type": "user", "userId": "local-board" } ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Codifies the **Reviewer-Liveness Contract** (FR-014a) as a first-class part of the Glass Cockpit `executionPolicy` schema (`specs/064-glass-cockpit/contracts/execution-policy.schema.json`). Follow-up to MCP-2534 (Gate-1 accepted "shell-fix-first") and MCP-3066 (the operational shell backstop). **Off critical path, low priority.**

A `review` stage may now carry an optional `liveness` block expressing health-based, model-diverse reviewer failover:
- `roster` — ordered, model-diverse fallback chain tried when the primary reviewer stalls.
- `slaMinutes` — **T**, silence-on-current-head before a silent stall (default **120** = 2h).
- `maxFallbacksPerHead` — **N**, fallback hops per head SHA (default **1**; resets when the head moves).
- `maxHops` — cumulative hops before `escalateTo` the CEO (default **2**).
- `failoverStallModes` — `silent` + `stale_ci_pending` only. A **substantive** `request_changes` on the current head is a **mandatory fence (mode3)** and is never routed around, so `substantive` is not a permitted value.

### Source of truth & parity
Values mirror the MCP-3066 shell backstop (`~/.mcpproxy-gatekeeper/bin/ensure-pr-gates.sh`: `classify_stall` + `route_fallback`), which **remains the source of truth**. The same-family exclusion (a roster reviewer must not share the primary's `modelFamily` — the backstop drops the gpt-5.5 Critic because CodexReviewer is also gpt-5.5) is a cross-entity invariant enforced by the Go test, not by JSON Schema. Contract values + rationale are documented in `reviewer-liveness.example.json`.

## Gates (intact)
- **Gate 3 untouched**: this is a contract/docs change only; it adds no merge/branch-protection capability and lets no agent self-merge.
- No per-spec design gate (Gate 2) execution policy was attached to MCP-3068, so implementation proceeded directly; this PR is the deliverable and the human merges it.

## Tests / verification
- New `execution_policy_test.go` (mirrors the spec-065 `corpus_test.go` precedent; reuses the existing `santhosh-tekuri/jsonschema/v6` dep — **no new dependencies**):
  - schema compiles; full-roster policy validates; malformed liveness blocks rejected (missing `modelFamily`, empty roster, no roster, unknown stall mode, non-positive SLA).
  - **back-compat**: legacy policies + all schema `examples` validate; absent `liveness` ⇒ unchanged behavior.
  - cross-invariant: committed example carries the MCP-3066 contract values and obeys the same-family / model-diversity exclusion.
- `go test -race`, `go vet`, `gofmt`, and `golangci-lint v2` (`.github/.golangci.yml`) all green locally.

## AC coverage
- [x] Schema validates; round-trips against existing policies with no behavior change when no roster is configured.
- [x] Contract values (T, N, roster) documented with rationale and matched to MCP-3066.
- [x] Tests added; PR opened (never agent-merged). QA + Critic ACCEPT to follow.

Related #MCP-3068