### PR TITLE
feat(security): US4 collapse scan-notification storm into one settled event (Spec 077, MCP-2207)

### DIFF
--- a/frontend/src/composables/useSecurityScannerStatus.ts
+++ b/frontend/src/composables/useSecurityScannerStatus.ts
@@ -17,6 +17,18 @@ const totalFindings = ref<number>(0)
 const totalScans = ref<number>(0)
 let inflight: Promise<void> | null = null
 
+// Spec 077 US4 (MCP-2207): the backend now collapses the per-scanner
+// scan_started/progress/completed/failed storm into a single debounced
+// `security.scan_settled` event per server per scan (forwarded by the system
+// store as `mcpproxy:scan-settled`). We consume that one settled signal to
+// refresh the cached scan totals, instead of tracking per-scanner lifecycle
+// events. Registered once at module scope so all consumers share it.
+if (typeof window !== 'undefined') {
+  window.addEventListener('mcpproxy:scan-settled', () => {
+    void refreshSecurityScannerStatus()
+  })
+}
+
 export async function refreshSecurityScannerStatus(): Promise<void> {
   if (inflight) {
     return inflight

--- a/frontend/src/stores/system.ts
+++ b/frontend/src/stores/system.ts
@@ -185,6 +185,19 @@ export const useSystemStore = defineStore('system', () => {
       }
     })
 
+    // Spec 077 US4 (MCP-2207): a single debounced settled event per server per
+    // scan replaces the per-scanner scan_started/progress/completed/failed
+    // storm. Forward it so scan-status consumers can refresh once per scan.
+    es.addEventListener('security.scan_settled', (event) => {
+      try {
+        const data = JSON.parse(event.data)
+        const payload = data.payload || data
+        window.dispatchEvent(new CustomEvent('mcpproxy:scan-settled', { detail: payload }))
+      } catch (error) {
+        console.error('Failed to parse SSE security.scan_settled event:', error)
+      }
+    })
+
     // Listen for activity events (tool calls, policy decisions, etc.)
     es.addEventListener('activity.tool_call.started', (event) => {
       try {

--- a/internal/runtime/activity_service.go
+++ b/internal/runtime/activity_service.go
@@ -246,13 +246,10 @@ func (s *ActivityService) handleEvent(evt Event) {
 	// Spec 032: Tool-level quarantine events
 	case EventTypeActivityToolQuarantineChange:
 		s.handleToolQuarantineChange(evt)
-	// Spec 039: Security scan events
-	case EventTypeSecurityScanStarted:
-		s.handleSecurityScanStarted(evt)
-	case EventTypeSecurityScanCompleted:
-		s.handleSecurityScanCompleted(evt)
-	case EventTypeSecurityScanFailed:
-		s.handleSecurityScanFailed(evt)
+	// Spec 077 US4: one settled activity record per server per scan replaces the
+	// former per-scanner started/completed/failed storm (Spec 039).
+	case EventTypeSecurityScanSettled:
+		s.handleSecurityScanSettled(evt)
 	default:
 		// Ignore other event types
 	}
@@ -855,82 +852,39 @@ func (s *ActivityService) handleToolQuarantineChange(evt Event) {
 }
 
 // handleSecurityScanStarted records a security scan start event (Spec 039).
-func (s *ActivityService) handleSecurityScanStarted(evt Event) {
+// handleSecurityScanSettled records the single settled scan result per server
+// per scan (Spec 077 US4, MCP-2207). It replaces the former started/completed/
+// failed handlers so the activity log carries one entry per scan instead of a
+// per-scanner storm.
+func (s *ActivityService) handleSecurityScanSettled(evt Event) {
 	serverName := getStringPayload(evt.Payload, "server_name")
-	jobID := getStringPayload(evt.Payload, "job_id")
-
-	metadata := map[string]interface{}{
-		"job_id": jobID,
-	}
-	if scanners := evt.Payload["scanners"]; scanners != nil {
-		metadata["scanners"] = scanners
-	}
-
-	record := &storage.ActivityRecord{
-		Type:       storage.ActivityTypeSecurityScan,
-		Source:     storage.ActivitySourceInternal,
-		ServerName: serverName,
-		ToolName:   "security_scan",
-		Status:     "started",
-		Timestamp:  evt.Timestamp,
-		Metadata:   metadata,
-	}
-
-	if err := s.storage.SaveActivity(record); err != nil {
-		s.logger.Error("Failed to save security scan started activity",
-			zap.String("server", serverName),
-			zap.Error(err))
-	}
-}
-
-// handleSecurityScanCompleted records a security scan completion event (Spec 039).
-func (s *ActivityService) handleSecurityScanCompleted(evt Event) {
-	serverName := getStringPayload(evt.Payload, "server_name")
+	scanStatus := getStringPayload(evt.Payload, "status")
+	errMsg := getStringPayload(evt.Payload, "error")
 
 	metadata := map[string]interface{}{}
 	if findingsSummary := getMapPayload(evt.Payload, "findings_summary"); findingsSummary != nil {
 		metadata["findings_summary"] = findingsSummary
 	}
-	if jobID := getStringPayload(evt.Payload, "job_id"); jobID != "" {
-		metadata["job_id"] = jobID
-	}
 
-	record := &storage.ActivityRecord{
-		Type:       storage.ActivityTypeSecurityScan,
-		Source:     storage.ActivitySourceInternal,
-		ServerName: serverName,
-		ToolName:   "security_scan",
-		Status:     "success",
-		Timestamp:  evt.Timestamp,
-		Metadata:   metadata,
+	// Map the scan's terminal state onto the activity record status.
+	status := "success"
+	if scanStatus == "failed" {
+		status = "error"
 	}
-
-	if err := s.storage.SaveActivity(record); err != nil {
-		s.logger.Error("Failed to save security scan completed activity",
-			zap.String("server", serverName),
-			zap.Error(err))
-	}
-}
-
-// handleSecurityScanFailed records a security scan failure event (Spec 039).
-func (s *ActivityService) handleSecurityScanFailed(evt Event) {
-	serverName := getStringPayload(evt.Payload, "server_name")
-	scannerID := getStringPayload(evt.Payload, "scanner_id")
-	errMsg := getStringPayload(evt.Payload, "error")
 
 	record := &storage.ActivityRecord{
 		Type:         storage.ActivityTypeSecurityScan,
 		Source:       storage.ActivitySourceInternal,
 		ServerName:   serverName,
 		ToolName:     "security_scan",
-		Status:       "error",
+		Status:       status,
 		ErrorMessage: errMsg,
 		Timestamp:    evt.Timestamp,
-		Metadata:     map[string]interface{}{"scanner_id": scannerID},
+		Metadata:     metadata,
 	}
 
 	if err := s.storage.SaveActivity(record); err != nil {
-		s.logger.Error("Failed to save security scan failed activity",
+		s.logger.Error("Failed to save settled security scan activity",
 			zap.String("server", serverName),
 			zap.Error(err))
 	}

--- a/internal/runtime/event_bus.go
+++ b/internal/runtime/event_bus.go
@@ -585,44 +585,54 @@ func (r *Runtime) EmitSensitiveDataDetected(activityID string, detectionCount in
 	r.publishEvent(newEvent(EventTypeSensitiveDataDetected, payload))
 }
 
-// EmitSecurityScanStarted emits an event when a security scan begins (Spec 039).
-func (r *Runtime) EmitSecurityScanStarted(serverName string, scanners []string, jobID string) {
-	payload := map[string]any{
-		"server_name": serverName,
-		"scanners":    scanners,
-		"job_id":      jobID,
-	}
-	r.publishEvent(newEvent(EventTypeSecurityScanStarted, payload))
+// EmitSecurityScanStarted feeds the scan-notification debouncer (Spec 077 US4,
+// MCP-2207). The started signal is intentionally dropped: it is part of the
+// per-scanner storm the debouncer collapses. The service still invalidates its
+// summary cache independently so the UI shows "scanning" while the scan runs.
+func (r *Runtime) EmitSecurityScanStarted(serverName string, _ []string, _ string) {
+	// No-op for notifications: a single settled event replaces the whole
+	// per-scanner lifecycle. Kept to satisfy the scanner EventEmitter contract.
+	_ = serverName
 }
 
-// EmitSecurityScanProgress emits an event for scanner progress updates (Spec 039).
-func (r *Runtime) EmitSecurityScanProgress(serverName, scannerID, status string, progress int) {
-	payload := map[string]any{
-		"server_name": serverName,
-		"scanner_id":  scannerID,
-		"status":      status,
-		"progress":    progress,
-	}
-	r.publishEvent(newEvent(EventTypeSecurityScanProgress, payload))
-}
+// EmitSecurityScanProgress is dropped: intermediate per-scanner progress is the
+// noise the settled-event model eliminates (Spec 077 US4).
+func (r *Runtime) EmitSecurityScanProgress(_, _, _ string, _ int) {}
 
-// EmitSecurityScanCompleted emits an event when a security scan completes (Spec 039).
+// EmitSecurityScanCompleted records a terminal scan result for the debouncer,
+// which publishes exactly one settled event per server per scan (Spec 077 US4).
 func (r *Runtime) EmitSecurityScanCompleted(serverName string, findingsSummary map[string]int) {
+	if r.scanNotify != nil {
+		r.scanNotify.noteTerminal(serverName, "completed", findingsSummary, "")
+		return
+	}
+	// Fallback (no debouncer wired, e.g. some tests): publish directly so the
+	// terminal result is not silently lost.
+	r.publishScanSettled(serverName, "completed", findingsSummary, "")
+}
+
+// EmitSecurityScanFailed records a terminal failure for the debouncer. Under
+// Spec 077 the baseline verdict is derived elsewhere; here we only ensure the
+// storm still collapses to a single settled event (Spec 077 US4).
+func (r *Runtime) EmitSecurityScanFailed(serverName, _, errMsg string) {
+	if r.scanNotify != nil {
+		r.scanNotify.noteTerminal(serverName, "failed", nil, errMsg)
+		return
+	}
+	r.publishScanSettled(serverName, "failed", nil, errMsg)
+}
+
+// publishScanSettled emits the single debounced terminal scan event.
+func (r *Runtime) publishScanSettled(serverName, status string, findingsSummary map[string]int, errMsg string) {
 	payload := map[string]any{
 		"server_name":      serverName,
+		"status":           status,
 		"findings_summary": findingsSummary,
 	}
-	r.publishEvent(newEvent(EventTypeSecurityScanCompleted, payload))
-}
-
-// EmitSecurityScanFailed emits an event when a scanner fails (Spec 039).
-func (r *Runtime) EmitSecurityScanFailed(serverName, scannerID, errMsg string) {
-	payload := map[string]any{
-		"server_name": serverName,
-		"scanner_id":  scannerID,
-		"error":       errMsg,
+	if errMsg != "" {
+		payload["error"] = errMsg
 	}
-	r.publishEvent(newEvent(EventTypeSecurityScanFailed, payload))
+	r.publishEvent(newEvent(EventTypeSecurityScanSettled, payload))
 }
 
 // EmitSecurityIntegrityAlert emits an event for integrity violations (Spec 039).

--- a/internal/runtime/events.go
+++ b/internal/runtime/events.go
@@ -60,6 +60,11 @@ const (
 	EventTypeSecurityScanCompleted EventType = "security.scan_completed"
 	// EventTypeSecurityScanFailed is emitted when a scanner fails.
 	EventTypeSecurityScanFailed EventType = "security.scan_failed"
+	// EventTypeSecurityScanSettled is the single, debounced terminal event that
+	// Spec 077 US4 (MCP-2207) emits per server per scan. It collapses the
+	// per-scanner scan_started/progress/completed/failed storm — including
+	// repeats from reconnect storms — into one settled result.
+	EventTypeSecurityScanSettled EventType = "security.scan_settled"
 	// EventTypeSecurityIntegrityAlert is emitted for integrity violations.
 	EventTypeSecurityIntegrityAlert EventType = "security.integrity_alert"
 	// EventTypeSecurityScannerChanged is emitted when a scanner plugin's state

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -89,6 +89,10 @@ type Runtime struct {
 	// GET /api/v1/servers.
 	coalescer *serversChangedCoalescer
 
+	// Spec 077 US4 (MCP-2207): debounces the per-scanner security-scan
+	// lifecycle storm into one settled event per server per scan.
+	scanNotify *scanNotifyDebouncer
+
 	// Phase 6: Supervisor for state reconciliation (lock-free reads via StateView)
 	supervisor *supervisor.Supervisor
 
@@ -281,6 +285,11 @@ func New(cfg *config.Config, cfgPath string, logger *zap.Logger) (*Runtime, erro
 	// events. Lifetime is tied to appCtx so it shuts down with the runtime.
 	rt.coalescer = newServersChangedCoalescer(rt, 50*time.Millisecond)
 	rt.coalescer.start(appCtx)
+
+	// Spec 077 US4 (MCP-2207): collapse the per-scanner scan-notification storm
+	// into one settled event per server. 750ms bridges the rapid lifecycle
+	// signals of a reconnect storm without noticeably delaying the result.
+	rt.scanNotify = newScanNotifyDebouncer(rt, 750*time.Millisecond)
 
 	return rt, nil
 }

--- a/internal/runtime/scan_notify.go
+++ b/internal/runtime/scan_notify.go
@@ -1,0 +1,101 @@
+package runtime
+
+import (
+	"sync"
+	"time"
+)
+
+// scanNotifyDebouncer collapses the per-scanner security-scan lifecycle storm
+// into a single debounced "settled" event per server per scan (Spec 077 US4,
+// MCP-2207). Prior partial fixes (#659, MCP-2223) trimmed individual event
+// classes but the reconnect-storm × per-scanner multiplication remained: every
+// reconnect re-ran the full scan_started/progress/completed lifecycle for every
+// enabled scanner, flooding SSE subscribers.
+//
+// The model here is deliberately terminal-triggered: only terminal signals
+// (scan completed / scan failed) arm the per-server debounce timer; the noisy
+// started/progress signals are dropped entirely. Each terminal signal for a
+// server (re)arms a short timer; when the timer finally fires quietly, exactly
+// one EventTypeSecurityScanSettled is published carrying the last-known terminal
+// state. A reconnect storm across N servers therefore yields at most N settled
+// events (one per server), satisfying FR-015/SC-006.
+//
+// Concurrency: a per-server generation counter guards against the classic
+// AfterFunc race where a timer that has already fired blocks on the mutex while
+// a fresh signal re-arms — only the flush whose generation still matches the
+// latest signal is allowed to publish, so a superseded timer is a no-op.
+type scanNotifyDebouncer struct {
+	rt       *Runtime
+	interval time.Duration
+
+	mu      sync.Mutex
+	pending map[string]*pendingScan
+}
+
+// pendingScan holds the debounced terminal state for one server between the
+// last terminal signal and the settled publish.
+type pendingScan struct {
+	gen     uint64
+	timer   *time.Timer
+	status  string         // "completed" | "failed"
+	summary map[string]int // findings-by-severity from the last completed scan
+	errMsg  string         // last error, when status == "failed"
+}
+
+func newScanNotifyDebouncer(rt *Runtime, interval time.Duration) *scanNotifyDebouncer {
+	return &scanNotifyDebouncer{
+		rt:       rt,
+		interval: interval,
+		pending:  make(map[string]*pendingScan),
+	}
+}
+
+// noteTerminal records a terminal scan signal for a server and (re)arms the
+// debounce timer. Non-nil summaries and non-empty statuses/errors overwrite the
+// prior state last-write-wins, so the eventual settled event reflects the most
+// recent scan in a storm.
+func (d *scanNotifyDebouncer) noteTerminal(server, status string, summary map[string]int, errMsg string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	p := d.pending[server]
+	if p == nil {
+		p = &pendingScan{}
+		d.pending[server] = p
+	}
+	if status != "" {
+		p.status = status
+	}
+	if summary != nil {
+		p.summary = summary
+	}
+	if errMsg != "" {
+		p.errMsg = errMsg
+	}
+
+	p.gen++
+	gen := p.gen
+	if p.timer != nil {
+		p.timer.Stop()
+	}
+	p.timer = time.AfterFunc(d.interval, func() { d.flush(server, gen) })
+}
+
+// flush publishes the single settled event for a server, but only if no newer
+// terminal signal has superseded the timer that scheduled this flush.
+func (d *scanNotifyDebouncer) flush(server string, gen uint64) {
+	d.mu.Lock()
+	p := d.pending[server]
+	if p == nil || p.gen != gen {
+		// Superseded by a newer signal (or already flushed) — do nothing.
+		d.mu.Unlock()
+		return
+	}
+	delete(d.pending, server)
+	status := p.status
+	summary := p.summary
+	errMsg := p.errMsg
+	d.mu.Unlock()
+
+	d.rt.publishScanSettled(server, status, summary, errMsg)
+}

--- a/internal/runtime/scan_notify_test.go
+++ b/internal/runtime/scan_notify_test.go
@@ -1,0 +1,123 @@
+package runtime
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// TestScanNotify_ReconnectStormCollapses proves Spec 077 US4 (MCP-2207): a
+// reconnect storm across N servers — each firing the full per-scanner
+// scan_started/progress/completed lifecycle multiple times — must collapse into
+// at most one settled scan event per server (<= N total), and must emit NO
+// per-scanner lifecycle events (those are the storm we are eliminating).
+func TestScanNotify_ReconnectStormCollapses(t *testing.T) {
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+	defer func() { _ = logger.Sync() }()
+
+	rt := &Runtime{
+		logger:    logger,
+		eventSubs: make(map[chan Event]struct{}),
+	}
+	// Short debounce so the test settles quickly.
+	rt.scanNotify = newScanNotifyDebouncer(rt, 40*time.Millisecond)
+
+	eventChan := rt.SubscribeEvents()
+	defer rt.UnsubscribeEvents(eventChan)
+
+	const numServers = 5
+	const reconnectsPerServer = 4
+
+	// Collect events in the background until the collection window closes.
+	settledPerServer := make(map[string]int)
+	legacyCount := 0
+	collectDone := make(chan struct{})
+	go func() {
+		defer close(collectDone)
+		timeout := time.After(2 * time.Second)
+		for {
+			select {
+			case evt := <-eventChan:
+				switch evt.Type {
+				case EventTypeSecurityScanSettled:
+					name, _ := evt.Payload["server_name"].(string)
+					settledPerServer[name]++
+				case EventTypeSecurityScanStarted,
+					EventTypeSecurityScanProgress,
+					EventTypeSecurityScanCompleted,
+					EventTypeSecurityScanFailed:
+					legacyCount++
+				}
+			case <-timeout:
+				return
+			}
+		}
+	}()
+
+	// Simulate a reconnect storm: every server reconnects several times in quick
+	// succession, each reconnect driving the full per-scanner lifecycle.
+	for r := 0; r < reconnectsPerServer; r++ {
+		for s := 0; s < numServers; s++ {
+			server := fmt.Sprintf("server-%d", s)
+			jobID := fmt.Sprintf("%s-job-%d", server, r)
+			rt.EmitSecurityScanStarted(server, []string{"tpa-descriptions"}, jobID)
+			rt.EmitSecurityScanProgress(server, "tpa-descriptions", "running", 0)
+			rt.EmitSecurityScanProgress(server, "tpa-descriptions", "completed", 100)
+			rt.EmitSecurityScanCompleted(server, map[string]int{"high": 1})
+		}
+	}
+
+	// Wait long enough for the debounce window to fire, then close collection.
+	time.Sleep(300 * time.Millisecond)
+	rt.UnsubscribeEvents(eventChan)
+	<-collectDone
+
+	totalSettled := 0
+	for _, c := range settledPerServer {
+		totalSettled += c
+	}
+
+	assert.Zero(t, legacyCount, "per-scanner lifecycle events must be collapsed away entirely")
+	assert.LessOrEqual(t, totalSettled, numServers,
+		"a reconnect storm across %d servers must yield at most %d settled events, got %d",
+		numServers, numServers, totalSettled)
+	assert.Equal(t, numServers, len(settledPerServer),
+		"every scanned server must receive exactly one settled event")
+	for server, count := range settledPerServer {
+		assert.Equal(t, 1, count, "server %s must settle exactly once", server)
+	}
+}
+
+// TestScanNotify_SettledCarriesTerminalSummary verifies the single settled event
+// carries the terminal findings summary and server identity.
+func TestScanNotify_SettledCarriesTerminalSummary(t *testing.T) {
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+	defer func() { _ = logger.Sync() }()
+
+	rt := &Runtime{
+		logger:    logger,
+		eventSubs: make(map[chan Event]struct{}),
+	}
+	rt.scanNotify = newScanNotifyDebouncer(rt, 30*time.Millisecond)
+
+	eventChan := rt.SubscribeEvents()
+	defer rt.UnsubscribeEvents(eventChan)
+
+	rt.EmitSecurityScanStarted("srv", []string{"tpa-descriptions"}, "job-1")
+	rt.EmitSecurityScanCompleted("srv", map[string]int{"high": 2, "low": 1})
+
+	select {
+	case evt := <-eventChan:
+		require.Equal(t, EventTypeSecurityScanSettled, evt.Type)
+		assert.Equal(t, "srv", evt.Payload["server_name"])
+		assert.NotZero(t, evt.Timestamp)
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not receive settled event within timeout")
+	}
+}


### PR DESCRIPTION
## Summary

Spec 077 US4 (MCP-2207): collapse the security-scan **notification storm** into a single debounced `security.scan_settled` event per server per scan.

The storm came from per-scanner `scan_started`/`progress`/`completed`/`failed` SSE events multiplied by reconnect storms (prior partial fixes: #659, MCP-2223). This replaces those per-scanner lifecycle emissions with one settled signal carrying the terminal findings summary.

> **Supersedes #787**, which GitHub auto-closed when US1 (`077-us1-baseline`) was squash-merged to `main` as `5b925e45`. This branch was rebased fresh onto `main` (`--onto origin/main 0f5838e6`) — **no conflicts**; US4 only touches the runtime scan-notify/event-bus layer and two frontend files, which do not overlap US1's detect/scanner changes.

## Changes

**Backend (`internal/runtime/`)**
- New `scanNotifyDebouncer` (`scan_notify.go`): terminal-triggered per-server debounce (750ms) with a generation counter guarding the `AfterFunc` race. Only `completed`/`failed` arm the timer; `started`/`progress` are dropped.
- New `EventTypeSecurityScanSettled`; route runtime `EmitSecurityScan*` through the debouncer and publish one settled event with the terminal summary.
- Wire `scanNotify` into `newRuntime` alongside the existing coalescer.
- Collapse the activity log to one `handleSecurityScanSettled` record per scan, removing the started/completed/failed handlers.

**Frontend**
- `stores/system.ts`: add a `security.scan_settled` SSE listener dispatching `mcpproxy:scan-settled`.
- `composables/useSecurityScannerStatus.ts`: refresh cached scan totals off that single settled signal instead of per-scanner lifecycle events.

## Verification (rebased head `1e46a820`, actual output)

- `go build ./...` → exit 0
- `go test -race ./internal/runtime/... -count=1` → all packages **ok** (runtime 118.3s)
- Reconnect-storm race test: `TestScanNotify_ReconnectStormCollapses` **PASS (2.00s)**, `TestScanNotify_SettledCarriesTerminalSummary` **PASS** (run with `-race`)
- `golangci-lint run --config .github/.golangci.yml ./internal/runtime/...` → **0 issues**
- `npx vue-tsc --noEmit` (frontend) → exit 0

Review verdict on the prior head was **approve**.

Related: Spec 077 (`specs/077-scanner-simplification`), #786 (US1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
