### PR TITLE
ci(bench): self-bootstrap Pages project + --commit-dirty (MCP-3193)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -131,13 +131,28 @@ jobs:
           retention-days: 90
           if-no-files-found: warn
 
+      # Bootstrap: create the Cloudflare Pages project if it does not yet exist.
+      # Idempotent — fails silently (continue-on-error) when the project already
+      # exists (Cloudflare error 8000007). Requires Pages:Edit scope on the token.
+      # If the token is deploy-only, create the project once manually in the
+      # Cloudflare dashboard (name: mcpproxy-bench, production branch: main) and
+      # this step will harmlessly fail every run thereafter.
+      - name: Create Cloudflare Pages project (if missing)
+        continue-on-error: true
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0  # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages project create mcpproxy-bench --production-branch=main
+
       # Publish to Cloudflare Pages (mcpproxy-bench project).
-      # On first deploy, wrangler auto-creates the project; subsequent deploys
-      # update it. The Pages URL will be mcpproxy-bench.pages.dev (or a custom
-      # domain such as bench.mcpproxy.app once configured in Cloudflare).
+      # --commit-dirty=true: bench results are written into the working tree during
+      # the run and never committed to git, so wrangler would otherwise reject the
+      # dirty-tree check. The Pages URL will be mcpproxy-bench.pages.dev (or a
+      # custom domain such as bench.mcpproxy.app once configured in Cloudflare).
       - name: Deploy benchmark dashboard to Cloudflare Pages
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0  # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy bench/results --project-name=mcpproxy-bench
+          command: pages deploy bench/results --project-name=mcpproxy-bench --commit-dirty=true


### PR DESCRIPTION
## Summary

Fixes two root causes from the first real `bench.yml` run (v0.45.0, run 28004959887) that prevented the dashboard from ever publishing. The job is `continue-on-error: true` so the release was not blocked, but the CF Pages site was never created.

### Root causes

| # | Error | Fix |
|---|-------|-----|
| 1 | `Project not found` (CF error 8000007) — wrangler does **not** auto-create Pages projects on deploy | Add a preceding `pages project create` step with `continue-on-error: true` (idempotent: succeeds on first run, fails silently on all subsequent runs once the project exists). Token must have **Pages:Edit** scope; if it is deploy-only, create the project once manually in the CF dashboard (`mcpproxy-bench`, production branch `main`) and the create step will harmlessly fail every time thereafter. |
| 2 | Dirty-tree warning: bench results land in `bench/results/` in the working tree but are never committed to git | Add `--commit-dirty=true` to the `pages deploy` command. |

### Verification path

Per MCP-3193 mandatory gates:
- CodexReviewer review
- QATester QA
- Verify via `workflow_dispatch` that the deploy succeeds (or cleanly skips if token-scoped out)

Closes MCP-3193.