### PR TITLE
feat(security): US2 unified report + cross-scanner consensus confidence (Spec 077)

### DIFF
--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -66,6 +66,11 @@ export interface SecurityScanFinding {
   scan_pass?: number            // 1 = security scan, 2 = supply chain audit
   evidence?: string             // Text/content that triggered the finding
   supply_chain_audit?: boolean  // True for real CVE/package findings — routes to the Supply Chain (CVEs) section regardless of scan_pass
+  // Spec 077 unified report — additive fields.
+  sources?: string[]            // Contributing scanner ids; ≥2 means scanners agreed (consensus)
+  tier?: string                 // "hard" (gates approval) | "soft" (review-only)
+  confidence?: number           // 0.0–1.0; raised when independent sources agree
+  signals?: string[]            // Deterministic detect check ids that fired
 }
 
 export interface SecurityScanReport {

--- a/frontend/src/views/ScanReport.vue
+++ b/frontend/src/views/ScanReport.vue
@@ -188,8 +188,18 @@
                   >
                     {{ finding.threat_level }}
                   </span>
+                  <span v-if="finding.severity" class="badge badge-xs badge-outline shrink-0 uppercase">
+                    {{ finding.severity }}
+                  </span>
                   <span class="font-medium text-sm flex-1">
                     {{ finding.rule_id || finding.title }}
+                  </span>
+                  <span
+                    v-if="findingHasConsensus(finding)"
+                    class="badge badge-xs badge-primary badge-outline shrink-0"
+                    :title="`Flagged independently by ${findingSources(finding).length} scanners`"
+                  >
+                    consensus &times;{{ findingSources(finding).length }}
                   </span>
                   <span v-if="finding.package_name" class="font-mono text-xs text-base-content/50">
                     {{ finding.package_name }}
@@ -229,9 +239,9 @@
                         <span class="text-base-content/50">Location:</span>
                         <code class="ml-1 bg-base-300 px-1 rounded">{{ finding.location }}</code>
                       </div>
-                      <div v-if="finding.scanner">
-                        <span class="text-base-content/50">Scanner:</span>
-                        <span class="ml-1">{{ scannerDisplayName(finding.scanner) }}</span>
+                      <div v-if="findingSources(finding).length">
+                        <span class="text-base-content/50">{{ findingSources(finding).length > 1 ? 'Sources:' : 'Source:' }}</span>
+                        <span class="ml-1">{{ findingSourcesLabel(finding) }}</span>
                       </div>
                     </div>
                     <a
@@ -285,8 +295,18 @@
                   >
                     {{ finding.threat_level }}
                   </span>
+                  <span v-if="finding.severity" class="badge badge-xs badge-outline shrink-0 uppercase">
+                    {{ finding.severity }}
+                  </span>
                   <span class="font-medium text-sm flex-1">
                     {{ finding.rule_id || finding.title }}
+                  </span>
+                  <span
+                    v-if="findingHasConsensus(finding)"
+                    class="badge badge-xs badge-primary badge-outline shrink-0"
+                    :title="`Flagged independently by ${findingSources(finding).length} scanners`"
+                  >
+                    consensus &times;{{ findingSources(finding).length }}
                   </span>
                   <span v-if="finding.package_name" class="font-mono text-xs text-base-content/50">
                     {{ finding.package_name }}
@@ -325,9 +345,9 @@
                         <span class="text-base-content/50">Location:</span>
                         <code class="ml-1 bg-base-300 px-1 rounded">{{ finding.location }}</code>
                       </div>
-                      <div v-if="finding.scanner">
-                        <span class="text-base-content/50">Scanner:</span>
-                        <span class="ml-1">{{ scannerDisplayName(finding.scanner) }}</span>
+                      <div v-if="findingSources(finding).length">
+                        <span class="text-base-content/50">{{ findingSources(finding).length > 1 ? 'Sources:' : 'Source:' }}</span>
+                        <span class="ml-1">{{ findingSourcesLabel(finding) }}</span>
                       </div>
                     </div>
                     <a
@@ -613,6 +633,24 @@ const scannerNames: Record<string, string> = {
 
 function scannerDisplayName(id: string): string {
   return scannerNames[id] || id
+}
+
+// Spec 077 unified report — a finding's contributing sources. Prefers the
+// merged `sources` list; falls back to the single `scanner` id for legacy
+// findings that predate multi-source attribution.
+function findingSources(finding: SecurityScanFinding): string[] {
+  if (finding.sources && finding.sources.length > 0) return finding.sources
+  if (finding.scanner) return [finding.scanner]
+  return []
+}
+
+// True when ≥2 independent scanners agreed on a finding (consensus).
+function findingHasConsensus(finding: SecurityScanFinding): boolean {
+  return findingSources(finding).length > 1
+}
+
+function findingSourcesLabel(finding: SecurityScanFinding): string {
+  return findingSources(finding).map(scannerDisplayName).join(', ')
 }
 
 // Scan context from the aggregated report (populated from job's ScanContext)

--- a/internal/security/scanner/engine.go
+++ b/internal/security/scanner/engine.go
@@ -766,8 +766,16 @@ func AggregateReports(jobID, serverName string, reports []*ScanReport) *Aggregat
 		agg.Reports = append(agg.Reports, *r)
 	}
 
-	// Classify findings that lack threat_type/threat_level (legacy data)
+	// Classify findings that lack threat_type/threat_level (legacy data). This
+	// must run before MergeFindings so consensus (which keys on threat_type) and
+	// severity backfill see fully-classified findings.
 	ClassifyAllFindings(agg.Findings)
+
+	// Spec 077 (T021, FR-010/FR-011/FR-012): collapse the per-scanner findings
+	// into a single unified list. Findings sharing (rule_id, location) merge into
+	// one entry whose Sources lists every contributing scanner; cross-source
+	// agreement on the same (location, threat_type) raises confidence.
+	agg.Findings = MergeFindings(agg.Findings)
 
 	// Flag findings that belong in the Supply Chain Audit (CVEs) UI section.
 	// Match only real CVE/package vulnerabilities so AI-scanner output from Pass 2

--- a/internal/security/scanner/sarif.go
+++ b/internal/security/scanner/sarif.go
@@ -289,14 +289,30 @@ func CalculateRiskScore(findings []ScanFinding) int {
 	// An empty threat_type cannot form consensus and keeps the legacy per-rule
 	// dedup (so existing single-scanner scoring is unchanged).
 	type consensusKey struct{ location, threatType string }
-	groupSources := make(map[consensusKey]map[string]struct{})
 	// A consensus group is scored ONCE, at the MOST-SEVERE threat category among
-	// all agreeing findings (not whichever is encountered first) and at the
-	// MAX per-finding weight — so the score is order-independent even when
-	// severity-derived threat_types (supply_chain, uncategorized, the
-	// malicious_code fallback) put different threat_levels on agreeing findings.
+	// all agreeing findings (not whichever is encountered first) — so the score is
+	// order-independent even when severity-derived threat_types (supply_chain,
+	// uncategorized, the malicious_code fallback) put different threat_levels on
+	// agreeing findings.
+	//
+	// catKey narrows a group to a single severity/category bucket. The weight
+	// applied to a bucket counts only the findings that ACTUALLY rated the issue
+	// at (at least) that category — a weaker agreeing finding (e.g. an info CVE
+	// sharing a location+threat_type with a dangerous one) must NOT add weight to
+	// the stronger bucket. It can still have raised the finding's confidence in
+	// MergeFindings, but it never inflates dangerous risk (Spec 077 US2, Codex R2 #1).
+	type catKey struct {
+		location, threatType string
+		cat                  int
+	}
+	groupSources := make(map[consensusKey]map[string]struct{})
 	groupMaxCat := make(map[consensusKey]int)
-	groupMaxWeight := make(map[consensusKey]int)
+	// Per (group, category): distinct sources and max per-finding signal weight of
+	// the findings that rated the issue at exactly that category. Because a group
+	// is only ever scored at its MAX category, the sources counted there are
+	// precisely those whose own finding is "at least" the max category.
+	catSources := make(map[catKey]map[string]struct{})
+	catMaxWeight := make(map[catKey]int)
 	for i := range findings {
 		f := &findings[i]
 		if f.ThreatType == "" {
@@ -308,14 +324,25 @@ func CalculateRiskScore(findings []ScanFinding) int {
 			set = make(map[string]struct{})
 			groupSources[ck] = set
 		}
-		for _, s := range findingSources(*f) {
+		srcs := findingSources(*f)
+		for _, s := range srcs {
 			set[s] = struct{}{}
 		}
-		if cat := threatCategory(f); cat > groupMaxCat[ck] {
+		cat := threatCategory(f)
+		if cat > groupMaxCat[ck] {
 			groupMaxCat[ck] = cat
 		}
-		if w := consensusWeight(*f); w > groupMaxWeight[ck] {
-			groupMaxWeight[ck] = w
+		catk := catKey{f.Location, f.ThreatType, cat}
+		cs := catSources[catk]
+		if cs == nil {
+			cs = make(map[string]struct{})
+			catSources[catk] = cs
+		}
+		for _, s := range srcs {
+			cs[s] = struct{}{}
+		}
+		if w := consensusWeight(*f); w > catMaxWeight[catk] {
+			catMaxWeight[catk] = w
 		}
 	}
 
@@ -355,11 +382,21 @@ func CalculateRiskScore(findings []ScanFinding) int {
 					continue
 				}
 				seenConsensus[ck] = true
-				weight := groupMaxWeight[ck]
-				if n > weight {
-					weight = n
+				// Score the group ONCE at its most-severe category, weighted only
+				// by the findings that actually rated it at that category: the
+				// number of distinct sources at the max category, or the max
+				// signal weight of a single such finding, whichever is greater.
+				// A weaker agreeing finding never inflates the stronger bucket.
+				maxCat := groupMaxCat[ck]
+				catk := catKey{ck.location, ck.threatType, maxCat}
+				weight := len(catSources[catk])
+				if w := catMaxWeight[catk]; w > weight {
+					weight = w
 				}
-				addWeight(groupMaxCat[ck], weight)
+				if weight < 1 {
+					weight = 1
+				}
+				addWeight(maxCat, weight)
 				continue
 			}
 		}
@@ -537,6 +574,16 @@ func sortedUnion(lists ...[]string) []string {
 	return out
 }
 
+// backfillString copies src into *dst only when *dst is empty, so the kept
+// (most-severe) finding keeps its own non-empty value and merely fills its gaps
+// from an absorbed duplicate. Order-independent: filling an empty from a
+// non-empty gives the same result whichever finding is the merge anchor.
+func backfillString(dst *string, src string) {
+	if *dst == "" && src != "" {
+		*dst = src
+	}
+}
+
 // MergeFindings collapses findings from every scanner into a single unified list
 // (Spec 077 FR-010/FR-011). Findings sharing a (rule_id, location) merge into one
 // entry whose Sources lists every contributing scanner. When ≥2 distinct sources
@@ -583,6 +630,34 @@ func MergeFindings(findings []ScanFinding) []ScanFinding {
 				result[pos].ThreatLevel = f.ThreatLevel
 			}
 			result[pos].Signals = sortedUnion(result[pos].Signals, f.Signals)
+			// Backfill any enrichment field the kept finding lacks from the
+			// absorbed duplicate (Spec 077 US2, Codex R2 #2). Union semantics:
+			// prefer the kept/most-severe finding's non-empty values and fill only
+			// its empties from the other, so the absorbed duplicate's HelpURI,
+			// CVE/package metadata, evidence, category, title/description, scan
+			// pass and supply-chain flag are never silently dropped on merge.
+			// Numeric CVSS takes the max; the supply-chain flag ORs; slices were
+			// unioned above — all order-independent so the merge stays stable.
+			kept := &result[pos]
+			backfillString(&kept.Category, f.Category)
+			backfillString(&kept.ThreatType, f.ThreatType)
+			backfillString(&kept.Title, f.Title)
+			backfillString(&kept.Description, f.Description)
+			backfillString(&kept.Scanner, f.Scanner)
+			backfillString(&kept.HelpURI, f.HelpURI)
+			backfillString(&kept.PackageName, f.PackageName)
+			backfillString(&kept.InstalledVersion, f.InstalledVersion)
+			backfillString(&kept.FixedVersion, f.FixedVersion)
+			backfillString(&kept.Evidence, f.Evidence)
+			if f.CVSSScore > kept.CVSSScore {
+				kept.CVSSScore = f.CVSSScore
+			}
+			if kept.ScanPass == 0 && f.ScanPass != 0 {
+				kept.ScanPass = f.ScanPass
+			}
+			if f.SupplyChainAudit {
+				kept.SupplyChainAudit = true
+			}
 			continue
 		}
 		f.Sources = sortedUnion(f.Sources, srcs)

--- a/internal/security/scanner/sarif.go
+++ b/internal/security/scanner/sarif.go
@@ -462,6 +462,45 @@ func tierRank(tier string) int {
 	}
 }
 
+// severityRank orders CVSS severities so the more-severe one wins on merge:
+// critical > high > medium > low > info > empty/unknown. The ordering is a
+// strict refinement of threatCategory's severity fallback (critical→dangerous,
+// high/medium→warning, low→info), so taking the max severity here never
+// disagrees with CalculateRiskScore's bucketing.
+func severityRank(sev string) int {
+	switch sev {
+	case SeverityCritical:
+		return 5
+	case SeverityHigh:
+		return 4
+	case SeverityMedium:
+		return 3
+	case SeverityLow:
+		return 2
+	case SeverityInfo:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// threatLevelRank orders user-facing threat levels so the more-severe one wins
+// on merge: dangerous > warning > info > empty/unknown. This mirrors
+// threatCategory's ThreatLevel bucketing exactly, so taking the max threat
+// level here is consistent with CalculateRiskScore.
+func threatLevelRank(level string) int {
+	switch level {
+	case ThreatLevelDangerous:
+		return 3
+	case ThreatLevelWarning:
+		return 2
+	case ThreatLevelInfo:
+		return 1
+	default:
+		return 0
+	}
+}
+
 // findingSources returns the contributing scanner ids for a finding, preferring
 // the explicit Sources list (Spec 077) and falling back to the single Scanner
 // id for legacy findings that predate multi-source attribution.
@@ -525,15 +564,23 @@ func MergeFindings(findings []ScanFinding) []ScanFinding {
 		if pos, ok := index[k]; ok {
 			result[pos].Sources = sortedUnion(result[pos].Sources, srcs)
 			// Absorb the duplicate's stronger fields (Spec 077): keep the
-			// higher confidence, the more-severe tier (hard > soft), and the
-			// union of signals — otherwise merging a hard/high-confidence
-			// finding with a same-(rule_id,location) soft/low-confidence
-			// duplicate would silently drop the hard tier and confidence.
+			// higher confidence, the more-severe tier (hard > soft), the
+			// more-severe CVSS severity and user-facing threat level, and the
+			// union of signals — otherwise merging a hard/high finding with a
+			// same-(rule_id,location) soft/low duplicate would silently drop
+			// the stronger fields, making CalculateRiskScore and the summary
+			// order-dependent.
 			if f.Confidence > result[pos].Confidence {
 				result[pos].Confidence = f.Confidence
 			}
 			if tierRank(f.Tier) > tierRank(result[pos].Tier) {
 				result[pos].Tier = f.Tier
+			}
+			if severityRank(f.Severity) > severityRank(result[pos].Severity) {
+				result[pos].Severity = f.Severity
+			}
+			if threatLevelRank(f.ThreatLevel) > threatLevelRank(result[pos].ThreatLevel) {
+				result[pos].ThreatLevel = f.ThreatLevel
 			}
 			result[pos].Signals = sortedUnion(result[pos].Signals, f.Signals)
 			continue

--- a/internal/security/scanner/sarif.go
+++ b/internal/security/scanner/sarif.go
@@ -262,11 +262,20 @@ func categorizeFromRule(ruleID string, props map[string]any, rules map[string]SA
 // Identical findings reported by several scanners (same rule_id + location) are
 // deduplicated before scoring.
 //
-// Spec 076 (FR-006, SC-007) — consensus is additive: the deterministic scanner
-// emits ONE finding per tool whose Signals list every independent check that
-// fired. A finding contributes its consensus weight (the count of distinct
-// contributing signals, min 1) to its category, so a tool flagged by several
-// checks raises the score instead of being collapsed to one. Findings from
+// Scoring is a pure function of each finding's OWN severity/category (Spec 077
+// US2). Cross-scanner AGREEMENT — two scanners independently flagging the same
+// (location, threat_type) via different rule ids — raises the merged finding's
+// CONFIDENCE in MergeFindings (SC-008) but adds NO risk-score weight: a weak
+// external finding that merely agrees with a strong one contributes only its own
+// (weak) category and can never inflate the stronger bucket. This keeps the score
+// deterministic, order-independent, and identical whether it is computed before
+// or after MergeFindings has run.
+//
+// Spec 076 (FR-006, SC-007) — a finding's OWN detect signals still add: the
+// deterministic scanner emits ONE finding per tool whose Signals list every
+// independent check that fired within that single scanner, so a finding flagged
+// by N of its own checks weighs N. That is a per-finding property of one
+// scanner's output, not cross-scanner agreement, so it is retained. Findings from
 // scanners that emit no per-signal data weigh 1, so legacy scoring is unchanged.
 //
 // Formula per category: category_score = weight * log2(1 + weighted_count)
@@ -281,80 +290,18 @@ func CalculateRiskScore(findings []ScanFinding) int {
 		return 0
 	}
 
-	// Precompute cross-source consensus: for each (location, threat_type) with a
-	// non-empty threat_type, the set of distinct sources that independently
-	// flagged it. Two different scanners agreeing on the same issue — even via
-	// different rule ids — is consensus and raises the weight (Spec 077 FR-012,
-	// T020). External/Docker findings that used to flatten to weight 1 now ADD.
-	// An empty threat_type cannot form consensus and keeps the legacy per-rule
-	// dedup (so existing single-scanner scoring is unchanged).
-	type consensusKey struct{ location, threatType string }
-	// A consensus group is scored ONCE, at the MOST-SEVERE threat category among
-	// all agreeing findings (not whichever is encountered first) — so the score is
-	// order-independent even when severity-derived threat_types (supply_chain,
-	// uncategorized, the malicious_code fallback) put different threat_levels on
-	// agreeing findings.
-	//
-	// catKey narrows a group to a single severity/category bucket. The weight
-	// applied to a bucket counts only the findings that ACTUALLY rated the issue
-	// at (at least) that category — a weaker agreeing finding (e.g. an info CVE
-	// sharing a location+threat_type with a dangerous one) must NOT add weight to
-	// the stronger bucket. It can still have raised the finding's confidence in
-	// MergeFindings, but it never inflates dangerous risk (Spec 077 US2, Codex R2 #1).
-	type catKey struct {
-		location, threatType string
-		cat                  int
-	}
-	groupSources := make(map[consensusKey]map[string]struct{})
-	groupMaxCat := make(map[consensusKey]int)
-	// Per (group, category): distinct sources and max per-finding signal weight of
-	// the findings that rated the issue at exactly that category. Because a group
-	// is only ever scored at its MAX category, the sources counted there are
-	// precisely those whose own finding is "at least" the max category.
-	catSources := make(map[catKey]map[string]struct{})
-	catMaxWeight := make(map[catKey]int)
-	for i := range findings {
-		f := &findings[i]
-		if f.ThreatType == "" {
-			continue
-		}
-		ck := consensusKey{f.Location, f.ThreatType}
-		set := groupSources[ck]
-		if set == nil {
-			set = make(map[string]struct{})
-			groupSources[ck] = set
-		}
-		srcs := findingSources(*f)
-		for _, s := range srcs {
-			set[s] = struct{}{}
-		}
-		cat := threatCategory(f)
-		if cat > groupMaxCat[ck] {
-			groupMaxCat[ck] = cat
-		}
-		catk := catKey{f.Location, f.ThreatType, cat}
-		cs := catSources[catk]
-		if cs == nil {
-			cs = make(map[string]struct{})
-			catSources[catk] = cs
-		}
-		for _, s := range srcs {
-			cs[s] = struct{}{}
-		}
-		if w := consensusWeight(*f); w > catMaxWeight[catk] {
-			catMaxWeight[catk] = w
-		}
-	}
-
-	// Deduplicate for scoring:
-	//   - legacy: group by (rule_id, location) to avoid triple-counting the same
-	//     rule reported by multiple scanners (unchanged behavior).
-	//   - consensus: when ≥2 distinct sources agree on the same (location,
-	//     threat_type), count that issue ONCE weighted by the number of agreeing
-	//     sources, so agreement raises the score without double-counting.
+	// Deduplicate by (rule_id, location): the same rule reported by several
+	// scanners (or twice in one report) is one issue, counted once. To stay
+	// order-independent — and independent of whether MergeFindings has run — the
+	// deduped issue is scored at the MAX threat category and MAX per-finding signal
+	// weight seen for that key, never whichever finding happened to be encountered
+	// first. Findings with an empty rule_id are never deduped: each is a distinct
+	// issue contributing its own category. Cross-scanner agreement across DIFFERENT
+	// rule ids adds no weight here — those are separate findings, each scored at its
+	// own category — so a weak agreeing finding cannot inflate a stronger one.
 	type dedupKey struct{ ruleID, location string }
-	seen := make(map[dedupKey]bool)
-	seenConsensus := make(map[consensusKey]bool)
+	type catWeight struct{ cat, weight int }
+	deduped := make(map[dedupKey]catWeight)
 	var dangerousCount, warningCount, infoCount int
 
 	addWeight := func(category, weight int) {
@@ -370,49 +317,31 @@ func CalculateRiskScore(findings []ScanFinding) int {
 
 	for i := range findings {
 		f := &findings[i]
+		cat := threatCategory(f)
+		// A finding's OWN detect signals add (Spec 076 FR-006); single-signal and
+		// legacy scanner findings weigh 1. Cross-scanner agreement adds nothing.
+		weight := consensusWeight(*f)
 
-		// Cross-source consensus path: only when ≥2 distinct sources agree on a
-		// classified (location, threat_type). Counted once, at the most-severe
-		// category and max weight of the whole group so the result is
-		// order-independent (not the first finding encountered).
-		if f.ThreatType != "" {
-			ck := consensusKey{f.Location, f.ThreatType}
-			if n := len(groupSources[ck]); n >= 2 {
-				if seenConsensus[ck] {
-					continue
-				}
-				seenConsensus[ck] = true
-				// Score the group ONCE at its most-severe category, weighted only
-				// by the findings that actually rated it at that category: the
-				// number of distinct sources at the max category, or the max
-				// signal weight of a single such finding, whichever is greater.
-				// A weaker agreeing finding never inflates the stronger bucket.
-				maxCat := groupMaxCat[ck]
-				catk := catKey{ck.location, ck.threatType, maxCat}
-				weight := len(catSources[catk])
-				if w := catMaxWeight[catk]; w > weight {
-					weight = w
-				}
-				if weight < 1 {
-					weight = 1
-				}
-				addWeight(maxCat, weight)
-				continue
-			}
+		if f.RuleID == "" {
+			// Never deduped; each empty-rule finding is a distinct issue.
+			addWeight(cat, weight)
+			continue
 		}
-
-		// Legacy per-rule dedup (single source, or unclassified findings).
 		key := dedupKey{f.RuleID, f.Location}
-		if key.ruleID != "" && seen[key] {
-			continue // Skip duplicate finding
+		cur := deduped[key]
+		if cat > cur.cat {
+			cur.cat = cat
 		}
-		if key.ruleID != "" {
-			seen[key] = true
+		if weight > cur.weight {
+			cur.weight = weight
 		}
+		deduped[key] = cur
+	}
 
-		// Consensus weight: independent signals on one tool ADD to the score
-		// (Spec 076 FR-006). A single-signal or signal-less finding weighs 1.
-		addWeight(threatCategory(f), consensusWeight(*f))
+	// Sum the deduped issues. Iteration order is irrelevant: addition is
+	// commutative, so the score is deterministic regardless of map order.
+	for _, cw := range deduped {
+		addWeight(cw.cat, cw.weight)
 	}
 
 	// Logarithmic diminishing returns: score = weight * log2(1 + count)
@@ -439,8 +368,8 @@ func CalculateRiskScore(findings []ScanFinding) int {
 }
 
 // Threat categories rank a finding's contribution to the risk score. Higher is
-// more severe; threatCatNone (the zero value) is not counted, so a group whose
-// members are all unclassified keeps the map default without spuriously scoring.
+// more severe; threatCatNone (the zero value) is not counted, so an unclassified
+// finding keeps the map default without spuriously scoring.
 const (
 	threatCatNone = iota
 	threatCatInfo
@@ -451,8 +380,8 @@ const (
 // threatCategory maps a finding to its risk bucket, preferring the explicit
 // user-facing ThreatLevel and falling back to CVSS severity for unclassified
 // findings. It mirrors the previous inline switch in addWeight so legacy scoring
-// is unchanged; extracting it lets a consensus group be scored at the
-// most-severe member instead of whichever finding is encountered first.
+// is unchanged; extracting it lets a deduped (rule_id, location) issue be scored
+// at its most-severe member instead of whichever finding is encountered first.
 func threatCategory(f *ScanFinding) int {
 	switch f.ThreatLevel {
 	case ThreatLevelDangerous:
@@ -475,10 +404,12 @@ func threatCategory(f *ScanFinding) int {
 
 // consensusWeight returns how much a single (deduplicated) finding contributes
 // to its risk category. The deterministic scanner (Spec 076) aggregates every
-// independent check that fired on a tool into one finding's Signals list, so a
-// finding flagged by N distinct checks weighs N — agreement raises the score
-// rather than being collapsed (FR-006). Findings with zero or one signal — and
-// every legacy scanner finding, which carries none — weigh 1.
+// independent check that fired on ONE tool — within that single scanner — into
+// the finding's Signals list, so a finding flagged by N of its own checks weighs
+// N (FR-006). This is a per-finding property of one scanner's output, NOT
+// cross-scanner agreement (which raises confidence, not score). Findings with
+// zero or one signal — and every legacy scanner finding, which carries none —
+// weigh 1.
 func consensusWeight(f ScanFinding) int {
 	if n := len(f.Signals); n > 1 {
 		return n

--- a/internal/security/scanner/sarif.go
+++ b/internal/security/scanner/sarif.go
@@ -4,9 +4,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"sort"
 	"strconv"
 	"strings"
 )
+
+// consensusConfidenceStep is how much each additional independent source raises
+// a finding's confidence when scanners agree on the same (location,
+// threat_type). Additive and capped at 1.0 (Spec 077 FR-012).
+const consensusConfidenceStep = 0.15
 
 // SARIF 2.1.0 types for parsing scanner output
 
@@ -275,25 +281,43 @@ func CalculateRiskScore(findings []ScanFinding) int {
 		return 0
 	}
 
-	// Deduplicate: group by (rule_id + location) to avoid triple-counting
-	// when multiple scanners report the same issue.
+	// Precompute cross-source consensus: for each (location, threat_type) with a
+	// non-empty threat_type, the set of distinct sources that independently
+	// flagged it. Two different scanners agreeing on the same issue — even via
+	// different rule ids — is consensus and raises the weight (Spec 077 FR-012,
+	// T020). External/Docker findings that used to flatten to weight 1 now ADD.
+	// An empty threat_type cannot form consensus and keeps the legacy per-rule
+	// dedup (so existing single-scanner scoring is unchanged).
+	type consensusKey struct{ location, threatType string }
+	groupSources := make(map[consensusKey]map[string]struct{})
+	for i := range findings {
+		f := &findings[i]
+		if f.ThreatType == "" {
+			continue
+		}
+		ck := consensusKey{f.Location, f.ThreatType}
+		set := groupSources[ck]
+		if set == nil {
+			set = make(map[string]struct{})
+			groupSources[ck] = set
+		}
+		for _, s := range findingSources(*f) {
+			set[s] = struct{}{}
+		}
+	}
+
+	// Deduplicate for scoring:
+	//   - legacy: group by (rule_id, location) to avoid triple-counting the same
+	//     rule reported by multiple scanners (unchanged behavior).
+	//   - consensus: when ≥2 distinct sources agree on the same (location,
+	//     threat_type), count that issue ONCE weighted by the number of agreeing
+	//     sources, so agreement raises the score without double-counting.
 	type dedupKey struct{ ruleID, location string }
 	seen := make(map[dedupKey]bool)
+	seenConsensus := make(map[consensusKey]bool)
 	var dangerousCount, warningCount, infoCount int
 
-	for _, f := range findings {
-		key := dedupKey{f.RuleID, f.Location}
-		if key.ruleID != "" && seen[key] {
-			continue // Skip duplicate finding
-		}
-		if key.ruleID != "" {
-			seen[key] = true
-		}
-
-		// Consensus weight: independent signals on one tool ADD to the score
-		// (FR-006). A single-signal or signal-less finding weighs 1.
-		weight := consensusWeight(f)
-
+	addWeight := func(f *ScanFinding, weight int) {
 		switch f.ThreatLevel {
 		case ThreatLevelDangerous:
 			dangerousCount += weight
@@ -314,6 +338,41 @@ func CalculateRiskScore(findings []ScanFinding) int {
 				infoCount += weight
 			}
 		}
+	}
+
+	for i := range findings {
+		f := &findings[i]
+
+		// Cross-source consensus path: only when ≥2 distinct sources agree on a
+		// classified (location, threat_type). Counted once, weighted by agreement.
+		if f.ThreatType != "" {
+			ck := consensusKey{f.Location, f.ThreatType}
+			if n := len(groupSources[ck]); n >= 2 {
+				if seenConsensus[ck] {
+					continue
+				}
+				seenConsensus[ck] = true
+				weight := consensusWeight(*f)
+				if n > weight {
+					weight = n
+				}
+				addWeight(f, weight)
+				continue
+			}
+		}
+
+		// Legacy per-rule dedup (single source, or unclassified findings).
+		key := dedupKey{f.RuleID, f.Location}
+		if key.ruleID != "" && seen[key] {
+			continue // Skip duplicate finding
+		}
+		if key.ruleID != "" {
+			seen[key] = true
+		}
+
+		// Consensus weight: independent signals on one tool ADD to the score
+		// (Spec 076 FR-006). A single-signal or signal-less finding weighs 1.
+		addWeight(f, consensusWeight(*f))
 	}
 
 	// Logarithmic diminishing returns: score = weight * log2(1 + count)
@@ -350,6 +409,114 @@ func consensusWeight(f ScanFinding) int {
 		return n
 	}
 	return 1
+}
+
+// findingSources returns the contributing scanner ids for a finding, preferring
+// the explicit Sources list (Spec 077) and falling back to the single Scanner
+// id for legacy findings that predate multi-source attribution.
+func findingSources(f ScanFinding) []string {
+	if len(f.Sources) > 0 {
+		return f.Sources
+	}
+	if f.Scanner != "" {
+		return []string{f.Scanner}
+	}
+	return nil
+}
+
+// sortedUnion returns the deduplicated, sorted union of the given source id
+// slices, dropping empty strings. Returns nil when the union is empty so the
+// JSON `sources` field stays omitted for legacy findings.
+func sortedUnion(lists ...[]string) []string {
+	set := make(map[string]struct{})
+	for _, list := range lists {
+		for _, s := range list {
+			if s != "" {
+				set[s] = struct{}{}
+			}
+		}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for s := range set {
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// MergeFindings collapses findings from every scanner into a single unified list
+// (Spec 077 FR-010/FR-011). Findings sharing a (rule_id, location) merge into one
+// entry whose Sources lists every contributing scanner. When ≥2 distinct sources
+// independently agree on the same (location, threat_type) — even via different
+// rule ids — each agreeing finding's Confidence is raised to reflect that
+// consensus (FR-012). Findings with an empty rule_id are never merged (each is
+// treated as a distinct issue) but still carry populated Sources.
+//
+// Order is preserved (first occurrence wins) so the report is stable.
+func MergeFindings(findings []ScanFinding) []ScanFinding {
+	result := make([]ScanFinding, 0, len(findings))
+
+	// Phase 1 — dedup by (rule_id, location); union contributing sources.
+	type key struct{ ruleID, location string }
+	index := make(map[key]int)
+	for i := range findings {
+		f := findings[i]
+		srcs := findingSources(f)
+		if f.RuleID == "" {
+			f.Sources = sortedUnion(f.Sources, srcs)
+			result = append(result, f)
+			continue
+		}
+		k := key{f.RuleID, f.Location}
+		if pos, ok := index[k]; ok {
+			result[pos].Sources = sortedUnion(result[pos].Sources, srcs)
+			continue
+		}
+		f.Sources = sortedUnion(f.Sources, srcs)
+		index[k] = len(result)
+		result = append(result, f)
+	}
+
+	// Phase 2 — consensus confidence boost by (location, threat_type).
+	type ckey struct{ location, threatType string }
+	group := make(map[ckey]map[string]struct{})
+	for i := range result {
+		f := &result[i]
+		if f.ThreatType == "" {
+			continue
+		}
+		ck := ckey{f.Location, f.ThreatType}
+		set := group[ck]
+		if set == nil {
+			set = make(map[string]struct{})
+			group[ck] = set
+		}
+		for _, s := range f.Sources {
+			set[s] = struct{}{}
+		}
+	}
+	for i := range result {
+		f := &result[i]
+		if f.ThreatType == "" {
+			continue
+		}
+		n := len(group[ckey{f.Location, f.ThreatType}])
+		if n < 2 {
+			continue
+		}
+		boosted := f.Confidence + consensusConfidenceStep*float64(n-1)
+		if boosted > 1.0 {
+			boosted = 1.0
+		}
+		if boosted > f.Confidence {
+			f.Confidence = boosted
+		}
+	}
+
+	return result
 }
 
 // SummarizeFindings produces a ReportSummary from findings
@@ -403,6 +570,14 @@ func parsePackageFromMessage(msg string) (pkg, installed, fixed string) {
 // ClassifyThreat assigns user-facing threat_type and threat_level to a finding
 // based on rule ID, category, description, and severity.
 func ClassifyThreat(f *ScanFinding) {
+	// Spec 077 (T022): guarantee every finding leaves classification with a
+	// user-readable severity. External/legacy SARIF findings sometimes arrive
+	// with no severity; backfill it from the classified threat level so the
+	// unified report never shows a blank severity. An explicit severity is
+	// preserved. Registered before the baseline early-return below so it also
+	// runs for detect findings — a no-op there since they already carry severity.
+	defer backfillSeverity(f)
+
 	// Baseline detect findings (Spec 076/077) already carry authoritative
 	// threat_type / threat_level / tier from the deterministic engine, so the
 	// legacy keyword classifier must NOT rewrite them. Overriding here can flip a
@@ -484,6 +659,25 @@ func ClassifyThreat(f *ScanFinding) {
 		f.ThreatLevel = ThreatLevelWarning
 	} else {
 		f.ThreatLevel = ThreatLevelInfo
+	}
+}
+
+// backfillSeverity derives a severity from the finding's classified threat
+// level when none was supplied, so every finding in the unified report carries a
+// clear severity (Spec 077 FR-013 / T022). Never overwrites an explicit value.
+func backfillSeverity(f *ScanFinding) {
+	if f.Severity != "" {
+		return
+	}
+	switch f.ThreatLevel {
+	case ThreatLevelDangerous:
+		f.Severity = SeverityHigh
+	case ThreatLevelWarning:
+		f.Severity = SeverityMedium
+	case ThreatLevelInfo:
+		f.Severity = SeverityInfo
+	default:
+		f.Severity = SeverityMedium
 	}
 }
 

--- a/internal/security/scanner/sarif.go
+++ b/internal/security/scanner/sarif.go
@@ -290,6 +290,13 @@ func CalculateRiskScore(findings []ScanFinding) int {
 	// dedup (so existing single-scanner scoring is unchanged).
 	type consensusKey struct{ location, threatType string }
 	groupSources := make(map[consensusKey]map[string]struct{})
+	// A consensus group is scored ONCE, at the MOST-SEVERE threat category among
+	// all agreeing findings (not whichever is encountered first) and at the
+	// MAX per-finding weight — so the score is order-independent even when
+	// severity-derived threat_types (supply_chain, uncategorized, the
+	// malicious_code fallback) put different threat_levels on agreeing findings.
+	groupMaxCat := make(map[consensusKey]int)
+	groupMaxWeight := make(map[consensusKey]int)
 	for i := range findings {
 		f := &findings[i]
 		if f.ThreatType == "" {
@@ -304,6 +311,12 @@ func CalculateRiskScore(findings []ScanFinding) int {
 		for _, s := range findingSources(*f) {
 			set[s] = struct{}{}
 		}
+		if cat := threatCategory(f); cat > groupMaxCat[ck] {
+			groupMaxCat[ck] = cat
+		}
+		if w := consensusWeight(*f); w > groupMaxWeight[ck] {
+			groupMaxWeight[ck] = w
+		}
 	}
 
 	// Deduplicate for scoring:
@@ -317,26 +330,14 @@ func CalculateRiskScore(findings []ScanFinding) int {
 	seenConsensus := make(map[consensusKey]bool)
 	var dangerousCount, warningCount, infoCount int
 
-	addWeight := func(f *ScanFinding, weight int) {
-		switch f.ThreatLevel {
-		case ThreatLevelDangerous:
+	addWeight := func(category, weight int) {
+		switch category {
+		case threatCatDangerous:
 			dangerousCount += weight
-		case ThreatLevelWarning:
+		case threatCatWarning:
 			warningCount += weight
-		case ThreatLevelInfo:
+		case threatCatInfo:
 			infoCount += weight
-		default:
-			// Unclassified: use severity as fallback
-			switch f.Severity {
-			case SeverityCritical:
-				dangerousCount += weight
-			case SeverityHigh:
-				warningCount += weight
-			case SeverityMedium:
-				warningCount += weight
-			case SeverityLow:
-				infoCount += weight
-			}
 		}
 	}
 
@@ -344,7 +345,9 @@ func CalculateRiskScore(findings []ScanFinding) int {
 		f := &findings[i]
 
 		// Cross-source consensus path: only when ≥2 distinct sources agree on a
-		// classified (location, threat_type). Counted once, weighted by agreement.
+		// classified (location, threat_type). Counted once, at the most-severe
+		// category and max weight of the whole group so the result is
+		// order-independent (not the first finding encountered).
 		if f.ThreatType != "" {
 			ck := consensusKey{f.Location, f.ThreatType}
 			if n := len(groupSources[ck]); n >= 2 {
@@ -352,11 +355,11 @@ func CalculateRiskScore(findings []ScanFinding) int {
 					continue
 				}
 				seenConsensus[ck] = true
-				weight := consensusWeight(*f)
+				weight := groupMaxWeight[ck]
 				if n > weight {
 					weight = n
 				}
-				addWeight(f, weight)
+				addWeight(groupMaxCat[ck], weight)
 				continue
 			}
 		}
@@ -372,7 +375,7 @@ func CalculateRiskScore(findings []ScanFinding) int {
 
 		// Consensus weight: independent signals on one tool ADD to the score
 		// (Spec 076 FR-006). A single-signal or signal-less finding weighs 1.
-		addWeight(f, consensusWeight(*f))
+		addWeight(threatCategory(f), consensusWeight(*f))
 	}
 
 	// Logarithmic diminishing returns: score = weight * log2(1 + count)
@@ -398,6 +401,41 @@ func CalculateRiskScore(findings []ScanFinding) int {
 	return score
 }
 
+// Threat categories rank a finding's contribution to the risk score. Higher is
+// more severe; threatCatNone (the zero value) is not counted, so a group whose
+// members are all unclassified keeps the map default without spuriously scoring.
+const (
+	threatCatNone = iota
+	threatCatInfo
+	threatCatWarning
+	threatCatDangerous
+)
+
+// threatCategory maps a finding to its risk bucket, preferring the explicit
+// user-facing ThreatLevel and falling back to CVSS severity for unclassified
+// findings. It mirrors the previous inline switch in addWeight so legacy scoring
+// is unchanged; extracting it lets a consensus group be scored at the
+// most-severe member instead of whichever finding is encountered first.
+func threatCategory(f *ScanFinding) int {
+	switch f.ThreatLevel {
+	case ThreatLevelDangerous:
+		return threatCatDangerous
+	case ThreatLevelWarning:
+		return threatCatWarning
+	case ThreatLevelInfo:
+		return threatCatInfo
+	}
+	switch f.Severity {
+	case SeverityCritical:
+		return threatCatDangerous
+	case SeverityHigh, SeverityMedium:
+		return threatCatWarning
+	case SeverityLow:
+		return threatCatInfo
+	}
+	return threatCatNone
+}
+
 // consensusWeight returns how much a single (deduplicated) finding contributes
 // to its risk category. The deterministic scanner (Spec 076) aggregates every
 // independent check that fired on a tool into one finding's Signals list, so a
@@ -409,6 +447,19 @@ func consensusWeight(f ScanFinding) int {
 		return n
 	}
 	return 1
+}
+
+// tierRank orders finding tiers so the more-severe tier wins on merge:
+// hard > soft > empty/unknown.
+func tierRank(tier string) int {
+	switch tier {
+	case TierHard:
+		return 2
+	case TierSoft:
+		return 1
+	default:
+		return 0
+	}
 }
 
 // findingSources returns the contributing scanner ids for a finding, preferring
@@ -473,6 +524,18 @@ func MergeFindings(findings []ScanFinding) []ScanFinding {
 		k := key{f.RuleID, f.Location}
 		if pos, ok := index[k]; ok {
 			result[pos].Sources = sortedUnion(result[pos].Sources, srcs)
+			// Absorb the duplicate's stronger fields (Spec 077): keep the
+			// higher confidence, the more-severe tier (hard > soft), and the
+			// union of signals — otherwise merging a hard/high-confidence
+			// finding with a same-(rule_id,location) soft/low-confidence
+			// duplicate would silently drop the hard tier and confidence.
+			if f.Confidence > result[pos].Confidence {
+				result[pos].Confidence = f.Confidence
+			}
+			if tierRank(f.Tier) > tierRank(result[pos].Tier) {
+				result[pos].Tier = f.Tier
+			}
+			result[pos].Signals = sortedUnion(result[pos].Signals, f.Signals)
 			continue
 		}
 		f.Sources = sortedUnion(f.Sources, srcs)

--- a/internal/security/scanner/sarif_test.go
+++ b/internal/security/scanner/sarif_test.go
@@ -452,49 +452,61 @@ func TestMergeFindingsConsensusBoostsConfidence(t *testing.T) {
 	}
 }
 
-// TestCalculateRiskScoreCrossSourceConsensusAdds proves Spec 077 (T020): two
-// independent external/Docker scanners agreeing on the same (location,
-// threat_type) via different rule ids ADD to the consensus weight instead of
-// each flattening to weight 1, so the score exceeds a single-source scan.
-func TestCalculateRiskScoreCrossSourceConsensusAdds(t *testing.T) {
-	single := []ScanFinding{
-		{RuleID: "cisco.x", Location: "srv:tool", ThreatType: ThreatToolPoisoning, ThreatLevel: ThreatLevelDangerous, Scanner: "cisco-mcp-scanner"},
+// TestCalculateRiskScoreCrossScannerAgreementDoesNotChangeScore proves the Spec
+// 077 US2 structural rule: cross-scanner AGREEMENT adds no risk-score weight. Two
+// scanners reporting the same issue (same rule_id + location) dedup to a single
+// contribution, so the score equals a lone finding — agreement never inflates it.
+// Agreement's effect is a CONFIDENCE boost (SC-008), proved separately in
+// TestMergeFindingsConsensusBoostsConfidence.
+func TestCalculateRiskScoreCrossScannerAgreementDoesNotChangeScore(t *testing.T) {
+	lone := []ScanFinding{
+		{RuleID: "detect.tpa", Location: "srv:tool", ThreatType: ThreatToolPoisoning, ThreatLevel: ThreatLevelDangerous, Scanner: "tpa-descriptions"},
 	}
-	consensus := []ScanFinding{
-		{RuleID: "cisco.x", Location: "srv:tool", ThreatType: ThreatToolPoisoning, ThreatLevel: ThreatLevelDangerous, Scanner: "cisco-mcp-scanner"},
-		{RuleID: "ramparts.y", Location: "srv:tool", ThreatType: ThreatToolPoisoning, ThreatLevel: ThreatLevelDangerous, Scanner: "ramparts"},
+	agreeing := []ScanFinding{
+		{RuleID: "detect.tpa", Location: "srv:tool", ThreatType: ThreatToolPoisoning, ThreatLevel: ThreatLevelDangerous, Scanner: "tpa-descriptions"},
+		{RuleID: "detect.tpa", Location: "srv:tool", ThreatType: ThreatToolPoisoning, ThreatLevel: ThreatLevelDangerous, Scanner: "cisco-mcp-scanner"},
 	}
 
-	singleScore := CalculateRiskScore(single)
-	consensusScore := CalculateRiskScore(consensus)
+	loneScore := CalculateRiskScore(lone)
+	agreeingScore := CalculateRiskScore(agreeing)
 
-	// single: one dangerous, one source → weight 1 → 25*log2(2)=25
-	if singleScore != 25 {
-		t.Errorf("single-source score = %d, want 25", singleScore)
+	// lone: one dangerous → 25*log2(2)=25.
+	if loneScore != 25 {
+		t.Errorf("lone dangerous score = %d, want 25", loneScore)
 	}
-	// consensus: one issue (location+threat_type), two distinct sources → weight
-	// 2 → 25*log2(3)=39. Counted once (not double), but heavier than single.
-	if consensusScore != 39 {
-		t.Errorf("cross-source consensus score = %d, want 39", consensusScore)
-	}
-	if consensusScore <= singleScore {
-		t.Errorf("consensus score %d must exceed single-source score %d", consensusScore, singleScore)
+	// Agreement adds NO score weight: the same (rule_id, location) dedups to one.
+	if agreeingScore != loneScore {
+		t.Errorf("cross-scanner agreement changed the score: agreeing=%d, lone=%d (want equal)", agreeingScore, loneScore)
 	}
 }
 
-// TestCalculateRiskScoreConsensusUsesMaxSeverity proves the consensus group is
-// scored at its MOST-SEVERE member's threat level, not whichever finding is
-// encountered first. For severity-derived threat_types (supply_chain here)
-// agreeing findings can carry different threat_levels; the previous code counted
-// the group at the first finding's level, making the score order-dependent and
-// able to drop a genuine warning. The score must be identical in both orders and
-// reflect the warning (high) member, not the info (low) one.
-//
-// It also guards Codex R2 #1: the weaker (info) member shares only the coarse
-// (location, threat_type) — it does NOT itself rate the issue at warning, so it
-// must NOT add weight to the warning bucket. The warning bucket is weighted by
-// its single genuine warning source (weight 1), not by the raw source count (2).
-func TestCalculateRiskScoreConsensusUsesMaxSeverity(t *testing.T) {
+// TestCalculateRiskScoreDistinctDangerousFindingsEachCount proves that two
+// GENUINELY DISTINCT dangerous findings (different rule ids at the same location)
+// each contribute their own category. This is NOT cross-scanner consensus
+// weighting — they are two separate issues in the unified report — so each is
+// scored at its own severity. Order-independent.
+func TestCalculateRiskScoreDistinctDangerousFindingsEachCount(t *testing.T) {
+	a := ScanFinding{RuleID: "detect.tpa", Location: "srv:tool", ThreatType: ThreatToolPoisoning, ThreatLevel: ThreatLevelDangerous, Scanner: "tpa-descriptions"}
+	b := ScanFinding{RuleID: "ramparts.y", Location: "srv:tool", ThreatType: ThreatToolPoisoning, ThreatLevel: ThreatLevelDangerous, Scanner: "ramparts"}
+
+	ab := CalculateRiskScore([]ScanFinding{a, b})
+	ba := CalculateRiskScore([]ScanFinding{b, a})
+	if ab != ba {
+		t.Fatalf("score is order-dependent: ab=%d ba=%d", ab, ba)
+	}
+	// two dangerous → 25*log2(3)=39.
+	if ab != 39 {
+		t.Errorf("two distinct dangerous findings score = %d, want 39", ab)
+	}
+}
+
+// TestCalculateRiskScoreWeakAgreeingFindingScoresAtOwnLevel proves the Spec 077
+// US2 model for severity-derived threat_types: when a warning and an info finding
+// share (location, threat_type) via DIFFERENT rule ids, each contributes ONLY its
+// own category. The info is never promoted to the warning bucket, and the warning
+// bucket stays at weight 1. The score is order-independent and does not depend on
+// which finding is encountered first.
+func TestCalculateRiskScoreWeakAgreeingFindingScoresAtOwnLevel(t *testing.T) {
 	warningFinding := ScanFinding{
 		RuleID:      "trivy.CVE-1",
 		Location:    "srv:tool",
@@ -516,24 +528,27 @@ func TestCalculateRiskScoreConsensusUsesMaxSeverity(t *testing.T) {
 	ba := CalculateRiskScore([]ScanFinding{infoFinding, warningFinding})
 
 	if ab != ba {
-		t.Fatalf("consensus score is order-dependent: [warning,info]=%d [info,warning]=%d", ab, ba)
+		t.Fatalf("score is order-dependent: [warning,info]=%d [info,warning]=%d", ab, ba)
 	}
-	// Scored at the warning level (the max), NOT the info level (2*log2(2)=2 would
-	// be the bug of using the first finding). Only one source (trivy) rated it
-	// warning, so the warning bucket weight is 1: 6*log2(2)=6. The info member
-	// does not inflate the warning bucket (Codex R2 #1).
-	if ab != 6 {
-		t.Errorf("consensus score = %d, want 6 (warning-level, 1 warning-rated source)", ab)
+	// warning bucket weight 1 (6*log2(2)=6) + info bucket weight 1 (2*log2(2)=2) = 8.
+	// The info NEVER inflates the warning bucket — it adds only its own info weight.
+	if ab != 8 {
+		t.Errorf("score = %d, want 8 (warning 6 + own info 2; info must not inflate warning)", ab)
+	}
+	// The warning contribution alone is unchanged by the agreeing info finding.
+	if lone := CalculateRiskScore([]ScanFinding{warningFinding}); lone != 6 {
+		t.Errorf("lone warning score = %d, want 6", lone)
 	}
 }
 
-// TestCalculateRiskScoreConsensusWeakDoesNotInflateStrong proves Codex R2 #1
-// directly: a HARD dangerous finding and a low/info finding that merely share a
-// (location, threat_type) must score the DANGEROUS bucket at weight 1 (the info
-// finding does not rate the issue as dangerous, so it adds no dangerous weight),
-// while two genuine dangerous findings from distinct sources score at weight 2.
-// The result is order-independent.
-func TestCalculateRiskScoreConsensusWeakDoesNotInflateStrong(t *testing.T) {
+// TestCalculateRiskScoreWeakDoesNotInflateStrongBucket proves the core Spec 077
+// US2 guarantee (resolving Codex R2 #1 structurally): a low/info finding that
+// merely shares a (location, threat_type) with a HARD dangerous finding does NOT
+// add weight to the DANGEROUS bucket. It contributes only its own info weight, so
+// the dangerous bucket stays at weight 1 — strictly less than two GENUINE
+// dangerous findings, which score the dangerous bucket at weight 2. The result is
+// order-independent.
+func TestCalculateRiskScoreWeakDoesNotInflateStrongBucket(t *testing.T) {
 	dangerous := ScanFinding{
 		RuleID:      "detect.tpa",
 		Location:    "srv:tool",
@@ -556,32 +571,35 @@ func TestCalculateRiskScoreConsensusWeakDoesNotInflateStrong(t *testing.T) {
 		Scanner:     "ramparts",
 	}
 
-	// dangerous + info: two sources gate consensus, but only ONE rated it
-	// dangerous → dangerous weight 1 → 25*log2(2)=25 (same as a lone dangerous).
+	// dangerous + info: dangerous bucket weight 1 (25*log2(2)=25) + own info weight
+	// 1 (2*log2(2)=2) = 27. The info NEVER reaches the dangerous bucket.
 	dangerFirst := CalculateRiskScore([]ScanFinding{dangerous, info})
 	infoFirst := CalculateRiskScore([]ScanFinding{info, dangerous})
 	if dangerFirst != infoFirst {
 		t.Fatalf("weak+strong score is order-dependent: danger-first=%d info-first=%d", dangerFirst, infoFirst)
 	}
-	if dangerFirst != 25 {
-		t.Errorf("dangerous+info consensus score = %d, want 25 (weight 1, info must not inflate dangerous)", dangerFirst)
+	if dangerFirst != 27 {
+		t.Errorf("dangerous+info score = %d, want 27 (dangerous 25 + own info 2)", dangerFirst)
 	}
-	if lone := CalculateRiskScore([]ScanFinding{dangerous}); dangerFirst != lone {
-		t.Errorf("dangerous+info score %d must equal lone-dangerous score %d — the info adds no dangerous weight", dangerFirst, lone)
+	// The DANGEROUS bucket is not inflated: dropping the info leaves the dangerous
+	// contribution (25) unchanged — the info never gains dangerous weight.
+	if lone := CalculateRiskScore([]ScanFinding{dangerous}); lone != 25 {
+		t.Errorf("lone dangerous score = %d, want 25", lone)
 	}
 
-	// Two genuine dangerous sources DO boost the dangerous bucket to weight 2 →
-	// 25*log2(3)=39. Order-independent.
+	// Two GENUINE dangerous findings DO score the dangerous bucket at weight 2 →
+	// 25*log2(3)=39, strictly more than the non-inflated weak+strong case.
+	// Order-independent.
 	twoAB := CalculateRiskScore([]ScanFinding{dangerous, dangerous2})
 	twoBA := CalculateRiskScore([]ScanFinding{dangerous2, dangerous})
 	if twoAB != twoBA {
 		t.Fatalf("two-dangerous score is order-dependent: %d vs %d", twoAB, twoBA)
 	}
 	if twoAB != 39 {
-		t.Errorf("two dangerous sources consensus score = %d, want 39 (weight 2)", twoAB)
+		t.Errorf("two dangerous findings score = %d, want 39 (dangerous weight 2)", twoAB)
 	}
 	if twoAB <= dangerFirst {
-		t.Errorf("genuine dangerous consensus %d must exceed the non-inflated weak+strong %d", twoAB, dangerFirst)
+		t.Errorf("two genuine dangerous %d must exceed weak+strong %d (info gained no dangerous weight)", twoAB, dangerFirst)
 	}
 }
 

--- a/internal/security/scanner/sarif_test.go
+++ b/internal/security/scanner/sarif_test.go
@@ -358,6 +358,63 @@ func TestMergeFindingsDedupByRuleAndLocation(t *testing.T) {
 	}
 }
 
+// TestMergeFindingsAbsorbsStrongerSeverity proves Spec 077 (US2): when a
+// low/info duplicate and a high/warning duplicate share the same
+// (rule_id, location), the merged finding takes the MORE-SEVERE Severity and
+// ThreatLevel (alongside max Confidence and most-severe Tier) regardless of the
+// order in which the two are presented. Absorbing only some of the stronger
+// fields would make CalculateRiskScore and the summary order-dependent.
+func TestMergeFindingsAbsorbsStrongerSeverity(t *testing.T) {
+	weak := ScanFinding{
+		RuleID: "detect.tpa", Location: "srv:tool", ThreatType: ThreatToolPoisoning,
+		Severity: SeverityInfo, ThreatLevel: ThreatLevelInfo, Tier: TierSoft,
+		Confidence: 0.3, Scanner: "scanner-a", Sources: []string{"scanner-a"},
+	}
+	strong := ScanFinding{
+		RuleID: "detect.tpa", Location: "srv:tool", ThreatType: ThreatToolPoisoning,
+		Severity: SeverityHigh, ThreatLevel: ThreatLevelWarning, Tier: TierHard,
+		Confidence: 0.9, Scanner: "scanner-b", Sources: []string{"scanner-b"},
+	}
+
+	assertMerged := func(t *testing.T, merged []ScanFinding) {
+		t.Helper()
+		if len(merged) != 1 {
+			t.Fatalf("expected exactly 1 merged finding, got %d: %+v", len(merged), merged)
+		}
+		f := merged[0]
+		if f.Severity != SeverityHigh {
+			t.Errorf("expected merged Severity=high, got %q", f.Severity)
+		}
+		if f.ThreatLevel != ThreatLevelWarning {
+			t.Errorf("expected merged ThreatLevel=warning, got %q", f.ThreatLevel)
+		}
+		if f.Tier != TierHard {
+			t.Errorf("expected merged Tier=hard, got %q", f.Tier)
+		}
+		// Max of the two confidences (0.9), possibly raised further by the
+		// two-source consensus boost — never the weak 0.3.
+		if f.Confidence < 0.9 {
+			t.Errorf("expected merged Confidence>=0.9, got %v", f.Confidence)
+		}
+	}
+
+	weakFirst := MergeFindings([]ScanFinding{weak, strong})
+	strongFirst := MergeFindings([]ScanFinding{strong, weak})
+	assertMerged(t, weakFirst)
+	assertMerged(t, strongFirst)
+
+	// The whole point: the merge — and therefore the aggregate risk score — is
+	// order-independent. A weak-then-strong ordering must not score lower than a
+	// strong-then-weak ordering.
+	if got, want := CalculateRiskScore(weakFirst), CalculateRiskScore(strongFirst); got != want {
+		t.Errorf("CalculateRiskScore is order-dependent: weak-first=%d strong-first=%d", got, want)
+	}
+	// And both must reflect the high/warning severity, not the info floor.
+	if s := CalculateRiskScore(weakFirst); s == 0 {
+		t.Errorf("expected non-zero risk score after absorbing the warning-level duplicate, got %d", s)
+	}
+}
+
 // TestMergeFindingsConsensusBoostsConfidence proves Spec 077 FR-012: when two
 // independent sources agree on the same (location, threat_type) — even via
 // different rule ids — the merged finding's confidence rises above the

--- a/internal/security/scanner/sarif_test.go
+++ b/internal/security/scanner/sarif_test.go
@@ -424,6 +424,86 @@ func TestCalculateRiskScoreCrossSourceConsensusAdds(t *testing.T) {
 	}
 }
 
+// TestCalculateRiskScoreConsensusUsesMaxSeverity proves the consensus group is
+// scored at its MOST-SEVERE member's threat level, not whichever finding is
+// encountered first. For severity-derived threat_types (supply_chain here)
+// agreeing findings can carry different threat_levels; the previous code counted
+// the group at the first finding's level, making the score order-dependent and
+// able to drop a genuine warning. The score must be identical in both orders and
+// reflect the warning (high) member, not the info (low) one.
+func TestCalculateRiskScoreConsensusUsesMaxSeverity(t *testing.T) {
+	warningFinding := ScanFinding{
+		RuleID:      "trivy.CVE-1",
+		Location:    "srv:tool",
+		ThreatType:  ThreatSupplyChain,
+		ThreatLevel: ThreatLevelWarning,
+		Severity:    SeverityHigh,
+		Scanner:     "trivy",
+	}
+	infoFinding := ScanFinding{
+		RuleID:      "grype.CVE-2",
+		Location:    "srv:tool",
+		ThreatType:  ThreatSupplyChain,
+		ThreatLevel: ThreatLevelInfo,
+		Severity:    SeverityLow,
+		Scanner:     "grype",
+	}
+
+	ab := CalculateRiskScore([]ScanFinding{warningFinding, infoFinding})
+	ba := CalculateRiskScore([]ScanFinding{infoFinding, warningFinding})
+
+	if ab != ba {
+		t.Fatalf("consensus score is order-dependent: [warning,info]=%d [info,warning]=%d", ab, ba)
+	}
+	// Two distinct sources agree → weight 2 at the warning level: 6*log2(3)=9.
+	// Scoring at the info level (the bug) would give 2*log2(3)=3.
+	if ab != 9 {
+		t.Errorf("consensus score = %d, want 9 (warning-level, 2 sources)", ab)
+	}
+}
+
+// TestMergeFindingsAbsorbsStrongerFields proves that phase-1 dedup keeps the
+// absorbed duplicate's stronger fields: on merge the result takes max(Confidence),
+// the more-severe Tier (hard > soft), and the union of Signals — regardless of
+// which finding is encountered first.
+func TestMergeFindingsAbsorbsStrongerFields(t *testing.T) {
+	hard := ScanFinding{
+		RuleID: "detect.tpa", Location: "srv:tool",
+		Tier: TierHard, Confidence: 0.9, Signals: []string{"unicode.hidden"},
+		Scanner: "tpa-descriptions",
+	}
+	soft := ScanFinding{
+		RuleID: "detect.tpa", Location: "srv:tool",
+		Tier: TierSoft, Confidence: 0.2, Signals: []string{"directive.imperative"},
+		Scanner: "cisco-mcp-scanner",
+	}
+
+	for _, tc := range []struct {
+		name string
+		in   []ScanFinding
+	}{
+		{"soft-first", []ScanFinding{soft, hard}},
+		{"hard-first", []ScanFinding{hard, soft}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			merged := MergeFindings(tc.in)
+			if len(merged) != 1 {
+				t.Fatalf("expected 1 merged finding, got %d: %+v", len(merged), merged)
+			}
+			m := merged[0]
+			if m.Tier != TierHard {
+				t.Errorf("merged tier = %q, want hard (more-severe tier must win)", m.Tier)
+			}
+			if m.Confidence != 0.9 {
+				t.Errorf("merged confidence = %v, want 0.9 (max)", m.Confidence)
+			}
+			if len(m.Signals) != 2 {
+				t.Errorf("merged signals = %v, want union of both (2)", m.Signals)
+			}
+		})
+	}
+}
+
 // TestClassifyThreatBackfillsSeverity proves Spec 077 (T022): a finding that
 // arrives with no severity (as some external/legacy SARIF findings do) is given
 // a user-readable severity derived from its classified threat level.

--- a/internal/security/scanner/sarif_test.go
+++ b/internal/security/scanner/sarif_test.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 )
 
@@ -488,6 +489,11 @@ func TestCalculateRiskScoreCrossSourceConsensusAdds(t *testing.T) {
 // the group at the first finding's level, making the score order-dependent and
 // able to drop a genuine warning. The score must be identical in both orders and
 // reflect the warning (high) member, not the info (low) one.
+//
+// It also guards Codex R2 #1: the weaker (info) member shares only the coarse
+// (location, threat_type) — it does NOT itself rate the issue at warning, so it
+// must NOT add weight to the warning bucket. The warning bucket is weighted by
+// its single genuine warning source (weight 1), not by the raw source count (2).
 func TestCalculateRiskScoreConsensusUsesMaxSeverity(t *testing.T) {
 	warningFinding := ScanFinding{
 		RuleID:      "trivy.CVE-1",
@@ -512,10 +518,70 @@ func TestCalculateRiskScoreConsensusUsesMaxSeverity(t *testing.T) {
 	if ab != ba {
 		t.Fatalf("consensus score is order-dependent: [warning,info]=%d [info,warning]=%d", ab, ba)
 	}
-	// Two distinct sources agree → weight 2 at the warning level: 6*log2(3)=9.
-	// Scoring at the info level (the bug) would give 2*log2(3)=3.
-	if ab != 9 {
-		t.Errorf("consensus score = %d, want 9 (warning-level, 2 sources)", ab)
+	// Scored at the warning level (the max), NOT the info level (2*log2(2)=2 would
+	// be the bug of using the first finding). Only one source (trivy) rated it
+	// warning, so the warning bucket weight is 1: 6*log2(2)=6. The info member
+	// does not inflate the warning bucket (Codex R2 #1).
+	if ab != 6 {
+		t.Errorf("consensus score = %d, want 6 (warning-level, 1 warning-rated source)", ab)
+	}
+}
+
+// TestCalculateRiskScoreConsensusWeakDoesNotInflateStrong proves Codex R2 #1
+// directly: a HARD dangerous finding and a low/info finding that merely share a
+// (location, threat_type) must score the DANGEROUS bucket at weight 1 (the info
+// finding does not rate the issue as dangerous, so it adds no dangerous weight),
+// while two genuine dangerous findings from distinct sources score at weight 2.
+// The result is order-independent.
+func TestCalculateRiskScoreConsensusWeakDoesNotInflateStrong(t *testing.T) {
+	dangerous := ScanFinding{
+		RuleID:      "detect.tpa",
+		Location:    "srv:tool",
+		ThreatType:  ThreatToolPoisoning,
+		ThreatLevel: ThreatLevelDangerous,
+		Scanner:     "tpa-descriptions",
+	}
+	info := ScanFinding{
+		RuleID:      "cisco.hint",
+		Location:    "srv:tool",
+		ThreatType:  ThreatToolPoisoning,
+		ThreatLevel: ThreatLevelInfo,
+		Scanner:     "cisco-mcp-scanner",
+	}
+	dangerous2 := ScanFinding{
+		RuleID:      "ramparts.y",
+		Location:    "srv:tool",
+		ThreatType:  ThreatToolPoisoning,
+		ThreatLevel: ThreatLevelDangerous,
+		Scanner:     "ramparts",
+	}
+
+	// dangerous + info: two sources gate consensus, but only ONE rated it
+	// dangerous → dangerous weight 1 → 25*log2(2)=25 (same as a lone dangerous).
+	dangerFirst := CalculateRiskScore([]ScanFinding{dangerous, info})
+	infoFirst := CalculateRiskScore([]ScanFinding{info, dangerous})
+	if dangerFirst != infoFirst {
+		t.Fatalf("weak+strong score is order-dependent: danger-first=%d info-first=%d", dangerFirst, infoFirst)
+	}
+	if dangerFirst != 25 {
+		t.Errorf("dangerous+info consensus score = %d, want 25 (weight 1, info must not inflate dangerous)", dangerFirst)
+	}
+	if lone := CalculateRiskScore([]ScanFinding{dangerous}); dangerFirst != lone {
+		t.Errorf("dangerous+info score %d must equal lone-dangerous score %d — the info adds no dangerous weight", dangerFirst, lone)
+	}
+
+	// Two genuine dangerous sources DO boost the dangerous bucket to weight 2 →
+	// 25*log2(3)=39. Order-independent.
+	twoAB := CalculateRiskScore([]ScanFinding{dangerous, dangerous2})
+	twoBA := CalculateRiskScore([]ScanFinding{dangerous2, dangerous})
+	if twoAB != twoBA {
+		t.Fatalf("two-dangerous score is order-dependent: %d vs %d", twoAB, twoBA)
+	}
+	if twoAB != 39 {
+		t.Errorf("two dangerous sources consensus score = %d, want 39 (weight 2)", twoAB)
+	}
+	if twoAB <= dangerFirst {
+		t.Errorf("genuine dangerous consensus %d must exceed the non-inflated weak+strong %d", twoAB, dangerFirst)
 	}
 }
 
@@ -558,6 +624,72 @@ func TestMergeFindingsAbsorbsStrongerFields(t *testing.T) {
 				t.Errorf("merged signals = %v, want union of both (2)", m.Signals)
 			}
 		})
+	}
+}
+
+// TestMergeFindingsBackfillsEnrichmentMetadata proves Codex R2 #2: when a
+// duplicate is absorbed on (rule_id, location) dedup, the kept finding fills any
+// field it lacks from the duplicate instead of dropping it — HelpURI, CVSSScore,
+// package/version metadata, Evidence, category/title/description, scan pass and
+// the supply-chain flag. The result is identical in both merge orders.
+func TestMergeFindingsBackfillsEnrichmentMetadata(t *testing.T) {
+	// bare carries the threat classification but none of the enrichment.
+	// Attribution rides Sources (Spec 077); the legacy per-anchor Scanner field is
+	// left empty so the DeepEqual order-independence check below is exact.
+	bare := ScanFinding{
+		RuleID: "CVE-2025-1", Location: "srv:tool", ThreatType: ThreatSupplyChain,
+		Severity: SeverityHigh, ThreatLevel: ThreatLevelWarning,
+		Sources: []string{"scanner-a"},
+	}
+	// enriched shares the (rule_id, location) but adds all the metadata.
+	enriched := ScanFinding{
+		RuleID: "CVE-2025-1", Location: "srv:tool", ThreatType: ThreatSupplyChain,
+		Severity: SeverityHigh, ThreatLevel: ThreatLevelWarning,
+		Category: "supply-chain", Title: "Vulnerable dependency",
+		Description: "Package foo has a known CVE", HelpURI: "https://cve/CVE-2025-1",
+		CVSSScore: 7.5, PackageName: "foo", InstalledVersion: "1.0.0",
+		FixedVersion: "1.1.0", ScanPass: 2, Evidence: "foo@1.0.0",
+		SupplyChainAudit: true, Sources: []string{"scanner-b"},
+	}
+
+	assertEnriched := func(t *testing.T, merged []ScanFinding) {
+		t.Helper()
+		if len(merged) != 1 {
+			t.Fatalf("expected exactly 1 merged finding, got %d: %+v", len(merged), merged)
+		}
+		f := merged[0]
+		if f.HelpURI != "https://cve/CVE-2025-1" {
+			t.Errorf("HelpURI = %q, want backfilled from duplicate", f.HelpURI)
+		}
+		if f.CVSSScore != 7.5 {
+			t.Errorf("CVSSScore = %v, want 7.5 (max)", f.CVSSScore)
+		}
+		if f.PackageName != "foo" || f.InstalledVersion != "1.0.0" || f.FixedVersion != "1.1.0" {
+			t.Errorf("package metadata not backfilled: %+v", f)
+		}
+		if f.Evidence != "foo@1.0.0" {
+			t.Errorf("Evidence = %q, want backfilled", f.Evidence)
+		}
+		if f.Category != "supply-chain" || f.Title == "" || f.Description == "" {
+			t.Errorf("category/title/description not backfilled: %+v", f)
+		}
+		if f.ScanPass != 2 {
+			t.Errorf("ScanPass = %d, want 2 (backfilled)", f.ScanPass)
+		}
+		if !f.SupplyChainAudit {
+			t.Errorf("SupplyChainAudit = false, want true (OR of both)")
+		}
+	}
+
+	bareFirst := MergeFindings([]ScanFinding{bare, enriched})
+	enrichedFirst := MergeFindings([]ScanFinding{enriched, bare})
+	assertEnriched(t, bareFirst)
+	assertEnriched(t, enrichedFirst)
+
+	// Order-independence: the merged finding is field-for-field identical whether
+	// the enriched or the bare duplicate is the merge anchor.
+	if !reflect.DeepEqual(bareFirst, enrichedFirst) {
+		t.Errorf("merge is order-dependent:\n bare-first    = %+v\n enriched-first= %+v", bareFirst, enrichedFirst)
 	}
 }
 

--- a/internal/security/scanner/sarif_test.go
+++ b/internal/security/scanner/sarif_test.go
@@ -336,6 +336,135 @@ func TestCalculateRiskScoreCrossScannerDedupRetained(t *testing.T) {
 	}
 }
 
+// TestMergeFindingsDedupByRuleAndLocation proves Spec 077 FR-010/FR-011: two
+// scanners reporting the same issue (same rule_id + location) collapse into a
+// single unified entry whose Sources lists every contributing scanner.
+func TestMergeFindingsDedupByRuleAndLocation(t *testing.T) {
+	findings := []ScanFinding{
+		{RuleID: "detect.tpa", Location: "srv:tool", ThreatType: ThreatToolPoisoning, ThreatLevel: ThreatLevelDangerous, Scanner: "tpa-descriptions", Sources: []string{"tpa-descriptions"}},
+		{RuleID: "detect.tpa", Location: "srv:tool", ThreatType: ThreatToolPoisoning, ThreatLevel: ThreatLevelDangerous, Scanner: "cisco-mcp-scanner", Sources: []string{"cisco-mcp-scanner"}},
+	}
+
+	merged := MergeFindings(findings)
+	if len(merged) != 1 {
+		t.Fatalf("expected exactly 1 merged finding, got %d: %+v", len(merged), merged)
+	}
+	if len(merged[0].Sources) != 2 {
+		t.Fatalf("expected merged finding to carry 2 sources, got %v", merged[0].Sources)
+	}
+	// Sources must be a stable (sorted) union so the wire output is deterministic.
+	if merged[0].Sources[0] != "cisco-mcp-scanner" || merged[0].Sources[1] != "tpa-descriptions" {
+		t.Errorf("expected sorted sources [cisco-mcp-scanner tpa-descriptions], got %v", merged[0].Sources)
+	}
+}
+
+// TestMergeFindingsConsensusBoostsConfidence proves Spec 077 FR-012: when two
+// independent sources agree on the same (location, threat_type) — even via
+// different rule ids — the merged finding's confidence rises above the
+// single-source confidence.
+func TestMergeFindingsConsensusBoostsConfidence(t *testing.T) {
+	single := MergeFindings([]ScanFinding{
+		{RuleID: "detect.tpa", Location: "srv:tool", ThreatType: ThreatToolPoisoning, ThreatLevel: ThreatLevelDangerous, Scanner: "tpa-descriptions", Confidence: 0.6},
+	})
+	if len(single) != 1 {
+		t.Fatalf("expected 1 finding for single source, got %d", len(single))
+	}
+	singleConf := single[0].Confidence
+
+	consensus := MergeFindings([]ScanFinding{
+		{RuleID: "detect.tpa", Location: "srv:tool", ThreatType: ThreatToolPoisoning, ThreatLevel: ThreatLevelDangerous, Scanner: "tpa-descriptions", Confidence: 0.6},
+		{RuleID: "cisco.poison", Location: "srv:tool", ThreatType: ThreatToolPoisoning, ThreatLevel: ThreatLevelDangerous, Scanner: "cisco-mcp-scanner", Confidence: 0.5},
+	})
+
+	// The tpa-descriptions finding (same rule as the single-source case) must be
+	// boosted by the agreement of the second, independent source.
+	var boosted float64
+	found := false
+	for _, f := range consensus {
+		if f.RuleID == "detect.tpa" {
+			boosted = f.Confidence
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected detect.tpa finding to survive merge, got %+v", consensus)
+	}
+	if boosted <= singleConf {
+		t.Errorf("consensus confidence %v must exceed single-source confidence %v", boosted, singleConf)
+	}
+}
+
+// TestCalculateRiskScoreCrossSourceConsensusAdds proves Spec 077 (T020): two
+// independent external/Docker scanners agreeing on the same (location,
+// threat_type) via different rule ids ADD to the consensus weight instead of
+// each flattening to weight 1, so the score exceeds a single-source scan.
+func TestCalculateRiskScoreCrossSourceConsensusAdds(t *testing.T) {
+	single := []ScanFinding{
+		{RuleID: "cisco.x", Location: "srv:tool", ThreatType: ThreatToolPoisoning, ThreatLevel: ThreatLevelDangerous, Scanner: "cisco-mcp-scanner"},
+	}
+	consensus := []ScanFinding{
+		{RuleID: "cisco.x", Location: "srv:tool", ThreatType: ThreatToolPoisoning, ThreatLevel: ThreatLevelDangerous, Scanner: "cisco-mcp-scanner"},
+		{RuleID: "ramparts.y", Location: "srv:tool", ThreatType: ThreatToolPoisoning, ThreatLevel: ThreatLevelDangerous, Scanner: "ramparts"},
+	}
+
+	singleScore := CalculateRiskScore(single)
+	consensusScore := CalculateRiskScore(consensus)
+
+	// single: one dangerous, one source → weight 1 → 25*log2(2)=25
+	if singleScore != 25 {
+		t.Errorf("single-source score = %d, want 25", singleScore)
+	}
+	// consensus: one issue (location+threat_type), two distinct sources → weight
+	// 2 → 25*log2(3)=39. Counted once (not double), but heavier than single.
+	if consensusScore != 39 {
+		t.Errorf("cross-source consensus score = %d, want 39", consensusScore)
+	}
+	if consensusScore <= singleScore {
+		t.Errorf("consensus score %d must exceed single-source score %d", consensusScore, singleScore)
+	}
+}
+
+// TestClassifyThreatBackfillsSeverity proves Spec 077 (T022): a finding that
+// arrives with no severity (as some external/legacy SARIF findings do) is given
+// a user-readable severity derived from its classified threat level.
+func TestClassifyThreatBackfillsSeverity(t *testing.T) {
+	tests := []struct {
+		name        string
+		in          ScanFinding
+		wantSevSet  bool
+		wantMinKeep string // if in.Severity already set, it must be preserved
+	}{
+		{
+			name:       "dangerous tool poisoning with no severity",
+			in:         ScanFinding{RuleID: "tool-poisoning", Description: "hidden instruction"},
+			wantSevSet: true,
+		},
+		{
+			name:       "supply chain cve with no severity",
+			in:         ScanFinding{RuleID: "CVE-2025-0001", PackageName: "lodash"},
+			wantSevSet: true,
+		},
+		{
+			name:        "explicit severity preserved",
+			in:          ScanFinding{RuleID: "anything", Severity: SeverityCritical},
+			wantSevSet:  true,
+			wantMinKeep: SeverityCritical,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := tt.in
+			ClassifyThreat(&f)
+			if tt.wantSevSet && f.Severity == "" {
+				t.Errorf("expected severity to be backfilled, got empty")
+			}
+			if tt.wantMinKeep != "" && f.Severity != tt.wantMinKeep {
+				t.Errorf("expected severity %q preserved, got %q", tt.wantMinKeep, f.Severity)
+			}
+		})
+	}
+}
+
 func TestSummarizeFindings(t *testing.T) {
 	findings := []ScanFinding{
 		{Severity: SeverityCritical},


### PR DESCRIPTION
## Spec 077 US2 — Unified report + cross-scanner consensus confidence

Supersedes the auto-closed **#788** (that PR was stacked on the pre-merge US1 head `0f5838e6`; GitHub auto-closed it when US1 squash-merged to `main` as `5b925e45`). This PR is the **same US2 work rebased fresh onto `main`**, so it applies cleanly on top of the final US1 baseline.

### What this adds (on top of merged US1)
- **Unified report + cross-scanner consensus** (`internal/security/scanner/sarif.go`, `engine.go`): `CalculateRiskScore` weights consensus groups (same location + threat_type from ≥2 distinct sources), additive confidence boost capped at 1.0 (`consensusConfidenceStep`), `Finding.Sources` populated + merged across scanners, severity backfill so external/legacy SARIF findings never render blank.
- **Round-1 review fix included** (`5c14f790`): consensus groups scored at **max severity**, stronger fields preserved on merge.
- **Web UI** (`frontend/src/views/ScanReport.vue`, `types/api.ts`): renders unified findings with severity + source attribution.

### Rebase conflict resolution
Only `internal/security/scanner/sarif.go` conflicted, in `ClassifyThreat`. US1 (final, on main) added an early `if f.Tier != "" { return }` so the legacy keyword classifier never rewrites authoritative detect findings; US2 added `defer backfillSeverity(f)`. **Both behaviors are kept**: the `defer` is registered *before* the early-return so it runs on every exit path (including baseline findings), and it is a no-op when severity is already set — so detect findings keep their authoritative classification while legacy/external findings still get a backfilled severity. No US1 fix was reverted.

### Verification (actual output)
- `go build ./...` → exit 0
- `go test ./internal/security/... -count=1` → all packages `ok` (security, detect, detect/checks, patterns, scanner)
- `go run ./cmd/scan-eval --gate --min-recall 0.90 --max-fp 0.05 --corpus specs/065-evaluation-foundation/datasets/detect_corpus_v1.json` → **GATE PASSED**: recall=1.0000 (≥0.90), fp=0.0000 (≤0.05)
- `golangci-lint run --config .github/.golangci.yml ./internal/security/...` → 0 issues

Related: Spec 077
