### PR TITLE
feat(telemetry): add non-reversible machine_id to heartbeat for install dedup

### DIFF
--- a/docs/features/telemetry.md
+++ b/docs/features/telemetry.md
@@ -4,11 +4,12 @@ MCPProxy collects anonymous usage statistics to help improve the product. This p
 
 ## What is collected
 
-MCPProxy sends a **daily heartbeat** containing only aggregate, non-identifying information. The current schema is **version 5** (`schema_version: 5` in the JSON payload); the schema is forward-compatible so older consumers simply ignore fields they don't recognize.
+MCPProxy sends a **daily heartbeat** containing only aggregate, non-identifying information. The current schema is **version 6** (`schema_version: 6` in the JSON payload); the schema is forward-compatible so older consumers simply ignore fields they don't recognize.
 
 | Field | Example | Purpose |
 |-------|---------|---------|
 | `anonymous_id` | `550e8400-...` | Random UUID for deduplication (not linked to you) |
+| `machine_id` | `9f86d081...` (64-hex) | Stable, **non-reversible** salted hash of the OS machine id — dedups ephemeral installs whose `anonymous_id` churns every run (schema v6). Empty/omitted when unreadable. Never the raw machine id |
 | `version` | `0.21.3` | Track version adoption |
 | `edition` | `personal` | Understand edition usage |
 | `os` | `darwin` | Platform distribution |
@@ -43,12 +44,26 @@ The following is **never** collected:
 - User identity, email, or account information
 - Tool call content, arguments, or responses
 - Any user-generated content
+- The **raw** OS machine id or any reversible hardware identifier (only the salted, non-reversible `machine_id` hash is sent — see below)
 
 ## Anonymous ID
 
 The anonymous ID is a random UUID (v4) generated on first run. It has **no correlation** to your hardware, user account, or identity. It exists solely to deduplicate heartbeats (so we don't count the same install twice in a day).
 
 You can delete it by removing the `telemetry.anonymous_id` field from your config — a new random ID will be generated on next startup.
+
+## Machine ID (schema v6)
+
+The `anonymous_id` above is a UUID persisted in the config file. In **ephemeral environments** — throwaway `HOME`s, layered Docker builds, CI runners — the config (and therefore the UUID) is regenerated on every run, so a single machine can masquerade as hundreds of distinct installs. That inflates our install counts and defeats deduplication.
+
+`machine_id` fixes this without collecting anything identifying:
+
+- It is a **salted, non-reversible hash** — `HMAC-SHA256` keyed by the OS machine id, scoped by an mcpproxy-specific application key. The **raw machine id is never transmitted**; only the hash leaves your machine.
+- The application-specific key means the value **cannot be correlated** with any other application's telemetry that hashes the same OS machine id.
+- It is **stable per physical machine**, so ephemeral installs collapse to one identity for counting.
+- If the OS machine id **cannot be read** (a container without `/etc/machine-id`, a permission error, or an exotic platform), the field is simply **omitted** — the heartbeat is never blocked, and the backend treats an absent value as "unknown".
+
+`machine_id` respects the **same opt-out** as every other field: when telemetry is disabled (see below), the entire heartbeat — including `machine_id` — is never sent.
 
 ## One-time opt-out signal
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/blevesearch/bleve/v2 v2.6.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/dop251/goja v0.0.0-20260305124333-6a7976c22267
 	github.com/evanw/esbuild v0.28.1
 	github.com/gen2brain/beeep v0.11.2
@@ -39,6 +40,7 @@ require (
 	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.46.0
 	golang.org/x/term v0.44.0
+	golang.org/x/text v0.37.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
 	pgregory.net/rapid v1.3.0
@@ -142,7 +144,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/tools v0.45.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/denisbrodbeck/machineid v1.0.1 h1:geKr9qtkB876mXguW2X6TU4ZynleN6ezuMSRhl4D7AQ=
+github.com/denisbrodbeck/machineid v1.0.1/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbjJCrnectwCyxcUSI=
 github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yAo=
 github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dop251/goja v0.0.0-20260305124333-6a7976c22267 h1:Kfmq11A6DLHD8XoOeljWjzWg/rrujeaLHWSb8u7+2qQ=

--- a/internal/telemetry/anonymity_test.go
+++ b/internal/telemetry/anonymity_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	"github.com/denisbrodbeck/machineid"
 )
 
 // TestScanForPII_BlockedPrefix_UsersPath asserts that a payload containing a
@@ -149,6 +151,41 @@ func TestPopulateBlockedValuesFrom(t *testing.T) {
 		if c > 1 {
 			t.Errorf("BlockedValues has duplicate %q (count=%d)", v, c)
 		}
+	}
+}
+
+// TestScanForPII_RawMachineIDBlocked asserts that when the raw OS machine id is
+// added to BlockedValues (defense-in-depth, as the telemetry service does for
+// hostname/tokens), a payload accidentally carrying the raw id is rejected. The
+// hashed machine_id we DO emit is unrelated to the raw value and passes. Skips
+// when the OS machine id is unreadable on this host.
+func TestScanForPII_RawMachineIDBlocked(t *testing.T) {
+	raw, err := machineid.ID()
+	if err != nil || len(raw) < 3 {
+		t.Skipf("OS machine id unavailable on this host (%v); skipping", err)
+	}
+
+	prev := BlockedValues
+	BlockedValues = []string{raw}
+	defer func() { BlockedValues = prev }()
+
+	// A payload leaking the raw id must be caught.
+	leak := []byte(`{"anonymous_id":"abc","machine_id":"` + raw + `"}`)
+	if scanErr := ScanForPII(leak); scanErr == nil {
+		t.Fatalf("expected violation when raw machine id present, got nil")
+	} else if !errors.Is(scanErr, ErrAnonymityViolation) {
+		t.Fatalf("expected ErrAnonymityViolation, got %v", scanErr)
+	}
+
+	// The hashed value we actually emit must NOT contain the raw id and must
+	// pass the scan.
+	hashed := protectedMachineID()
+	if hashed != "" && strings.Contains(hashed, raw) {
+		t.Fatalf("hashed machine_id leaked the raw id")
+	}
+	clean := []byte(`{"anonymous_id":"abc","machine_id":"` + hashed + `"}`)
+	if scanErr := ScanForPII(clean); scanErr != nil {
+		t.Errorf("hashed machine_id payload should pass scan, got %v", scanErr)
 	}
 }
 

