### PR TITLE
feat(tray): add "Install server…" Go systray entry (deep-link /repositories) (MCP-3246)

### DIFF
--- a/cmd/mcpproxy-tray/internal/api/client.go
+++ b/cmd/mcpproxy-tray/internal/api/client.go
@@ -819,8 +819,15 @@ func (c *Client) SearchTools(query string, limit int) ([]SearchResult, error) {
 	return searchResults, nil
 }
 
-// OpenWebUI opens the web control panel in the default browser
+// OpenWebUI opens the web control panel in the default browser.
 func (c *Client) OpenWebUI() error {
+	return c.OpenWebUIPath("")
+}
+
+// OpenWebUIPath opens the web control panel in the default browser at the given
+// path under the resolved web UI base (e.g. "repositories" for the marketplace
+// deep-link). An empty path opens the base control panel, matching OpenWebUI.
+func (c *Client) OpenWebUIPath(path string) error {
 	// Get the actual web UI URL from the /api/v1/info endpoint
 	// This ensures we use the correct HTTP URL even when connected via socket
 	resp, err := c.makeRequest("GET", "/api/v1/info", nil)
@@ -839,6 +846,13 @@ func (c *Client) OpenWebUI() error {
 	webUIURL, ok := resp.Data["web_ui_url"].(string)
 	if !ok || webUIURL == "" {
 		return fmt.Errorf("web_ui_url not found in server info")
+	}
+
+	// Append the requested deep-link path (preserving any query string such as
+	// the apikey the core may already include in web_ui_url).
+	webUIURL, err = appendWebUIPath(webUIURL, path)
+	if err != nil {
+		return fmt.Errorf("failed to build web UI URL: %w", err)
 	}
 
 	// Add API key if not using socket communication
@@ -885,6 +899,27 @@ func (c *Client) OpenWebUI() error {
 	default:
 		return fmt.Errorf("unsupported OS for OpenWebUI: %s", runtime.GOOS)
 	}
+}
+
+// appendWebUIPath joins a relative path onto a resolved web UI base URL,
+// preserving any existing query string (e.g. an apikey already embedded by the
+// core). An empty path returns the base URL unchanged.
+func appendWebUIPath(webUIURL, path string) (string, error) {
+	if path == "" {
+		return webUIURL, nil
+	}
+
+	u, err := url.Parse(webUIURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid web UI URL %q: %w", webUIURL, err)
+	}
+
+	if !strings.HasSuffix(u.Path, "/") {
+		u.Path += "/"
+	}
+	u.Path += strings.TrimPrefix(path, "/")
+
+	return u.String(), nil
 }
 
 // makeRequest makes an HTTP request to the API with enhanced error handling and retry logic

--- a/cmd/mcpproxy-tray/internal/api/client_test.go
+++ b/cmd/mcpproxy-tray/internal/api/client_test.go
@@ -64,3 +64,66 @@ func TestClientGetServers_LogsZeroServersOnlyOnStateChange(t *testing.T) {
 	assert.Equal(t, 2, recorded.FilterMessage("API returned zero upstream servers").Len())
 	assert.Equal(t, 1, recorded.FilterMessage("Server state changed").Len())
 }
+
+func TestAppendWebUIPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		webUIURL  string
+		path      string
+		want      string
+		expectErr bool
+	}{
+		{
+			name:     "empty path returns base unchanged",
+			webUIURL: "http://127.0.0.1:8080/ui/",
+			path:     "",
+			want:     "http://127.0.0.1:8080/ui/",
+		},
+		{
+			name:     "appends path to trailing-slash base",
+			webUIURL: "http://127.0.0.1:8080/ui/",
+			path:     "repositories",
+			want:     "http://127.0.0.1:8080/ui/repositories",
+		},
+		{
+			name:     "appends path when base lacks trailing slash",
+			webUIURL: "http://127.0.0.1:8080/ui",
+			path:     "repositories",
+			want:     "http://127.0.0.1:8080/ui/repositories",
+		},
+		{
+			name:     "leading slash on path is normalized",
+			webUIURL: "http://127.0.0.1:8080/ui/",
+			path:     "/repositories",
+			want:     "http://127.0.0.1:8080/ui/repositories",
+		},
+		{
+			name:     "preserves existing query string (apikey)",
+			webUIURL: "http://127.0.0.1:8080/ui/?apikey=secret",
+			path:     "repositories",
+			want:     "http://127.0.0.1:8080/ui/repositories?apikey=secret",
+		},
+		{
+			name:      "invalid URL returns error",
+			webUIURL:  "ht tp://bad url",
+			path:      "repositories",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := appendWebUIPath(tt.webUIURL, tt.path)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -55,6 +55,7 @@ If you installed MCPProxy using the **DMG installer** (macOS) or **Windows insta
 :::tip Tray Menu Options
 Right-click (or click on macOS) the tray icon to access:
 - **Open Web UI** - Launch the management dashboard
+- **Install server…** - Open the Web UI marketplace to browse and install MCP servers
 - **View Logs** - See server activity
 - **Upstream Servers** - View status of all MCP servers, enable/disable individual servers
 - **Quit** - Stop MCPProxy completely

--- a/internal/tray/tray.go
+++ b/internal/tray/tray.go
@@ -93,10 +93,13 @@ type ServerInterface interface {
 // App represents the system tray application
 type App struct {
 	server    ServerInterface
-	apiClient interface{ OpenWebUI() error } // API client for web UI access (optional)
-	logger    *zap.SugaredLogger
-	version   string
-	shutdown  func()
+	apiClient interface {
+		OpenWebUI() error
+		OpenWebUIPath(path string) error
+	} // API client for web UI access (optional)
+	logger   *zap.SugaredLogger
+	version  string
+	shutdown func()
 
 	connectionState   ConnectionState
 	connectionStateMu sync.RWMutex
@@ -128,11 +131,11 @@ type App struct {
 	autostartItem    *systray.MenuItem
 
 	// Update notification menu item (hidden until update is available)
-	updateMenuItem     *systray.MenuItem
-	updateAvailable    bool
-	latestVersion      string
-	latestReleaseURL   string
-	updateCheckMu      sync.RWMutex
+	updateMenuItem   *systray.MenuItem
+	updateAvailable  bool
+	latestVersion    string
+	latestReleaseURL string
+	updateCheckMu    sync.RWMutex
 
 	// Config path for opening from menu
 	configPath string
@@ -161,7 +164,10 @@ func New(server ServerInterface, logger *zap.SugaredLogger, version string, shut
 }
 
 // NewWithAPIClient creates a new tray application with an API client for web UI access
-func NewWithAPIClient(server ServerInterface, apiClient interface{ OpenWebUI() error }, logger *zap.SugaredLogger, version string, shutdown func()) *App {
+func NewWithAPIClient(server ServerInterface, apiClient interface {
+	OpenWebUI() error
+	OpenWebUIPath(path string) error
+}, logger *zap.SugaredLogger, version string, shutdown func()) *App {
 	app := &App{
 		server:          server,
 		apiClient:       apiClient,
@@ -574,8 +580,12 @@ func (a *App) onReady() {
 
 	// Add Web Control Panel menu item if API client is available
 	var openWebUIItem *systray.MenuItem
+	var installServerItem *systray.MenuItem
 	if a.apiClient != nil {
 		openWebUIItem = systray.AddMenuItem("Open Web Control Panel", "Open the web control panel in your browser")
+		// Deep-link into the Web UI marketplace (Repositories.vue) to browse
+		// and install MCP servers (MCP-37a).
+		installServerItem = systray.AddMenuItem("Install server…", "Browse and install MCP servers in the web UI marketplace")
 	}
 	systray.AddSeparator()
 
@@ -737,6 +747,20 @@ func (a *App) onReady() {
 				select {
 				case <-openWebUIItem.ClickedCh:
 					a.handleOpenWebUI()
+				case <-a.ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+
+	// --- Install Server Click Handler (deep-link to the marketplace) ---
+	if installServerItem != nil {
+		go func() {
+			for {
+				select {
+				case <-installServerItem.ClickedCh:
+					a.handleInstallServer()
 				case <-a.ctx.Done():
 					return
 				}
@@ -1765,6 +1789,23 @@ func (a *App) handleOpenWebUI() {
 		a.logger.Error("Failed to open web control panel", zap.Error(err))
 	} else {
 		a.logger.Info("Successfully opened web control panel")
+	}
+}
+
+// handleInstallServer deep-links to the Web UI marketplace (Repositories.vue)
+// so users can browse and install MCP servers (MCP-37a).
+func (a *App) handleInstallServer() {
+	if a.apiClient == nil {
+		a.logger.Warn("API client not available, cannot open marketplace")
+		return
+	}
+
+	a.logger.Info("Opening server marketplace from tray menu")
+
+	if err := a.apiClient.OpenWebUIPath("repositories"); err != nil {
+		a.logger.Error("Failed to open server marketplace", zap.Error(err))
+	} else {
+		a.logger.Info("Successfully opened server marketplace")
 	}
 }
 

--- a/internal/tray/tray_stub.go
+++ b/internal/tray/tray_stub.go
@@ -51,7 +51,10 @@ func New(_ ServerInterface, logger *zap.SugaredLogger, _ string, _ func()) *App 
 }
 
 // NewWithAPIClient creates a new tray application with an API client (stub version)
-func NewWithAPIClient(_ ServerInterface, _ interface{ OpenWebUI() error }, logger *zap.SugaredLogger, _ string, _ func()) *App {
+func NewWithAPIClient(_ ServerInterface, _ interface {
+	OpenWebUI() error
+	OpenWebUIPath(path string) error
+}, logger *zap.SugaredLogger, _ string, _ func()) *App {
 	return &App{
 		logger: logger,
 	}


### PR DESCRIPTION
## Summary
Adds an **"Install server…"** entry to the Go systray that deep-links to the Web UI marketplace at `/repositories` (Repositories.vue) in the default browser. This closes the *tray* exit criterion for the non-macOS (Go systray) surface of MCP-37. The macOS/Swift counterpart is MCP-3247 (#sibling PR).

Most of MCP-37 is already shipped (Web UI browse/search + one-click "Add to MCP" install + auto-quarantine); this is a pure deep-link, no native dialog.

## Changes
- **`cmd/mcpproxy-tray/internal/api/client.go`** — `OpenWebUI()` now delegates to a new `OpenWebUIPath(path)`. A pure `appendWebUIPath(webUIURL, path)` helper joins a relative path onto the resolved `web_ui_url` from `/api/v1/info`, **preserving any existing query string** (e.g. the `apikey` the core may embed) and normalizing trailing/leading slashes.
- **`internal/tray/tray.go`** — new "Install server…" menu item right after "Open Web Control Panel", its click-handler goroutine, and `handleInstallServer()` (calls `OpenWebUIPath("repositories")`). Widened the `apiClient` interface to include `OpenWebUIPath`.
- **`internal/tray/tray_stub.go`** — matching interface widening for the `!gui`/linux stub build.
- **`docs/getting-started/quick-start.md`** — list the new tray entry (ENG-9).

## Testing
- TDD: added `TestAppendWebUIPath` (6 cases: empty path, trailing/no-trailing slash, leading-slash normalization, apikey query preservation, invalid URL → error). Written failing first, then implemented.
- `go test -race ./cmd/mcpproxy-tray/internal/api/ ./internal/tray/...` → PASS
- Host build + `GOOS=linux` stub build → green
- `golangci-lint run --config .github/.golangci.yml` on changed packages → 0 issues
- `gofmt`/`goimports` clean

## Exit criteria
- [x] New tray item "Install server…" opens `<webUiBase>/repositories`
- [x] No regression to existing "Open Web Control Panel" (it now routes through the same helper with an empty path)
- [x] `go build ./cmd/mcpproxy-tray` green; gofmt/goimports clean

Related #MCP-3246
