### PR TITLE
ci(release): restore prerelease guard on retry-sign-release publish jobs (MCP-3020)

### DIFF
--- a/.github/workflows/retry-sign-release.yml
+++ b/.github/workflows/retry-sign-release.yml
@@ -399,7 +399,7 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     environment: production
-    if: github.repository == 'smart-mcp-proxy/mcpproxy-go'
+    if: github.repository == 'smart-mcp-proxy/mcpproxy-go' && !contains(inputs.tag, '-')
 
     steps:
       - name: Checkout tap repository
@@ -585,7 +585,7 @@ jobs:
   # Publish signed apt/yum repositories to Cloudflare R2 (mirrors release.yml)
   publish-linux-repos:
     needs: [release]
-    if: github.repository == 'smart-mcp-proxy/mcpproxy-go'
+    if: github.repository == 'smart-mcp-proxy/mcpproxy-go' && !contains(inputs.tag, '-')
     runs-on: ubuntu-latest
     environment: production
 


### PR DESCRIPTION
Re-target of #737 to **main**. The original #737 was based on the already-merged `fix/mcp-2905` branch and merged there, so the guard never landed on main (caught while cutting v0.44.0).

## Change
Adds `&& !contains(inputs.tag, '-')` to the `update-homebrew` and `publish-linux-repos` jobs in `retry-sign-release.yml`, so the **retry** path skips publishing to stable Homebrew/Linux channels for prerelease tags (`-rc.*` / `-next.*`) — mirroring the guard already in `release.yml`.

## Scope
Failure-retry path only; does not affect the primary release.yml flow. Supersedes #737 (which should be closed — it merged into a dead branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)