### PR TITLE
test: exercise server-edition observability user_id/profile label values (MCP-3207)

### DIFF
--- a/internal/observability/metrics_test.go
+++ b/internal/observability/metrics_test.go
@@ -3,6 +3,7 @@ package observability
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
@@ -32,6 +33,26 @@ func TestQuarantineEvents_Scraped(t *testing.T) {
 	require.Contains(t, body, "mcpproxy_quarantine_events_total")
 	require.Contains(t, body, `scope="tool"`)
 	require.Contains(t, body, `action="pending"`)
+}
+
+// MCP-3207: the tool-call metric must stay low-cardinality — it carries only
+// {server,tool,status} and never per-user / per-profile labels (user_id and
+// profile are OTLP span attributes instead; see
+// internal/server/observability_edition_server.go). This locks the design so a
+// future change can't silently push per-tenant cardinality into the metric, in
+// either edition. (Acceptance: metric-layer negative control.)
+func TestToolCallMetric_NoPerUserCardinalityLabels(t *testing.T) {
+	mm := NewMetricsManager(zap.NewNop().Sugar())
+	mm.RecordToolCall("github", "create_issue", StatusSuccess, time.Millisecond)
+
+	body := scrapeMetrics(t, mm)
+	require.Contains(t, body, "mcpproxy_tool_calls_total")
+	require.Contains(t, body, `server="github"`)
+	require.Contains(t, body, `tool="create_issue"`)
+	require.Contains(t, body, `status="success"`)
+
+	assert.NotContains(t, body, "user_id=", "tool-call metric must not carry a user_id label")
+	assert.NotContains(t, body, "profile=", "tool-call metric must not carry a profile label")
 }
 
 func scrapeMetrics(t *testing.T, mm *MetricsManager) string {

--- a/internal/server/observability_edition_server_test.go
+++ b/internal/server/observability_edition_server_test.go
@@ -1,0 +1,170 @@
+//go:build server
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+)
+
+// MCP-3207: exercise the server-edition tool-call telemetry label VALUES that
+// editionToolCallAttributes() injects (MCP-32). The QA pass (OBS-05) code-verified
+// the path but never drove ≥2 authenticated users to confirm the emitted user_id /
+// profile values are distinct and correct.
+//
+// IMPORTANT design note (provenance: internal/server/observability_edition_server.go:13-17):
+// user_id and profile are OTLP SPAN attributes, NOT Prometheus metric labels. The
+// tool-call counter mcpproxy_tool_calls_total carries only {server,tool,status} to
+// keep metric cardinality bounded. Therefore "exercise the label values" is faithfully
+// and deterministically tested at the span layer here; the metric-layer negative
+// control (no per-user labels) lives in
+// internal/observability/metrics_test.go::TestToolCallMetric_NoPerUserCardinalityLabels,
+// and the personal-edition negative control lives in observability_edition_test.go.
+
+// attrValue returns the string value of the named attribute, or "" plus a bool
+// indicating presence.
+func attrValue(attrs []attribute.KeyValue, key string) (string, bool) {
+	for _, a := range attrs {
+		if string(a.Key) == key {
+			return a.Value.AsString(), true
+		}
+	}
+	return "", false
+}
+
+// TestEditionToolCallAttributes_TwoUsersDistinctValues verifies that two distinct
+// authenticated users on the same non-default profile yield distinct, correct
+// user_id values and the same correct profile value.
+func TestEditionToolCallAttributes_TwoUsersDistinctValues(t *testing.T) {
+	const profileSlug = "team-acme"
+
+	// User A: regular OAuth user.
+	ctxA := auth.WithAuthContext(context.Background(),
+		auth.UserContext("01HZUSERAAAAAAAAAAAAAAAAA", "alice@example.com", "Alice", "google"))
+	// User B: OAuth admin user — IsUser() must also be true for admin_user.
+	ctxB := auth.WithAuthContext(context.Background(),
+		auth.AdminUserContext("01HZUSERBBBBBBBBBBBBBBBBB", "bob@example.com", "Bob", "github"))
+
+	attrsA := editionToolCallAttributes(ctxA, profileSlug)
+	attrsB := editionToolCallAttributes(ctxB, profileSlug)
+
+	uidA, okA := attrValue(attrsA, "user_id")
+	require.True(t, okA, "user A span must carry user_id")
+	assert.Equal(t, "01HZUSERAAAAAAAAAAAAAAAAA", uidA)
+
+	uidB, okB := attrValue(attrsB, "user_id")
+	require.True(t, okB, "user B (admin_user) span must carry user_id")
+	assert.Equal(t, "01HZUSERBBBBBBBBBBBBBBBBB", uidB)
+
+	assert.NotEqual(t, uidA, uidB, "the two callers must produce distinct user_id label values")
+
+	profA, okPA := attrValue(attrsA, "profile")
+	require.True(t, okPA)
+	assert.Equal(t, profileSlug, profA)
+	profB, okPB := attrValue(attrsB, "profile")
+	require.True(t, okPB)
+	assert.Equal(t, profileSlug, profB)
+}
+
+// TestEditionToolCallAttributes_AdminAPIKey_NoUserID verifies that a non-OAuth
+// caller (personal-style API-key admin) does NOT get a user_id label even in the
+// server edition, while a profile, if present, is still attached.
+func TestEditionToolCallAttributes_AdminAPIKey_NoUserID(t *testing.T) {
+	ctx := auth.WithAuthContext(context.Background(), auth.AdminContext())
+
+	attrs := editionToolCallAttributes(ctx, "team-acme")
+
+	_, hasUID := attrValue(attrs, "user_id")
+	assert.False(t, hasUID, "API-key admin (non-user) must not carry a user_id label")
+
+	prof, hasProf := attrValue(attrs, "profile")
+	require.True(t, hasProf, "profile label is independent of user identity")
+	assert.Equal(t, "team-acme", prof)
+}
+
+// TestEditionToolCallAttributes_NoAuthContext verifies a missing auth context
+// yields no user_id (defensive: avoids panics / empty-string labels).
+func TestEditionToolCallAttributes_NoAuthContext(t *testing.T) {
+	attrs := editionToolCallAttributes(context.Background(), "")
+	assert.Empty(t, attrs, "no auth context and no profile => no edition attributes")
+
+	attrsProfileOnly := editionToolCallAttributes(context.Background(), "default")
+	uid, hasUID := attrValue(attrsProfileOnly, "user_id")
+	assert.False(t, hasUID, "no auth context must not emit a user_id")
+	assert.Empty(t, uid)
+}
+
+// TestEditionToolCallAttributes_EmptyUserIDOmitted verifies a user context whose
+// UserID is empty does not emit an empty-valued user_id label (cardinality / noise).
+func TestEditionToolCallAttributes_EmptyUserIDOmitted(t *testing.T) {
+	ctx := auth.WithAuthContext(context.Background(),
+		auth.UserContext("", "noid@example.com", "NoID", "google"))
+	attrs := editionToolCallAttributes(ctx, "team-acme")
+	_, hasUID := attrValue(attrs, "user_id")
+	assert.False(t, hasUID, "empty user_id must be omitted, not emitted as user_id=\"\"")
+}
+
+// TestToolCallSpan_CarriesDistinctUserAndProfileValues drives the attributes onto
+// real, emitted OTLP spans for two users and asserts each recorded span carries the
+// matching caller's user_id and the active profile. This is the closest faithful
+// "exercise the values on emitted telemetry" check that stays deterministic (an
+// in-memory span recorder, no live OTLP collector).
+func TestToolCallSpan_CarriesDistinctUserAndProfileValues(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	tracer := tp.Tracer("mcp-3207-test")
+
+	const profileSlug = "team-acme"
+	callers := []struct {
+		name   string
+		ctx    context.Context
+		userID string
+	}{
+		{
+			name:   "alice",
+			ctx:    auth.WithAuthContext(context.Background(), auth.UserContext("01HZUSERAAAAAAAAAAAAAAAAA", "alice@example.com", "Alice", "google")),
+			userID: "01HZUSERAAAAAAAAAAAAAAAAA",
+		},
+		{
+			name:   "bob",
+			ctx:    auth.WithAuthContext(context.Background(), auth.AdminUserContext("01HZUSERBBBBBBBBBBBBBBBBB", "bob@example.com", "Bob", "github")),
+			userID: "01HZUSERBBBBBBBBBBBBBBBBB",
+		},
+	}
+
+	// Mirror the production emission path (startToolCallSpan): start a tool.call
+	// span, then attach edition attributes from the caller's auth context.
+	for _, c := range callers {
+		_, span := tracer.Start(c.ctx, "tool.call")
+		span.SetAttributes(editionToolCallAttributes(c.ctx, profileSlug)...)
+		span.End()
+	}
+
+	ended := sr.Ended()
+	require.Len(t, ended, len(callers), "one emitted span per caller")
+
+	seen := map[string]string{} // user_id -> profile
+	for _, s := range ended {
+		uid, hasUID := attrValue(s.Attributes(), "user_id")
+		require.True(t, hasUID, "emitted span missing user_id")
+		prof, hasProf := attrValue(s.Attributes(), "profile")
+		require.True(t, hasProf, "emitted span missing profile")
+		seen[uid] = prof
+	}
+
+	require.Len(t, seen, len(callers), "each caller must emit a distinct user_id on its span")
+	for _, c := range callers {
+		prof, ok := seen[c.userID]
+		require.Truef(t, ok, "no emitted span carried user_id=%s", c.userID)
+		assert.Equal(t, profileSlug, prof, "profile value must match the active profile for user %s", c.name)
+	}
+}

