### PR TITLE
docs: cap cross-model Codex review at 5 rounds per PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ Only halt and ask a human IF:
 1. You need destructive data operations or to delete core proxy logic that cannot be mocked.
 2. A required environment variable is missing from `.env` and cannot be mocked for the task's scope.
 3. You are stuck in an error loop for the same `go test` failing after 5 consecutive attempts.
+4. **Cross-model (Codex) review round cap — per PR:** when a PR is gated by a cross-model Codex review, run at most **5 fix→re-review rounds on that PR**. If Codex has not returned a clean verdict after the 5th round, STOP and ask the human how to proceed (do not auto-run round 6). The counter is per-PR and resets for each new PR. (Verify each Codex finding is genuine before fixing — Codex can false-positive; a round only counts when you push a fix and re-review.)
 
 ## Project Overview
 


### PR DESCRIPTION
Adds **Escalation Trigger #4** to `CLAUDE.md`: when a PR is gated by a cross-model **Codex** review, run at most **5 fix→re-review rounds on that PR**; if Codex isn't clean after the 5th, **stop and ask the human** (no auto round 6). The counter is **per-PR** and resets for each new PR.

Motivation: heuristic-style findings (e.g. the phrase-position tuning on #786) can generate an endless long tail of new specific findings each round. This bounds the loop while keeping the review gate meaningful, and mirrors the existing `go test` 5-attempt escalation rule. Also reiterates: verify each Codex finding is genuine before fixing (Codex can false-positive), and a round only counts when a fix is pushed + re-reviewed.

Docs-only; loaded into every session, so it takes effect on merge to main.