### PR TITLE
feat(security): US2 Unified report + cross-scanner consensus confidence (Spec 077)

### DIFF
--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -66,6 +66,11 @@ export interface SecurityScanFinding {
   scan_pass?: number            // 1 = security scan, 2 = supply chain audit
   evidence?: string             // Text/content that triggered the finding
   supply_chain_audit?: boolean  // True for real CVE/package findings — routes to the Supply Chain (CVEs) section regardless of scan_pass
+  // Spec 077 unified report — additive fields.
+  sources?: string[]            // Contributing scanner ids; ≥2 means scanners agreed (consensus)
+  tier?: string                 // "hard" (gates approval) | "soft" (review-only)
+  confidence?: number           // 0.0–1.0; raised when independent sources agree
+  signals?: string[]            // Deterministic detect check ids that fired
 }
 
 export interface SecurityScanReport {

--- a/frontend/src/views/ScanReport.vue
+++ b/frontend/src/views/ScanReport.vue
@@ -188,8 +188,18 @@
                   >
                     {{ finding.threat_level }}
                   </span>
+                  <span v-if="finding.severity" class="badge badge-xs badge-outline shrink-0 uppercase">
+                    {{ finding.severity }}
+                  </span>
                   <span class="font-medium text-sm flex-1">
                     {{ finding.rule_id || finding.title }}
+                  </span>
+                  <span
+                    v-if="findingHasConsensus(finding)"
+                    class="badge badge-xs badge-primary badge-outline shrink-0"
+                    :title="`Flagged independently by ${findingSources(finding).length} scanners`"
+                  >
+                    consensus &times;{{ findingSources(finding).length }}
                   </span>
                   <span v-if="finding.package_name" class="font-mono text-xs text-base-content/50">
                     {{ finding.package_name }}
@@ -229,9 +239,9 @@
                         <span class="text-base-content/50">Location:</span>
                         <code class="ml-1 bg-base-300 px-1 rounded">{{ finding.location }}</code>
                       </div>
-                      <div v-if="finding.scanner">
-                        <span class="text-base-content/50">Scanner:</span>
-                        <span class="ml-1">{{ scannerDisplayName(finding.scanner) }}</span>
+                      <div v-if="findingSources(finding).length">
+                        <span class="text-base-content/50">{{ findingSources(finding).length > 1 ? 'Sources:' : 'Source:' }}</span>
+                        <span class="ml-1">{{ findingSourcesLabel(finding) }}</span>
                       </div>
                     </div>
                     <a
@@ -285,8 +295,18 @@
                   >
                     {{ finding.threat_level }}
                   </span>
+                  <span v-if="finding.severity" class="badge badge-xs badge-outline shrink-0 uppercase">
+                    {{ finding.severity }}
+                  </span>
                   <span class="font-medium text-sm flex-1">
                     {{ finding.rule_id || finding.title }}
+                  </span>
+                  <span
+                    v-if="findingHasConsensus(finding)"
+                    class="badge badge-xs badge-primary badge-outline shrink-0"
+                    :title="`Flagged independently by ${findingSources(finding).length} scanners`"
+                  >
+                    consensus &times;{{ findingSources(finding).length }}
                   </span>
                   <span v-if="finding.package_name" class="font-mono text-xs text-base-content/50">
                     {{ finding.package_name }}
@@ -325,9 +345,9 @@
                         <span class="text-base-content/50">Location:</span>
                         <code class="ml-1 bg-base-300 px-1 rounded">{{ finding.location }}</code>
                       </div>
-                      <div v-if="finding.scanner">
-                        <span class="text-base-content/50">Scanner:</span>
-                        <span class="ml-1">{{ scannerDisplayName(finding.scanner) }}</span>
+                      <div v-if="findingSources(finding).length">
+                        <span class="text-base-content/50">{{ findingSources(finding).length > 1 ? 'Sources:' : 'Source:' }}</span>
+                        <span class="ml-1">{{ findingSourcesLabel(finding) }}</span>
                       </div>
                     </div>
                     <a
@@ -613,6 +633,24 @@ const scannerNames: Record<string, string> = {
 
 function scannerDisplayName(id: string): string {
   return scannerNames[id] || id
+}
+
+// Spec 077 unified report — a finding's contributing sources. Prefers the
+// merged `sources` list; falls back to the single `scanner` id for legacy
+// findings that predate multi-source attribution.
+function findingSources(finding: SecurityScanFinding): string[] {
+  if (finding.sources && finding.sources.length > 0) return finding.sources
+  if (finding.scanner) return [finding.scanner]
+  return []
+}
+
+// True when ≥2 independent scanners agreed on a finding (consensus).
+function findingHasConsensus(finding: SecurityScanFinding): boolean {
+  return findingSources(finding).length > 1
+}
+
+function findingSourcesLabel(finding: SecurityScanFinding): string {
+  return findingSources(finding).map(scannerDisplayName).join(', ')
 }
 
 // Scan context from the aggregated report (populated from job's ScanContext)

--- a/internal/security/scanner/engine.go
+++ b/internal/security/scanner/engine.go
@@ -766,8 +766,16 @@ func AggregateReports(jobID, serverName string, reports []*ScanReport) *Aggregat
 		agg.Reports = append(agg.Reports, *r)
 	}
 
-	// Classify findings that lack threat_type/threat_level (legacy data)
+	// Classify findings that lack threat_type/threat_level (legacy data). This
+	// must run before MergeFindings so consensus (which keys on threat_type) and
+	// severity backfill see fully-classified findings.
 	ClassifyAllFindings(agg.Findings)
+
+	// Spec 077 (T021, FR-010/FR-011/FR-012): collapse the per-scanner findings
+	// into a single unified list. Findings sharing (rule_id, location) merge into
+	// one entry whose Sources lists every contributing scanner; cross-source
+	// agreement on the same (location, threat_type) raises confidence.
+	agg.Findings = MergeFindings(agg.Findings)
 
 	// Flag findings that belong in the Supply Chain Audit (CVEs) UI section.
 	// Match only real CVE/package vulnerabilities so AI-scanner output from Pass 2

--- a/internal/security/scanner/sarif.go
+++ b/internal/security/scanner/sarif.go
@@ -4,9 +4,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"sort"
 	"strconv"
 	"strings"
 )