--- a/internal/server/observability_edition_test.go
+++ b/internal/server/observability_edition_test.go
@@ -1,0 +1,25 @@
+//go:build !server
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+)
+
+// MCP-3207 negative control: the personal edition is single-user and MUST NOT
+// emit user_id / profile telemetry labels, regardless of any auth context that
+// happens to be present (MCP-32, internal/server/observability_edition.go).
+func TestEditionToolCallAttributes_PersonalEditionEmitsNoLabels(t *testing.T) {
+	// Even with a fully-populated user auth context and a non-default profile,
+	// the personal-edition stub returns no edition attributes.
+	ctx := auth.WithAuthContext(context.Background(),
+		auth.UserContext("01HZUSERAAAAAAAAAAAAAAAAA", "alice@example.com", "Alice", "google"))
+
+	attrs := editionToolCallAttributes(ctx, "team-acme")
+	assert.Empty(t, attrs, "personal edition must not attach user_id/profile telemetry attributes")
+}


### PR DESCRIPTION
## Summary

The v0.45.0 QA pass (OBS-05) **code-verified** the server-edition tool-call telemetry label injection (`editionToolCallAttributes`, MCP-32) and confirmed `mcpproxy-server` exposes `/metrics`, but never drove ≥2 authenticated users to confirm the emitted `user_id`/`profile` label **values** are distinct and correct. This PR closes that gap with deterministic tests.

