### PR TITLE
feat(profiles): per-agent-token profile_pin + server-side enforcement (Profiles v2 T3, MCP-3242)

### DIFF
--- a/cmd/mcpproxy/token_cmd.go
+++ b/cmd/mcpproxy/token_cmd.go
@@ -23,6 +23,7 @@ var (
 	tokenServers     string
 	tokenPermissions string
 	tokenExpires     string
+	tokenProfilePin  string
 )
 
 // GetTokenCommand returns the token parent command.
@@ -73,6 +74,7 @@ Examples:
 	cmd.Flags().StringVar(&tokenServers, "servers", "", "Comma-separated list of allowed server names, or \"*\" for all (required)")
 	cmd.Flags().StringVar(&tokenPermissions, "permissions", "", "Comma-separated permission tiers: read, write, destructive (required, must include read)")
 	cmd.Flags().StringVar(&tokenExpires, "expires", "30d", "Token expiry duration (e.g., 7d, 30d, 90d, 365d)")
+	cmd.Flags().StringVar(&tokenProfilePin, "profile-pin", "", "Pin this token to a profile; it can only operate in that profile (cannot switch via set_profile or /mcp/p/<other>)")
 	_ = cmd.MarkFlagRequired("name")
 	_ = cmd.MarkFlagRequired("servers")
 	_ = cmd.MarkFlagRequired("permissions")
@@ -160,6 +162,9 @@ func runTokenCreate(_ *cobra.Command, _ []string) error {
 		"permissions":     permissions,
 		"expires_in":      tokenExpires,
 	}
