### PR TITLE
feat(index): per-profile Bleve indexes (Profiles v2 T1) — MCP-3240

### DIFF
--- a/docs/features/profiles.md
+++ b/docs/features/profiles.md
@@ -50,6 +50,33 @@ Error attribution:
 
 Tool-call activity records from profile URLs carry `metadata["profile"] = "<slug>"`. Records from `/mcp` omit this field.
 
+## Per-profile search index
+
+Each profile gets a physically separate Bleve index so switching profiles is fast and a config reload that changes one profile does not re-index the others.
+
+Layout under the data dir (`~/.mcpproxy/` by default):
+
+```
+index.bleve/                 # shared default index — all servers' tools (used by /mcp)
+index.bleve/profiles/<slug>/ # one index per profile — only that profile's servers' tools
+```
+
+Notes:
+
+- Per-profile indexes live under `index.bleve/profiles/` (not directly under `index.bleve/<slug>/`) so they never collide with Bleve's own internal files and `store/` subdirectory.
+- A per-profile index is a derived view: it is (re)built from the shared default index, so the shared index remains the source of truth and the allow-all fallback for `/mcp`.
+- `<slug>` is the validated profile name (`^[a-z0-9][a-z0-9_-]{0,62}$`), so the directory name is always filesystem-safe.
+
+Lifecycle:
+
+| Event | Effect |
+|-------|--------|
+| Profile added / first use | Its index is built lazily from the shared index. |
+| A member server's tools change | Only the profiles that include that server are rebuilt. |
+| Profile membership changes on reload | Only the affected profile is rebuilt; others are untouched. |
+| Profile removed from config | Its index directory is deleted (including orphans left by a prior run). |
+| Server disabled / quarantined | Profiles that include it are refreshed so its tools drop out. |
+
 ## Hot reload
 
 Profile changes take effect for new connections on the next config reload. In-flight sessions keep their snapshot.

