### PR TITLE
feat(macos): add "Install server…" tray menu entry (MCP-37b)

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -55,6 +55,7 @@ If you installed MCPProxy using the **DMG installer** (macOS) or **Windows insta
 :::tip Tray Menu Options
 Right-click (or click on macOS) the tray icon to access:
 - **Open Web UI** - Launch the management dashboard
+- **Install server…** - Open the Web UI marketplace to browse and install MCP servers
 - **View Logs** - See server activity
 - **Upstream Servers** - View status of all MCP servers, enable/disable individual servers
 - **Quit** - Stop MCPProxy completely

--- a/native/macos/MCPProxy/MCPProxy/Menu/TrayMenu.swift
+++ b/native/macos/MCPProxy/MCPProxy/Menu/TrayMenu.swift
@@ -316,6 +316,10 @@ struct TrayMenu: View {
             openWebUI()
         }
 
+        Button("Install server…") {
+            openWebUI(path: "repositories")
+        }
+
         Button("Open Config File") {
             openConfigFile()
         }
@@ -481,10 +485,16 @@ struct TrayMenu: View {
     }
 
     private func openWebUI(path: String = "") {
-        let baseURLString = appState.webUIBaseURL
-        if let url = URL(string: "\(baseURLString)/ui/\(path)") {
+        if let url = TrayMenu.webUIURL(base: appState.webUIBaseURL, path: path) {
             NSWorkspace.shared.open(url)
         }
+    }
+
+    /// Build the Web UI deep-link URL from a base and a path under `/ui/`.
+    /// Pure so it can be unit-tested without driving the SwiftUI view
+    /// (e.g. the "Install server…" → `repositories` marketplace deep-link).
+    static func webUIURL(base: String, path: String = "") -> URL? {
+        URL(string: "\(base)/ui/\(path)")
     }
 
     private func openConfigFile() {

--- a/native/macos/MCPProxy/MCPProxyTests/TrayMenuDeepLinkTests.swift
+++ b/native/macos/MCPProxy/MCPProxyTests/TrayMenuDeepLinkTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import MCPProxy
+
+/// Covers the pure deep-link URL builder the tray menu relies on. The
+/// "Install server…" action (MCP-37b) opens the Web UI marketplace at
+/// `<base>/ui/repositories`; these assertions pin that path plus the existing
+/// deep-link patterns ("Open Web UI", server approve, sensitive activity) so a
+/// future change to `webUIURL` can't silently break any of them.
+final class TrayMenuDeepLinkTests: XCTestCase {
+
+    private let base = "http://127.0.0.1:8080"
+
+    func testInstallServerDeepLink() {
+        XCTAssertEqual(
+            TrayMenu.webUIURL(base: base, path: "repositories")?.absoluteString,
+            "http://127.0.0.1:8080/ui/repositories"
+        )
+    }
+
+    func testOpenWebUIRootDeepLink() {
+        XCTAssertEqual(
+            TrayMenu.webUIURL(base: base)?.absoluteString,
+            "http://127.0.0.1:8080/ui/"
+        )
+    }
+
+    func testServerAndActivityDeepLinks() {
+        XCTAssertEqual(
+            TrayMenu.webUIURL(base: base, path: "servers/github")?.absoluteString,
+            "http://127.0.0.1:8080/ui/servers/github"
+        )
+        XCTAssertEqual(
+            TrayMenu.webUIURL(base: base, path: "activity?sensitive=true")?.absoluteString,
+            "http://127.0.0.1:8080/ui/activity?sensitive=true"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Adds an **Install server…** item to the macOS Swift tray Actions section that deep-links the Web UI marketplace at `/ui/repositories`. This is the macOS half of the MCP-37 tray exit criterion (Go systray half is MCP-37a).

Related MCP-3247 · part of MCP-37.

## Changes
- `native/macos/MCPProxy/MCPProxy/Menu/TrayMenu.swift`
  - New `Button("Install server…") { openWebUI(path: "repositories") }` in the Actions section, next to "Open Web UI" — pure deep-link reusing the existing, already-shipped `openWebUI(path:)` helper (same pattern as `servers/<name>` and `activity?sensitive=true`).
  - Extracted the deep-link URL construction into a pure `TrayMenu.webUIURL(base:path:)` static helper so it's unit-testable without driving the SwiftUI view. No behavior change.
- `native/macos/MCPProxy/MCPProxyTests/TrayMenuDeepLinkTests.swift` — new tests covering the `repositories` deep-link plus the existing patterns (root, `servers/<name>`, `activity?sensitive=true`).
- `docs/getting-started/quick-start.md` — document the new tray option (ENG-9).

## Verification
- `swiftc -O -emit-executable` production tray build: compiles clean, no errors.
- `swift test --filter TrayMenuDeepLinkTests`: **3/3 pass** — `webUIURL(base:"http://127.0.0.1:8080", path:"repositories")` → `http://127.0.0.1:8080/ui/repositories` ✓ (matches exit criterion).
- Dev `.app` bundle (`com.smartmcpproxy.mcpproxy.dev`) launches and registers its status-bar item (confirmed via `mcpproxy-ui-test list_running_apps`).
- Pre-existing test failures in `AutoStartTests`/`SSEParserTests`/`MergePatchEncodingTests`/`ModelsTests` are unrelated to this change — confirmed by reproducing them on a clean `origin/main` checkout (6 failures with my changes stashed).

### Note on UI-test visual verification
The AX-based menu click/screenshot verification (`list_menu_items` / `screenshot_status_bar_menu`) could **not** run in this headless environment — the `mcpproxy-ui-test` process lacks macOS Accessibility permission, which requires interactive System Settings approval. The change is covered by the build, the pure-unit deep-link tests, and the launch/status-item check; the QA gate (with AX granted) can confirm the visual click→navigate.

## Notes
Pure deep-link; the marketplace UI + install flow already exist.