## ⚠️ Design correction surfaced while writing these tests

The issue assumes `user_id`/`profile` are scraped from `/metrics`. They are **not**: they are **OTLP span (trace) attributes**, not Prometheus metric labels. The tool-call counter `mcpproxy_tool_calls_total` carries only `{server, tool, status}` — by design, to bound metric cardinality (`internal/server/observability_edition_server.go:13-17`).

Consequence: a full 2-user `mcpproxy-server` boot scraping `/metrics` could **never** surface these labels and would only add flakiness (real OTLP collector, OAuth dance). So "exercise the label values" is tested faithfully and **deterministically at the span layer**, which is where the values actually land.

## Tests added

- **`internal/server/observability_edition_server_test.go`** (`//go:build server`):
  - two distinct callers (regular `user` + `admin_user`) yield **distinct, correct** `user_id` values and the same correct `profile`;
  - API-key admin and missing/empty auth contexts emit **no** `user_id`;
  - spans emitted through an in-memory `tracetest` recorder carry the matching caller's `user_id` + active `profile` (closest faithful "values on emitted telemetry" check without a live collector).
- **`internal/server/observability_edition_test.go`** (`//go:build !server`): personal-edition negative control — **no** `user_id`/`profile` even with a populated user auth context.
- **`internal/observability/metrics_test.go`**: metric-layer negative control — the tool-call counter never carries per-user/per-profile labels in either edition (locks the cardinality design).

## Verification

- `go test -tags server ./internal/server/ -run 'TestEditionToolCallAttributes|TestToolCallSpan'` → PASS (5 tests)
- `go test ./internal/server/ -run TestEditionToolCallAttributes_PersonalEdition` → PASS
- `go test -race ./internal/observability/` (both tags) → PASS
- golangci-lint v2 (`.github/.golangci.yml`), both default and `--build-tags server` → **0 issues**
- Mutation check: dropping the `user_id` attribute in production code makes the suite fail (tests are not vacuous).

Provenance: QA report `~/mcpproxy-qa/mcpproxy-qa-v0.45.0.html` (OBS-05, partial).

Related #746