--- a/internal/config/profiles.go
+++ b/internal/config/profiles.go
@@ -18,6 +18,15 @@ type ProfileConfig struct {
 // alphanumeric start, then up to 62 more of [a-z0-9_-] — max 63 chars total.
 var profileSlugPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{0,62}$`)
 
+// IsValidProfileSlug reports whether name is a valid, filesystem-safe profile
+// slug (FR-007): a lowercase-alphanumeric start followed by up to 62 more of
+// [a-z0-9_-] (1-63 chars total). Callers that map a slug onto a directory path
+// (e.g. per-profile Bleve indexes) use this as a defense-in-depth guard against
+// path traversal, in addition to ValidateProfiles' load-time enforcement.
+func IsValidProfileSlug(name string) bool {
+	return profileSlugPattern.MatchString(name)
+}
+
 // reservedProfileSlugs are URL path segments that collide with existing /mcp
 // routes (/mcp/code, /mcp/call) or the /mcp/p prefix itself, plus "all"
 // reserved for a future explicit all-servers profile (FR-007).

--- a/internal/index/bleve.go
+++ b/internal/index/bleve.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -32,14 +33,24 @@ type ToolDocument struct {
 	SearchableText   string `json:"searchable_text"` // Combined searchable content
 }
 
-// NewBleveIndex creates a new Bleve index
+// NewBleveIndex creates (or opens) the shared default Bleve index at
+// <dataDir>/index.bleve.
 func NewBleveIndex(dataDir string, logger *zap.Logger) (*BleveIndex, error) {
-	indexPath := filepath.Join(dataDir, "index.bleve")
+	return newBleveIndexAt(filepath.Join(dataDir, "index.bleve"), logger)
+}
 
+// newBleveIndexAt opens an existing Bleve index at indexPath, or creates one if
+// it does not yet exist. The parent directory is created as needed so callers
+// may nest a per-profile index under the shared index dir
+// (<dataDir>/index.bleve/<slug>/) without pre-creating it.
+func newBleveIndexAt(indexPath string, logger *zap.Logger) (*BleveIndex, error) {
 	// Try to open existing index
 	index, err := bleve.Open(indexPath)
 	if err != nil {
 		// If index doesn't exist, create a new one
+		if mkErr := os.MkdirAll(filepath.Dir(indexPath), 0o755); mkErr != nil {
+			return nil, fmt.Errorf("failed to create index parent dir: %w", mkErr)
+		}
 		logger.Info("Creating new Bleve index", zap.String("path", indexPath))
 		index, err = createBleveIndex(indexPath)
 		if err != nil {
@@ -286,6 +297,28 @@ func (b *BleveIndex) SearchTools(queryStr string, limit int) ([]*config.SearchRe
 // GetDocumentCount returns the number of documents in the index
 func (b *BleveIndex) GetDocumentCount() (uint64, error) {
 	return b.index.DocCount()
+}
+
+// DeleteAll removes every document from the index, leaving an empty index in
+// place. Used to rebuild a per-profile index from scratch without recreating
+// its on-disk directory.
+func (b *BleveIndex) DeleteAll() error {
+	query := bleve.NewMatchAllQuery()
+	searchReq := bleve.NewSearchRequest(query)
+	searchReq.Size = 100000 // generous upper bound on indexed tools
+	searchResult, err := b.index.Search(searchReq)
+	if err != nil {
+		return fmt.Errorf("failed to enumerate documents for delete-all: %w", err)
+	}
+
+	batch := b.index.NewBatch()
+	for _, hit := range searchResult.Hits {
+		batch.Delete(hit.ID)
+	}
+	if batch.Size() == 0 {
+		return nil
+	}
+	return b.index.Batch(batch)
 }
 
 // Batch operations for efficiency

--- a/internal/index/bleve.go
+++ b/internal/index/bleve.go
@@ -342,14 +342,15 @@ func (b *BleveIndex) BatchIndex(tools []*config.ToolMetadata) error {
 			toolMeta.ParamsJSON)
 
 		doc := &ToolDocument{
-			ToolName:       toolName,
-			FullToolName:   toolMeta.Name,
-			ServerName:     toolMeta.ServerName,
-			Description:    toolMeta.Description,
-			ParamsJSON:     toolMeta.ParamsJSON,
-			Hash:           toolMeta.Hash,
-			Tags:           "",
-			SearchableText: searchableText,
+			ToolName:         toolName,
+			FullToolName:     toolMeta.Name,
+			ServerName:       toolMeta.ServerName,
+			Description:      toolMeta.Description,
+			ParamsJSON:       toolMeta.ParamsJSON,
+			OutputSchemaJSON: toolMeta.OutputSchemaJSON,
+			Hash:             toolMeta.Hash,
+			Tags:             "",
+			SearchableText:   searchableText,
 		}
 
 		docID := fmt.Sprintf("%s:%s", toolMeta.ServerName, toolName)
@@ -384,7 +385,7 @@ func (b *BleveIndex) GetToolsByServer(serverName string) ([]*config.ToolMetadata
 	// Create search request with high limit to get all tools
 	searchReq := bleve.NewSearchRequest(query)
 	searchReq.Size = 10000 // Maximum tools per server
-	searchReq.Fields = []string{"tool_name", "full_tool_name", "server_name", "description", "params_json", "hash"}
+	searchReq.Fields = []string{"tool_name", "full_tool_name", "server_name", "description", "params_json", "output_schema_json", "hash"}
 
 	b.logger.Debug("Querying tools by server", zap.String("server", serverName))
 
@@ -397,11 +398,12 @@ func (b *BleveIndex) GetToolsByServer(serverName string) ([]*config.ToolMetadata
 	var tools []*config.ToolMetadata
 	for _, hit := range searchResult.Hits {
 		toolMeta := &config.ToolMetadata{
-			Name:        getStringField(hit.Fields, "full_tool_name"),
-			ServerName:  getStringField(hit.Fields, "server_name"),
-			Description: getStringField(hit.Fields, "description"),
-			ParamsJSON:  getStringField(hit.Fields, "params_json"),
-			Hash:        getStringField(hit.Fields, "hash"),
+			Name:             getStringField(hit.Fields, "full_tool_name"),
+			ServerName:       getStringField(hit.Fields, "server_name"),
+			Description:      getStringField(hit.Fields, "description"),
+			ParamsJSON:       getStringField(hit.Fields, "params_json"),
+			OutputSchemaJSON: getStringField(hit.Fields, "output_schema_json"),
+			Hash:             getStringField(hit.Fields, "hash"),
 		}
 		tools = append(tools, toolMeta)
 	}

--- a/internal/index/manager.go
+++ b/internal/index/manager.go
@@ -2,6 +2,8 @@ package index
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
@@ -9,14 +11,43 @@ import (
 	"go.uber.org/zap"
 )
 
-// Manager provides a unified interface for indexing operations
+// profilesDirName is the subdirectory of index.bleve that holds per-profile
+// indexes: <dataDir>/index.bleve/profiles/<slug>/. Per-profile indexes are kept
+// under their own namespace (rather than directly under index.bleve/<slug>/) so
+// they never collide with the shared index's internal entries — Bleve creates
+// its own `store/` subdirectory and metadata files directly under index.bleve,
+// and a sibling dir there could be mistaken for a profile during cleanup.
+const profilesDirName = "profiles"
+
+// Manager provides a unified interface for indexing operations.
+//
+// A root Manager (created via NewManager) owns the shared default index at
+// <dataDir>/index.bleve plus a lazily-populated map of per-profile sub-Managers
+// (Profiles v2, Spec 057). Each sub-Manager, obtained via ForProfile, wraps its
+// own index at <dataDir>/index.bleve/profiles/<slug>/ and reuses the full Manager
+// method surface. Sub-Managers do not themselves nest further (their profiles map
+// is nil), so ForProfile is only meaningful on the root.
 type Manager struct {
 	bleveIndex *BleveIndex
 	mu         sync.RWMutex
 	logger     *zap.Logger
+
+	dataDir  string              // root data dir; "" for sub-Managers
+	profiles map[string]*Manager // slug -> per-profile sub-Manager (root only)
 }
 
-// NewManager creates a new index manager
+// profilesBaseDir returns <dataDir>/index.bleve/profiles, the parent directory
+// of all per-profile indexes.
+func (m *Manager) profilesBaseDir() string {
+	return filepath.Join(m.dataDir, "index.bleve", profilesDirName)
+}
+
+// profileIndexPath returns the on-disk index path for a profile slug.
+func (m *Manager) profileIndexPath(slug string) string {
+	return filepath.Join(m.profilesBaseDir(), slug)
+}
+
+// NewManager creates a new root index manager backed by the shared default index.
 func NewManager(dataDir string, logger *zap.Logger) (*Manager, error) {
 	bleveIndex, err := NewBleveIndex(dataDir, logger)
 	if err != nil {
@@ -26,18 +57,32 @@ func NewManager(dataDir string, logger *zap.Logger) (*Manager, error) {
 	return &Manager{
 		bleveIndex: bleveIndex,
 		logger:     logger,
+		dataDir:    dataDir,
+		profiles:   make(map[string]*Manager),
 	}, nil
 }
 
-// Close closes the index manager
+// Close closes the index manager and every per-profile index it opened.
 func (m *Manager) Close() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if m.bleveIndex != nil {
-		return m.bleveIndex.Close()
+	var firstErr error
+	for slug, sub := range m.profiles {
+		if sub.bleveIndex != nil {
+			if err := sub.bleveIndex.Close(); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		delete(m.profiles, slug)
 	}
-	return nil
+
+	if m.bleveIndex != nil {
+		if err := m.bleveIndex.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }
 
 // IndexTool indexes a single tool
@@ -138,4 +183,165 @@ func (m *Manager) GetToolsByServer(serverName string) ([]*config.ToolMetadata, e
 	defer m.mu.RUnlock()
 
 	return m.bleveIndex.GetToolsByServer(serverName)
+}
+
+// ForProfile returns the index Manager scoped to the named profile, backed by a
+// physically separate index at <dataDir>/index.bleve/profiles/<slug>/. The
+// per-profile index is opened (or created) lazily on first use and cached, so
+// repeated calls for the same slug return the same handle. An empty slug returns
+// the root (shared default) Manager. The slug must be a valid, filesystem-safe
+// profile slug (see config.IsValidProfileSlug) — invalid slugs are rejected to
+// prevent path traversal. Only valid on a root Manager.
+func (m *Manager) ForProfile(slug string) (*Manager, error) {
+	if slug == "" {
+		return m, nil
+	}
+	if m.profiles == nil {
+		return nil, fmt.Errorf("ForProfile is only valid on the root index manager")
+	}
+	if !config.IsValidProfileSlug(slug) {
+		return nil, fmt.Errorf("invalid profile slug %q: not filesystem-safe", slug)
+	}
+
+	// Fast path: already opened.
+	m.mu.RLock()
+	if sub, ok := m.profiles[slug]; ok {
+		m.mu.RUnlock()
+		return sub, nil
+	}
+	m.mu.RUnlock()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// Re-check under the write lock in case of a concurrent opener.
+	if sub, ok := m.profiles[slug]; ok {
+		return sub, nil
+	}
+
+	indexPath := m.profileIndexPath(slug)
+	bleveIndex, err := newBleveIndexAt(indexPath, m.logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open profile index %q: %w", slug, err)
+	}
+
+	sub := &Manager{
+		bleveIndex: bleveIndex,
+		logger:     m.logger,
+		// Sub-Managers carry no dataDir/profiles map: they do not nest further.
+	}
+	m.profiles[slug] = sub
+	m.logger.Info("Opened per-profile index", zap.String("profile", slug), zap.String("path", indexPath))
+	return sub, nil
+}
+
+// ClearAll removes every document from this index, leaving it empty.
+func (m *Manager) ClearAll() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.bleveIndex.DeleteAll()
+}
+
+// RebuildProfileFromShared (re)builds the named profile's index to contain
+// exactly the tools of the given servers, sourced from the shared default index.
+// The profile index is cleared first, so the operation is idempotent and only
+// ever touches the named profile — other profiles are left untouched (reload
+// isolation). Servers with no indexed tools contribute nothing; an empty server
+// list yields an empty profile index.
+func (m *Manager) RebuildProfileFromShared(slug string, servers []string) error {
+	pm, err := m.ForProfile(slug)
+	if err != nil {
+		return err
+	}
+
+	if err := pm.ClearAll(); err != nil {
+		return fmt.Errorf("failed to clear profile index %q: %w", slug, err)
+	}
+
+	var tools []*config.ToolMetadata
+	for _, srv := range servers {
+		srvTools, err := m.GetToolsByServer(srv)
+		if err != nil {
+			return fmt.Errorf("failed to read shared index for server %q: %w", srv, err)
+		}
+		tools = append(tools, srvTools...)
+	}
+
+	if len(tools) == 0 {
+		return nil
+	}
+	return pm.BatchIndexTools(tools)
+}
+
+// DropProfile closes the named profile's index (if open) and removes its on-disk
+// directory. It is a no-op if the profile was never opened and its directory does
+// not exist. The empty (default) slug cannot be dropped.
+func (m *Manager) DropProfile(slug string) error {
+	if slug == "" {
+		return fmt.Errorf("cannot drop the shared default index")
+	}
+	if m.dataDir == "" {
+		return fmt.Errorf("DropProfile is only valid on the root index manager")
+	}
+	if !config.IsValidProfileSlug(slug) {
+		return fmt.Errorf("invalid profile slug %q: not filesystem-safe", slug)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if sub, ok := m.profiles[slug]; ok {
+		if sub.bleveIndex != nil {
+			if err := sub.bleveIndex.Close(); err != nil {
+				m.logger.Warn("Failed to close profile index before drop",
+					zap.String("profile", slug), zap.Error(err))
+			}
+		}
+		delete(m.profiles, slug)
+	}
+
+	dir := m.profileIndexPath(slug)
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("failed to remove profile index dir %q: %w", dir, err)
+	}
+	m.logger.Info("Dropped per-profile index", zap.String("profile", slug), zap.String("path", dir))
+	return nil
+}
+
+// ExistingProfileDirs returns the slugs of every per-profile index directory
+// present on disk under <dataDir>/index.bleve/profiles/, regardless of whether
+// it is currently open. Only valid, filesystem-safe slug directories are
+// returned. Used to reclaim orphaned profile indexes left by a prior run.
+func (m *Manager) ExistingProfileDirs() ([]string, error) {
+	if m.dataDir == "" {
+		return nil, nil
+	}
+	base := m.profilesBaseDir()
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read index dir %q: %w", base, err)
+	}
+
+	var slugs []string
+	for _, e := range entries {
+		if e.IsDir() && config.IsValidProfileSlug(e.Name()) {
+			slugs = append(slugs, e.Name())
+		}
+	}
+	return slugs, nil
+}
+
+// ProfileSlugs returns the slugs of all currently open per-profile indexes.
+func (m *Manager) ProfileSlugs() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	slugs := make([]string, 0, len(m.profiles))
+	for slug := range m.profiles {
+		slugs = append(slugs, slug)
+	}
+	return slugs
 }

--- a/internal/index/profile_index_test.go
+++ b/internal/index/profile_index_test.go
@@ -1,0 +1,171 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+)
+
+// toolFor builds a minimal ToolMetadata for a given server and tool name.
+func toolFor(server, tool string) *config.ToolMetadata {
+	return &config.ToolMetadata{
+		Name:        server + ":" + tool,
+		ServerName:  server,
+		Description: "tool " + tool + " on " + server,
+		ParamsJSON:  `{"type":"object","properties":{},"required":[]}`,
+		Hash:        server + "-" + tool + "-hash",
+	}
+}
+
+// TestManager_ForProfile_CreatesIsolatedIndex verifies that ForProfile lazily
+// creates index.bleve/profiles/<slug>/ and that docs in one profile are isolated
+// from other profiles and from the shared default index.
+func TestManager_ForProfile_CreatesIsolatedIndex(t *testing.T) {
+	dataDir := t.TempDir()
+	logger := zap.NewNop()
+
+	m, err := NewManager(dataDir, logger)
+	require.NoError(t, err)
+	defer m.Close()
+
+	alpha, err := m.ForProfile("alpha")
+	require.NoError(t, err)
+	require.NoError(t, alpha.BatchIndexTools([]*config.ToolMetadata{
+		toolFor("s1", "a"),
+		toolFor("s1", "b"),
+	}))
+
+	// The per-profile index directory must exist on disk under index.bleve/profiles/<slug>/.
+	alphaDir := filepath.Join(dataDir, "index.bleve", "profiles", "alpha")
+	info, statErr := os.Stat(alphaDir)
+	require.NoError(t, statErr, "expected per-profile index dir at %s", alphaDir)
+	require.True(t, info.IsDir())
+
+	beta, err := m.ForProfile("beta")
+	require.NoError(t, err)
+	require.NoError(t, beta.BatchIndexTools([]*config.ToolMetadata{
+		toolFor("s2", "c"),
+	}))
+
+	alphaCount, err := alpha.GetDocumentCount()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2), alphaCount, "alpha should hold only its own 2 docs")
+
+	betaCount, err := beta.GetDocumentCount()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), betaCount, "beta should hold only its own 1 doc")
+
+	// The shared default index is untouched by profile indexing.
+	sharedCount, err := m.GetDocumentCount()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), sharedCount, "shared index must stay empty")
+}
+
+// TestManager_ForProfile_SameSlugReturnsSameIndex verifies ForProfile caches one
+// index per slug so concurrent callers observe the same underlying documents.
+func TestManager_ForProfile_SameSlugReturnsSameIndex(t *testing.T) {
+	dataDir := t.TempDir()
+	m, err := NewManager(dataDir, zap.NewNop())
+	require.NoError(t, err)
+	defer m.Close()
+
+	first, err := m.ForProfile("alpha")
+	require.NoError(t, err)
+	require.NoError(t, first.IndexTool(toolFor("s1", "a")))
+
+	second, err := m.ForProfile("alpha")
+	require.NoError(t, err)
+	require.Same(t, first, second, "ForProfile must return a cached, stable handle per slug")
+
+	count, err := second.GetDocumentCount()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), count)
+}
+
+// TestManager_ForProfile_RejectsInvalidSlug guards against path traversal: only
+// validated, filesystem-safe slugs may map to a directory.
+func TestManager_ForProfile_RejectsInvalidSlug(t *testing.T) {
+	dataDir := t.TempDir()
+	m, err := NewManager(dataDir, zap.NewNop())
+	require.NoError(t, err)
+	defer m.Close()
+
+	for _, bad := range []string{"../escape", "UPPER", "with/slash", "with space", ".."} {
+		_, err := m.ForProfile(bad)
+		assert.Error(t, err, "slug %q must be rejected", bad)
+	}
+
+	// Empty slug returns the shared default manager.
+	shared, err := m.ForProfile("")
+	require.NoError(t, err)
+	assert.Same(t, m, shared)
+}
+
+// TestManager_RebuildProfileFromShared_IsolatesOtherProfiles is the reload-isolation
+// invariant: rebuilding profile A from the shared index must not touch profile B.
+func TestManager_RebuildProfileFromShared_IsolatesOtherProfiles(t *testing.T) {
+	dataDir := t.TempDir()
+	m, err := NewManager(dataDir, zap.NewNop())
+	require.NoError(t, err)
+	defer m.Close()
+
+	// Populate the shared index: s1 has 2 tools, s2 has 3 tools.
+	require.NoError(t, m.BatchIndexTools([]*config.ToolMetadata{
+		toolFor("s1", "a"), toolFor("s1", "b"),
+		toolFor("s2", "c"), toolFor("s2", "d"), toolFor("s2", "e"),
+	}))
+
+	require.NoError(t, m.RebuildProfileFromShared("alpha", []string{"s1"}))
+	require.NoError(t, m.RebuildProfileFromShared("beta", []string{"s2"}))
+
+	alpha, _ := m.ForProfile("alpha")
+	beta, _ := m.ForProfile("beta")
+
+	alphaCount, _ := alpha.GetDocumentCount()
+	betaCount, _ := beta.GetDocumentCount()
+	assert.Equal(t, uint64(2), alphaCount)
+	assert.Equal(t, uint64(3), betaCount)
+
+	// Change alpha's membership to {s1, s2}; beta must be untouched.
+	require.NoError(t, m.RebuildProfileFromShared("alpha", []string{"s1", "s2"}))
+
+	alphaCount, _ = alpha.GetDocumentCount()
+	betaCountAfter, _ := beta.GetDocumentCount()
+	assert.Equal(t, uint64(5), alphaCount, "alpha rebuilt with both servers")
+	assert.Equal(t, uint64(3), betaCountAfter, "beta doc-count must be unchanged")
+}
+
+// TestManager_DropProfile_RemovesDir verifies that deleting a profile drops its
+// on-disk index directory and that a later ForProfile recreates it empty.
+func TestManager_DropProfile_RemovesDir(t *testing.T) {
+	dataDir := t.TempDir()
+	m, err := NewManager(dataDir, zap.NewNop())
+	require.NoError(t, err)
+	defer m.Close()
+
+	alpha, err := m.ForProfile("alpha")
+	require.NoError(t, err)
+	require.NoError(t, alpha.IndexTool(toolFor("s1", "a")))
+
+	alphaDir := filepath.Join(dataDir, "index.bleve", "profiles", "alpha")
+	_, statErr := os.Stat(alphaDir)
+	require.NoError(t, statErr)
+
+	require.NoError(t, m.DropProfile("alpha"))
+
+	_, statErr = os.Stat(alphaDir)
+	assert.True(t, os.IsNotExist(statErr), "profile index dir must be removed on drop")
+
+	// Recreating the profile yields a fresh, empty index.
+	recreated, err := m.ForProfile("alpha")
+	require.NoError(t, err)
+	count, err := recreated.GetDocumentCount()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), count)
+}

--- a/internal/index/profile_index_test.go
+++ b/internal/index/profile_index_test.go
@@ -141,6 +141,41 @@ func TestManager_RebuildProfileFromShared_IsolatesOtherProfiles(t *testing.T) {
 	assert.Equal(t, uint64(3), betaCountAfter, "beta doc-count must be unchanged")
 }
 
+// TestManager_RebuildProfileFromShared_PreservesOutputSchema is a regression
+// guard (CodexReviewer on PR #756): the profile rebuild path must not drop
+// OutputSchemaJSON. The shared index is populated via BatchIndexTools (the real
+// indexing path), then a profile is rebuilt from it; the field must survive
+// both the read (GetToolsByServer) and the write (BatchIndex) and be returned by
+// the profile's search results — the exact path retrieve_tools uses.
+func TestManager_RebuildProfileFromShared_PreservesOutputSchema(t *testing.T) {
+	dataDir := t.TempDir()
+	m, err := NewManager(dataDir, zap.NewNop())
+	require.NoError(t, err)
+	defer m.Close()
+
+	const outputSchema = `{"type":"object","properties":{"result":{"type":"string"}}}`
+	tool := toolFor("s1", "schematool")
+	tool.OutputSchemaJSON = outputSchema
+
+	require.NoError(t, m.BatchIndexTools([]*config.ToolMetadata{tool}))
+	require.NoError(t, m.RebuildProfileFromShared("alpha", []string{"s1"}))
+
+	alpha, err := m.ForProfile("alpha")
+	require.NoError(t, err)
+
+	// Via GetToolsByServer on the profile index.
+	got, err := alpha.GetToolsByServer("s1")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, outputSchema, got[0].OutputSchemaJSON, "output schema must survive profile rebuild (GetToolsByServer)")
+
+	// Via search on the profile index (what retrieve_tools consumes).
+	results, err := alpha.SearchTools("schematool", 10)
+	require.NoError(t, err)
+	require.NotEmpty(t, results)
+	assert.Equal(t, outputSchema, results[0].Tool.OutputSchemaJSON, "output schema must survive profile rebuild (SearchTools)")
+}
+
 // TestManager_DropProfile_RemovesDir verifies that deleting a profile drops its
 // on-disk index directory and that a later ForProfile recreates it empty.
 func TestManager_DropProfile_RemovesDir(t *testing.T) {

--- a/internal/runtime/lifecycle.go
+++ b/internal/runtime/lifecycle.go
@@ -430,6 +430,11 @@ func (r *Runtime) discoverAndIndexTools(ctx context.Context, dueOnly bool) error
 		}
 	}
 
+	// Profiles v2 (Spec 057, T1): reconcile per-profile indexes against the
+	// current config — build new profiles, rebuild those whose membership changed
+	// and drop removed ones. Unchanged profiles are left untouched.
+	r.reconcileProfileIndexes()
+
 	r.logger.Info("Successfully indexed tools", zap.Int("count", len(tools)))
 	return nil
 }
@@ -552,7 +557,12 @@ func (r *Runtime) applyDifferentialToolUpdate(ctx context.Context, serverName st
 			zap.Error(err))
 		// Filter out blocked tools before full batch index
 		allowedTools := filterBlockedTools(newTools, approvalResult.BlockedTools)
-		return r.indexManager.BatchIndexTools(allowedTools)
+		if err := r.indexManager.BatchIndexTools(allowedTools); err != nil {
+			return err
+		}
+		// The shared index changed for this server; refresh dependent profiles.
+		r.reindexAffectedProfiles(serverName)
+		return nil
 	}
 
 	// Build maps for efficient lookup
@@ -697,6 +707,15 @@ func (r *Runtime) applyDifferentialToolUpdate(ctx context.Context, serverName st
 		if err := r.indexManager.BatchIndexTools(allowedModifiedTools); err != nil {
 			return fmt.Errorf("failed to re-index modified tools: %w", err)
 		}
+	}
+
+	// If the shared index changed for this server, refresh the per-profile indexes
+	// that include it (Profiles v2, Spec 057). Profiles without this server are
+	// untouched. Skipped when nothing changed to avoid churn on idle sweeps.
+	changed := len(addedTools) > 0 || len(modifiedTools) > 0 || len(removedTools) > 0 ||
+		len(approvalResult.BlockedTools) > 0
+	if changed {
+		r.reindexAffectedProfiles(serverName)
 	}
 
 	return nil
@@ -1119,6 +1138,8 @@ func (r *Runtime) EnableServer(serverName string, enabled bool) error {
 			} else {
 				r.logger.Info("Removed disabled server tools from search index",
 					zap.String("server", serverName))
+				// Refresh per-profile indexes that include this now-disabled server.
+				r.reindexAffectedProfiles(serverName)
 			}
 		}
 
@@ -1157,6 +1178,8 @@ func (r *Runtime) QuarantineServer(serverName string, quarantined bool) error {
 		} else {
 			r.logger.Info("Removed quarantined server tools from index",
 				zap.String("server", serverName))
+			// Refresh per-profile indexes that include this now-quarantined server.
+			r.reindexAffectedProfiles(serverName)
 		}
 	}
 

--- a/internal/runtime/profile_index.go
+++ b/internal/runtime/profile_index.go
@@ -1,0 +1,130 @@
+package runtime
+
+import (
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+
+	"go.uber.org/zap"
+)
+
+// profileEffectiveServers builds the desired profile -> effective-server-set map
+// from the current config. Each profile's server list is filtered to servers that
+// actually exist (warn-skip semantics, see config.ProfileConfig.EffectiveServers).
+// Returns nil when there are no profiles.
+func profileEffectiveServers(cfg *config.Config) map[string][]string {
+	if cfg == nil || len(cfg.Profiles) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(cfg.Profiles))
+	for _, p := range cfg.Profiles {
+		out[p.Name] = p.EffectiveServers(cfg)
+	}
+	return out
+}
+
+// reindexAffectedProfiles rebuilds every per-profile index that references
+// serverName, after that server's tools changed in the shared index. Profiles
+// that do not reference the server are left untouched (reload isolation). Called
+// from applyDifferentialToolUpdate only when the shared index actually changed.
+func (r *Runtime) reindexAffectedProfiles(serverName string) {
+	if r.indexManager == nil {
+		return
+	}
+	desired := profileEffectiveServers(r.Config())
+	if len(desired) == 0 {
+		return
+	}
+
+	r.profileIndexMu.Lock()
+	defer r.profileIndexMu.Unlock()
+
+	for name, servers := range desired {
+		if !containsString(servers, serverName) {
+			continue
+		}
+		if err := r.indexManager.RebuildProfileFromShared(name, servers); err != nil {
+			r.logger.Error("Failed to rebuild per-profile index",
+				zap.String("profile", name),
+				zap.String("trigger_server", serverName),
+				zap.Error(err))
+			continue
+		}
+		r.profileMembership[name] = servers
+	}
+}
+
+// reconcileProfileIndexes reconciles all per-profile indexes against the current
+// config and shared index. It builds new profiles, rebuilds profiles whose
+// effective server set changed since the last sync, and drops profiles that were
+// removed from config (including orphaned index dirs left by a previous run).
+// Profiles whose membership is unchanged are left untouched. Called after each
+// discovery pass and after config reloads.
+func (r *Runtime) reconcileProfileIndexes() {
+	if r.indexManager == nil {
+		return
+	}
+	desired := profileEffectiveServers(r.Config())
+
+	r.profileIndexMu.Lock()
+	defer r.profileIndexMu.Unlock()
+
+	// Build or rebuild new / changed profiles; leave unchanged ones untouched.
+	for name, servers := range desired {
+		if prev, existed := r.profileMembership[name]; existed && stringSlicesEqual(prev, servers) {
+			continue
+		}
+		if err := r.indexManager.RebuildProfileFromShared(name, servers); err != nil {
+			r.logger.Error("Failed to (re)build per-profile index",
+				zap.String("profile", name),
+				zap.Error(err))
+			continue
+		}
+		r.profileMembership[name] = servers
+	}
+
+	// Drop profiles no longer present in config — both those we tracked this run
+	// and orphaned directories persisted from a prior run.
+	stale := make(map[string]struct{})
+	for name := range r.profileMembership {
+		if _, ok := desired[name]; !ok {
+			stale[name] = struct{}{}
+		}
+	}
+	if onDisk, err := r.indexManager.ExistingProfileDirs(); err != nil {
+		r.logger.Warn("Failed to list per-profile index dirs during reconcile", zap.Error(err))
+	} else {
+		for _, name := range onDisk {
+			if _, ok := desired[name]; !ok {
+				stale[name] = struct{}{}
+			}
+		}
+	}
+	for name := range stale {
+		if err := r.indexManager.DropProfile(name); err != nil {
+			r.logger.Error("Failed to drop removed per-profile index",
+				zap.String("profile", name),
+				zap.Error(err))
+		}
+		delete(r.profileMembership, name)
+	}
+}
+
+func containsString(s []string, target string) bool {
+	for _, v := range s {
+		if v == target {
+			return true
+		}
+	}
+	return false
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/runtime/profile_index_test.go
+++ b/internal/runtime/profile_index_test.go
@@ -1,0 +1,130 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/index"
+)
+
+// newProfileTestRuntime builds a minimal Runtime wired to a real on-disk index
+// manager and the given config, sufficient to exercise per-profile index
+// reconciliation without standing up the full runtime.
+func newProfileTestRuntime(t *testing.T, cfg *config.Config) (*Runtime, *index.Manager) {
+	t.Helper()
+	dataDir := t.TempDir()
+	cfg.DataDir = dataDir
+
+	mgr, err := index.NewManager(dataDir, zap.NewNop())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mgr.Close() })
+
+	r := &Runtime{
+		logger:            zap.NewNop(),
+		cfg:               cfg,
+		indexManager:      mgr,
+		profileMembership: make(map[string][]string),
+	}
+	return r, mgr
+}
+
+func toolMeta(server, tool string) *config.ToolMetadata {
+	return &config.ToolMetadata{
+		Name:        server + ":" + tool,
+		ServerName:  server,
+		Description: "tool " + tool,
+		ParamsJSON:  `{"type":"object","properties":{},"required":[]}`,
+		Hash:        server + "-" + tool,
+	}
+}
+
+func profileDocCount(t *testing.T, mgr *index.Manager, slug string) uint64 {
+	t.Helper()
+	pm, err := mgr.ForProfile(slug)
+	require.NoError(t, err)
+	c, err := pm.GetDocumentCount()
+	require.NoError(t, err)
+	return c
+}
+
+func TestReconcileProfileIndexes_BuildsAndIsolates(t *testing.T) {
+	cfg := &config.Config{
+		Servers: []*config.ServerConfig{{Name: "s1"}, {Name: "s2"}},
+		Profiles: []config.ProfileConfig{
+			{Name: "alpha", Servers: []string{"s1"}},
+			{Name: "beta", Servers: []string{"s2"}},
+		},
+	}
+	r, mgr := newProfileTestRuntime(t, cfg)
+
+	// Populate the shared index: s1 has 2 tools, s2 has 3.
+	require.NoError(t, mgr.BatchIndexTools([]*config.ToolMetadata{
+		toolMeta("s1", "a"), toolMeta("s1", "b"),
+		toolMeta("s2", "c"), toolMeta("s2", "d"), toolMeta("s2", "e"),
+	}))
+
+	r.reconcileProfileIndexes()
+
+	assert.Equal(t, uint64(2), profileDocCount(t, mgr, "alpha"))
+	assert.Equal(t, uint64(3), profileDocCount(t, mgr, "beta"))
+
+	// Reload isolation: widen alpha to {s1, s2}; beta must be untouched.
+	cfg.Profiles[0].Servers = []string{"s1", "s2"}
+	r.reconcileProfileIndexes()
+
+	assert.Equal(t, uint64(5), profileDocCount(t, mgr, "alpha"), "alpha rebuilt with both servers")
+	assert.Equal(t, uint64(3), profileDocCount(t, mgr, "beta"), "beta doc-count must be unchanged")
+}
+
+func TestReconcileProfileIndexes_DropsRemovedProfile(t *testing.T) {
+	cfg := &config.Config{
+		Servers: []*config.ServerConfig{{Name: "s1"}},
+		Profiles: []config.ProfileConfig{
+			{Name: "alpha", Servers: []string{"s1"}},
+		},
+	}
+	r, mgr := newProfileTestRuntime(t, cfg)
+	require.NoError(t, mgr.BatchIndexTools([]*config.ToolMetadata{toolMeta("s1", "a")}))
+
+	r.reconcileProfileIndexes()
+	alphaDir := filepath.Join(cfg.DataDir, "index.bleve", "profiles", "alpha")
+	_, statErr := os.Stat(alphaDir)
+	require.NoError(t, statErr, "alpha index dir should exist after build")
+
+	// Remove the profile from config and reconcile: its dir must be dropped.
+	cfg.Profiles = nil
+	r.reconcileProfileIndexes()
+
+	_, statErr = os.Stat(alphaDir)
+	assert.True(t, os.IsNotExist(statErr), "removed profile's index dir must be deleted")
+}
+
+func TestReindexAffectedProfiles_OnlyTouchesProfilesWithServer(t *testing.T) {
+	cfg := &config.Config{
+		Servers: []*config.ServerConfig{{Name: "s1"}, {Name: "s2"}},
+		Profiles: []config.ProfileConfig{
+			{Name: "alpha", Servers: []string{"s1"}},
+			{Name: "beta", Servers: []string{"s2"}},
+		},
+	}
+	r, mgr := newProfileTestRuntime(t, cfg)
+	require.NoError(t, mgr.BatchIndexTools([]*config.ToolMetadata{
+		toolMeta("s1", "a"), toolMeta("s2", "c"),
+	}))
+	r.reconcileProfileIndexes()
+	assert.Equal(t, uint64(1), profileDocCount(t, mgr, "alpha"))
+	assert.Equal(t, uint64(1), profileDocCount(t, mgr, "beta"))
+
+	// A new tool appears on s1 in the shared index; refresh only s1's profiles.
+	require.NoError(t, mgr.IndexTool(toolMeta("s1", "b")))
+	r.reindexAffectedProfiles("s1")
+
+	assert.Equal(t, uint64(2), profileDocCount(t, mgr, "alpha"), "alpha picks up new s1 tool")
+	assert.Equal(t, uint64(1), profileDocCount(t, mgr, "beta"), "beta (no s1) is untouched")
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -101,6 +101,13 @@ type Runtime struct {
 	lastGoodToolsMu sync.RWMutex
 	lastGoodTools   map[string][]*config.ToolMetadata
 
+	// Profiles v2 (Spec 057, T1): tracks the last-synced effective server set per
+	// profile so a config reload can rebuild only the profiles whose membership
+	// actually changed and drop profiles removed from config. Guards the
+	// per-profile Bleve index reconciliation (internal/runtime/profile_index.go).
+	profileIndexMu    sync.Mutex
+	profileMembership map[string][]string
+
 	// Schema v3 (telemetry): time-cached Docker daemon availability. The
 	// probe has a 2s `docker info` cost, so we don't want to run it on every
 	// heartbeat — but we also can't memoize it for the whole process lifetime:
@@ -263,10 +270,11 @@ func New(cfg *config.Config, cfgPath string, logger *zap.Logger) (*Runtime, erro
 			Message:     "Runtime is initializing...",
 			LastUpdated: time.Now(),
 		},
-		statusCh:      make(chan Status, 10),
-		eventSubs:     make(map[chan Event]struct{}),
-		phaseMachine:  newPhaseMachine(PhaseInitializing),
-		lastGoodTools: make(map[string][]*config.ToolMetadata),
+		statusCh:          make(chan Status, 10),
+		eventSubs:         make(map[chan Event]struct{}),
+		phaseMachine:      newPhaseMachine(PhaseInitializing),
+		lastGoodTools:     make(map[string][]*config.ToolMetadata),
+		profileMembership: make(map[string][]string),
 	}
 
 	// Spec 047: drainer goroutine that publishes coalesced servers.changed


### PR DESCRIPTION
## Profiles v2 — T1: per-profile Bleve indexes + lifecycle

Parent: MCP-33 · Foundation that T2 (`set_profile`) wires switching to. Does **not** change URL-profile filtering yet.

### What
Introduces physically separate per-profile Bleve indexes so switching profiles is fast and a config reload that changes one profile does not re-index the others.

### `index.Manager` API
- `ForProfile(slug)` — lazily opens/creates a per-profile index, cached one-per-slug; invalid (non-filesystem-safe) slugs rejected.
- `RebuildProfileFromShared(slug, servers)` — rebuilds a profile index as a **derived view** of the shared default index, touching only that profile.
- `DropProfile(slug)` — closes + removes a profile's index directory.
- `ExistingProfileDirs` / `ClearAll` / `DeleteAll` helpers.

### On-disk layout
```
index.bleve/                 # shared default index (all servers' tools, /mcp allow-all fallback)
index.bleve/profiles/<slug>/ # one index per profile (only that profile's servers' tools)
```
**Design note (deviation from the issue's literal `index.bleve/<profile>/`):** Bleve creates its own `store/` subdirectory and metadata files directly under `index.bleve/`. A naive `index.bleve/*` enumeration for orphan cleanup mistook Bleve's `store/` dir for a profile and deleted it — caught by a real test failure during development. Namespacing under `index.bleve/profiles/` keeps per-profile indexes under `index.bleve` (the spec's spirit) while isolating them from Bleve internals so enumeration is always safe.

### Runtime wiring (`internal/runtime/profile_index.go`)
- `reconcileProfileIndexes` — after each discovery pass and config reload: build new profiles, rebuild membership-changed ones, drop removed ones (incl. orphaned dirs from a prior run); **unchanged profiles are untouched**.
- `reindexAffectedProfiles` — when a server's tools change in the shared index (discovery / disable / quarantine), refresh **only** the profiles that include that server.

The shared index stays the source of truth; per-profile indexes are derived from it (no re-discovery from upstreams).

### Tests (TDD)
- `internal/index`: `ForProfile` isolation, reload isolation (rebuild A only, B doc-count unchanged), drop removes dir, invalid-slug rejection.
- `internal/runtime`: reconcile builds + isolates, drops removed profile dir, server-scoped refresh only touches profiles with that server.

### Verification
- `go test -race ./internal/index/... ./internal/config/... ./internal/runtime/...` — green.
- `golangci-lint run --config .github/.golangci.yml ./internal/index/... ./internal/runtime/... ./internal/config/...` — 0 issues.
- `go build ./...` / `go vet` — clean.
- Docs: `docs/features/profiles.md` documents the layout + lifecycle table.

No config-schema fields added (only a `config.IsValidProfileSlug` helper), so no swagger change.

Related: MCP-3240