### PR TITLE
feat: Profiles v2 T5 — tray profile switcher (Go + Swift) + active_profile SSE (MCP-3244)

### DIFF
--- a/cmd/mcpproxy-tray/internal/api/adapter.go
+++ b/cmd/mcpproxy-tray/internal/api/adapter.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 
 	internalRuntime "github.com/smart-mcp-proxy/mcpproxy-go/internal/runtime"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/tray"
 )
 
 // ClientInterface defines the methods required by ServerAdapter from the API client.
@@ -20,6 +21,9 @@ type ClientInterface interface {
 	UnquarantineServer(serverName string) error
 	TriggerOAuthLogin(serverName string) error
 	StatusChannel() <-chan StatusUpdate
+	GetProfiles() ([]tray.ProfileInfo, error)
+	GetActiveProfile() (string, error)
+	SetActiveProfile(name string) error
 }
 
 // isServerHealthy returns true if the server is considered healthy.
@@ -122,7 +126,7 @@ func (a *ServerAdapter) GetStatus() interface{} {
 
 	// Fallback to empty if we couldn't get it
 	if listenAddr == "" {
-		listenAddr = ""  // Empty means tray will show "Status: Running" without address
+		listenAddr = "" // Empty means tray will show "Status: Running" without address
 	}
 
 	servers, serverErr := a.client.GetServers()
@@ -184,6 +188,21 @@ func (a *ServerAdapter) StatusChannel() <-chan interface{} {
 // EventsChannel returns nil as the remote API does not yet proxy runtime events.
 func (a *ServerAdapter) EventsChannel() <-chan internalRuntime.Event {
 	return nil
+}
+
+// GetProfiles returns the configured profiles for the tray switcher (Profiles v2 T5).
+func (a *ServerAdapter) GetProfiles() ([]tray.ProfileInfo, error) {
+	return a.client.GetProfiles()
+}
+
+// GetActiveProfile returns the server-level default active profile (empty = all servers).
+func (a *ServerAdapter) GetActiveProfile() (string, error) {
+	return a.client.GetActiveProfile()
+}
+
+// SetActiveProfile sets the server-level default active profile (empty clears it).
+func (a *ServerAdapter) SetActiveProfile(name string) error {
+	return a.client.SetActiveProfile(name)
 }
 
 // GetQuarantinedServers returns quarantined servers

--- a/cmd/mcpproxy-tray/internal/api/adapter_test.go
+++ b/cmd/mcpproxy-tray/internal/api/adapter_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/tray"
 )
 
 // =============================================================================
@@ -21,11 +23,13 @@ type MockClient struct {
 	enableErr            error
 	quarantineErr        error
 	oauthErr             error
-	enabledServers       map[string]bool   // tracks enable/disable calls
-	quarantinedServers   map[string]bool   // tracks quarantine calls
-	unquarantinedServers []string          // tracks unquarantine calls
-	oauthTriggered       []string          // tracks OAuth login calls
+	enabledServers       map[string]bool // tracks enable/disable calls
+	quarantinedServers   map[string]bool // tracks quarantine calls
+	unquarantinedServers []string        // tracks unquarantine calls
+	oauthTriggered       []string        // tracks OAuth login calls
 	statusCh             chan StatusUpdate
+	profiles             []tray.ProfileInfo // Profiles v2 T5
+	activeProfile        string             // Profiles v2 T5
 }
 
 func NewMockClient() *MockClient {
@@ -85,6 +89,46 @@ func (m *MockClient) TriggerOAuthLogin(serverName string) error {
 
 func (m *MockClient) StatusChannel() <-chan StatusUpdate {
 	return m.statusCh
+}
+
+func (m *MockClient) GetProfiles() ([]tray.ProfileInfo, error) {
+	return m.profiles, nil
+}
+
+func (m *MockClient) GetActiveProfile() (string, error) {
+	return m.activeProfile, nil
+}
+
+func (m *MockClient) SetActiveProfile(name string) error {
+	m.activeProfile = name
+	return nil
+}
+
+// TestServerAdapterProfileDelegation verifies the adapter forwards the profile
+// switcher calls (Profiles v2 T5) to the underlying client.
+func TestServerAdapterProfileDelegation(t *testing.T) {
+	mock := NewMockClient()
+	mock.profiles = []tray.ProfileInfo{
+		{Name: "research", ToolCount: 3},
+		{Name: "deploy", ToolCount: 2},
+	}
+	mock.activeProfile = "research"
+	adapter := NewServerAdapter(mock)
+
+	profiles, err := adapter.GetProfiles()
+	require.NoError(t, err)
+	require.Len(t, profiles, 2)
+	assert.Equal(t, "research", profiles[0].Name)
+	assert.Equal(t, 3, profiles[0].ToolCount)
+
+	active, err := adapter.GetActiveProfile()
+	require.NoError(t, err)
+	assert.Equal(t, "research", active)
+
+	require.NoError(t, adapter.SetActiveProfile("deploy"))
+	active, err = adapter.GetActiveProfile()
+	require.NoError(t, err)
+	assert.Equal(t, "deploy", active)
 }
 
 // =============================================================================

--- a/cmd/mcpproxy-tray/internal/api/client.go
+++ b/cmd/mcpproxy-tray/internal/api/client.go
@@ -2,12 +2,14 @@ package api
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -638,6 +640,63 @@ func (c *Client) TriggerOAuthLogin(serverName string) error {
 	return nil
 }
 
+// GetProfiles fetches the configured profiles (Profiles v2 T5) from
+// GET /api/v1/profiles for the tray profile switcher.
+func (c *Client) GetProfiles() ([]tray.ProfileInfo, error) {
+	resp, err := c.makeRequest("GET", "/api/v1/profiles", nil)
+	if err != nil {
+		return nil, err
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("API error: %s", resp.Error)
+	}
+
+	raw, ok := resp.Data["profiles"].([]interface{})
+	if !ok {
+		// No profiles configured is a valid, empty result.
+		return nil, nil
+	}
+
+	var result []tray.ProfileInfo
+	for _, p := range raw {
+		pm, ok := p.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		result = append(result, tray.ProfileInfo{
+			Name:      getString(pm, "name"),
+			ToolCount: getInt(pm, "tool_count"),
+		})
+	}
+	return result, nil
+}
+
+// GetActiveProfile fetches the server-level default active profile from
+// GET /api/v1/profiles/active. An empty string means "all servers".
+func (c *Client) GetActiveProfile() (string, error) {
+	resp, err := c.makeRequest("GET", "/api/v1/profiles/active", nil)
+	if err != nil {
+		return "", err
+	}
+	if !resp.Success {
+		return "", fmt.Errorf("API error: %s", resp.Error)
+	}
+	return getString(resp.Data, "active_profile"), nil
+}
+
+// SetActiveProfile sets the server-level default active profile via
+// PUT /api/v1/profiles/active. An empty name clears the selection (all servers).
+func (c *Client) SetActiveProfile(name string) error {
+	resp, err := c.makeRequest("PUT", "/api/v1/profiles/active", map[string]string{"profile": name})
+	if err != nil {
+		return err
+	}
+	if !resp.Success {
+		return fmt.Errorf("API error: %s", resp.Error)
+	}
+	return nil
+}
+
 // GetServerTools gets tools for a specific server
 func (c *Client) GetServerTools(serverName string) ([]Tool, error) {
 	endpoint := fmt.Sprintf("/api/v1/servers/%s/tools", serverName)
@@ -887,8 +946,10 @@ func (c *Client) OpenWebUI() error {
 	}
 }
 
-// makeRequest makes an HTTP request to the API with enhanced error handling and retry logic
-func (c *Client) makeRequest(method, path string, _ interface{}) (*Response, error) {
+// makeRequest makes an HTTP request to the API with enhanced error handling and retry logic.
+// When body is non-nil it is JSON-encoded and sent as the request payload (e.g. PUT bodies);
+// nil yields a bodyless request, preserving every existing call site.
+func (c *Client) makeRequest(method, path string, body interface{}) (*Response, error) {
 	url, err := c.buildURL(path)
 	if err != nil {
 		return nil, err
@@ -896,8 +957,21 @@ func (c *Client) makeRequest(method, path string, _ interface{}) (*Response, err
 	maxRetries := 3
 	baseDelay := 1 * time.Second
 
+	var bodyBytes []byte
+	if body != nil {
+		bodyBytes, err = json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal request body: %w", err)
+		}
+	}
+
 	for attempt := 1; attempt <= maxRetries; attempt++ {
-		req, err := http.NewRequest(method, url, http.NoBody)
+		// Recreate the reader each attempt so retries resend the full body.
+		var bodyReader io.Reader = http.NoBody
+		if bodyBytes != nil {
+			bodyReader = bytes.NewReader(bodyBytes)
+		}
+		req, err := http.NewRequest(method, url, bodyReader)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create request: %w", err)
 		}

--- a/internal/httpapi/profiles.go
+++ b/internal/httpapi/profiles.go
@@ -147,8 +147,18 @@ func (s *Server) handleSetActiveProfile(w http.ResponseWriter, r *http.Request) 
 	}
 
 	s.activeProfileMu.Lock()
+	changed := s.activeProfile != slug
 	s.activeProfile = slug
 	s.activeProfileMu.Unlock()
+
+	// Notify other clients (Web UI, tray) via SSE only on an actual change, so a
+	// switch made here is reflected everywhere (Profiles v2 T5). Emitted through
+	// an optional capability assertion to avoid widening ServerController.
+	if changed {
+		if emitter, ok := s.controller.(interface{ EmitActiveProfileChanged(string) }); ok {
+			emitter.EmitActiveProfileChanged(slug)
+		}
+	}
 
 	s.getRequestLogger(r).Infow("default active profile updated", "profile", slug)
 	s.writeSuccess(w, map[string]interface{}{"active_profile": slug})

--- a/internal/httpapi/profiles_test.go
+++ b/internal/httpapi/profiles_test.go
@@ -131,3 +131,50 @@ func TestHandleSetActiveProfileBadBody(t *testing.T) {
 	w, _ := doJSON(t, srv, http.MethodPut, "/api/v1/profiles/active", []byte(`not json`))
 	require.Equal(t, http.StatusBadRequest, w.Code)
 }
+
+// profileEventRecorder records EmitActiveProfileChanged calls so we can assert
+// the handler notifies other clients (via SSE) only on an actual change.
+type profileEventRecorder struct {
+	mockProfilesController
+	emitted []string
+}
+
+func (m *profileEventRecorder) EmitActiveProfileChanged(profile string) {
+	m.emitted = append(m.emitted, profile)
+}
+
+func TestSetActiveProfileEmitsChangeEvent(t *testing.T) {
+	cfg := &config.Config{
+		APIKey: "test-key",
+		Servers: []*config.ServerConfig{
+			{Name: "research-srv"},
+			{Name: "deploy-srv"},
+		},
+		Profiles: []config.ProfileConfig{
+			{Name: "research", Servers: []string{"research-srv"}},
+			{Name: "deploy", Servers: []string{"deploy-srv"}},
+		},
+	}
+	rec := &profileEventRecorder{mockProfilesController: mockProfilesController{apiKey: "test-key", cfg: cfg}}
+	srv := NewServer(rec, zap.NewNop().Sugar(), nil)
+
+	// Setting a new profile emits one change event.
+	w, _ := doJSON(t, srv, http.MethodPut, "/api/v1/profiles/active", []byte(`{"profile":"research"}`))
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, []string{"research"}, rec.emitted)
+
+	// Setting the same profile again is a no-op — no duplicate event.
+	w, _ = doJSON(t, srv, http.MethodPut, "/api/v1/profiles/active", []byte(`{"profile":"research"}`))
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, []string{"research"}, rec.emitted)
+
+	// Clearing emits an empty-string change event.
+	w, _ = doJSON(t, srv, http.MethodPut, "/api/v1/profiles/active", []byte(`{"profile":""}`))
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, []string{"research", ""}, rec.emitted)
+
+	// A rejected (unknown) profile emits nothing.
+	w, _ = doJSON(t, srv, http.MethodPut, "/api/v1/profiles/active", []byte(`{"profile":"ghost"}`))
+	require.Equal(t, http.StatusNotFound, w.Code)
+	require.Equal(t, []string{"research", ""}, rec.emitted)
+}

--- a/internal/runtime/event_bus.go
+++ b/internal/runtime/event_bus.go
@@ -353,6 +353,15 @@ func (r *Runtime) emitSecretsChanged(operation string, secretName string, extra 
 	r.publishEvent(newEvent(EventTypeSecretsChanged, payload))
 }
 
+// EmitActiveProfileChanged emits an event when the server-level default active
+// profile changes (Profiles v2). UI surfaces subscribe and refetch
+// GET /api/v1/profiles/active so a switch made by one client (Web UI, tray, CLI)
+// is reflected everywhere. An empty profile means "all servers".
+func (r *Runtime) EmitActiveProfileChanged(profile string) {
+	payload := map[string]any{"active_profile": profile}
+	r.publishEvent(newEvent(EventTypeActiveProfileChanged, payload))
+}
+
 // EmitOAuthTokenRefreshed emits an event when proactive token refresh succeeds.
 // This is used by the RefreshManager to notify subscribers of successful token refresh.
 func (r *Runtime) EmitOAuthTokenRefreshed(serverName string, expiresAt time.Time) {

--- a/internal/runtime/events.go
+++ b/internal/runtime/events.go
@@ -14,6 +14,10 @@ const (
 	EventTypeConfigSaved EventType = "config.saved"
 	// EventTypeSecretsChanged is emitted when secrets are added, updated, or deleted.
 	EventTypeSecretsChanged EventType = "secrets.changed"
+	// EventTypeActiveProfileChanged is emitted when the server-level default
+	// active profile changes (Profiles v2). UI surfaces (Web UI, tray) refetch
+	// GET /api/v1/profiles/active to reflect a switch made by another client.
+	EventTypeActiveProfileChanged EventType = "active_profile.changed"
 	// EventTypeOAuthTokenRefreshed is emitted when proactive token refresh succeeds.
 	EventTypeOAuthTokenRefreshed EventType = "oauth.token_refreshed"
 	// EventTypeOAuthRefreshFailed is emitted when proactive token refresh fails after retries.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2579,6 +2579,15 @@ func (s *Server) NotifySecretsChanged(ctx context.Context, operation, secretName
 	return s.runtime.NotifySecretsChanged(ctx, operation, secretName)
 }
 
+// EmitActiveProfileChanged broadcasts an active_profile.changed event so UI
+// surfaces (Web UI, tray) reflect a default-profile switch made by another
+// client (Profiles v2 T2/T5). The REST handler invokes this via an optional
+// capability assertion, so adding it here does not widen the httpapi
+// ServerController interface.
+func (s *Server) EmitActiveProfileChanged(profile string) {
+	s.runtime.EmitActiveProfileChanged(profile)
+}
+
 // GetCurrentConfig returns the current configuration
 func (s *Server) GetCurrentConfig() interface{} {
 	return s.runtime.GetCurrentConfig()

--- a/internal/tray/managers.go
+++ b/internal/tray/managers.go
@@ -289,6 +289,7 @@ type MenuManager struct {
 	// Menu references
 	upstreamServersMenu *systray.MenuItem
 	quarantineMenu      *systray.MenuItem
+	profileMenu         *systray.MenuItem
 
 	// Menu tracking to prevent duplicates
 	serverMenuItems       map[string]*systray.MenuItem // server name -> menu item
@@ -300,6 +301,12 @@ type MenuManager struct {
 	quarantineInfoEmpty   *systray.MenuItem            // "No servers" info item
 	quarantineInfoHelp    *systray.MenuItem            // "Click to unquarantine" help item
 
+	// Profile switcher tracking (Profiles v2 T5). profileMenuItems is keyed by
+	// profile slug; the "" key is the synthetic "All servers" entry.
+	profileMenuItems    map[string]*systray.MenuItem
+	latestProfileNames  []string // sorted slugs currently rendered (excludes the "" entry)
+	latestActiveProfile string   // "" means all servers
+
 	// Latest server data snapshots
 	latestServers     []map[string]interface{}
 	latestQuarantined []map[string]interface{}
@@ -308,18 +315,24 @@ type MenuManager struct {
 	onServerAction func(serverName string, action string) // callback for server actions
 }
 
+// profileAllServersKey is the map key + display sentinel for the "no profile"
+// (all servers) choice in the profile switcher submenu.
+const profileAllServersKey = ""
+
 // NewMenuManager creates a new menu manager
-func NewMenuManager(upstreamMenu, quarantineMenu *systray.MenuItem, logger *zap.SugaredLogger) *MenuManager {
+func NewMenuManager(upstreamMenu, quarantineMenu, profileMenu *systray.MenuItem, logger *zap.SugaredLogger) *MenuManager {
 	return &MenuManager{
 		logger:                logger,
 		upstreamServersMenu:   upstreamMenu,
 		quarantineMenu:        quarantineMenu,
+		profileMenu:           profileMenu,
 		serverMenuItems:       make(map[string]*systray.MenuItem),
 		quarantineMenuItems:   make(map[string]*systray.MenuItem),
 		serverActionItems:     make(map[string]*systray.MenuItem),
 		serverQuarantineItems: make(map[string]*systray.MenuItem),
 		serverOAuthItems:      make(map[string]*systray.MenuItem),
 		serverRestartItems:    make(map[string]*systray.MenuItem),
+		profileMenuItems:      make(map[string]*systray.MenuItem),
 	}
 }
 
@@ -328,6 +341,114 @@ func (m *MenuManager) SetActionCallback(callback func(serverName string, action 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.onServerAction = callback
+}
+
+// UpdateProfilesMenu refreshes the profile switcher submenu (Profiles v2 T5).
+// It renders an "All servers" entry plus one checkbox per configured profile,
+// checks the active one, and (re)wires click handlers that ask the core to switch
+// the server-level default active profile. systray menu items cannot be removed,
+// only hidden, so the items are rebuilt only when the set of profile slugs
+// changes; otherwise titles and checkmarks are updated in place. Because the
+// active profile is re-read on every sync, a switch made by another client
+// (Web UI, CLI) is reflected here within one sync interval.
+func (m *MenuManager) UpdateProfilesMenu(profiles []ProfileInfo, active string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.profileMenu == nil {
+		return
+	}
+
+	// Build the sorted slug list and a lookup of tool counts.
+	names := make([]string, 0, len(profiles))
+	toolCounts := make(map[string]int, len(profiles))
+	for _, p := range profiles {
+		if p.Name == "" {
+			continue
+		}
+		names = append(names, p.Name)
+		toolCounts[p.Name] = p.ToolCount
+	}
+	sort.Strings(names)
+
+	m.profileMenu.SetTitle(profileMenuTitle(active))
+
+	// Rebuild the items when the configured profile set changed (new/removed
+	// profiles); otherwise reuse existing items and only refresh checkmarks.
+	if m.profileSetChanged(names) {
+		for _, item := range m.profileMenuItems {
+			item.Hide()
+		}
+		m.profileMenuItems = make(map[string]*systray.MenuItem)
+
+		// "All servers" entry (clears the active profile).
+		allItem := m.profileMenu.AddSubMenuItemCheckbox("All servers", "Use all enabled servers (no profile)", active == profileAllServersKey)
+		m.profileMenuItems[profileAllServersKey] = allItem
+		m.wireProfileClick(profileAllServersKey, allItem)
+
+		for _, name := range names {
+			title := fmt.Sprintf("%s (%d tools)", name, toolCounts[name])
+			item := m.profileMenu.AddSubMenuItemCheckbox(title, fmt.Sprintf("Switch the active profile to %s", name), name == active)
+			m.profileMenuItems[name] = item
+			m.wireProfileClick(name, item)
+		}
+		m.latestProfileNames = names
+	} else {
+		// Refresh titles (tool counts may change) and checkmarks in place.
+		for _, name := range names {
+			if item, ok := m.profileMenuItems[name]; ok {
+				item.SetTitle(fmt.Sprintf("%s (%d tools)", name, toolCounts[name]))
+			}
+		}
+	}
+
+	// Reconcile checkmarks against the active profile.
+	for key, item := range m.profileMenuItems {
+		if key == active {
+			item.Check()
+		} else {
+			item.Uncheck()
+		}
+	}
+	m.latestActiveProfile = active
+}
+
+// profileSetChanged reports whether the sorted profile slug list differs from
+// what is currently rendered (excluding the synthetic "All servers" entry).
+func (m *MenuManager) profileSetChanged(names []string) bool {
+	if len(m.profileMenuItems) == 0 {
+		return true
+	}
+	if len(names) != len(m.latestProfileNames) {
+		return true
+	}
+	for i := range names {
+		if names[i] != m.latestProfileNames[i] {
+			return true
+		}
+	}
+	return false
+}
+
+// wireProfileClick starts a goroutine that forwards clicks on a profile entry to
+// the action callback as a "switch_profile" action keyed by the profile slug.
+func (m *MenuManager) wireProfileClick(slug string, item *systray.MenuItem) {
+	go func(name string, it *systray.MenuItem) {
+		for range it.ClickedCh {
+			if m.onServerAction != nil {
+				go m.onServerAction(name, "switch_profile")
+			}
+		}
+	}(slug, item)
+}
+
+// profileMenuTitle renders the top-level profile menu label with the active
+// selection, e.g. "Profile: research" or "Profile: All servers".
+func profileMenuTitle(active string) string {
+	if active == profileAllServersKey {
+		return "Profile: All servers"
+	}
+	return fmt.Sprintf("Profile: %s", active)
 }
 
 // UpdateUpstreamServersMenu updates the upstream servers menu without duplicates
@@ -1139,6 +1260,17 @@ func (m *SynchronizationManager) performSync() error {
 		m.menuManager.UpdateQuarantineMenu(quarantinedServers)
 	}
 
+	// Refresh the profile switcher (Profiles v2 T5). Re-reading the active
+	// profile each sync is how a switch made by another client is reflected in
+	// the tray. Profile errors are non-fatal: keep the rest of the menu fresh.
+	if profiles, profErr := m.server.GetProfiles(); profErr != nil {
+		m.logger.Debug("Failed to get profiles, skipping profile menu update", zap.Error(profErr))
+	} else if active, activeErr := m.server.GetActiveProfile(); activeErr != nil {
+		m.logger.Debug("Failed to get active profile, skipping profile menu update", zap.Error(activeErr))
+	} else {
+		m.menuManager.UpdateProfilesMenu(profiles, active)
+	}
+
 	if m.onSync != nil {
 		m.onSync()
 	}
@@ -1257,4 +1389,3 @@ func extractHealthLevel(server map[string]interface{}) string {
 
 	return ""
 }
-

--- a/internal/tray/managers_test.go
+++ b/internal/tray/managers_test.go
@@ -6,8 +6,52 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/contracts"
 )
+
+func TestProfileMenuTitle(t *testing.T) {
+	require.Equal(t, "Profile: All servers", profileMenuTitle(""))
+	require.Equal(t, "Profile: research", profileMenuTitle("research"))
+}
+
+func TestProfileSetChanged(t *testing.T) {
+	m := NewMenuManager(nil, nil, nil, zap.NewNop().Sugar())
+
+	// With no rendered items yet, any set is considered changed (forces the
+	// initial build).
+	require.True(t, m.profileSetChanged([]string{"a"}))
+
+	// Mark a rendered set (the map value is irrelevant to the comparison).
+	m.profileMenuItems[""] = nil
+	m.latestProfileNames = []string{"a", "b"}
+
+	require.True(t, m.profileSetChanged([]string{"a"}), "different length must rebuild")
+	require.False(t, m.profileSetChanged([]string{"a", "b"}), "identical set must not rebuild")
+	require.True(t, m.profileSetChanged([]string{"a", "c"}), "different member must rebuild")
+}
+
+// TestPerformSyncRefreshesProfiles verifies the sync loop consults the profile
+// getters (so a switch made by another client is reflected) without erroring
+// when the menu items are not backed by a live systray run loop.
+func TestPerformSyncRefreshesProfiles(t *testing.T) {
+	logger := zap.NewNop().Sugar()
+	mock := NewMockServer()
+	mock.profiles = []ProfileInfo{{Name: "research", ToolCount: 3}}
+	mock.activeProfile = "research"
+
+	mm := NewMenuManager(nil, nil, nil, logger) // nil profileMenu → UpdateProfilesMenu no-ops safely
+	sm := NewSynchronizationManager(NewServerStateManager(mock, logger), mock, mm, logger)
+	sm.SetConnected(true)
+
+	require.NoError(t, sm.performSync())
+
+	active, err := mock.GetActiveProfile()
+	require.NoError(t, err)
+	require.Equal(t, "research", active)
+}
 
 func TestMenuSorting(t *testing.T) {
 
@@ -754,13 +798,13 @@ func TestConnectedCountHealthLevelOnly(t *testing.T) {
 // TestHealthActionMenuItemSelection tests that correct menu items are shown based on health.action
 func TestHealthActionMenuItemSelection(t *testing.T) {
 	testCases := []struct {
-		name               string
-		healthAction       string
-		expectedMenuItem   string
-		shouldShowLogin    bool
-		shouldShowSecret   bool
+		name                string
+		healthAction        string
+		expectedMenuItem    string
+		shouldShowLogin     bool
+		shouldShowSecret    bool
 		shouldShowConfigure bool
-		shouldShowRestart  bool
+		shouldShowRestart   bool
 	}{
 		{
 			name:             "login action shows Login Required",
@@ -775,9 +819,9 @@ func TestHealthActionMenuItemSelection(t *testing.T) {
 			shouldShowSecret: true,
 		},
 		{
-			name:               "configure action shows Configure",
-			healthAction:       "configure",
-			expectedMenuItem:   "⚠️ Configure",
+			name:                "configure action shows Configure",
+			healthAction:        "configure",
+			expectedMenuItem:    "⚠️ Configure",
 			shouldShowConfigure: true,
 		},
 		{

--- a/internal/tray/profile.go
+++ b/internal/tray/profile.go
@@ -1,0 +1,10 @@
+package tray
+
+// ProfileInfo is a tray-facing summary of a configured profile (Profiles v2 T5).
+// Name is the profile slug; an empty active profile means "all servers". It lives
+// in a build-constraint-free file so the cross-platform tray API adapter can
+// reference it even in stub (headless/linux) builds of this package.
+type ProfileInfo struct {
+	Name      string
+	ToolCount int
+}

--- a/internal/tray/tray.go
+++ b/internal/tray/tray.go
@@ -88,6 +88,13 @@ type ServerInterface interface {
 
 	// OAuth control
 	TriggerOAuthLogin(serverName string) error
+
+	// Profile switcher (Profiles v2 T5). The tray holds no state — it reads the
+	// configured profiles and the server-level default active profile from the
+	// core, and writes the active profile back, all via REST.
+	GetProfiles() ([]ProfileInfo, error)
+	GetActiveProfile() (string, error)
+	SetActiveProfile(name string) error
 }
 
 // App represents the system tray application
@@ -111,6 +118,7 @@ type App struct {
 	// startStopItem removed - tray doesn't directly control core lifecycle
 	upstreamServersMenu *systray.MenuItem
 	quarantineMenu      *systray.MenuItem
+	profileMenu         *systray.MenuItem
 	portConflictMenu    *systray.MenuItem
 	portConflictInfo    *systray.MenuItem
 	portConflictRetry   *systray.MenuItem
@@ -128,11 +136,11 @@ type App struct {
 	autostartItem    *systray.MenuItem
 
 	// Update notification menu item (hidden until update is available)
-	updateMenuItem     *systray.MenuItem
-	updateAvailable    bool
-	latestVersion      string
-	latestReleaseURL   string
-	updateCheckMu      sync.RWMutex
+	updateMenuItem   *systray.MenuItem
+	updateAvailable  bool
+	latestVersion    string
+	latestReleaseURL string
+	updateCheckMu    sync.RWMutex
 
 	// Config path for opening from menu
 	configPath string
@@ -540,10 +548,13 @@ func (a *App) onReady() {
 	// --- Upstream & Quarantine Menus ---
 	a.upstreamServersMenu = systray.AddMenuItem("Upstream Servers", "Manage upstream servers")
 	a.quarantineMenu = systray.AddMenuItem("Security Quarantine", "Manage quarantined servers")
+
+	// --- Profile Switcher (Profiles v2 T5) ---
+	a.profileMenu = systray.AddMenuItem("Profile: All servers", "Switch the active tool-discovery profile")
 	systray.AddSeparator()
 
 	// --- Initialize Managers ---
-	a.menuManager = NewMenuManager(a.upstreamServersMenu, a.quarantineMenu, a.logger)
+	a.menuManager = NewMenuManager(a.upstreamServersMenu, a.quarantineMenu, a.profileMenu, a.logger)
 	a.syncManager = NewSynchronizationManager(a.stateManager, a.server, a.menuManager, a.logger)
 	a.syncManager.SetOnSync(func() {
 		a.instrumentation.NotifyMenus()
@@ -1606,6 +1617,10 @@ func (a *App) handleServerAction(serverName, action string) {
 	case "unquarantine":
 		err = a.syncManager.HandleServerUnquarantine(serverName)
 
+	case "switch_profile":
+		// Profiles v2 T5: serverName carries the profile slug ("" = all servers).
+		err = a.handleSwitchProfile(serverName)
+
 	default:
 		a.logger.Warn("Unknown server action requested", zap.String("action", action))
 	}
@@ -1616,6 +1631,26 @@ func (a *App) handleServerAction(serverName, action string) {
 			zap.String("action", action),
 			zap.Error(err))
 	}
+}
+
+// handleSwitchProfile sets the server-level default active profile via the core
+// REST surface (Profiles v2 T5) and triggers an immediate sync so the submenu's
+// title and checkmarks reflect the new selection without waiting for the next
+// poll. An empty slug clears the profile (all servers).
+func (a *App) handleSwitchProfile(slug string) error {
+	if a.server == nil {
+		return fmt.Errorf("server interface unavailable")
+	}
+	a.logger.Info("Switching active profile from tray", zap.String("profile", slug))
+	if err := a.server.SetActiveProfile(slug); err != nil {
+		return fmt.Errorf("failed to set active profile %q: %w", slug, err)
+	}
+	if a.syncManager != nil {
+		if err := a.syncManager.SyncNow(); err != nil {
+			a.logger.Debug("Profile switch sync refresh failed", zap.Error(err))
+		}
+	}
+	return nil
 }
 
 // handleOAuthLogin handles OAuth authentication for a server from the tray menu

--- a/internal/tray/tray_test.go
+++ b/internal/tray/tray_test.go
@@ -24,6 +24,8 @@ type MockServerInterface struct {
 	configPath                string
 	reloadConfigurationCalled bool
 	suggestedAddress          string
+	profiles                  []ProfileInfo
+	activeProfile             string
 }
 
 func NewMockServer() *MockServerInterface {
@@ -164,6 +166,19 @@ func (m *MockServerInterface) GetLogDir() string {
 func (m *MockServerInterface) TriggerOAuthLogin(serverName string) error {
 	// Simulate successful trigger without doing anything
 	_ = serverName
+	return nil
+}
+
+func (m *MockServerInterface) GetProfiles() ([]ProfileInfo, error) {
+	return m.profiles, nil
+}
+
+func (m *MockServerInterface) GetActiveProfile() (string, error) {
+	return m.activeProfile, nil
+}
+
+func (m *MockServerInterface) SetActiveProfile(name string) error {
+	m.activeProfile = name
 	return nil
 }
 

--- a/native/macos/MCPProxy/MCPProxy/API/APIClient.swift
+++ b/native/macos/MCPProxy/MCPProxy/API/APIClient.swift
@@ -153,6 +153,32 @@ actor APIClient {
         try await postAction(path: "/api/v1/servers/\(id)/login")
     }
 
+    // MARK: - Profiles (Profiles v2 T5)
+
+    /// List configured profiles from `GET /api/v1/profiles`.
+    func profiles() async throws -> [ProfileSummary] {
+        let response: ProfilesListResponse = try await fetchWrapped(path: "/api/v1/profiles")
+        return response.profiles
+    }
+
+    /// Get the server-level default active profile from
+    /// `GET /api/v1/profiles/active`. An empty string means "all servers".
+    func activeProfile() async throws -> String {
+        let response: ActiveProfileResponse = try await fetchWrapped(path: "/api/v1/profiles/active")
+        return response.activeProfile
+    }
+
+    /// Set the server-level default active profile via
+    /// `PUT /api/v1/profiles/active`. An empty slug clears the selection.
+    func setActiveProfile(_ slug: String) async throws {
+        let bodyData = try JSONSerialization.data(withJSONObject: ["profile": slug])
+        let (data, response) = try await performRequest(path: "/api/v1/profiles/active", method: "PUT", body: bodyData)
+        if let errorResponse = try? JSONDecoder().decode(APIErrorResponse.self, from: data),
+           !errorResponse.success, let message = errorResponse.error {
+            throw APIClientError.httpError(statusCode: response.statusCode, message: message)
+        }
+    }
+
     /// Quarantine a server via `POST /api/v1/servers/{id}/quarantine`.
     func quarantineServer(_ id: String) async throws {
         try await postAction(path: "/api/v1/servers/\(id)/quarantine")

--- a/native/macos/MCPProxy/MCPProxy/API/Models.swift
+++ b/native/macos/MCPProxy/MCPProxy/API/Models.swift
@@ -852,6 +852,39 @@ struct ServersListResponse: Codable {
     let servers: [ServerStatus]
 }
 
+// MARK: - Profiles (Profiles v2 T5)
+
+/// One configured profile, matching `httpapi.ProfileSummary` from
+/// `GET /api/v1/profiles`. A profile scopes tool discovery to a named subset of
+/// upstream servers.
+struct ProfileSummary: Codable, Identifiable, Equatable {
+    let name: String
+    let servers: [String]
+    let toolCount: Int
+
+    var id: String { name }
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case servers
+        case toolCount = "tool_count"
+    }
+}
+
+/// Response wrapper for `GET /api/v1/profiles`.
+struct ProfilesListResponse: Codable {
+    let profiles: [ProfileSummary]
+}
+
+/// Response wrapper for `GET|PUT /api/v1/profiles/active`.
+struct ActiveProfileResponse: Codable {
+    let activeProfile: String
+
+    enum CodingKeys: String, CodingKey {
+        case activeProfile = "active_profile"
+    }
+}
+
 // MARK: - Server Action Response
 
 /// Response for server action endpoints (enable, disable, restart, etc.).

--- a/native/macos/MCPProxy/MCPProxy/Core/CoreProcessManager.swift
+++ b/native/macos/MCPProxy/MCPProxy/Core/CoreProcessManager.swift
@@ -574,6 +574,13 @@ actor CoreProcessManager {
                 }
             }
 
+        case "active_profile.changed":
+            // Profiles v2 T5: the server-level default active profile was switched
+            // (possibly by another client). Refetch profiles + active so the tray
+            // submenu reflects it. The payload carries active_profile, but a
+            // refetch also picks up tool-count/profile-set changes uniformly.
+            await refreshProfiles()
+
         case "ping":
             // Keepalive; no action needed
             break
@@ -621,6 +628,7 @@ actor CoreProcessManager {
         await refreshSessions()
         await refreshTokenMetrics()
         await refreshSecurityStatus()
+        await refreshProfiles()
         // Bump activityVersion so ActivityView reloads
         // (SSE doesn't emit "activity" events, so periodic refresh is needed)
         await MainActor.run { appState.activityVersion += 1 }
@@ -688,6 +696,24 @@ actor CoreProcessManager {
     /// this is *not* the on-demand refresh path (that's been retired).
     func refreshServersForSafetyNet() async {
         await refreshServers()
+    }
+
+    /// Fetch the configured profiles + active profile and update appState
+    /// (Profiles v2 T5). Driven on connect, on the periodic refresh, and on the
+    /// `active_profile.changed` SSE event so a switch made by another client
+    /// (Web UI, CLI, the Go tray) is reflected in the macOS tray submenu.
+    func refreshProfiles() async {
+        guard let apiClient else { return }
+        do {
+            let profiles = try await apiClient.profiles()
+            let active = try await apiClient.activeProfile()
+            await MainActor.run {
+                if appState.profiles != profiles { appState.profiles = profiles }
+                if appState.activeProfile != active { appState.activeProfile = active }
+            }
+        } catch {
+            // Non-fatal; we'll retry on the next refresh or SSE event.
+        }
     }
 
     /// Fetch recent activity and update appState.

--- a/native/macos/MCPProxy/MCPProxy/MCPProxyApp.swift
+++ b/native/macos/MCPProxy/MCPProxy/MCPProxyApp.swift
@@ -697,6 +697,38 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate, NS
             menu.addItem(.separator())
         }
 
+        // Profile switcher (Profiles v2 T5) — only shown when profiles are
+        // configured. Lists "All servers" (clears the profile) plus each profile
+        // with its tool count; the active selection carries a checkmark. Clicking
+        // switches the server-level default active profile via REST; a switch made
+        // by another client arrives over SSE (`active_profile.changed`) and
+        // repaints this submenu.
+        if !appState.profiles.isEmpty {
+            let activeLabel = appState.activeProfile.isEmpty ? "All servers" : appState.activeProfile
+            let profileMenuItem = NSMenuItem(title: "Profile: \(activeLabel)", action: nil, keyEquivalent: "")
+            let profileSubmenu = NSMenu()
+
+            let allItem = NSMenuItem(title: "All servers", action: #selector(switchProfile(_:)), keyEquivalent: "")
+            allItem.target = self
+            allItem.representedObject = ""
+            allItem.state = appState.activeProfile.isEmpty ? .on : .off
+            profileSubmenu.addItem(allItem)
+            profileSubmenu.addItem(.separator())
+
+            for profile in appState.profiles {
+                let item = NSMenuItem(title: "\(profile.name) (\(profile.toolCount) tools)",
+                                      action: #selector(switchProfile(_:)), keyEquivalent: "")
+                item.target = self
+                item.representedObject = profile.name
+                item.state = profile.name == appState.activeProfile ? .on : .off
+                profileSubmenu.addItem(item)
+            }
+
+            profileMenuItem.submenu = profileSubmenu
+            menu.addItem(profileMenuItem)
+            menu.addItem(.separator())
+        }
+
         // Actions
         let addServer = NSMenuItem(title: "Add Server...", action: #selector(showAddServer), keyEquivalent: "n")
         addServer.target = self
@@ -873,6 +905,18 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate, NS
     @objc private func restartServer(_ sender: NSMenuItem) {
         guard let id = sender.representedObject as? String else { return }
         Task { try? await appState.apiClient?.restartServer(id) }
+    }
+
+    /// Switch the server-level default active profile (Profiles v2 T5). The
+    /// represented object is the profile slug ("" clears it / all servers). The
+    /// explicit refresh gives immediate feedback; the core also emits
+    /// `active_profile.changed` over SSE which repaints every client.
+    @objc private func switchProfile(_ sender: NSMenuItem) {
+        guard let slug = sender.representedObject as? String else { return }
+        Task {
+            try? await appState.apiClient?.setActiveProfile(slug)
+            await coreManager?.refreshProfiles()
+        }
     }
 
     @objc private func loginServer(_ sender: NSMenuItem) {

--- a/native/macos/MCPProxy/MCPProxy/State/AppState.swift
+++ b/native/macos/MCPProxy/MCPProxy/State/AppState.swift
@@ -46,6 +46,12 @@ final class AppState: ObservableObject {
     @Published var totalServers: Int = 0
     @Published var totalTools: Int = 0
 
+    // MARK: - Profiles (Profiles v2 T5)
+    /// Configured profiles for the tray profile switcher.
+    @Published var profiles: [ProfileSummary] = []
+    /// Server-level default active profile slug; empty means "all servers".
+    @Published var activeProfile: String = ""
+
     /// Set to true once the tray has received its first response from
     /// `/api/v1/servers`. Used by `statusSummary` to distinguish "haven't
     /// fetched yet" from "fetched and the list is genuinely empty", so the

--- a/native/macos/MCPProxy/MCPProxyTests/ProfileModelsTests.swift
+++ b/native/macos/MCPProxy/MCPProxyTests/ProfileModelsTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import MCPProxy
+
+/// Decoding tests for the Profiles v2 T5 tray switcher models. The JSON mirrors
+/// the wire shape produced by the Go REST handlers `GET /api/v1/profiles` and
+/// `GET|PUT /api/v1/profiles/active` (see internal/httpapi/profiles.go).
+final class ProfileModelsTests: XCTestCase {
+
+    private func decode<T: Decodable>(_ type: T.Type, from jsonString: String) throws -> T {
+        let data = jsonString.data(using: .utf8)!
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    func testDecodeProfilesListResponse() throws {
+        let json = """
+        {
+            "profiles": [
+                {"name": "research", "servers": ["research-srv"], "tool_count": 3},
+                {"name": "deploy", "servers": ["deploy-srv", "ci-srv"], "tool_count": 5}
+            ]
+        }
+        """
+        let resp = try decode(ProfilesListResponse.self, from: json)
+        XCTAssertEqual(resp.profiles.count, 2)
+        XCTAssertEqual(resp.profiles[0].name, "research")
+        XCTAssertEqual(resp.profiles[0].servers, ["research-srv"])
+        XCTAssertEqual(resp.profiles[0].toolCount, 3)
+        XCTAssertEqual(resp.profiles[1].toolCount, 5)
+        // Identifiable id is the slug, so SwiftUI/menu keys stay stable.
+        XCTAssertEqual(resp.profiles[1].id, "deploy")
+    }
+
+    func testDecodeActiveProfileResponse() throws {
+        let set = try decode(ActiveProfileResponse.self, from: #"{"active_profile": "research"}"#)
+        XCTAssertEqual(set.activeProfile, "research")
+
+        // Empty string is the valid "all servers" sentinel, not nil.
+        let cleared = try decode(ActiveProfileResponse.self, from: #"{"active_profile": ""}"#)
+        XCTAssertEqual(cleared.activeProfile, "")
+    }
+
+    func testProfileSummaryEquatableDrivesMenuRefresh() throws {
+        // AppState only repaints when the decoded profile set actually changes;
+        // equality must be value-based for that guard to work.
+        let a = ProfileSummary(name: "research", servers: ["s1"], toolCount: 3)
+        let b = ProfileSummary(name: "research", servers: ["s1"], toolCount: 3)
+        let c = ProfileSummary(name: "research", servers: ["s1"], toolCount: 4)
+        XCTAssertEqual(a, b)
+        XCTAssertNotEqual(a, c)
+    }
+}

--- a/native/macos/MCPProxy/Package.resolved
+++ b/native/macos/MCPProxy/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
+        "version" : "2.9.3"
+      }
+    }
+  ],
+  "version" : 2
+}


### PR DESCRIPTION
## Profiles v2 T5 — tray profile switcher parity (MCP-3244)

Adds a **profile switcher** to both trays plus the backend SSE event that keeps every client in sync. The tray holds no state — it lists/switches profiles purely through the REST surface from MCP-3241 (`GET /api/v1/profiles`, `GET|PUT /api/v1/profiles/active`).

### Commits
1. **Backend** (`1c2a52eb`) — `PUT /api/v1/profiles/active` now emits an `active_profile.changed` runtime/SSE event on an actual change, so UI surfaces refetch and reflect a switch made by another client. Emitted via an optional capability assertion so `ServerController` isn't widened (no mock fan-out).
2. **Go tray** (`ffdcc3a5`) — cross-platform systray (macOS/Windows/Linux): a `Profile` submenu listing `All servers` + each configured profile (with tool counts); the active one is checkmarked; clicking switches via REST. Refreshes on the existing 3 s sync loop — consistent with how the REST-adapter tray already reflects server/quarantine changes (its `EventsChannel` is nil; it doesn't proxy runtime events).
3. **Swift macOS tray** (`f6f85c0d`) — native AppKit `Profile` submenu with the same UX; `CoreProcessManager.refreshProfiles` runs on connect, on the periodic refresh, and on the `active_profile.changed` **SSE** event for real-time reflection.

### Design notes
- **SSE reflection split (honest):** the Swift macOS tray consumes SSE directly, so it gets real-time `active_profile.changed` updates. The Go systray tray's REST adapter does not proxy runtime events at all (`EventsChannel()` returns `nil`); like every other section of that menu it reflects other-client changes via the 3 s poll (≤3 s latency). Wiring a full SSE→runtime-event bridge into the adapter was out of scope for this stretch item.
- Profile submenu is only shown when at least one profile is configured.

### Tests / DoD
- Go: `TestSetActiveProfileEmitsChangeEvent` (change-only emit), `profileMenuTitle`/`profileSetChanged`, `performSync` profile refresh, `ServerAdapter` profile delegation. `httpapi`/`runtime`/`tray`/`api` all green under `-race`; cross-builds darwin/windows/linux; `golangci-lint` v2 (CI config) → 0 issues; no swagger drift.
- Swift: `ProfileModelsTests` (decode + Equatable); `swift build` + `swift test` green.
- **Remaining gate:** `mcpproxy-ui-test` menu verification (per `docs/development/macos-tray.md`) + CodexReviewer + QATester.

> Note: `internal/server` `TestCodeExecClientModeE2E` fails locally ("socket not ready after 15s") — **verified pre-existing on clean `origin/main`** (env/load flake in the daemon-subprocess E2E), unrelated to this change.