--- a/internal/telemetry/machine_id.go
+++ b/internal/telemetry/machine_id.go
@@ -1,0 +1,61 @@
+package telemetry
+
+import (
+	"sync"
+
+	"github.com/denisbrodbeck/machineid"
+)
+
+// machineIDAppKey scopes the hashed machine id to mcpproxy. machineid.ProtectedID
+// feeds it as the HMAC-SHA256 message keyed by the OS machine id, so the emitted
+// value is a non-reversible per-app hash: it cannot be reversed to the raw id and
+// cannot be correlated with any other application that hashes the same OS machine
+// id with a different key.
+const machineIDAppKey = "mcpproxy-telemetry"
+
+// machineIDProvider is the seam used to obtain the app-scoped, non-reversible
+// machine-id hash. Production points it at protectedMachineID; tests override it
+// to inject deterministic values or simulate an unreadable machine id. It mirrors
+// the function-pointer injection style used elsewhere in this package
+// (see populateBlockedValuesFrom, DetectEnvKind).
+var machineIDProvider = protectedMachineID
+
+// protectedMachineID returns HMAC-SHA256(osMachineID, machineIDAppKey) as a
+// lowercase hex string (64 chars). On any failure to read the OS machine id
+// (permission errors, missing /etc/machine-id in a minimal container, an exotic
+// platform) it returns "" — the caller then omits the field, and the backend
+// treats empty as "unknown". The raw OS machine id is NEVER returned or
+// transmitted, only the salted hash.
+func protectedMachineID() string {
+	id, err := machineid.ProtectedID(machineIDAppKey)
+	if err != nil {
+		return ""
+	}
+	return id
+}
+
+// machineIDOnce guards the cached machine-id hash so repeated heartbeats reuse
+// one value without re-probing the OS each time.
+var (
+	machineIDOnce   sync.Once
+	machineIDCached string
+)
+
+// resolveMachineID computes the app-scoped machine-id hash once per process and
+// caches it. Subsequent heartbeats reuse the cached value, guaranteeing the
+// field is stable across payload builds without re-probing the OS. Empty string
+// when the OS machine id is unavailable.
+func resolveMachineID() string {
+	machineIDOnce.Do(func() {
+		machineIDCached = machineIDProvider()
+	})
+	return machineIDCached
+}
+
+// resetMachineIDForTest clears the cached machine-id hash so tests can re-run
+// resolveMachineID with a freshly injected machineIDProvider. MUST NOT be called
+// from production code — guard calls behind _test.go files only.
+func resetMachineIDForTest() {
+	machineIDOnce = sync.Once{}
+	machineIDCached = ""
+}