+
+// consensusConfidenceStep is how much each additional independent source raises
+// a finding's confidence when scanners agree on the same (location,
+// threat_type). Additive and capped at 1.0 (Spec 077 FR-012).
+const consensusConfidenceStep = 0.15
 
 // SARIF 2.1.0 types for parsing scanner output
 
@@ -275,25 +281,43 @@ func CalculateRiskScore(findings []ScanFinding) int {
 		return 0
 	}
 
-	// Deduplicate: group by (rule_id + location) to avoid triple-counting
-	// when multiple scanners report the same issue.
+	// Precompute cross-source consensus: for each (location, threat_type) with a
+	// non-empty threat_type, the set of distinct sources that independently
+	// flagged it. Two different scanners agreeing on the same issue — even via
+	// different rule ids — is consensus and raises the weight (Spec 077 FR-012,
+	// T020). External/Docker findings that used to flatten to weight 1 now ADD.
+	// An empty threat_type cannot form consensus and keeps the legacy per-rule
+	// dedup (so existing single-scanner scoring is unchanged).
+	type consensusKey struct{ location, threatType string }
+	groupSources := make(map[consensusKey]map[string]struct{})
+	for i := range findings {
+		f := &findings[i]
+		if f.ThreatType == "" {
+			continue
+		}
+		ck := consensusKey{f.Location, f.ThreatType}
+		set := groupSources[ck]
+		if set == nil {
+			set = make(map[string]struct{})
+			groupSources[ck] = set
+		}
+		for _, s := range findingSources(*f) {
+			set[s] = struct{}{}
+		}
+	}
+
+	// Deduplicate for scoring:
+	//   - legacy: group by (rule_id, location) to avoid triple-counting the same
+	//     rule reported by multiple scanners (unchanged behavior).
+	//   - consensus: when ≥2 distinct sources agree on the same (location,
+	//     threat_type), count that issue ONCE weighted by the number of agreeing
+	//     sources, so agreement raises the score without double-counting.
 	type dedupKey struct{ ruleID, location string }
 	seen := make(map[dedupKey]bool)
+	seenConsensus := make(map[consensusKey]bool)
 	var dangerousCount, warningCount, infoCount int
 