+	if tokenProfilePin != "" {
+		body["profile_pin"] = tokenProfilePin
+	}
 
 	bodyJSON, err := json.Marshal(body)
 	if err != nil {
@@ -209,6 +214,9 @@ func runTokenCreate(_ *cobra.Command, _ []string) error {
 	printField("  Name:        ", result, "name")
 	printListField("  Servers:     ", result, "allowed_servers")
 	printListField("  Permissions: ", result, "permissions")
+	if pin := getMapString(result, "profile_pin"); pin != "" {
+		fmt.Printf("  Profile Pin: %s\n", pin)
+	}
 	printField("  Expires:     ", result, "expires_at")
 
 	return nil
@@ -257,9 +265,9 @@ func runTokenList(_ *cobra.Command, _ []string) error {
 	}
 
 	// Table format
-	fmt.Printf("%-20s %-14s %-25s %-20s %-8s %-25s\n",
-		"NAME", "PREFIX", "SERVERS", "PERMISSIONS", "REVOKED", "EXPIRES")
-	fmt.Println(strings.Repeat("-", 115))
+	fmt.Printf("%-20s %-14s %-25s %-20s %-8s %-12s %-25s\n",
+		"NAME", "PREFIX", "SERVERS", "PERMISSIONS", "REVOKED", "PROFILE PIN", "EXPIRES")
+	fmt.Println(strings.Repeat("-", 128))
 
 	for _, t := range tokens {
 		tok, ok := t.(map[string]interface{})
@@ -276,6 +284,11 @@ func runTokenList(_ *cobra.Command, _ []string) error {
 		serverList := joinInterfaceSlice(tok, "allowed_servers", 23)
 		permList := joinInterfaceSlice(tok, "permissions", 0)
 
+		pin := getMapString(tok, "profile_pin")
+		if pin == "" {
+			pin = "-"
+		}
+
 		expiresAt := getMapString(tok, "expires_at")
 		if expiresAt != "" {
 			if t, parseErr := time.Parse(time.RFC3339, expiresAt); parseErr == nil {
@@ -283,8 +296,8 @@ func runTokenList(_ *cobra.Command, _ []string) error {
 			}
 		}
 
-		fmt.Printf("%-20s %-14s %-25s %-20s %-8s %-25s\n",
-			name, prefix, serverList, permList, revoked, expiresAt)
+		fmt.Printf("%-20s %-14s %-25s %-20s %-8s %-12s %-25s\n",
+			name, prefix, serverList, permList, revoked, pin, expiresAt)
 	}
 
 	return nil
@@ -335,6 +348,9 @@ func runTokenShow(_ *cobra.Command, args []string) error {
 	printField("Token Prefix:   ", result, "token_prefix")
 	printListField("Servers:        ", result, "allowed_servers")
 	printListField("Permissions:    ", result, "permissions")
+	if pin := getMapString(result, "profile_pin"); pin != "" {
+		fmt.Printf("Profile Pin:    %s\n", pin)
+	}
 	if revoked, ok := result["revoked"].(bool); ok {
 		fmt.Printf("Revoked:        %v\n", revoked)
 	}

--- a/docs/features/agent-tokens.md
+++ b/docs/features/agent-tokens.md
@@ -176,6 +176,38 @@ Server scoping is enforced at two levels:
 1. **Tool discovery** (`retrieve_tools`) — only returns tools from allowed servers
 2. **Tool execution** (`call_tool_*`) — blocks calls to out-of-scope servers
 
+## Profile Pinning
+
+A [profile](../../docs/architecture.md) scopes tool discovery and calls to a named subset of upstream servers. With `--profile-pin`, you can **bind a token to a single profile** so it can never operate outside it — regardless of the URL it connects to or any `set_profile` call it makes.
+
+```bash
+# This token can ONLY ever see/use the "research" profile
+mcpproxy token create \
+  --name research-agent \
+  --servers "*" \
+  --permissions read \
+  --profile-pin research
+```
+
+Server-side enforcement (no client cooperation required):
+
+- **`set_profile("other")` is rejected** — a pinned token cannot switch its session to a different profile (switching to its own pinned profile, or clearing, is allowed).
+- **`/mcp/p/<other>` returns `403`** — connecting to any profile URL other than the pinned one is forbidden; the pinned profile's own URL works.
+- **The pin is the highest-precedence resolver source**, above an explicit `/mcp/p/<slug>` URL scope and above a session `set_profile` selection.
+
+Resolution precedence (highest wins):
+
+```
+1. agent-token profile_pin   (server-enforced; this section)
+2. /mcp/p/<slug> URL scope    (per-request override)
+3. set_profile session state  (base /mcp endpoint default for the session)
+4. none                        (no profile filtering — all allowed servers)
+```
+
+**Validation & config changes**: the pinned slug must name a configured profile at creation time (creation is rejected otherwise). If the profile is later removed from the configuration, requests are **warn-skipped** rather than hard-failed — the pin still blocks switching away, so the token can never silently widen its scope, but profile filtering falls through to the next precedence tier. Pinning composes with server scoping and permission tiers: a request must satisfy **all** of them.
+
+The pin is shown by `token list` (PROFILE PIN column) and `token show` (Profile Pin field), and is preserved across `token regenerate`.
+
 ## Managing Tokens
 
 ### List All Tokens
@@ -304,3 +336,4 @@ mcpproxy serve --require-mcp-auth    # Enforce /mcp authentication
 | `--servers` | Yes | — | Comma-separated server names or `"*"` |
 | `--permissions` | Yes | — | Comma-separated: `read`, `write`, `destructive` |
 | `--expires` | No | `30d` | Expiry duration (e.g., `7d`, `90d`, `365d`) |
+| `--profile-pin` | No | — | Pin the token to a single profile (see [Profile Pinning](#profile-pinning)) |

--- a/docs/features/agent-tokens.md
+++ b/docs/features/agent-tokens.md
@@ -178,7 +178,7 @@ Server scoping is enforced at two levels:
 
 ## Profile Pinning
 
-A [profile](../../docs/architecture.md) scopes tool discovery and calls to a named subset of upstream servers. With `--profile-pin`, you can **bind a token to a single profile** so it can never operate outside it — regardless of the URL it connects to or any `set_profile` call it makes.
+A [profile](./profiles.md) scopes tool discovery and calls to a named subset of upstream servers. With `--profile-pin`, you can **bind a token to a single profile** so it can never operate outside it — regardless of the URL it connects to or any `set_profile` call it makes.
 
 ```bash
 # This token can ONLY ever see/use the "research" profile

--- a/internal/auth/agent_token.go
+++ b/internal/auth/agent_token.go
@@ -42,7 +42,8 @@ type AgentToken struct {
 	CreatedAt      time.Time  `json:"created_at"`
 	LastUsedAt     *time.Time `json:"last_used_at,omitempty"`
 	Revoked        bool       `json:"revoked"`
-	UserID         string     `json:"user_id,omitempty"` // Owner user ID (server edition)
+	UserID         string     `json:"user_id,omitempty"`     // Owner user ID (server edition)
+	ProfilePin     string     `json:"profile_pin,omitempty"` // Profile this token is pinned to (Profiles v2 T3)
 }
 
 // IsExpired returns true if the token has passed its expiry time.

--- a/internal/auth/context.go
+++ b/internal/auth/context.go
@@ -17,6 +17,7 @@ type AuthContext struct {
 	TokenPrefix    string   // First 12 chars of raw token (empty for admin)
 	AllowedServers []string // Servers this token can access (nil = all for admin)
 	Permissions    []string // Permission tiers (nil = all for admin)
+	ProfilePin     string   // Profile this agent token is pinned to (Profiles v2 T3; empty if unpinned)
 
 	// Multi-user OAuth fields (server edition). Empty for non-user auth types.
 	UserID      string // User's unique ULID identifier

--- a/internal/httpapi/tokens.go
+++ b/internal/httpapi/tokens.go
@@ -38,6 +38,7 @@ type createTokenRequest struct {
 	AllowedServers []string `json:"allowed_servers"`
 	Permissions    []string `json:"permissions"`
 	ExpiresIn      string   `json:"expires_in"`
+	ProfilePin     string   `json:"profile_pin,omitempty"`
 }
 
 // createTokenResponse is the JSON response for POST /api/v1/tokens.
@@ -48,6 +49,7 @@ type createTokenResponse struct {
 	Permissions    []string  `json:"permissions"`
 	ExpiresAt      time.Time `json:"expires_at"`
 	CreatedAt      time.Time `json:"created_at"`
+	ProfilePin     string    `json:"profile_pin,omitempty"`
 }
 
 // tokenInfoResponse is the JSON response for GET endpoints (no secret).
@@ -60,6 +62,7 @@ type tokenInfoResponse struct {
 	CreatedAt      time.Time  `json:"created_at"`
 	LastUsedAt     *time.Time `json:"last_used_at,omitempty"`
 	Revoked        bool       `json:"revoked"`
+	ProfilePin     string     `json:"profile_pin,omitempty"`
 }
 
 // regenerateTokenResponse is the JSON response for POST /api/v1/tokens/{name}/regenerate.
@@ -148,6 +151,16 @@ func (s *Server) handleCreateToken(w http.ResponseWriter, r *http.Request) {
 		req.AllowedServers = []string{"*"}
 	}
 
+	// Validate profile_pin (Profiles v2 T3): the slug must name a configured
+	// profile at creation time. Later config changes are warn-skipped at request
+	// time by the resolver, not hard-failed here.
+	if req.ProfilePin != "" {
+		if err := s.validateProfilePin(req.ProfilePin); err != nil {
+			s.writeError(w, r, http.StatusBadRequest, err.Error())
+			return
+		}
+	}
+
 	// Generate token
 	rawToken, err := auth.GenerateToken()
 	if err != nil {
@@ -171,6 +184,7 @@ func (s *Server) handleCreateToken(w http.ResponseWriter, r *http.Request) {
 		Permissions:    req.Permissions,
 		ExpiresAt:      expiresAt,
 		CreatedAt:      now,
+		ProfilePin:     req.ProfilePin,
 	}
 
 	if err := s.tokenStore.CreateAgentToken(agentToken, rawToken, hmacKey); err != nil {
@@ -191,6 +205,7 @@ func (s *Server) handleCreateToken(w http.ResponseWriter, r *http.Request) {
 		Permissions:    req.Permissions,
 		ExpiresAt:      expiresAt,
 		CreatedAt:      now,
+		ProfilePin:     req.ProfilePin,
 	}
 
 	s.writeJSON(w, http.StatusCreated, contracts.NewSuccessResponse(resp))
@@ -350,6 +365,26 @@ func validateTokenPermissions(perms []string) error {
 	return auth.ValidatePermissions(perms)
 }
 
+// validateProfilePin checks that the given profile slug names a profile in the
+// current configuration (Profiles v2 T3). It errors if profiles are unavailable
+// or the slug is unknown, so a token cannot be pinned to a non-existent profile.
+func (s *Server) validateProfilePin(slug string) error {
+	cfg, err := s.controller.GetConfig()
+	if err != nil || cfg == nil {
+		return fmt.Errorf("cannot validate profile_pin: configuration unavailable")
+	}
+	for i := range cfg.Profiles {
+		if cfg.Profiles[i].Name == slug {
+			return nil
+		}
+	}
+	available := make([]string, 0, len(cfg.Profiles))
+	for i := range cfg.Profiles {
+		available = append(available, cfg.Profiles[i].Name)
+	}
+	return fmt.Errorf("unknown profile_pin %q (available: %s)", slug, strings.Join(available, ", "))
+}
+
 // parseExpiry parses an expiry duration string and returns the absolute expiry time.
 // Accepted formats: "30d" (days), "720h" (hours), or any Go duration string.
 // Maximum allowed duration is 365 days. Empty string defaults to 30 days.
@@ -434,5 +469,6 @@ func tokenToInfoResponse(t auth.AgentToken) tokenInfoResponse {
 		CreatedAt:      t.CreatedAt,
 		LastUsedAt:     t.LastUsedAt,
 		Revoked:        t.Revoked,
+		ProfilePin:     t.ProfilePin,
 	}
 }

--- a/internal/httpapi/tokens_test.go
+++ b/internal/httpapi/tokens_test.go
@@ -115,14 +115,23 @@ func (m *mockTokenStore) RegenerateAgentToken(name string, _ string, _ []byte) (
 
 type mockTokenController struct {
 	baseController
-	apiKey  string
-	servers []string
+	apiKey   string
+	servers  []string
+	profiles []string
 }
 
 func (m *mockTokenController) GetCurrentConfig() interface{} {
 	return &config.Config{
 		APIKey: m.apiKey,
 	}
+}
+
+func (m *mockTokenController) GetConfig() (*config.Config, error) {
+	cfg := &config.Config{APIKey: m.apiKey}
+	for _, name := range m.profiles {
+		cfg.Profiles = append(cfg.Profiles, config.ProfileConfig{Name: name})
+	}
+	return cfg, nil
 }
 
 func (m *mockTokenController) GetAllServers() ([]map[string]interface{}, error) {
@@ -150,6 +159,21 @@ func newTestTokenServer(t *testing.T, store *mockTokenStore, servers []string) *
 	// Use a temp dir for HMAC key
 	dataDir := t.TempDir()
 	srv.SetTokenStore(store, dataDir)
+	return srv
+}
+
+// newTestTokenServerWithProfiles is like newTestTokenServer but also configures
+// the controller's known profiles (for profile_pin validation tests).
+func newTestTokenServerWithProfiles(t *testing.T, store *mockTokenStore, servers, profiles []string) *Server {
+	t.Helper()
+	logger := zap.NewNop().Sugar()
+	ctrl := &mockTokenController{
+		apiKey:   "test-api-key",
+		servers:  servers,
+		profiles: profiles,
+	}
+	srv := NewServer(ctrl, logger, nil)
+	srv.SetTokenStore(store, t.TempDir())
 	return srv
 }
 
@@ -218,6 +242,55 @@ func TestCreateToken_Success(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, stored)
 	assert.Equal(t, "my-agent", stored.Name)
+}
+
+func TestCreateToken_ProfilePin(t *testing.T) {
+	store := newMockTokenStore()
+	srv := newTestTokenServerWithProfiles(t, store, []string{"server1"}, []string{"research", "deploy"})
+
+	body := createTokenRequest{
+		Name:           "pinned-agent",
+		AllowedServers: []string{"server1"},
+		Permissions:    []string{"read"},
+		ProfilePin:     "research",
+	}
+
+	w := doRequest(t, srv, http.MethodPost, "/api/v1/tokens", body)
+	require.Equal(t, http.StatusCreated, w.Code, "expected 201; body=%s", w.Body.String())
+
+	var resp createTokenResponse
+	decodeSuccess(t, w, &resp)
+	assert.Equal(t, "research", resp.ProfilePin, "profile_pin must be echoed on create")
+
+	// Stored record carries the pin.
+	stored, err := store.GetAgentTokenByName("pinned-agent")
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.Equal(t, "research", stored.ProfilePin)
+
+	// GET surfaces the pin.
+	g := doRequest(t, srv, http.MethodGet, "/api/v1/tokens/pinned-agent", nil)
+	require.Equal(t, http.StatusOK, g.Code)
+	var info tokenInfoResponse
+	decodeSuccess(t, g, &info)
+	assert.Equal(t, "research", info.ProfilePin, "profile_pin must be surfaced on read")
+}
+
+func TestCreateToken_ProfilePinUnknownRejected(t *testing.T) {
+	store := newMockTokenStore()
+	srv := newTestTokenServerWithProfiles(t, store, []string{"server1"}, []string{"research"})
+
+	body := createTokenRequest{
+		Name:        "bad-pin",
+		Permissions: []string{"read"},
+		ProfilePin:  "ghost",
+	}
+
+	w := doRequest(t, srv, http.MethodPost, "/api/v1/tokens", body)
+	assert.Equal(t, http.StatusBadRequest, w.Code, "unknown profile_pin must be rejected at creation")
+
+	_, err := store.GetAgentTokenByName("bad-pin")
+	require.NoError(t, err)
 }
 
 func TestCreateToken_DefaultPermissions(t *testing.T) {

--- a/internal/server/profile_integration_test.go
+++ b/internal/server/profile_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
 )
@@ -614,6 +615,88 @@ func TestProfile_SetProfileUnknown(t *testing.T) {
 	_, _, isErr, text := env.callSetProfile(ctx, c, "nonexistent")
 	assert.True(t, isErr, "set_profile with an unknown slug must error")
 	assert.Contains(t, text, "unknown profile 'nonexistent'", "error must name the bad slug: %s", text)
+}
+
+// ---------------------------------------------------------------------------
+// Profiles v2 (T3): per-agent-token profile_pin — server-side URL enforcement
+// ---------------------------------------------------------------------------
+
+// mintPinnedToken creates a stored agent token pinned to the given profile and
+// returns its raw secret. It uses the same HMAC key path the auth middleware
+// reads, so the minted token validates end-to-end.
+func (e *profileTestEnv) mintPinnedToken(name, pin string) string {
+	e.t.Helper()
+	cfg := e.proxyServer.runtime.Config()
+	hmacKey, err := auth.GetOrCreateHMACKey(cfg.DataDir)
+	require.NoError(e.t, err)
+	rawToken, err := auth.GenerateToken()
+	require.NoError(e.t, err)
+	require.NoError(e.t, e.proxyServer.runtime.StorageManager().CreateAgentToken(auth.AgentToken{
+		Name:           name,
+		AllowedServers: []string{"*"},
+		Permissions:    []string{"read"},
+		ExpiresAt:      time.Now().Add(24 * time.Hour),
+		ProfilePin:     pin,
+	}, rawToken, hmacKey))
+	return rawToken
+}
+
+// TestProfile_PinnedTokenURLEnforcement verifies the T3 server-side guard: an
+// agent token pinned to "research" is rejected with 403 at /mcp/p/deploy, but
+// reaches its own /mcp/p/research endpoint.
+func TestProfile_PinnedTokenURLEnforcement(t *testing.T) {
+	env := newProfileTestEnv(t)
+	rawToken := env.mintPinnedToken("pinned-research", "research")
+
+	baseURL := strings.TrimSuffix(env.proxyAddr, "/mcp")
+	const initBody = `{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`
+
+	post := func(slug string) *http.Response {
+		req, err := http.NewRequest(http.MethodPost, baseURL+"/mcp/p/"+slug, strings.NewReader(initBody))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+rawToken)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		return resp
+	}
+
+	// Different profile → 403 with a pin-naming error.
+	resp := post("deploy")
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusForbidden, resp.StatusCode, "pinned token must be 403 on a non-pinned profile URL")
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	errMsg, _ := body["error"].(string)
+	assert.Contains(t, errMsg, "pinned to profile 'research'", "403 error must name the pin: %s", errMsg)
+
+	// Its own pinned profile → route matched, not forbidden.
+	resp2 := post("research")
+	defer resp2.Body.Close()
+	assert.NotEqual(t, http.StatusForbidden, resp2.StatusCode,
+		"pinned token must reach its own profile URL; got %d", resp2.StatusCode)
+}
+
+// TestProfile_UnpinnedTokenUnaffected verifies an unpinned agent token can reach
+// any profile URL (no T3 enforcement applied).
+func TestProfile_UnpinnedTokenUnaffected(t *testing.T) {
+	env := newProfileTestEnv(t)
+	rawToken := env.mintPinnedToken("free-agent", "") // empty pin = unpinned
+
+	baseURL := strings.TrimSuffix(env.proxyAddr, "/mcp")
+	const initBody = `{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`
+
+	for _, slug := range []string{"research", "deploy"} {
+		req, err := http.NewRequest(http.MethodPost, baseURL+"/mcp/p/"+slug, strings.NewReader(initBody))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+rawToken)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+		assert.NotEqual(t, http.StatusForbidden, resp.StatusCode,
+			"unpinned token must not be forbidden at /mcp/p/%s; got %d", slug, resp.StatusCode)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/server/profile_resolver.go
+++ b/internal/server/profile_resolver.go
@@ -4,7 +4,9 @@ import (
 	"context"
 
 	mcpserver "github.com/mark3labs/mcp-go/server"
+	"go.uber.org/zap"
 
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/profile"
 )
@@ -22,11 +24,14 @@ func sessionIDFromContext(ctx context.Context) string {
 }
 
 // profilePinFromContext returns the agent-token profile_pin bound to the
-// request, or "" when the token is unpinned. Profiles v2 T3 (per-agent-token
-// profile_pin, Spec 028) will populate this from the auth context; until then
-// the hook is intentionally inert and always returns "", so the precedence
-// chain below degrades to URL > session > none.
-func profilePinFromContext(_ context.Context) string {
+// request, or "" when the token is unpinned. The pin is set on the AuthContext
+// by the MCP auth middleware after validating an agent token (Profiles v2 T3,
+// Spec 028). Only agent-token contexts can carry a pin; admin / user / tray
+// contexts are never pinned.
+func profilePinFromContext(ctx context.Context) string {
+	if ac := auth.AuthContextFromContext(ctx); ac != nil && ac.Type == auth.AuthTypeAgent {
+		return ac.ProfilePin
+	}
 	return ""
 }
 
@@ -72,11 +77,19 @@ func (p *MCPProxyServer) profileScopeForSlug(slug string) *profile.ProfileScope 
 // configured profile is treated as stale: it is cleared and resolution falls
 // through to "none".
 func (p *MCPProxyServer) resolveActiveProfile(ctx context.Context) (string, *profile.ProfileScope) {
-	// 1. Agent-token pin (T3 hook). When present it is authoritative and bounds
-	//    everything below; a non-matching pin slug falls through (defensive).
+	// 1. Agent-token pin (T3). When present it is authoritative and bounds
+	//    everything below. If the pinned profile was removed from config after
+	//    the token was minted, we warn-skip rather than hard-fail (parity with
+	//    the unknown-server warn-skip): resolution degrades to URL/session/none,
+	//    while the set_profile and /mcp/p/<slug> guards still pin the token by
+	//    its stored slug so it cannot silently widen scope by switching.
 	if pin := profilePinFromContext(ctx); pin != "" {
 		if scope := p.profileScopeForSlug(pin); scope != nil {
 			return pin, scope
+		}
+		if p.logger != nil {
+			p.logger.Warn("agent-token profile_pin no longer matches any configured profile; falling through",
+				zap.String("profile_pin", pin))
 		}
 	}
 

--- a/internal/server/profile_resolver_test.go
+++ b/internal/server/profile_resolver_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/profile"
 )
@@ -74,6 +75,63 @@ func TestResolveActiveProfile_Precedence(t *testing.T) {
 	require.Equal(t, "", name)
 	require.Nil(t, scope)
 	require.Equal(t, "", p.sessionStore.GetActiveProfile("sess-1"), "stale selection should be cleared")
+}
+
+// TestProfilePinFromContext reads the agent-token profile_pin off the auth
+// context (Profiles v2 T3). Non-agent contexts and unpinned tokens yield "".
+func TestProfilePinFromContext(t *testing.T) {
+	// No auth context at all.
+	require.Equal(t, "", profilePinFromContext(context.Background()))
+
+	// Agent token with a pin.
+	pinned := auth.WithAuthContext(context.Background(),
+		&auth.AuthContext{Type: auth.AuthTypeAgent, ProfilePin: "research"})
+	require.Equal(t, "research", profilePinFromContext(pinned))
+
+	// Agent token without a pin.
+	unpinned := auth.WithAuthContext(context.Background(),
+		&auth.AuthContext{Type: auth.AuthTypeAgent})
+	require.Equal(t, "", profilePinFromContext(unpinned))
+
+	// Admin context never carries a pin even if the field is set.
+	admin := auth.WithAuthContext(context.Background(),
+		&auth.AuthContext{Type: auth.AuthTypeAdmin, ProfilePin: "research"})
+	require.Equal(t, "", profilePinFromContext(admin))
+}
+
+// TestResolveActiveProfile_PinHighestPrecedence verifies that a token
+// profile_pin is the highest-precedence resolver source: it wins over an
+// explicit URL scope and over a session set_profile selection (Profiles v2 T3).
+func TestResolveActiveProfile_PinHighestPrecedence(t *testing.T) {
+	cfg := &config.Config{
+		Servers: []*config.ServerConfig{
+			{Name: "research-srv"},
+			{Name: "deploy-srv"},
+		},
+		Profiles: []config.ProfileConfig{
+			{Name: "research", Servers: []string{"research-srv"}},
+			{Name: "deploy", Servers: []string{"deploy-srv"}},
+		},
+	}
+	p := &MCPProxyServer{config: cfg, sessionStore: NewSessionStore(zap.NewNop())}
+
+	helper := mcpserver.NewMCPServer("test", "1.0.0")
+	base := helper.WithContext(context.Background(), &fakeClientSession{id: "sess-pin"})
+
+	// Pin to "research" via the auth context.
+	pinned := auth.WithAuthContext(base,
+		&auth.AuthContext{Type: auth.AuthTypeAgent, ProfilePin: "research"})
+
+	// Even with a conflicting session selection AND a conflicting URL scope, the
+	// pin wins.
+	p.sessionStore.SetActiveProfile("sess-pin", "deploy")
+	pinned = profile.WithProfileScope(pinned, profile.NewProfileScope("deploy", []string{"deploy-srv"}))
+
+	name, scope := p.resolveActiveProfile(pinned)
+	require.Equal(t, "research", name)
+	require.NotNil(t, scope)
+	require.True(t, scope.Allows("research-srv"))
+	require.False(t, scope.Allows("deploy-srv"))
 }
 
 // TestSessionStore_ActiveProfileLifecycle verifies the per-session profile map

--- a/internal/server/profile_tool_test.go
+++ b/internal/server/profile_tool_test.go
@@ -1,0 +1,108 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+)
+
+// setProfileCtx builds a request context carrying a stable session id and an
+// optional agent-token profile_pin.
+func setProfileCtx(sessionID, pin string) context.Context {
+	helper := mcpserver.NewMCPServer("test", "1.0.0")
+	ctx := helper.WithContext(context.Background(), &fakeClientSession{id: sessionID})
+	if pin != "" {
+		ctx = auth.WithAuthContext(ctx, &auth.AuthContext{Type: auth.AuthTypeAgent, ProfilePin: pin})
+	}
+	return ctx
+}
+
+func newSetProfileTestServer() *MCPProxyServer {
+	cfg := &config.Config{
+		Servers: []*config.ServerConfig{
+			{Name: "research-srv"},
+			{Name: "deploy-srv"},
+		},
+		Profiles: []config.ProfileConfig{
+			{Name: "research", Servers: []string{"research-srv"}},
+			{Name: "deploy", Servers: []string{"deploy-srv"}},
+		},
+	}
+	return &MCPProxyServer{
+		config:       cfg,
+		logger:       zap.NewNop(),
+		sessionStore: NewSessionStore(zap.NewNop()),
+	}
+}
+
+func callSetProfileTool(t *testing.T, p *MCPProxyServer, ctx context.Context, slug string) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Name = "set_profile"
+	req.Params.Arguments = map[string]interface{}{"profile": slug}
+	res, err := p.handleSetProfile(ctx, req)
+	require.NoError(t, err)
+	return res
+}
+
+func setProfileResultText(t *testing.T, res *mcp.CallToolResult) string {
+	t.Helper()
+	require.NotEmpty(t, res.Content)
+	b, err := json.Marshal(res.Content[0])
+	require.NoError(t, err)
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(b, &m))
+	text, _ := m["text"].(string)
+	return text
+}
+
+// TestHandleSetProfile_PinnedRejectsOtherSlug verifies a profile-pinned agent
+// token cannot switch away from its pinned profile via set_profile (Profiles v2 T3).
+func TestHandleSetProfile_PinnedRejectsOtherSlug(t *testing.T) {
+	p := newSetProfileTestServer()
+	ctx := setProfileCtx("sess-pinned", "research")
+
+	res := callSetProfileTool(t, p, ctx, "deploy")
+	require.True(t, res.IsError, "switching a pinned token to another profile must error")
+	require.Contains(t, setProfileResultText(t, res), "pinned to profile 'research'")
+
+	// The session selection must NOT have been changed by the rejected call.
+	require.Equal(t, "", p.sessionStore.GetActiveProfile("sess-pinned"))
+}
+
+// TestHandleSetProfile_PinnedAllowsSameSlug verifies set_profile to the pinned
+// profile itself succeeds.
+func TestHandleSetProfile_PinnedAllowsSameSlug(t *testing.T) {
+	p := newSetProfileTestServer()
+	ctx := setProfileCtx("sess-same", "research")
+
+	res := callSetProfileTool(t, p, ctx, "research")
+	require.False(t, res.IsError, "set_profile to the pinned profile must succeed: %s", setProfileResultText(t, res))
+
+	var payload struct {
+		ActiveProfile string   `json:"active_profile"`
+		Servers       []string `json:"servers"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(setProfileResultText(t, res)), &payload))
+	require.Equal(t, "research", payload.ActiveProfile)
+	require.Contains(t, payload.Servers, "research-srv")
+}
+
+// TestHandleSetProfile_UnpinnedUnchanged verifies tokens without a pin retain
+// the existing T2 switching behaviour.
+func TestHandleSetProfile_UnpinnedUnchanged(t *testing.T) {
+	p := newSetProfileTestServer()
+	ctx := setProfileCtx("sess-free", "")
+
+	res := callSetProfileTool(t, p, ctx, "deploy")
+	require.False(t, res.IsError, "unpinned token must switch freely: %s", setProfileResultText(t, res))
+	require.Equal(t, "deploy", p.sessionStore.GetActiveProfile("sess-free"))
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -275,6 +275,7 @@ func (s *Server) mcpAuthMiddleware(next http.Handler) http.Handler {
 				TokenPrefix:    agentToken.TokenPrefix,
 				AllowedServers: agentToken.AllowedServers,
 				Permissions:    agentToken.Permissions,
+				ProfilePin:     agentToken.ProfilePin,
 			}
 			ctx := auth.WithAuthContext(r.Context(), authCtx)
 			next.ServeHTTP(w, r.WithContext(ctx))
@@ -1678,6 +1679,19 @@ func (s *Server) profileMiddleware(next http.Handler) http.Handler {
 		slug := strings.TrimPrefix(r.URL.Path, "/mcp/p/")
 		slug = strings.TrimPrefix(slug, "/mcp/p") // handle /mcp/p with no trailing slash
 		slug = strings.Trim(slug, "/")
+
+		// Profiles v2 T3: a profile-pinned agent token may only operate within its
+		// pinned profile. A request to any other /mcp/p/<slug> is forbidden (403),
+		// regardless of whether that slug is a real profile. Auth has already run
+		// (mcpAuthMiddleware wraps this handler), so the pin is on the context.
+		if pin := profilePinFromContext(r.Context()); pin != "" && pin != slug {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"error": fmt.Sprintf("agent token is pinned to profile '%s' and cannot access profile '%s'", pin, slug),
+			})
+			return
+		}
 
 		// Look up profile by slug (lock-free snapshot).
 		var found *config.ProfileConfig

--- a/specs/028-agent-tokens/spec.md
+++ b/specs/028-agent-tokens/spec.md
@@ -117,6 +117,8 @@ Users manage agent tokens through the MCPProxy web dashboard. The UI provides a 
 - What happens when the maximum token count is reached? The system enforces a maximum of 100 agent tokens per instance and rejects creation requests with a clear error.
 - What happens when a token with `allowed_servers: ["*"]` is used after new servers are added? The wildcard includes all non-quarantined servers dynamically — new servers are automatically accessible.
 - What happens when the token's expiry is set beyond the maximum (365 days)? The system rejects the request and informs the user of the maximum allowed expiry.
+- What happens when a token is pinned to a profile (`profile_pin`) and the agent tries to switch profiles? The pin is server-enforced: `set_profile` to any other slug is rejected, and a `/mcp/p/<other>` URL returns 403. The pinned profile is the highest-precedence resolution source (above URL scope and session `set_profile`).
+- What happens when a pinned profile is later removed from the configuration? Creation validates the slug exists, but a later config change is **warn-skipped** at request time (logged, not hard-failed): profile resolution degrades to URL/session/none while the pin still blocks switching away — the token cannot silently widen its scope.
 
 ## Requirements *(mandatory)*
 
@@ -142,11 +144,12 @@ Users manage agent tokens through the MCPProxy web dashboard. The UI provides a 
 - **FR-018**: System MUST support agent token authentication via both `Authorization: Bearer` and `X-API-Key` headers.
 - **FR-019**: System MUST provide a web UI for token management including creation with server selection, permission picker, expiry setting, and revocation.
 - **FR-020**: System MUST support activity log filtering by agent name and authentication type.
+- **FR-021** (Profiles v2 T3): System MUST support an optional per-token `profile_pin`. When set, the token operates ONLY within its pinned profile: `set_profile` to a different slug MUST be rejected, a `/mcp/p/<other>` URL MUST return 403, and the pin MUST be the highest-precedence profile-resolution source (above URL scope and session `set_profile`). The pinned slug MUST be validated against configured profiles at creation time; a later config change MUST warn-skip (not hard-fail). Tokens without a pin retain unchanged behavior.
 
 ### Key Entities
 
-- **Agent Token**: A scoped credential with name, hashed secret, prefix, allowed server list, permission list, expiry timestamp, creation timestamp, last-used timestamp, and revocation status.
-- **Auth Context**: The resolved authentication identity for a request — includes auth type (admin/agent), agent name (if applicable), allowed servers, and permissions.
+- **Agent Token**: A scoped credential with name, hashed secret, prefix, allowed server list, permission list, expiry timestamp, creation timestamp, last-used timestamp, revocation status, and an optional `profile_pin` binding it to a single profile (Profiles v2 T3).
+- **Auth Context**: The resolved authentication identity for a request — includes auth type (admin/agent), agent name (if applicable), allowed servers, permissions, and the agent token's `profile_pin` (if any).
 - **Token Scope**: The combination of allowed servers and permitted tool call tiers that define what an agent can do.
 
 ## Success Criteria *(mandatory)*
@@ -159,6 +162,7 @@ Users manage agent tokens through the MCPProxy web dashboard. The UI provides a 
 - **SC-004**: Activity log entries for agent requests include sufficient identity information to determine which agent performed which action.
 - **SC-005**: Zero breaking changes for existing users — all existing API key authentication and MCP functionality works identically after the feature is deployed.
 - **SC-006**: Token secrets cannot be recovered from storage — only the one-time display at creation reveals the secret.
+- **SC-007** (Profiles v2 T3): A profile-pinned token is provably confined to its profile — `set_profile("other")` is rejected, `/mcp/p/<other>` returns 403, and the pinned profile works; unpinned tokens are unaffected (covered by automated tests).
 
 ## Assumptions
 


### PR DESCRIPTION
## Profiles v2 — T3 (MCP-3242)

Adds **server-enforced per-agent-token profile pinning**: an agent token bound to one profile cannot operate outside it, regardless of the `/mcp/p/<slug>` URL it connects to or any `set_profile` call. Fills the resolver hook left by T2 ([#761](https://github.com/smart-mcp-proxy/mcpproxy-go/pull/761)).

### What changed
- **auth**: `ProfilePin` on `AgentToken` (stored; survives `regenerate`) and `AuthContext`.
- **resolver** (`profile_resolver.go`): `profilePinFromContext` reads the pin off the agent `AuthContext`; the pin is the **highest-precedence** resolution source (above URL scope and session `set_profile`). If a pinned profile is later removed from config it is **warn-skipped** (logged, not hard-failed) — the pin still blocks switching away, so scope can never silently widen.
- **enforcement**: `/mcp/p/<other>` → **403** for a pinned token (`profileMiddleware` guard, after `mcpAuthMiddleware`); the `set_profile` rejection wired by T2 goes live.
- **REST**: `profile_pin` accepted on token create (validated against configured profiles at creation), surfaced on token read/list.
- **CLI**: `mcpproxy token create --profile-pin <slug>`; pin shown in `token list` (PROFILE PIN column) and `token show`.
- **spec/docs**: spec 028 FR-021 + SC-007 + edge cases; `docs/features/agent-tokens.md` Profile Pinning section with precedence table.

### Resolution precedence (highest wins)
```
1. agent-token profile_pin   (server-enforced — this PR)
2. /mcp/p/<slug> URL scope
3. set_profile session state
4. none
```

### Tests (TDD — red→green)
- `TestProfilePinFromContext`, `TestResolveActiveProfile_PinHighestPrecedence` — pin wins over URL + session.
- `TestHandleSetProfile_PinnedRejectsOtherSlug` / `PinnedAllowsSameSlug` / `UnpinnedUnchanged`.
- `TestProfile_PinnedTokenURLEnforcement` — real minted pinned token: `/mcp/p/deploy` → 403, `/mcp/p/research` reachable.
- `TestProfile_UnpinnedTokenUnaffected`.
- `TestCreateToken_ProfilePin` / `ProfilePinUnknownRejected` — REST create/read + unknown-pin 400.

### Verification
- `golangci-lint` v2 (`.github/.golangci.yml`): **0 issues**.
- `go test -race ./internal/auth/... ./internal/httpapi/... ./internal/server/` (profile+token): **pass**.
- `make swagger`: no diff (token endpoints are not swagger-annotated; no config field added).

Closes MCP-3242.