### PR TITLE
feat(sandbox): spike Landlock non-docker sandbox PoC (MCP-34.1)

### DIFF
--- a/docs/development/sandbox-spike-mcp-34.md
+++ b/docs/development/sandbox-spike-mcp-34.md
@@ -1,0 +1,177 @@
+# Spike: non-Docker sandbox mechanism for snap-docker Ubuntu 24.04 (MCP-3232)
+
+**Status:** recommendation · gates [MCP-34](../../) (Non-Docker isolation mode) · resolves design decisions **D2** and **D3** in the [MCP-34 plan](../../).
+**Author:** BackendEngineer · **PoC:** `internal/sandbox/` (this branch).
+
+## TL;DR
+
+Use the **Linux Landlock LSM** (kernel 5.13+) for the writable-scope filesystem
+allowlist, plus **`setrlimit`** for resource caps, plus **best-effort
+`SysProcAttr.Credential{Uid,Gid}`** for uid/gid drop. **Deprioritize user
+namespaces / bubblewrap** — they are blocked by default on the exact hosts we
+target. This matches the plan's D2 assumption and the spike confirms it with a
+working PoC.
+
+The PoC (`internal/sandbox`) proves the load-bearing claim from a Go process:
+Landlock **denies a path outside the allowlist, permits the allowlisted
+read-write subtree, and preserves raw stdin/stdout JSON-RPC framing** — all
+without user namespaces, so it is unaffected by
+`kernel.apparmor_restrict_unprivileged_userns=1`.
+
+## Why Docker fails on these hosts (reproduction target)
+
+On Ubuntu where Docker is installed via **snap**, AppArmor's profile transition
+fights the security flags the scanner sandbox requires
+(`--security-opt no-new-privileges` + a pinned AppArmor profile), so in-container
+commands fail with *operation not permitted*
+(`MCPX_DOCKER_SNAP_APPARMOR`, GH #71; the related systemd/snap-confine variant is
+already detected by `cmd/mcpproxy/doctor_env_snapdocker.go`, repo issue #457).
+The escapes today — remove snap docker / disable scanner / disable isolation —
+are all adoption blockers. We need an isolation path that does **not** depend on
+Docker or on a primitive AppArmor blocks.
+
+## Candidate mechanisms compared
+
+| Mechanism | Unprivileged? | Blocked by Ubuntu 24.04 AppArmor userns restriction? | FS write-allowlist | rlimits | uid/gid drop | Verdict |
+|---|---|---|---|---|---|---|
+| **Landlock LSM** (5.13+) | ✅ yes | ❌ **no** — needs no userns | ✅ path-beneath allowlist | n/a (pair with setrlimit) | ❌ no (orthogonal) | **Chosen** |
+| **user namespaces / bubblewrap** | ✅ yes (in principle) | ⚠️ **yes by default** — `apparmor_restrict_unprivileged_userns=1` blocks `unshare(CLONE_NEWUSER)` unless a per-binary AppArmor profile grants `userns` | ✅ via bind mounts | ✅ | ✅ (maps uid in the ns) | **Deprioritized** |
+| **`setpriv` + `setrlimit` only** | ✅ yes | ❌ no | ❌ none | ✅ | ❌ no (needs CAP_SETUID) | **Floor / fallback** |
+
+### Landlock — chosen (resolves D2)
+
+- **Unprivileged and userns-free.** Landlock confines the calling thread/process
+  via three syscalls (`landlock_create_ruleset`, `landlock_add_rule`,
+  `landlock_restrict_self`); it requires **no** user or mount namespace, so the
+  Ubuntu 23.10+/24.04 `apparmor_restrict_unprivileged_userns=1` default — which
+  is exactly what breaks bubblewrap on our target hosts — **does not apply**.
+  Confirmed by Chromium's and Ubuntu's own guidance (sources below).
+- **Inherited across `exec`.** A Landlock domain is preserved across `execve`
+  and applied to every descendant; a child can only *further* restrict itself,
+  never escape. That makes the integration a tiny **re-exec wrapper**: lock the
+  OS thread, `Apply()` the ruleset, then `exec` the untrusted `npx`/`uvx`
+  command. The proxy keeps owning the child's raw stdin/stdout pipes (D1: native
+  launcher, not `process-compose`).
+- **Best-effort across kernels.** `landlock_create_ruleset(NULL,0,VERSION)`
+  reports the supported ABI; we mask the handled access-rights down to that ABI
+  so the same binary degrades cleanly from 6.10 (ABI 5) to 5.13 (ABI 1).
+  Ubuntu 24.04 ships kernel 6.8 → **ABI 4** (adds TCP bind/connect; FS rights
+  fully covered). `internal/sandbox/sandbox_linux.go:handledAccessFS`.
+- **No new dependency.** `golang.org/x/sys/unix v0.46` (already a direct
+  dependency) ships the `SYS_LANDLOCK_*` numbers and `LandlockRulesetAttr` /
+  `LandlockPathBeneathAttr` types. The PoC calls the raw syscalls — satisfies
+  the repo's "avoid new dependencies" rule. (For the full build, the maintained
+  `github.com/landlock-lsm/go-landlock` library — which also solves Go's
+  multi-thread `restrict_self` caveat — is a reasonable alternative; the re-exec
+  wrapper sidesteps that caveat by `exec`-ing a single-threaded image
+  immediately after `Apply`.)
+
+### user namespaces / bubblewrap — deprioritized (confirms D2)
+
+Bubblewrap builds its sandbox with `unshare(CLONE_NEWUSER)`. Ubuntu 23.10+
+sets `kernel.apparmor_restrict_unprivileged_userns=1` by default, which **blocks
+unprivileged userns creation unless the program has an AppArmor profile granting
+the `userns` permission**. bubblewrap ships such a profile in recent Ubuntu, but
+a *custom Go binary* spawning userns would be denied on 24.04 out of the box —
+i.e. the userns-first design risks being blocked on the very hosts we target.
+This is the same failure class that breaks Docker-snap; choosing it would trade
+one AppArmor block for another. Deprioritized.
+
+### setpriv + setrlimit only — the floor
+
+No filesystem allowlist at all — only resource caps and (with privilege)
+capability/uid drop. Useful as a graceful fallback when Landlock is unavailable
+(kernel < 5.13 or LSM disabled), but it does **not** meet the "writable-scope
+allowlist" exit criterion on its own. The PoC applies `setrlimit` independently
+of Landlock so this floor is always available.
+
+## Honest limits (must be documented — D2 caveat)
+
+- **No uid/gid separation without privilege.** Landlock restricts *paths*, not
+  *identity*. The confined process runs as the **same uid** as mcpproxy; it can
+  still touch anything that uid owns *within the allowlist*. Real uid/gid drop
+  needs `SysProcAttr.Credential{Uid,Gid}`, which requires root / `CAP_SETUID`
+  (server edition under systemd, not the unprivileged desktop case). **Do not
+  overclaim Docker parity on uid/gid** for the unprivileged desktop case — set
+  it best-effort and surface the limitation.
+- **Filesystem + (on ABI 4+) TCP only.** Landlock does not restrict arbitrary
+  syscalls (that is seccomp), nor PID/IPC/network namespaces. A confined process
+  can still see `/proc`, signal same-uid processes, and (below kernel 6.7) open
+  arbitrary network sockets. Pair with seccomp + `setrlimit(RLIMIT_NPROC)` for
+  defense-in-depth in a later iteration; out of scope for this spike.
+- **Allowlist must include the loader + interpreter.** `exec`-ing `npx`/`uvx`
+  needs read+execute on the binary, its `node`/`python` runtime, and the shared
+  libraries (`/usr`, `/lib`, `/lib64`, …). The launcher must compute and grant
+  these RO paths or the child fails to start. (The PoC test grants a generous
+  system RO set to demonstrate this.)
+
+## What the PoC proves vs. what still needs the host
+
+**Proven by `internal/sandbox` (runs in CI on `ubuntu-latest` = Ubuntu 24.04 —
+see `.github/workflows/unit-tests.yml`, `go test -race ./...`):**
+
+- `TestLandlockEnforcesFilesystemAllowlist` — re-execs a confined child that
+  (1) echoes stdin→stdout (JSON-RPC framing survives), (2) reads+writes inside
+  the RW allowlist, (3) is **denied** a secret path outside it. Exit-code
+  assertions; skips gracefully if the kernel lacks Landlock.
+- `TestHandledAccessFSMasksByABI` — ABI down-masking is correct.
+- Cross-platform stub (`sandbox_other.go`) keeps macOS/Windows building with a
+  documented no-op / fail-closed `ErrUnsupported`.
+
+**Still requires a real snap-docker Ubuntu 24.04 host (deferred to MCP-34
+child issues #3/#4, where the spawn branch lands):**
+
+- End-to-end launch of an actual `npx` and `uvx` MCP server under the wrapper
+  (the PoC proves the *primitive* + passthrough; the server-specific RO
+  allowlist tuning is launcher work).
+- Reproducing the `MCPX_DOCKER_SNAP_APPARMOR` Docker failure side-by-side to
+  show the Landlock path succeeds where Docker-snap fails. (By construction
+  Landlock is unaffected by the AppArmor userns restriction, so it is expected
+  to work; this is the empirical confirmation step.)
+
+## Recommendation for the D3 scanner question
+
+The scanner *plugin* runtime is Docker-based (Spec 039) and is the broken path
+on snap-docker hosts. **Recommend D3 option (b): clean, surfaced degradation** —
+run isolated stdio servers under the Landlock `sandbox` launcher, and when
+`isolation.mode: sandbox` is active on a host where the Docker scanner cannot
+run, **skip the Docker scanner pre-flight and surface a health-degraded warning**
+(via the unified `health` field + a `doctor` check, mirroring
+`doctor_env_snapdocker.go`). A native non-Docker scanner path (option a) is a
+larger effort and can follow once the sandbox launcher exists; degradation
+unblocks adoption now and is testable on the snap-docker host. Final call sits
+with the scanner child issue (MCP-34 #4).
+
+## Proposed integration shape (for MCP-34 #2/#3, not built here)
+
+- Config: `isolation.mode: "docker" | "sandbox" | "none"` (global + per-server),
+  back-compat-mapped from today's `Enabled`/`DockerIsolation`. New
+  `config.Config`/`ServerConfig` fields ⇒ register in
+  `TestSaveServerSyncFieldCoverage` `expectedFields` and run `make swagger`
+  (prior-art gotcha, memory).
+- Spawn: a fourth branch in `connectStdio` / `buildLauncherCmd` alongside the
+  existing docker-isolation / user-`docker run` / shell-wrap branches. On Linux
+  with `mode: sandbox`, route through a `mcpproxy sandbox-exec`-style re-exec
+  wrapper that calls `sandbox.Apply(spec)` then `exec`s the resolved command;
+  reuse the existing `SysProcAttr{Setpgid:true}` process-group cleanup
+  (`process_unix.go`). macOS/Windows = documented no-op → effective `none`.
+- `Spec` is already shaped for this: `ReadOnlyPaths` (loader/runtime/binary),
+  `ReadWritePaths` (working dir, cache, `/tmp` scope), `Rlimits`, `BestEffort`.
+
+## Sources
+
+- Linux kernel — Landlock (no userns required; ABI versions):
+  https://docs.kernel.org/userspace-api/landlock.html
+- Ubuntu — Restricted unprivileged user namespaces (default `=1` since 23.10):
+  https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces
+- Chromium docs — AppArmor userns restrictions vs. Landlock fallback (Landlock
+  works where bwrap/userns is blocked):
+  https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+- bubblewrap blocked on Ubuntu 24.04 by AppArmor userns restriction:
+  https://github.com/microsoft/vscode/issues/316046
+- go-landlock (library + multi-thread `restrict_self` caveat + `landlock-restrict`
+  re-exec example): https://github.com/landlock-lsm/go-landlock
+- Repo: `golang.org/x/sys/unix v0.46` Landlock primitives (`go.mod`);
+  snap-docker detection `cmd/mcpproxy/doctor_env_snapdocker.go` (issue #457);
+  MCP-34 plan decisions D1–D3 (Paperclip plan doc).
+```

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -1,0 +1,82 @@
+// Package sandbox is a spike (MCP-3232) proving an *unprivileged*, non-Docker
+// confinement primitive for stdio MCP servers on hosts where Docker is
+// unavailable or broken — notably Ubuntu 24.04 with snap-installed Docker under
+// AppArmor, where the deb's systemd hardening fights snap-confine (see
+// internal repo issue #457 / cmd/mcpproxy/doctor_env_snapdocker.go).
+//
+// The mechanism chosen by the spike is the Linux Landlock LSM (kernel 5.13+).
+// Unlike user-namespace / bubblewrap sandboxes, Landlock does NOT require
+// unprivileged user namespaces and is therefore NOT blocked by
+// `kernel.apparmor_restrict_unprivileged_userns=1`, which Ubuntu 23.10+/24.04
+// enable by default. See docs/development/sandbox-spike-mcp-34.md for the full
+// recommendation and the honest limits (no uid/gid separation without
+// privilege, filesystem-allowlist + rlimits only).
+//
+// This package is intentionally minimal: it confines the *current* process and,
+// because Landlock domains are inherited across execve, every child it then
+// execs (the npx/uvx server and its descendants). The intended integration is a
+// tiny re-exec wrapper that calls Apply and then execs the untrusted command;
+// the package test exercises exactly that shape.
+package sandbox
+
+import "errors"
+
+// ErrUnsupported is returned by Apply on platforms or kernels that do not
+// provide the requested confinement primitive (e.g. non-Linux, or a kernel
+// without Landlock). Callers that want fail-open behaviour set Spec.BestEffort.
+var ErrUnsupported = errors.New("sandbox: confinement primitive unavailable on this platform/kernel")
+
+// Spec describes the confinement to apply to the current process before it
+// execs an untrusted stdio MCP server. The zero value applies no filesystem
+// restriction (only rlimits, if any).
+type Spec struct {
+	// ReadOnlyPaths are filesystem subtrees the confined process may read and
+	// execute. Anything not covered by a ReadOnlyPaths/ReadWritePaths entry is
+	// denied. Missing paths are skipped (best-effort) and noted in the Report.
+	ReadOnlyPaths []string
+
+	// ReadWritePaths are subtrees the confined process may read, execute, and
+	// write (create/delete/truncate within).
+	ReadWritePaths []string
+
+	// Rlimits are resource limits applied via setrlimit before confinement.
+	Rlimits []Rlimit
+
+	// BestEffort, when true, downgrades "primitive unavailable" from an error
+	// to a no-op recorded in Report.LandlockNote, mirroring go-landlock's
+	// BestEffort semantics. When false (the default, fail-closed), Apply
+	// returns ErrUnsupported if Landlock cannot be enforced — a security
+	// boundary should fail closed rather than silently run unconfined.
+	BestEffort bool
+}
+
+// Rlimit is a single setrlimit request. Resource is one of the unix.RLIMIT_*
+// constants (e.g. RLIMIT_AS, RLIMIT_NOFILE, RLIMIT_NPROC, RLIMIT_CPU).
+type Rlimit struct {
+	Resource int
+	Cur      uint64
+	Max      uint64
+}
+
+// Report records what Apply actually enforced, so callers can log an honest
+// account of the confinement (important because Apply is best-effort across
+// kernels with different Landlock ABI levels).
+type Report struct {
+	// LandlockABI is the kernel's reported Landlock ABI version that was
+	// enforced (>=1), 0 if Landlock was not requested, or -1 if Landlock is
+	// unavailable on this kernel/platform.
+	LandlockABI int
+	// LandlockNote is a human-readable note (e.g. why Landlock was skipped, or
+	// which paths were missing).
+	LandlockNote string
+	// RlimitsSet is the number of rlimits successfully applied.
+	RlimitsSet int
+	// NoNewPrivs reports whether PR_SET_NO_NEW_PRIVS was set (always true when
+	// Landlock is enforced; Landlock requires it).
+	NoNewPrivs bool
+}
+
+// wantsLandlock reports whether the spec asks for any filesystem confinement.
+func (s Spec) wantsLandlock() bool {
+	return len(s.ReadOnlyPaths) > 0 || len(s.ReadWritePaths) > 0
+}

--- a/internal/sandbox/sandbox_linux.go
+++ b/internal/sandbox/sandbox_linux.go
@@ -1,0 +1,199 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"fmt"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// Filesystem access-right groups. Read-only entries get read+execute; the
+// read-write group adds every mutating right. The full set is masked down to
+// what the running kernel's Landlock ABI actually understands (see
+// handledAccessFS) — handing a ruleset bits from a newer ABI yields EINVAL.
+const (
+	accessFSRead = unix.LANDLOCK_ACCESS_FS_EXECUTE |
+		unix.LANDLOCK_ACCESS_FS_READ_FILE |
+		unix.LANDLOCK_ACCESS_FS_READ_DIR
+
+	accessFSWrite = unix.LANDLOCK_ACCESS_FS_WRITE_FILE |
+		unix.LANDLOCK_ACCESS_FS_REMOVE_DIR |
+		unix.LANDLOCK_ACCESS_FS_REMOVE_FILE |
+		unix.LANDLOCK_ACCESS_FS_MAKE_CHAR |
+		unix.LANDLOCK_ACCESS_FS_MAKE_DIR |
+		unix.LANDLOCK_ACCESS_FS_MAKE_REG |
+		unix.LANDLOCK_ACCESS_FS_MAKE_SOCK |
+		unix.LANDLOCK_ACCESS_FS_MAKE_FIFO |
+		unix.LANDLOCK_ACCESS_FS_MAKE_BLOCK |
+		unix.LANDLOCK_ACCESS_FS_MAKE_SYM |
+		unix.LANDLOCK_ACCESS_FS_REFER | // ABI 2
+		unix.LANDLOCK_ACCESS_FS_TRUNCATE | // ABI 3
+		unix.LANDLOCK_ACCESS_FS_IOCTL_DEV // ABI 5
+
+	accessFSReadWrite = accessFSRead | accessFSWrite
+)
+
+// handledAccessFS returns the set of filesystem access rights the ruleset
+// should "handle" (i.e. deny by default unless granted), masked to the bits the
+// given Landlock ABI version supports. This is the standard best-effort pattern
+// so the same binary degrades cleanly from a 6.10 kernel down to 5.13.
+func handledAccessFS(abi int) uint64 {
+	h := uint64(accessFSReadWrite)
+	if abi < 5 {
+		h &^= unix.LANDLOCK_ACCESS_FS_IOCTL_DEV
+	}
+	if abi < 3 {
+		h &^= unix.LANDLOCK_ACCESS_FS_TRUNCATE
+	}
+	if abi < 2 {
+		h &^= unix.LANDLOCK_ACCESS_FS_REFER
+	}
+	return h
+}
+
+// Apply confines the current process per spec. On success the calling process
+// — and every process it subsequently execs — can only touch the filesystem
+// subtrees in the allowlist, under the supplied rlimits. The restriction is
+// irreversible for the lifetime of the process, which is why the intended
+// caller is a short-lived re-exec wrapper that calls Apply and immediately
+// execs the untrusted command.
+func Apply(spec Spec) (Report, error) {
+	var rep Report
+
+	// Resource limits first — cheap, and independent of Landlock availability.
+	for i := range spec.Rlimits {
+		rl := spec.Rlimits[i]
+		lim := unix.Rlimit{Cur: rl.Cur, Max: rl.Max}
+		if err := unix.Setrlimit(rl.Resource, &lim); err != nil {
+			return rep, fmt.Errorf("sandbox: setrlimit(%d): %w", rl.Resource, err)
+		}
+		rep.RlimitsSet++
+	}
+
+	if !spec.wantsLandlock() {
+		rep.LandlockNote = "no filesystem allowlist requested; rlimits only"
+		return rep, nil
+	}
+
+	abi, err := landlockABI()
+	if err != nil || abi < 1 {
+		rep.LandlockABI = -1
+		rep.LandlockNote = fmt.Sprintf("Landlock unavailable on this kernel (%v)", err)
+		if spec.BestEffort {
+			return rep, nil
+		}
+		return rep, fmt.Errorf("%w: %v", ErrUnsupported, err)
+	}
+
+	handled := handledAccessFS(abi)
+	attr := unix.LandlockRulesetAttr{Access_fs: handled}
+	rulesetFD, err := landlockCreateRuleset(&attr)
+	if err != nil {
+		return rep, fmt.Errorf("sandbox: landlock_create_ruleset: %w", err)
+	}
+	defer unix.Close(rulesetFD)
+
+	var missing []string
+	addAll := func(paths []string, access uint64) error {
+		access &= handled
+		for _, p := range paths {
+			ok, addErr := addPathRule(rulesetFD, p, access)
+			if addErr != nil {
+				return fmt.Errorf("sandbox: add rule for %q: %w", p, addErr)
+			}
+			if !ok {
+				missing = append(missing, p)
+			}
+		}
+		return nil
+	}
+	if err := addAll(spec.ReadOnlyPaths, accessFSRead); err != nil {
+		return rep, err
+	}
+	if err := addAll(spec.ReadWritePaths, accessFSReadWrite); err != nil {
+		return rep, err
+	}
+
+	// Landlock requires no_new_privs so a confined process cannot regain
+	// privileges via a SUID binary and escape the ruleset.
+	if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+		return rep, fmt.Errorf("sandbox: prctl(PR_SET_NO_NEW_PRIVS): %w", err)
+	}
+	rep.NoNewPrivs = true
+
+	if err := landlockRestrictSelf(rulesetFD); err != nil {
+		return rep, fmt.Errorf("sandbox: landlock_restrict_self: %w", err)
+	}
+
+	rep.LandlockABI = abi
+	if len(missing) > 0 {
+		rep.LandlockNote = "skipped missing paths: " + strings.Join(missing, ", ")
+	}
+	return rep, nil
+}
+
+// addPathRule grants access to the subtree beneath path. Returns (false, nil)
+// when the path does not exist so the caller can record it as skipped rather
+// than fail the whole confinement.
+func addPathRule(rulesetFD int, path string, access uint64) (bool, error) {
+	fd, err := unix.Open(path, unix.O_PATH|unix.O_CLOEXEC, 0)
+	if err != nil {
+		if err == unix.ENOENT {
+			return false, nil
+		}
+		return false, err
+	}
+	defer unix.Close(fd)
+
+	beneath := unix.LandlockPathBeneathAttr{
+		Allowed_access: access,
+		Parent_fd:      int32(fd),
+	}
+	if err := landlockAddPathBeneath(rulesetFD, &beneath); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// --- raw syscall wrappers (x/sys/unix v0.46 ships the numbers/types but not
+// high-level helpers for these three syscalls) -----------------------------
+
+// landlockABI queries the kernel's supported Landlock ABI version via
+// landlock_create_ruleset(NULL, 0, LANDLOCK_CREATE_RULESET_VERSION).
+func landlockABI() (int, error) {
+	r, _, e := unix.Syscall(unix.SYS_LANDLOCK_CREATE_RULESET, 0, 0, uintptr(unix.LANDLOCK_CREATE_RULESET_VERSION))
+	if e != 0 {
+		return 0, e
+	}
+	return int(r), nil
+}
+
+func landlockCreateRuleset(attr *unix.LandlockRulesetAttr) (int, error) {
+	r, _, e := unix.Syscall(unix.SYS_LANDLOCK_CREATE_RULESET,
+		uintptr(unsafe.Pointer(attr)), unsafe.Sizeof(*attr), 0)
+	if e != 0 {
+		return 0, e
+	}
+	return int(r), nil
+}
+
+func landlockAddPathBeneath(rulesetFD int, attr *unix.LandlockPathBeneathAttr) error {
+	_, _, e := unix.Syscall6(unix.SYS_LANDLOCK_ADD_RULE,
+		uintptr(rulesetFD), uintptr(unix.LANDLOCK_RULE_PATH_BENEATH),
+		uintptr(unsafe.Pointer(attr)), 0, 0, 0)
+	if e != 0 {
+		return e
+	}
+	return nil
+}
+
+func landlockRestrictSelf(rulesetFD int) error {
+	_, _, e := unix.Syscall(unix.SYS_LANDLOCK_RESTRICT_SELF, uintptr(rulesetFD), 0, 0)
+	if e != 0 {
+		return e
+	}
+	return nil
+}

--- a/internal/sandbox/sandbox_linux_test.go
+++ b/internal/sandbox/sandbox_linux_test.go
@@ -1,0 +1,140 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// Child-process protocol (see sandboxChild). The enforcement test re-execs this
+// same test binary with envChild set; Landlock confinement is irreversible, so
+// it MUST run in a throwaway subprocess rather than the test process itself.
+const (
+	envChild  = "MCPPROXY_SANDBOX_TEST_CHILD"
+	envRWDir  = "MCPPROXY_SANDBOX_TEST_RW"
+	envSecret = "MCPPROXY_SANDBOX_TEST_SECRET"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv(envChild) == "1" {
+		os.Exit(sandboxChild())
+	}
+	os.Exit(m.Run())
+}
+
+// sandboxChild applies a Landlock allowlist confinement to itself, then proves:
+//  1. raw stdin->stdout passthrough still works (JSON-RPC framing survives),
+//  2. the read-write allowlist entry is readable AND writable,
+//  3. a path OUTSIDE the allowlist is DENIED.
+//
+// Exit codes are the assertion channel back to the parent test.
+func sandboxChild() int {
+	rwDir := os.Getenv(envRWDir)
+	secret := os.Getenv(envSecret)
+
+	spec := Spec{
+		// Generous system RO set so the Go runtime/loader keep working; none of
+		// these cover the secret (which lives under its own temp dir).
+		ReadOnlyPaths:  []string{"/usr", "/lib", "/lib64", "/bin", "/etc", "/proc", "/sys", "/dev"},
+		ReadWritePaths: []string{rwDir},
+	}
+	if rep, err := Apply(spec); err != nil {
+		fmt.Fprintln(os.Stderr, "child: Apply failed:", err)
+		return 12
+	} else if rep.LandlockABI < 1 {
+		fmt.Fprintln(os.Stderr, "child: Landlock not enforced:", rep.LandlockNote)
+		return 12
+	}
+
+	// (1) passthrough
+	line, _ := bufio.NewReader(os.Stdin).ReadString('\n')
+	fmt.Fprint(os.Stdout, line)
+
+	// (2) RW allowlist works
+	if _, err := os.ReadFile(filepath.Join(rwDir, "allowed.txt")); err != nil {
+		fmt.Fprintln(os.Stderr, "child: allowed read failed:", err)
+		return 11
+	}
+	if err := os.WriteFile(filepath.Join(rwDir, "written.txt"), []byte("ok"), 0o600); err != nil {
+		fmt.Fprintln(os.Stderr, "child: allowed write failed:", err)
+		return 11
+	}
+
+	// (3) outside the allowlist must be denied
+	if _, err := os.ReadFile(secret); err == nil {
+		fmt.Fprintln(os.Stderr, "child: SECRET WAS READABLE — sandbox did not deny")
+		return 10
+	}
+	return 0
+}
+
+func TestLandlockEnforcesFilesystemAllowlist(t *testing.T) {
+	if abi, err := landlockABI(); err != nil || abi < 1 {
+		t.Skipf("Landlock unavailable (abi=%d, err=%v); needs kernel 5.13+ with Landlock LSM enabled", abi, err)
+	}
+
+	rwDir := t.TempDir()
+	secretDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(rwDir, "allowed.txt"), []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	secret := filepath.Join(secretDir, "secret.txt")
+	if err := os.WriteFile(secret, []byte("TOPSECRET"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(os.Args[0]) //nolint:gosec // re-exec of this test binary by design
+	cmd.Env = append(os.Environ(),
+		envChild+"=1",
+		envRWDir+"="+rwDir,
+		envSecret+"="+secret,
+	)
+	cmd.Stdin = strings.NewReader("PING-1234\n")
+	var out, errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	runErr := cmd.Run()
+
+	// stdin->stdout framing must survive confinement.
+	if got := strings.TrimSpace(out.String()); got != "PING-1234" {
+		t.Errorf("stdio passthrough broken: got %q (stderr: %s)", got, errb.String())
+	}
+	// exit 0 == secret denied AND allowlist usable.
+	if runErr != nil {
+		t.Fatalf("confined child failed: %v\nchild stderr:\n%s", runErr, errb.String())
+	}
+	// the child should have been able to write inside the RW allowlist.
+	if _, err := os.Stat(filepath.Join(rwDir, "written.txt")); err != nil {
+		t.Errorf("expected child to write inside RW allowlist: %v", err)
+	}
+}
+
+func TestHandledAccessFSMasksByABI(t *testing.T) {
+	// ABI 1 must not advertise rights introduced by later ABIs.
+	h1 := handledAccessFS(1)
+	for _, bit := range []struct {
+		name string
+		v    uint64
+	}{
+		{"REFER (ABI2)", unix.LANDLOCK_ACCESS_FS_REFER},
+		{"TRUNCATE (ABI3)", unix.LANDLOCK_ACCESS_FS_TRUNCATE},
+		{"IOCTL_DEV (ABI5)", unix.LANDLOCK_ACCESS_FS_IOCTL_DEV},
+	} {
+		if h1&bit.v != 0 {
+			t.Errorf("handledAccessFS(1) must not include %s", bit.name)
+		}
+	}
+	// ABI 5 must advertise the full set.
+	if h5 := handledAccessFS(5); h5 != uint64(accessFSReadWrite) {
+		t.Errorf("handledAccessFS(5) = %#x, want full set %#x", h5, uint64(accessFSReadWrite))
+	}
+}

--- a/internal/sandbox/sandbox_other.go
+++ b/internal/sandbox/sandbox_other.go
@@ -1,0 +1,23 @@
+//go:build !linux
+
+package sandbox
+
+// Apply is a no-op stub on non-Linux platforms. Landlock is a Linux-only LSM,
+// so there is no equivalent unprivileged filesystem-allowlist primitive here.
+// With BestEffort the caller may proceed unconfined (recorded in the Report);
+// otherwise Apply fails closed with ErrUnsupported.
+//
+// Note: macOS/Windows already have their own first-class sandbox stories
+// (Seatbelt / Docker Desktop / Windows containers); this package targets the
+// Linux snap-docker gap specifically (see package doc).
+func Apply(spec Spec) (Report, error) {
+	// No filesystem allowlist requested → nothing to enforce, same as Linux.
+	if !spec.wantsLandlock() {
+		return Report{LandlockNote: "no filesystem allowlist requested; Landlock is Linux-only"}, nil
+	}
+	rep := Report{LandlockABI: -1, LandlockNote: "Landlock is Linux-only"}
+	if !spec.BestEffort {
+		return rep, ErrUnsupported
+	}
+	return rep, nil
+}

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -1,0 +1,42 @@
+package sandbox
+
+import "testing"
+
+func TestWantsLandlock(t *testing.T) {
+	cases := []struct {
+		name string
+		spec Spec
+		want bool
+	}{
+		{"empty", Spec{}, false},
+		{"ro only", Spec{ReadOnlyPaths: []string{"/usr"}}, true},
+		{"rw only", Spec{ReadWritePaths: []string{"/tmp/x"}}, true},
+		{"rlimits only", Spec{Rlimits: []Rlimit{{Resource: 0, Cur: 1, Max: 1}}}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.spec.wantsLandlock(); got != c.want {
+				t.Errorf("wantsLandlock() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestApplyEmptySpecIsSafe verifies Apply with no filesystem allowlist and no
+// rlimits is a harmless no-op on every platform (it must NOT restrict the test
+// process, which would break the rest of the suite).
+func TestApplyEmptySpecIsSafe(t *testing.T) {
+	rep, err := Apply(Spec{})
+	if err != nil {
+		t.Fatalf("Apply(empty) returned error: %v", err)
+	}
+	if rep.LandlockABI != 0 {
+		t.Errorf("expected LandlockABI=0 for no-fs spec, got %d", rep.LandlockABI)
+	}
+	if rep.RlimitsSet != 0 {
+		t.Errorf("expected RlimitsSet=0, got %d", rep.RlimitsSet)
+	}
+	if rep.LandlockNote == "" {
+		t.Error("expected a non-empty note explaining no confinement was applied")
+	}
+}


### PR DESCRIPTION
## Spike: non-Docker sandbox mechanism for snap-docker Ubuntu 24.04 (MCP-34.1)

Gates [MCP-34] (Non-Docker isolation mode). Determines — **before** the 1.5–2w
full build commits — which *unprivileged* primitive actually works for stdio MCP
servers on Ubuntu 24.04 with snap-installed Docker under AppArmor.

### Recommendation (resolves plan decisions D2 + D3)
- **D2 — mechanism:** **Landlock LSM** (5.13+) for the filesystem write-allowlist
  + **`setrlimit`** for resource caps + **best-effort `SysProcAttr.Credential`**
  for uid/gid. Landlock needs **no user namespace**, so it is **not blocked by**
  `kernel.apparmor_restrict_unprivileged_userns=1` — the default on Ubuntu
  23.10+/24.04 that breaks bubblewrap. **userns/bwrap deprioritized** (would
  trade one AppArmor block for another). Honest limit: no uid/gid separation
  without root/CAP_SETUID.
- **D3 — scanner:** recommend surfaced degradation (run stdio under the sandbox
  launcher; skip the Docker scanner with a health-surfaced warning) over a native
  scanner rewrite; final call in the scanner child issue.

Full write-up: `docs/development/sandbox-spike-mcp-34.md`.

### Minimal PoC — `internal/sandbox/`
- Landlock fs allowlist via raw `golang.org/x/sys/unix` syscalls (**no new
  dependency**), `setrlimit`, ABI best-effort down-masking, fail-closed
  cross-platform stub.
- `TestLandlockEnforcesFilesystemAllowlist` re-execs a **confined child** that
  proves: (1) stdin→stdout JSON-RPC framing survives, (2) RW allowlist is
  read+writable, (3) a path **outside** the allowlist is **denied**.

### Verification
- `go build ./...` (darwin + linux amd64/arm64) ✅ · `golangci-lint` v2 (both
  GOOS) **0 issues** ✅ · cross-platform tests pass on macOS ✅.
- **Empirical proof on the target OS:** the enforcement test runs in CI on
  `ubuntu-latest` (= Ubuntu 24.04) via `go test -race ./...` (not in the skip
  list). I authored this on macOS and cannot exercise Landlock locally — the
  PR's own CI run on ubuntu-latest is the proof; it `t.Skip`s gracefully if the
  runner lacks Landlock.
- **Not done here (host-dependent, deferred to MCP-34 #3/#4):** end-to-end
  `npx`/`uvx` launch under the wrapper and the side-by-side `MCPX_DOCKER_SNAP_APPARMOR`
  reproduction — these belong with the launcher/spawn-branch work.

No production spawn path is modified; this is a spike (package + test + doc).

Related MCP-3232, MCP-34.