--- a/internal/telemetry/machine_id_test.go
+++ b/internal/telemetry/machine_id_test.go
@@ -1,0 +1,179 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denisbrodbeck/machineid"
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+)
+
+// isLowerHex reports whether s is a non-empty string of lowercase hex digits.
+func isLowerHex(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'f':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// newMachineIDTestService builds a minimal telemetry Service suitable for
+// exercising BuildPayload in machine-id tests.
+func newMachineIDTestService(t *testing.T) *Service {
+	t.Helper()
+	cfg := &config.Config{
+		Telemetry: &config.TelemetryConfig{
+			AnonymousID:          "fixed-id",
+			AnonymousIDCreatedAt: time.Now().UTC().Format(time.RFC3339),
+		},
+	}
+	return New(cfg, "", "v1.2.3", "personal", zap.NewNop())
+}
+
+// TestMachineID_PresentAndStable asserts the machine_id field is populated and
+// identical across two payload builds on the same machine.
+func TestMachineID_PresentAndStable(t *testing.T) {
+	const fixed = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	prev := machineIDProvider
+	machineIDProvider = func() string { return fixed }
+	resetMachineIDForTest()
+	defer func() {
+		machineIDProvider = prev
+		resetMachineIDForTest()
+	}()
+
+	svc := newMachineIDTestService(t)
+
+	p1 := svc.BuildPayload()
+	p2 := svc.BuildPayload()
+
+	if p1.MachineID == "" {
+		t.Fatalf("machine_id is empty, want %q", fixed)
+	}
+	if p1.MachineID != fixed {
+		t.Errorf("machine_id = %q, want %q", p1.MachineID, fixed)
+	}
+	if p1.MachineID != p2.MachineID {
+		t.Errorf("machine_id not stable across builds: %q != %q", p1.MachineID, p2.MachineID)
+	}
+}
+
+// TestMachineID_OmittedWhenUnavailable asserts that when the OS machine id
+// cannot be read, the field is empty and omitted from the serialized JSON
+// (never failing the heartbeat).
+func TestMachineID_OmittedWhenUnavailable(t *testing.T) {
+	prev := machineIDProvider
+	machineIDProvider = func() string { return "" }
+	resetMachineIDForTest()
+	defer func() {
+		machineIDProvider = prev
+		resetMachineIDForTest()
+	}()
+
+	svc := newMachineIDTestService(t)
+	payload := svc.BuildPayload()
+
+	if payload.MachineID != "" {
+		t.Errorf("machine_id = %q, want empty when unavailable", payload.MachineID)
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	if strings.Contains(string(data), "machine_id") {
+		t.Errorf("empty machine_id should be omitted from JSON, got: %s", data)
+	}
+}
+
+// TestResolveMachineID_CachedOncePerProcess asserts resolveMachineID probes the
+// provider at most once and caches the result.
+func TestResolveMachineID_CachedOncePerProcess(t *testing.T) {
+	calls := 0
+	prev := machineIDProvider
+	machineIDProvider = func() string {
+		calls++
+		return "cached-value"
+	}
+	resetMachineIDForTest()
+	defer func() {
+		machineIDProvider = prev
+		resetMachineIDForTest()
+	}()
+
+	_ = resolveMachineID()
+	_ = resolveMachineID()
+	_ = resolveMachineID()
+
+	if calls != 1 {
+		t.Errorf("machineIDProvider called %d times, want 1 (result must be cached)", calls)
+	}
+}
+
+// TestProtectedMachineID_NotRawAndHex verifies the production hash is a
+// lowercase-hex string, is not the raw OS machine id, and is scoped to the app
+// key (differs from the raw id and from a bare hash of another app key). Skips
+// when the OS machine id is unreadable (e.g. CI containers without
+// /etc/machine-id) — the graceful-fallback path is covered separately.
+func TestProtectedMachineID_NotRawAndHex(t *testing.T) {
+	raw, err := machineid.ID()
+	if err != nil || raw == "" {
+		t.Skipf("OS machine id unavailable on this host (%v); skipping raw-comparison", err)
+	}
+
+	got := protectedMachineID()
+	if got == "" {
+		t.Fatal("protectedMachineID returned empty despite a readable OS machine id")
+	}
+	if !isLowerHex(got) {
+		t.Errorf("protectedMachineID = %q, want lowercase hex", got)
+	}
+	// HMAC-SHA256 hex is 64 chars.
+	if len(got) != 64 {
+		t.Errorf("protectedMachineID length = %d, want 64 (SHA-256 hex)", len(got))
+	}
+	if strings.Contains(got, raw) || got == raw {
+		t.Errorf("protectedMachineID leaked the raw machine id")
+	}
+}
+
+// TestProtectedMachineID_RawNeverInPayload builds a real payload (production
+// provider) and asserts the raw OS machine id never appears in the serialized
+// JSON, while the hashed machine_id does. Skips when the raw id is unreadable.
+func TestProtectedMachineID_RawNeverInPayload(t *testing.T) {
+	raw, err := machineid.ID()
+	if err != nil || raw == "" {
+		t.Skipf("OS machine id unavailable on this host (%v); skipping", err)
+	}
+
+	// Ensure the production provider is in effect and the cache is fresh.
+	resetMachineIDForTest()
+	defer resetMachineIDForTest()
+
+	svc := newMachineIDTestService(t)
+	payload := svc.BuildPayload()
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	js := string(data)
+
+	if strings.Contains(js, raw) {
+		t.Errorf("PRIVACY VIOLATION: payload contains the raw machine id")
+	}
+	if payload.MachineID != "" && !strings.Contains(js, payload.MachineID) {
+		t.Errorf("hashed machine_id missing from serialized payload")
+	}
+}

--- a/internal/telemetry/payload_privacy_test.go
+++ b/internal/telemetry/payload_privacy_test.go
@@ -144,7 +144,7 @@ func TestPayloadHasNoForbiddenSubstrings(t *testing.T) {
 	// Sanity check: the payload should still contain the legitimate fields,
 	// otherwise we've over-redacted.
 	for _, required := range []string{
-		`"schema_version":5`,
+		`"schema_version":6`,
 		`"surface_requests"`,
 		`"builtin_tool_calls"`,
 		`"upstream_tool_call_count_bucket"`,

--- a/internal/telemetry/payload_v2_test.go
+++ b/internal/telemetry/payload_v2_test.go
@@ -88,8 +88,8 @@ func TestHeartbeatPayloadV2Marshal(t *testing.T) {
 
 	payload := svc.BuildPayload()
 
-	if payload.SchemaVersion != 5 {
-		t.Errorf("schema_version = %d, want 5", payload.SchemaVersion)
+	if payload.SchemaVersion != 6 {
+		t.Errorf("schema_version = %d, want 6", payload.SchemaVersion)
 	}
 	if payload.AnonymousID != "fixed-id" {
 		t.Errorf("anonymous_id = %q", payload.AnonymousID)
@@ -135,7 +135,7 @@ func TestHeartbeatPayloadV2Marshal(t *testing.T) {
 	}
 	js := string(data)
 	for _, key := range []string{
-		`"schema_version":5`,
+		`"schema_version":6`,
 		`"surface_requests"`,
 		`"builtin_tool_calls"`,
 		`"upstream_tool_call_count_bucket":"11-100"`,

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -37,13 +37,33 @@ import (
 // three new diagnostics codes surfaced via error_code_counts_24h
 // (MCPX_DOCKER_CLI_NOT_FOUND / MCPX_DOCKER_EXEC_NOT_FOUND /
 // MCPX_DOCKER_OCI_RUNTIME). Additive only — v3/v4 consumers ignore them.
-const SchemaVersion = 5
+//
+// v6 (schema bump from 5): adds machine_id — a stable, non-reversible hash of
+// the OS machine id (HMAC-SHA256 keyed by the OS machine id, scoped by an
+// app-specific key). It lets the dashboard dedup installs whose anonymous_id
+// churns every run (ephemeral Docker layers, throwaway HOMEs, CI). Additive
+// and forward-compatible: v3/v4/v5 consumers ignore it, and the ingest worker
+// stores payload_json wholesale without rejecting unknown fields or higher
+// schema versions.
+const SchemaVersion = 6
 
 // HeartbeatPayload is the anonymous telemetry payload sent periodically.
 // Spec 042 expanded the payload with Tier 2 fields; v1 fields are preserved.
 type HeartbeatPayload struct {
 	// v1 fields (preserved unchanged)
-	AnonymousID          string `json:"anonymous_id"`
+	AnonymousID string `json:"anonymous_id"`
+	// MachineID (schema v6) is a stable, non-reversible hash of the OS machine
+	// id — HMAC-SHA256 keyed by the OS machine id, scoped by an app-specific key
+	// (see machine_id.go). Unlike anonymous_id (a UUID persisted in the config
+	// file, which is regenerated on every run in ephemeral environments —
+	// throwaway HOMEs, Docker layers, CI), this value is stable per physical
+	// machine, letting the dashboard dedup ephemeral installs. Empty/omitted
+	// when the OS machine id cannot be read (containers without /etc/machine-id,
+	// permission errors, exotic platforms); the backend treats empty as
+	// "unknown". The raw machine id is NEVER transmitted — only the salted hash.
+	// It rides the same opt-out gate as every other field (the whole heartbeat
+	// is suppressed when telemetry is disabled).
+	MachineID            string `json:"machine_id,omitempty"`
 	Version              string `json:"version"`
 	Edition              string `json:"edition"`
 	OS                   string `json:"os"`
@@ -549,6 +569,10 @@ func (s *Service) buildHeartbeat() HeartbeatPayload {
 		Timestamp:      time.Now().UTC().Format(time.RFC3339),
 		SchemaVersion:  SchemaVersion,
 		CurrentVersion: s.version,
+		// Schema v6: stable, non-reversible machine-id hash. Cached after the
+		// first call so repeated heartbeats do not re-probe the OS. Empty when
+		// the OS machine id is unreadable — never blocks the heartbeat.
+		MachineID: resolveMachineID(),
 	}
 
 	if s.config.Telemetry != nil {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -302,20 +302,20 @@ func TestEnsureAnonymousID(t *testing.T) {
 	}
 }
 
-// TestSchemaVersionV5 verifies that HeartbeatPayload carries schema_version=5
-// once the MCP-2745 docker-isolation visibility fields ship. This is a tripwire
-// against accidental downgrades.
-func TestSchemaVersionV5(t *testing.T) {
-	if SchemaVersion != 5 {
-		t.Fatalf("SchemaVersion = %d, want 5", SchemaVersion)
+// TestSchemaVersionV6 verifies that HeartbeatPayload carries schema_version=6
+// once the machine_id field ships. This is a tripwire against accidental
+// downgrades.
+func TestSchemaVersionV6(t *testing.T) {
+	if SchemaVersion != 6 {
+		t.Fatalf("SchemaVersion = %d, want 6", SchemaVersion)
 	}
 
 	cfg := &config.Config{}
 	svc := New(cfg, "", "v1.0.0", "personal", zap.NewNop())
 	svc.SetRuntimeStats(&mockRuntimeStats{})
 	payload := svc.BuildPayload()
-	if payload.SchemaVersion != 5 {
-		t.Errorf("payload.SchemaVersion = %d, want 5", payload.SchemaVersion)
+	if payload.SchemaVersion != 6 {
+		t.Errorf("payload.SchemaVersion = %d, want 6", payload.SchemaVersion)
 	}
 }
 
@@ -475,8 +475,8 @@ func TestAnonymousIDStable_V2ToV3(t *testing.T) {
 	if p1.AnonymousID != p2.AnonymousID {
 		t.Errorf("anonymous_id drifted between builds: %q vs %q", p1.AnonymousID, p2.AnonymousID)
 	}
-	// SchemaVersion is 5 after MCP-2745's docker-isolation visibility additions.
-	if p1.SchemaVersion != 5 {
-		t.Errorf("schema_version = %d, want 5 (MCP-2745 docker telemetry)", p1.SchemaVersion)
+	// SchemaVersion is 6 after the machine_id addition.
+	if p1.SchemaVersion != 6 {
+		t.Errorf("schema_version = %d, want 6 (machine_id addition)", p1.SchemaVersion)
 	}
 }


### PR DESCRIPTION
## Motivation

Telemetry `anonymous_id` is a UUIDv4 persisted in the config file. In **ephemeral environments** — layered Docker builds, throwaway `HOME`s, CI runners — the config (and therefore the UUID) is regenerated on every run, so a single physical machine masquerades as many distinct installs. One CI block alone produced **1,231 `anonymous_id`s from 3 IPv6 /64s**, inflating install counts.

The dashboard (`mcpproxy-dash/src/lib/shared/dedup.ts`) currently dedups via a lossy `normalized_ip|os|arch|edition` heuristic, and its header comment explicitly asks for the fix this PR delivers:

> "The only way to fix both would be a stable hashed machine id in the payload (see telemetry client TODO)."

## What this adds

A new heartbeat field **`machine_id`** (schema **v6**): a stable, **non-reversible** hash of the OS machine id.

- **Hash scheme** — `HMAC-SHA256(osMachineID, appKey)` via `denisbrodbeck/machineid`'s `ProtectedID` pattern, hex-encoded (64 chars). The mcpproxy-specific `appKey` scopes the value so it **cannot be correlated** with any other application that hashes the same OS machine id. The **raw machine id is never returned or transmitted** — only the salted hash.
- **Stability** — resolved once per process and cached (`resolveMachineID`), so the value is identical across every heartbeat build on a machine.
- **Graceful fallback** — if the OS machine id is unreadable (container without `/etc/machine-id`, permission error, exotic platform), `protectedMachineID` returns `""`, the field is omitted (`omitempty`), and the heartbeat is **never blocked**. The backend treats empty as "unknown".
- **Opt-out** — no new gate needed: `machine_id` is built inside `buildHeartbeat`, which is only reached through the existing opt-out-gated `Start`/`sendHeartbeat` path (`MCPPROXY_TELEMETRY=false`, `DO_NOT_TRACK`, config disable, and the mid-flight `optedOut` latch all cover it).

## Design decisions

**Hash scheme.** `ProtectedID` keys the HMAC with the machine id and uses the app key as the message, yielding a per-app, non-reversible digest — exactly the "ProtectedID" pattern requested. Chosen over a bare `SHA256(machineID)` because the app-key scoping prevents cross-application correlation.

**Dependency — added `github.com/denisbrodbeck/machineid` v1.0.1 (yes).** Nothing in-tree or in existing deps reads the OS machine id (checked repo + `go.mod`). Rolling it by hand is non-trivial cross-platform (macOS needs `ioreg`, Windows the registry `MachineGuid`, Linux `/etc/machine-id` + dbus fallback). The library is tiny, **stdlib-only (no transitive deps)**, and is the standard answer. Per CLAUDE.md ("avoid new deps without clear need"), the need is clear and the footprint minimal. Now a direct dependency in `go.mod`.

**Schema version — bumped `5 → 6` (safe, verified against the worker).** I read the ingest worker (`mcpproxy-telemetry`, read-only) to confirm this cannot break ingestion:
- `src/index.ts` / `src/validation.ts` only validate fields conditionally on `schema_version >= 3` and `>= 4`; there is **no upper-bound check** and **no unknown-field rejection**.
- The daemon **already sends `schema_version: 5`** while the worker validates only up to v4 — empirical proof it tolerates higher-than-known versions.
- `schema.sql` stores the whole payload in `payload_json` wholesale.

So a higher version carrying one additive field is ignored by older consumers and preserved in `payload_json`. Bumping (vs. keeping v5) matches this codebase's convention — every prior field set bumped the version — and keeps the version→fields contract honest for the dashboard.

## Privacy

- Only the **salted, non-reversible** hash is sent; the raw machine id never leaves the process.
- App-key scoping blocks cross-application correlation.
- `docs/features/telemetry.md` updated: new field row, a dedicated "Machine ID (schema v6)" section, and a "what is NOT collected" bullet (raw machine id / reversible hardware ids).
- Tests assert the raw id never appears in the serialized payload and that the field is omitted when unavailable; `anonymity_test.go` extended so the anonymity scanner catches a raw-id leak while the hashed value passes.

## Tests (TDD, failing-first)

`internal/telemetry/machine_id_test.go` + extended `anonymity_test.go`:
- field present & **stable** across two payload builds;
- production hash is **64-char lowercase hex** and **≠ raw** machine id;
- **empty/omitted** when the underlying id is unavailable (injected via the `machineIDProvider` seam, matching the package's function-pointer test style);
- resolver **caches** (provider probed once);
- raw id **never** in the serialized payload; anonymity scanner blocks a raw-id leak.

Results:
- `go build ./...` — OK
- `go test -race ./internal/telemetry/...` — **ok** (raw-comparison tests ran, not skipped)
- `golangci-lint run --config .github/.golangci.yml ./...` — **0 issues**
- `gofmt`/`goimports` — clean

## Follow-ups (not in this PR)

1. **Worker migration** (`mcpproxy-telemetry`): add a `machine_id TEXT` column + extraction in `validateV*Payload`/`index.ts` and an index, so dedup can query it directly rather than digging into `payload_json`. Not required for ingestion today (stored wholesale).
2. **Dashboard** (`mcpproxy-dash`): update `identityExpr` in `dedup.ts` to prefer `machine_id` when present, falling back to the current `normalized_ip|os|arch|edition` heuristic for pre-v6 rows. Resolves the TODO that motivated this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