-	for _, f := range findings {
-		key := dedupKey{f.RuleID, f.Location}
-		if key.ruleID != "" && seen[key] {
-			continue // Skip duplicate finding
-		}
-		if key.ruleID != "" {
-			seen[key] = true
-		}
-
-		// Consensus weight: independent signals on one tool ADD to the score
-		// (FR-006). A single-signal or signal-less finding weighs 1.
-		weight := consensusWeight(f)
-
+	addWeight := func(f *ScanFinding, weight int) {
 		switch f.ThreatLevel {
 		case ThreatLevelDangerous:
 			dangerousCount += weight
@@ -314,6 +338,41 @@ func CalculateRiskScore(findings []ScanFinding) int {
 				infoCount += weight
 			}
 		}
+	}
+
+	for i := range findings {
+		f := &findings[i]
+
+		// Cross-source consensus path: only when ≥2 distinct sources agree on a
+		// classified (location, threat_type). Counted once, weighted by agreement.
+		if f.ThreatType != "" {
+			ck := consensusKey{f.Location, f.ThreatType}
+			if n := len(groupSources[ck]); n >= 2 {
+				if seenConsensus[ck] {
+					continue
+				}
+				seenConsensus[ck] = true
+				weight := consensusWeight(*f)
+				if n > weight {
+					weight = n
+				}
+				addWeight(f, weight)
+				continue
+			}
+		}
+
+		// Legacy per-rule dedup (single source, or unclassified findings).
+		key := dedupKey{f.RuleID, f.Location}
+		if key.ruleID != "" && seen[key] {
+			continue // Skip duplicate finding
+		}
+		if key.ruleID != "" {
+			seen[key] = true
+		}
+
+		// Consensus weight: independent signals on one tool ADD to the score
+		// (Spec 076 FR-006). A single-signal or signal-less finding weighs 1.
+		addWeight(f, consensusWeight(*f))
 	}
 
 	// Logarithmic diminishing returns: score = weight * log2(1 + count)
@@ -350,6 +409,114 @@ func consensusWeight(f ScanFinding) int {
 		return n
 	}
 	return 1
+}
+
+// findingSources returns the contributing scanner ids for a finding, preferring
+// the explicit Sources list (Spec 077) and falling back to the single Scanner
+// id for legacy findings that predate multi-source attribution.
+func findingSources(f ScanFinding) []string {
+	if len(f.Sources) > 0 {
+		return f.Sources
+	}
+	if f.Scanner != "" {
+		return []string{f.Scanner}
+	}
+	return nil
+}
+
+// sortedUnion returns the deduplicated, sorted union of the given source id
+// slices, dropping empty strings. Returns nil when the union is empty so the
+// JSON `sources` field stays omitted for legacy findings.
+func sortedUnion(lists ...[]string) []string {
+	set := make(map[string]struct{})
+	for _, list := range lists {
+		for _, s := range list {
+			if s != "" {
+				set[s] = struct{}{}
+			}
+		}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for s := range set {
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// MergeFindings collapses findings from every scanner into a single unified list
+// (Spec 077 FR-010/FR-011). Findings sharing a (rule_id, location) merge into one
+// entry whose Sources lists every contributing scanner. When ≥2 distinct sources
+// independently agree on the same (location, threat_type) — even via different
+// rule ids — each agreeing finding's Confidence is raised to reflect that
+// consensus (FR-012). Findings with an empty rule_id are never merged (each is
+// treated as a distinct issue) but still carry populated Sources.
+//
+// Order is preserved (first occurrence wins) so the report is stable.
+func MergeFindings(findings []ScanFinding) []ScanFinding {
+	result := make([]ScanFinding, 0, len(findings))
+
+	// Phase 1 — dedup by (rule_id, location); union contributing sources.
+	type key struct{ ruleID, location string }
+	index := make(map[key]int)
+	for i := range findings {
+		f := findings[i]
+		srcs := findingSources(f)
+		if f.RuleID == "" {
+			f.Sources = sortedUnion(f.Sources, srcs)
+			result = append(result, f)
+			continue
+		}
+		k := key{f.RuleID, f.Location}
+		if pos, ok := index[k]; ok {
+			result[pos].Sources = sortedUnion(result[pos].Sources, srcs)
+			continue
+		}
+		f.Sources = sortedUnion(f.Sources, srcs)
+		index[k] = len(result)
+		result = append(result, f)
+	}
+
+	// Phase 2 — consensus confidence boost by (location, threat_type).
+	type ckey struct{ location, threatType string }
+	group := make(map[ckey]map[string]struct{})
+	for i := range result {
+		f := &result[i]
+		if f.ThreatType == "" {
+			continue
+		}
+		ck := ckey{f.Location, f.ThreatType}
+		set := group[ck]
+		if set == nil {
+			set = make(map[string]struct{})
+			group[ck] = set
+		}
+		for _, s := range f.Sources {
+			set[s] = struct{}{}
+		}
+	}
+	for i := range result {
+		f := &result[i]
+		if f.ThreatType == "" {
+			continue
+		}
+		n := len(group[ckey{f.Location, f.ThreatType}])
+		if n < 2 {
+			continue
+		}
+		boosted := f.Confidence + consensusConfidenceStep*float64(n-1)
+		if boosted > 1.0 {
+			boosted = 1.0
+		}
+		if boosted > f.Confidence {
+			f.Confidence = boosted
+		}
+	}
+
+	return result
 }
 
 // SummarizeFindings produces a ReportSummary from findings
@@ -403,6 +570,13 @@ func parsePackageFromMessage(msg string) (pkg, installed, fixed string) {
 // ClassifyThreat assigns user-facing threat_type and threat_level to a finding
 // based on rule ID, category, description, and severity.
 func ClassifyThreat(f *ScanFinding) {
+	// Spec 077 (T022): guarantee every finding leaves classification with a
+	// user-readable severity. External/legacy SARIF findings sometimes arrive
+	// with no severity; backfill it from the classified threat level so the
+	// unified report never shows a blank severity. An explicit severity is
+	// preserved.
+	defer backfillSeverity(f)
+
 	ruleLC := strings.ToLower(f.RuleID)
 	catLC := strings.ToLower(f.Category)
 	titleLC := strings.ToLower(f.Title)
@@ -471,6 +645,25 @@ func ClassifyThreat(f *ScanFinding) {
 		f.ThreatLevel = ThreatLevelWarning
 	} else {
 		f.ThreatLevel = ThreatLevelInfo
+	}
+}
+
+// backfillSeverity derives a severity from the finding's classified threat
+// level when none was supplied, so every finding in the unified report carries a
+// clear severity (Spec 077 FR-013 / T022). Never overwrites an explicit value.
+func backfillSeverity(f *ScanFinding) {
+	if f.Severity != "" {
+		return
+	}
+	switch f.ThreatLevel {
+	case ThreatLevelDangerous:
+		f.Severity = SeverityHigh
+	case ThreatLevelWarning:
+		f.Severity = SeverityMedium
+	case ThreatLevelInfo:
+		f.Severity = SeverityInfo
+	default:
+		f.Severity = SeverityMedium
 	}
 }
 

--- a/internal/security/scanner/sarif.go
+++ b/internal/security/scanner/sarif.go
@@ -290,6 +290,13 @@ func CalculateRiskScore(findings []ScanFinding) int {
 	// dedup (so existing single-scanner scoring is unchanged).
 	type consensusKey struct{ location, threatType string }
 	groupSources := make(map[consensusKey]map[string]struct{})
+	// A consensus group is scored ONCE, at the MOST-SEVERE threat category among
+	// all agreeing findings (not whichever is encountered first) and at the
+	// MAX per-finding weight — so the score is order-independent even when
+	// severity-derived threat_types (supply_chain, uncategorized, the
+	// malicious_code fallback) put different threat_levels on agreeing findings.
+	groupMaxCat := make(map[consensusKey]int)
+	groupMaxWeight := make(map[consensusKey]int)
 	for i := range findings {
 		f := &findings[i]
 		if f.ThreatType == "" {
@@ -304,6 +311,12 @@ func CalculateRiskScore(findings []ScanFinding) int {
 		for _, s := range findingSources(*f) {
 			set[s] = struct{}{}
 		}
+		if cat := threatCategory(f); cat > groupMaxCat[ck] {
+			groupMaxCat[ck] = cat
+		}
+		if w := consensusWeight(*f); w > groupMaxWeight[ck] {
+			groupMaxWeight[ck] = w
+		}
 	}
 
 	// Deduplicate for scoring:
@@ -317,26 +330,14 @@ func CalculateRiskScore(findings []ScanFinding) int {
 	seenConsensus := make(map[consensusKey]bool)
 	var dangerousCount, warningCount, infoCount int
 
-	addWeight := func(f *ScanFinding, weight int) {
-		switch f.ThreatLevel {
-		case ThreatLevelDangerous:
+	addWeight := func(category, weight int) {
+		switch category {
+		case threatCatDangerous:
 			dangerousCount += weight
-		case ThreatLevelWarning:
+		case threatCatWarning:
 			warningCount += weight
-		case ThreatLevelInfo:
+		case threatCatInfo:
 			infoCount += weight
-		default:
-			// Unclassified: use severity as fallback
-			switch f.Severity {
-			case SeverityCritical:
-				dangerousCount += weight
-			case SeverityHigh:
-				warningCount += weight
-			case SeverityMedium:
-				warningCount += weight
-			case SeverityLow:
-				infoCount += weight
-			}
 		}
 	}
 
@@ -344,7 +345,9 @@ func CalculateRiskScore(findings []ScanFinding) int {
 		f := &findings[i]
 
 		// Cross-source consensus path: only when ≥2 distinct sources agree on a
-		// classified (location, threat_type). Counted once, weighted by agreement.
+		// classified (location, threat_type). Counted once, at the most-severe
+		// category and max weight of the whole group so the result is
+		// order-independent (not the first finding encountered).
 		if f.ThreatType != "" {
 			ck := consensusKey{f.Location, f.ThreatType}
 			if n := len(groupSources[ck]); n >= 2 {
@@ -352,11 +355,11 @@ func CalculateRiskScore(findings []ScanFinding) int {
 					continue
 				}
 				seenConsensus[ck] = true
-				weight := consensusWeight(*f)
+				weight := groupMaxWeight[ck]
 				if n > weight {
 					weight = n
 				}
-				addWeight(f, weight)
+				addWeight(groupMaxCat[ck], weight)
 				continue
 			}
 		}
@@ -372,7 +375,7 @@ func CalculateRiskScore(findings []ScanFinding) int {
 
 		// Consensus weight: independent signals on one tool ADD to the score
 		// (Spec 076 FR-006). A single-signal or signal-less finding weighs 1.
-		addWeight(f, consensusWeight(*f))
+		addWeight(threatCategory(f), consensusWeight(*f))
 	}
 
 	// Logarithmic diminishing returns: score = weight * log2(1 + count)
@@ -398,6 +401,41 @@ func CalculateRiskScore(findings []ScanFinding) int {
 	return score
 }
 
+// Threat categories rank a finding's contribution to the risk score. Higher is
+// more severe; threatCatNone (the zero value) is not counted, so a group whose
+// members are all unclassified keeps the map default without spuriously scoring.
+const (
+	threatCatNone = iota
+	threatCatInfo
+	threatCatWarning
+	threatCatDangerous
+)
+
+// threatCategory maps a finding to its risk bucket, preferring the explicit
+// user-facing ThreatLevel and falling back to CVSS severity for unclassified
+// findings. It mirrors the previous inline switch in addWeight so legacy scoring
+// is unchanged; extracting it lets a consensus group be scored at the
+// most-severe member instead of whichever finding is encountered first.
+func threatCategory(f *ScanFinding) int {
+	switch f.ThreatLevel {
+	case ThreatLevelDangerous:
+		return threatCatDangerous
+	case ThreatLevelWarning:
+		return threatCatWarning
+	case ThreatLevelInfo:
+		return threatCatInfo
+	}
+	switch f.Severity {
+	case SeverityCritical:
+		return threatCatDangerous
+	case SeverityHigh, SeverityMedium:
+		return threatCatWarning
+	case SeverityLow:
+		return threatCatInfo
+	}
+	return threatCatNone
+}
+
 // consensusWeight returns how much a single (deduplicated) finding contributes
 // to its risk category. The deterministic scanner (Spec 076) aggregates every
 // independent check that fired on a tool into one finding's Signals list, so a
@@ -409,6 +447,19 @@ func consensusWeight(f ScanFinding) int {
 		return n
 	}
 	return 1
+}
+
+// tierRank orders finding tiers so the more-severe tier wins on merge:
+// hard > soft > empty/unknown.
+func tierRank(tier string) int {
+	switch tier {
+	case TierHard:
+		return 2
+	case TierSoft:
+		return 1
+	default:
+		return 0
+	}
 }
 
 // findingSources returns the contributing scanner ids for a finding, preferring
@@ -473,6 +524,18 @@ func MergeFindings(findings []ScanFinding) []ScanFinding {
 		k := key{f.RuleID, f.Location}
 		if pos, ok := index[k]; ok {
 			result[pos].Sources = sortedUnion(result[pos].Sources, srcs)
+			// Absorb the duplicate's stronger fields (Spec 077): keep the
+			// higher confidence, the more-severe tier (hard > soft), and the
+			// union of signals — otherwise merging a hard/high-confidence
+			// finding with a same-(rule_id,location) soft/low-confidence
+			// duplicate would silently drop the hard tier and confidence.
+			if f.Confidence > result[pos].Confidence {
+				result[pos].Confidence = f.Confidence
+			}
+			if tierRank(f.Tier) > tierRank(result[pos].Tier) {
+				result[pos].Tier = f.Tier
+			}
+			result[pos].Signals = sortedUnion(result[pos].Signals, f.Signals)
 			continue
 		}
 		f.Sources = sortedUnion(f.Sources, srcs)

--- a/internal/security/scanner/sarif_test.go
+++ b/internal/security/scanner/sarif_test.go
@@ -424,6 +424,86 @@ func TestCalculateRiskScoreCrossSourceConsensusAdds(t *testing.T) {
 	}
 }
 
+// TestCalculateRiskScoreConsensusUsesMaxSeverity proves the consensus group is
+// scored at its MOST-SEVERE member's threat level, not whichever finding is
+// encountered first. For severity-derived threat_types (supply_chain here)
+// agreeing findings can carry different threat_levels; the previous code counted
+// the group at the first finding's level, making the score order-dependent and
+// able to drop a genuine warning. The score must be identical in both orders and
+// reflect the warning (high) member, not the info (low) one.
+func TestCalculateRiskScoreConsensusUsesMaxSeverity(t *testing.T) {
+	warningFinding := ScanFinding{
+		RuleID:      "trivy.CVE-1",
+		Location:    "srv:tool",
+		ThreatType:  ThreatSupplyChain,
+		ThreatLevel: ThreatLevelWarning,
+		Severity:    SeverityHigh,
+		Scanner:     "trivy",
+	}
+	infoFinding := ScanFinding{
+		RuleID:      "grype.CVE-2",
+		Location:    "srv:tool",
+		ThreatType:  ThreatSupplyChain,
+		ThreatLevel: ThreatLevelInfo,
+		Severity:    SeverityLow,
+		Scanner:     "grype",
+	}
+
+	ab := CalculateRiskScore([]ScanFinding{warningFinding, infoFinding})
+	ba := CalculateRiskScore([]ScanFinding{infoFinding, warningFinding})
+
+	if ab != ba {
+		t.Fatalf("consensus score is order-dependent: [warning,info]=%d [info,warning]=%d", ab, ba)
+	}
+	// Two distinct sources agree → weight 2 at the warning level: 6*log2(3)=9.
+	// Scoring at the info level (the bug) would give 2*log2(3)=3.
+	if ab != 9 {
+		t.Errorf("consensus score = %d, want 9 (warning-level, 2 sources)", ab)
+	}
+}
+
+// TestMergeFindingsAbsorbsStrongerFields proves that phase-1 dedup keeps the
+// absorbed duplicate's stronger fields: on merge the result takes max(Confidence),
+// the more-severe Tier (hard > soft), and the union of Signals — regardless of
+// which finding is encountered first.
+func TestMergeFindingsAbsorbsStrongerFields(t *testing.T) {
+	hard := ScanFinding{
+		RuleID: "detect.tpa", Location: "srv:tool",
+		Tier: TierHard, Confidence: 0.9, Signals: []string{"unicode.hidden"},
+		Scanner: "tpa-descriptions",
+	}
+	soft := ScanFinding{
+		RuleID: "detect.tpa", Location: "srv:tool",
+		Tier: TierSoft, Confidence: 0.2, Signals: []string{"directive.imperative"},
+		Scanner: "cisco-mcp-scanner",
+	}
+
+	for _, tc := range []struct {
+		name string
+		in   []ScanFinding
+	}{
+		{"soft-first", []ScanFinding{soft, hard}},
+		{"hard-first", []ScanFinding{hard, soft}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			merged := MergeFindings(tc.in)
+			if len(merged) != 1 {
+				t.Fatalf("expected 1 merged finding, got %d: %+v", len(merged), merged)
+			}
+			m := merged[0]
+			if m.Tier != TierHard {
+				t.Errorf("merged tier = %q, want hard (more-severe tier must win)", m.Tier)
+			}
+			if m.Confidence != 0.9 {
+				t.Errorf("merged confidence = %v, want 0.9 (max)", m.Confidence)
+			}
+			if len(m.Signals) != 2 {
+				t.Errorf("merged signals = %v, want union of both (2)", m.Signals)
+			}
+		})
+	}
+}
+
 // TestClassifyThreatBackfillsSeverity proves Spec 077 (T022): a finding that
 // arrives with no severity (as some external/legacy SARIF findings do) is given
 // a user-readable severity derived from its classified threat level.

--- a/internal/security/scanner/sarif_test.go
+++ b/internal/security/scanner/sarif_test.go
@@ -336,6 +336,135 @@ func TestCalculateRiskScoreCrossScannerDedupRetained(t *testing.T) {
 	}
 }
 
+// TestMergeFindingsDedupByRuleAndLocation proves Spec 077 FR-010/FR-011: two
+// scanners reporting the same issue (same rule_id + location) collapse into a
+// single unified entry whose Sources lists every contributing scanner.
+func TestMergeFindingsDedupByRuleAndLocation(t *testing.T) {
+	findings := []ScanFinding{
+		{RuleID: "detect.tpa", Location: "srv:tool", ThreatType: ThreatToolPoisoning, ThreatLevel: ThreatLevelDangerous, Scanner: "tpa-descriptions", Sources: []string{"tpa-descriptions"}},
+		{RuleID: "detect.tpa", Location: "srv:tool", ThreatType: ThreatToolPoisoning, ThreatLevel: ThreatLevelDangerous, Scanner: "cisco-mcp-scanner", Sources: []string{"cisco-mcp-scanner"}},
+	}
+
+	merged := MergeFindings(findings)
+	if len(merged) != 1 {
+		t.Fatalf("expected exactly 1 merged finding, got %d: %+v", len(merged), merged)
+	}
+	if len(merged[0].Sources) != 2 {
+		t.Fatalf("expected merged finding to carry 2 sources, got %v", merged[0].Sources)
+	}
+	// Sources must be a stable (sorted) union so the wire output is deterministic.
+	if merged[0].Sources[0] != "cisco-mcp-scanner" || merged[0].Sources[1] != "tpa-descriptions" {
+		t.Errorf("expected sorted sources [cisco-mcp-scanner tpa-descriptions], got %v", merged[0].Sources)
+	}
+}
+
+// TestMergeFindingsConsensusBoostsConfidence proves Spec 077 FR-012: when two
+// independent sources agree on the same (location, threat_type) — even via
+// different rule ids — the merged finding's confidence rises above the
+// single-source confidence.
+func TestMergeFindingsConsensusBoostsConfidence(t *testing.T) {
+	single := MergeFindings([]ScanFinding{
+		{RuleID: "detect.tpa", Location: "srv:tool", ThreatType: ThreatToolPoisoning, ThreatLevel: ThreatLevelDangerous, Scanner: "tpa-descriptions", Confidence: 0.6},
+	})
+	if len(single) != 1 {
+		t.Fatalf("expected 1 finding for single source, got %d", len(single))
+	}
+	singleConf := single[0].Confidence
+
+	consensus := MergeFindings([]ScanFinding{
+		{RuleID: "detect.tpa", Location: "srv:tool", ThreatType: ThreatToolPoisoning, ThreatLevel: ThreatLevelDangerous, Scanner: "tpa-descriptions", Confidence: 0.6},
+		{RuleID: "cisco.poison", Location: "srv:tool", ThreatType: ThreatToolPoisoning, ThreatLevel: ThreatLevelDangerous, Scanner: "cisco-mcp-scanner", Confidence: 0.5},
+	})
+
+	// The tpa-descriptions finding (same rule as the single-source case) must be
+	// boosted by the agreement of the second, independent source.
+	var boosted float64
+	found := false
+	for _, f := range consensus {
+		if f.RuleID == "detect.tpa" {
+			boosted = f.Confidence
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected detect.tpa finding to survive merge, got %+v", consensus)
+	}
+	if boosted <= singleConf {
+		t.Errorf("consensus confidence %v must exceed single-source confidence %v", boosted, singleConf)
+	}
+}
+
+// TestCalculateRiskScoreCrossSourceConsensusAdds proves Spec 077 (T020): two
+// independent external/Docker scanners agreeing on the same (location,
+// threat_type) via different rule ids ADD to the consensus weight instead of
+// each flattening to weight 1, so the score exceeds a single-source scan.
+func TestCalculateRiskScoreCrossSourceConsensusAdds(t *testing.T) {
+	single := []ScanFinding{
+		{RuleID: "cisco.x", Location: "srv:tool", ThreatType: ThreatToolPoisoning, ThreatLevel: ThreatLevelDangerous, Scanner: "cisco-mcp-scanner"},
+	}
+	consensus := []ScanFinding{
+		{RuleID: "cisco.x", Location: "srv:tool", ThreatType: ThreatToolPoisoning, ThreatLevel: ThreatLevelDangerous, Scanner: "cisco-mcp-scanner"},
+		{RuleID: "ramparts.y", Location: "srv:tool", ThreatType: ThreatToolPoisoning, ThreatLevel: ThreatLevelDangerous, Scanner: "ramparts"},
+	}
+
+	singleScore := CalculateRiskScore(single)
+	consensusScore := CalculateRiskScore(consensus)
+
+	// single: one dangerous, one source → weight 1 → 25*log2(2)=25
+	if singleScore != 25 {
+		t.Errorf("single-source score = %d, want 25", singleScore)
+	}
+	// consensus: one issue (location+threat_type), two distinct sources → weight
+	// 2 → 25*log2(3)=39. Counted once (not double), but heavier than single.
+	if consensusScore != 39 {
+		t.Errorf("cross-source consensus score = %d, want 39", consensusScore)
+	}
+	if consensusScore <= singleScore {
+		t.Errorf("consensus score %d must exceed single-source score %d", consensusScore, singleScore)
+	}
+}
+
+// TestClassifyThreatBackfillsSeverity proves Spec 077 (T022): a finding that
+// arrives with no severity (as some external/legacy SARIF findings do) is given
+// a user-readable severity derived from its classified threat level.
+func TestClassifyThreatBackfillsSeverity(t *testing.T) {
+	tests := []struct {
+		name        string
+		in          ScanFinding
+		wantSevSet  bool
+		wantMinKeep string // if in.Severity already set, it must be preserved
+	}{
+		{
+			name:       "dangerous tool poisoning with no severity",
+			in:         ScanFinding{RuleID: "tool-poisoning", Description: "hidden instruction"},
+			wantSevSet: true,
+		},
+		{
+			name:       "supply chain cve with no severity",
+			in:         ScanFinding{RuleID: "CVE-2025-0001", PackageName: "lodash"},
+			wantSevSet: true,
+		},
+		{
+			name:        "explicit severity preserved",
+			in:          ScanFinding{RuleID: "anything", Severity: SeverityCritical},
+			wantSevSet:  true,
+			wantMinKeep: SeverityCritical,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := tt.in
+			ClassifyThreat(&f)
+			if tt.wantSevSet && f.Severity == "" {
+				t.Errorf("expected severity to be backfilled, got empty")
+			}
+			if tt.wantMinKeep != "" && f.Severity != tt.wantMinKeep {
+				t.Errorf("expected severity %q preserved, got %q", tt.wantMinKeep, f.Severity)
+			}
+		})
+	}
+}
+
 func TestSummarizeFindings(t *testing.T) {
 	findings := []ScanFinding{
 		{Severity: SeverityCritical},


### PR DESCRIPTION
## Summary

Spec 077 **US2 — one unified, readable report**. Collapses the per-scanner
findings into a single deduplicated list, lets independent scanners that agree
on the same issue raise confidence and the risk score (instead of producing
duplicate entries), guarantees every finding carries a severity, and surfaces
source attribution in the Web UI.

**Base is `077-us1-baseline`** — this PR is stacked on US1 (#786). Review/merge US1 first.

## Per-task changes

- **T018 / T019 (test-first)** `internal/security/scanner/sarif_test.go` — dedup
  by `(rule_id, location)` yields exactly one finding; two independent sources
  agreeing on `(location, threat_type)` boost confidence above single-source.
- **T021** `sarif.go` `MergeFindings` + `engine.go` `AggregateReports` — merge is
  run after classification; the merged entry's `Sources` lists every
  contributing scanner (union, sorted, deterministic). Findings with an empty
  `rule_id` are never merged.
- **T020** `sarif.go` `CalculateRiskScore` — matched external/Docker findings on
  `(location, threat_type)` now ADD to consensus: the issue is counted once,
  weighted by the number of agreeing sources, rather than each flattening to
  weight 1. The legacy per-`(rule_id, location)` dedup and detect `Signals`
  weighting are preserved for the empty-`threat_type` path, so all existing
  scoring tests are unchanged.
- **T022** `sarif.go` `ClassifyThreat` — backfills a user-readable severity from
  the classified threat level for external/legacy SARIF findings that arrive
  without one. An explicit severity is never overwritten.
- **T023** `frontend/src/views/ScanReport.vue` + `types/api.ts` — the single
  merged finding list now renders a severity badge, a `Source(s)` row, and a
  `consensus xN` badge when ≥2 scanners agreed. `SecurityScanFinding` gains the
  additive `sources`/`tier`/`confidence`/`signals` fields.

No new third-party dependency. The quarantine state machine
(`internal/runtime/tool_quarantine.go`) is untouched.

## Verification (actual output)

- `go build ./...` — clean (exit 0).
- `go test ./...` — pass. The only failures were the `internal/server`
  `TestBinary*` / `TestMCPProtocol*` E2E cases, which require a pre-built
  `mcpproxy` binary (`binary not found ... run: go build -o mcpproxy ./cmd/mcpproxy`);
  after `go build -o mcpproxy ./cmd/mcpproxy && cp mcpproxy internal/server/`,
  `go test ./internal/server/` passes (exit 0). All other packages green,
  including `internal/security/scanner`.
- `go run ./cmd/scan-eval --corpus specs/065-evaluation-foundation/datasets/detect_corpus_v1.json --gate --min-recall 0.90 --max-fp 0.05`
  → `GATE PASSED: recall=1.0000 (>=0.9000), fp=0.0000 (<=0.0500)`.
- `golangci-lint run --config .github/.golangci.yml ./...` → `0 issues.`
- `cd frontend && npm run build` (`vue-tsc && vite build`) → built clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)