### PR TITLE
feat(web): surface connect backup path in wizard and Connect modal (Spec 078 US2)

### DIFF
--- a/frontend/src/components/ConnectModal.vue
+++ b/frontend/src/components/ConnectModal.vue
@@ -69,7 +69,7 @@
               </button>
               <button
                 v-else
-                @click="connect(client.id)"
+                @click="connectSingle(client.id)"
                 class="btn btn-primary btn-xs"
                 :disabled="loading.clients[client.id]"
               >
@@ -157,6 +157,37 @@
         >
           No prior config file existed, so no backup was needed.
         </div>
+        <!-- Spec 078 US2 / SC-005: Connect All renders EVERY successful
+             client's backup outcome — one line per client, each with its own
+             copy affordance — instead of only the last connect's path. -->
+        <div v-if="bulkBackups.length > 0" data-test="connect-bulk-backups" class="mt-2 space-y-1">
+          <div
+            v-for="b in bulkBackups"
+            :key="b.id"
+            :data-test="`connect-bulk-backup-${b.id}`"
+            class="flex items-start justify-between gap-2 rounded-lg bg-base-200 px-3 py-2"
+          >
+            <span class="text-xs leading-relaxed min-w-0">
+              <span class="font-medium">{{ b.name }}:</span>
+              <template v-if="b.backupPath">
+                a backup of your previous config was saved to
+                <code class="font-mono text-[11px] break-all" :title="b.backupPath">{{ b.backupPath }}</code>
+              </template>
+              <template v-else>
+                No prior config file existed, so no backup was needed.
+              </template>
+            </span>
+            <button
+              v-if="b.backupPath"
+              :data-test="`connect-bulk-copy-${b.id}`"
+              @click="copyBulkBackupPath(b)"
+              class="btn btn-ghost btn-xs shrink-0"
+              title="Copy this backup path to the clipboard"
+            >
+              {{ copiedBulkClient === b.id ? 'Copied ✓' : 'Copy path' }}
+            </button>
+          </div>
+        </div>
       </div>
 
       <div class="modal-action">
@@ -203,6 +234,12 @@ const resultSuccess = ref(false)
 // back up; undefined = no successful operation to report on.
 const resultBackupPath = ref<string | null | undefined>(undefined)
 const copiedBackup = ref(false)
+// Spec 078 US2 / SC-005: per-client backup outcomes for Connect All. Every
+// successful connect in the bulk run keeps its own entry (string = backup
+// created; null = no prior file), so no client's backup path is overwritten
+// by the next one. Empty when the last operation was a single connect.
+const bulkBackups = ref<Array<{ id: string; name: string; backupPath: string | null }>>([])
+const copiedBulkClient = ref<string | null>(null)
 const loading = reactive({
   initial: false,
   clients: {} as Record<string, boolean>,
@@ -289,7 +326,17 @@ async function fetchClients() {
   }
 }
 
-async function connect(clientId: string) {
+// Single-connect entry point (row button): a fresh single operation supersedes
+// any earlier Connect All per-client backup list.
+async function connectSingle(clientId: string) {
+  bulkBackups.value = []
+  copiedBulkClient.value = null
+  await connect(clientId)
+}
+
+// Returns the outcome so connectAll can accumulate per-client backup results
+// (ok=true with backupPath string = backup created; null = no prior file).
+async function connect(clientId: string): Promise<{ ok: boolean; backupPath: string | null }> {
   loading.clients[clientId] = true
   resultMessage.value = ''
   resultBackupPath.value = undefined
@@ -301,20 +348,21 @@ async function connect(clientId: string) {
       resultMessage.value = response.data.message || `Connected to ${clientId}`
       resultSuccess.value = true
       // Empty/absent backup_path on success means no prior file existed.
-      resultBackupPath.value = response.data.backup_path || null
+      const backupPath = response.data.backup_path || null
+      resultBackupPath.value = backupPath
       await fetchClients()
       systemStore.addToast({
         type: 'success',
         title: 'Client Connected',
         message: `MCPProxy registered in ${clientId}`,
       })
-    } else {
-      resultMessage.value = response.error || 'Failed to connect'
-      resultSuccess.value = false
-      // The write may have failed because macOS blocked the config. Resolve the
-      // access state in-band so a denial surfaces as the actionable banner.
-      void checkAccess(clientId)
+      return { ok: true, backupPath }
     }
+    resultMessage.value = response.error || 'Failed to connect'
+    resultSuccess.value = false
+    // The write may have failed because macOS blocked the config. Resolve the
+    // access state in-band so a denial surfaces as the actionable banner.
+    void checkAccess(clientId)
   } catch (err) {
     resultMessage.value = err instanceof Error ? err.message : 'Unknown error'
     resultSuccess.value = false
@@ -322,6 +370,7 @@ async function connect(clientId: string) {
   } finally {
     loading.clients[clientId] = false
   }
+  return { ok: false, backupPath: null }
 }
 
 async function disconnect(clientId: string) {
@@ -329,6 +378,8 @@ async function disconnect(clientId: string) {
   resultMessage.value = ''
   resultBackupPath.value = undefined
   copiedBackup.value = false
+  bulkBackups.value = []
+  copiedBulkClient.value = null
 
   try {
     const client = clients.value.find(c => c.id === clientId)
@@ -429,9 +480,42 @@ async function copyBackupPath() {
   }
 }
 
+// Spec 078 US2 / SC-005: Connect All accumulates every successful client's
+// backup outcome instead of letting each connect() overwrite the previous
+// client's backup path.
 async function connectAll() {
-  for (const client of connectableClients.value) {
-    await connect(client.id)
+  bulkBackups.value = []
+  copiedBulkClient.value = null
+  // Snapshot: connect() refetches the client list mid-loop, which mutates the
+  // connectableClients computed while we iterate it.
+  const targets = [...connectableClients.value]
+  const collected: Array<{ id: string; name: string; backupPath: string | null }> = []
+  for (const client of targets) {
+    const outcome = await connect(client.id)
+    if (outcome.ok) {
+      collected.push({ id: client.id, name: client.name, backupPath: outcome.backupPath })
+    }
+  }
+  if (collected.length > 0) {
+    bulkBackups.value = collected
+    // The per-client list is authoritative for a bulk run; suppress the
+    // single-result line that would otherwise repeat only the last backup.
+    resultBackupPath.value = undefined
+  }
+}
+
+// Per-row copy for the Connect All backup list.
+async function copyBulkBackupPath(entry: { id: string; backupPath: string | null }) {
+  if (!entry.backupPath) return
+  try {
+    await navigator.clipboard.writeText(entry.backupPath)
+    copiedBulkClient.value = entry.id
+    setTimeout(() => {
+      if (copiedBulkClient.value === entry.id) copiedBulkClient.value = null
+    }, 2000)
+  } catch {
+    // Clipboard unavailable (e.g. insecure context): the full path is already
+    // rendered, so the user can select and copy it manually.
   }
 }
 
@@ -439,6 +523,8 @@ function close() {
   resultMessage.value = ''
   resultBackupPath.value = undefined
   copiedBackup.value = false
+  bulkBackups.value = []
+  copiedBulkClient.value = null
   emit('close')
 }
 
@@ -452,6 +538,8 @@ watch(() => props.show, (newVal) => {
     resultMessage.value = ''
     resultBackupPath.value = undefined
     copiedBackup.value = false
+    bulkBackups.value = []
+    copiedBulkClient.value = null
   }
 })
 </script>

--- a/frontend/src/components/ConnectModal.vue
+++ b/frontend/src/components/ConnectModal.vue
@@ -129,6 +129,34 @@
         <div class="alert alert-sm" :class="resultSuccess ? 'alert-success' : 'alert-error'">
           <span class="text-sm">{{ resultMessage }}</span>
         </div>
+        <!-- Spec 078 US2 / FR-006: surface the timestamped backup after a
+             successful connect/disconnect; the "no prior file" case is stated
+             explicitly rather than showing a blank path. -->
+        <div
+          v-if="resultSuccess && resultBackupPath"
+          data-test="connect-backup-path"
+          class="mt-2 flex items-start justify-between gap-2 rounded-lg bg-base-200 px-3 py-2"
+        >
+          <span class="text-xs leading-relaxed min-w-0">
+            A backup of your previous config was saved to
+            <code class="font-mono text-[11px] break-all" :title="resultBackupPath">{{ resultBackupPath }}</code>
+          </span>
+          <button
+            data-test="connect-copy-backup"
+            @click="copyBackupPath"
+            class="btn btn-ghost btn-xs shrink-0"
+            title="Copy the backup path to the clipboard"
+          >
+            {{ copiedBackup ? 'Copied ✓' : 'Copy path' }}
+          </button>
+        </div>
+        <div
+          v-else-if="resultSuccess && resultBackupPath === null"
+          data-test="connect-no-backup"
+          class="mt-2 rounded-lg bg-base-200 px-3 py-2 text-xs opacity-70"
+        >
+          No prior config file existed, so no backup was needed.
+        </div>
       </div>
 
       <div class="modal-action">
@@ -170,6 +198,11 @@ const clients = ref<ClientStatus[]>([])
 const error = ref<string | null>(null)
 const resultMessage = ref('')
 const resultSuccess = ref(false)
+// Spec 078 US2: backup path of the last successful connect/disconnect.
+// string = timestamped backup created; null = success but no prior file to
+// back up; undefined = no successful operation to report on.
+const resultBackupPath = ref<string | null | undefined>(undefined)
+const copiedBackup = ref(false)
 const loading = reactive({
   initial: false,
   clients: {} as Record<string, boolean>,
@@ -259,12 +292,16 @@ async function fetchClients() {
 async function connect(clientId: string) {
   loading.clients[clientId] = true
   resultMessage.value = ''
+  resultBackupPath.value = undefined
+  copiedBackup.value = false
 
   try {
     const response = await api.connectClient(clientId)
     if (response.success && response.data) {
       resultMessage.value = response.data.message || `Connected to ${clientId}`
       resultSuccess.value = true
+      // Empty/absent backup_path on success means no prior file existed.
+      resultBackupPath.value = response.data.backup_path || null
       await fetchClients()
       systemStore.addToast({
         type: 'success',
@@ -290,6 +327,8 @@ async function connect(clientId: string) {
 async function disconnect(clientId: string) {
   loading.clients[clientId] = true
   resultMessage.value = ''
+  resultBackupPath.value = undefined
+  copiedBackup.value = false
 
   try {
     const client = clients.value.find(c => c.id === clientId)
@@ -297,6 +336,7 @@ async function disconnect(clientId: string) {
     if (response.success && response.data) {
       resultMessage.value = response.data.message || `Disconnected from ${clientId}`
       resultSuccess.value = true
+      resultBackupPath.value = response.data.backup_path || null
       await fetchClients()
       systemStore.addToast({
         type: 'info',
@@ -373,6 +413,22 @@ async function copyTccutil(client: ClientStatus) {
   }
 }
 
+// Spec 078 US2: one-click copy of the backup path (same clipboard pattern as
+// copyTccutil above).
+async function copyBackupPath() {
+  if (!resultBackupPath.value) return
+  try {
+    await navigator.clipboard.writeText(resultBackupPath.value)
+    copiedBackup.value = true
+    setTimeout(() => {
+      copiedBackup.value = false
+    }, 2000)
+  } catch {
+    // Clipboard unavailable (e.g. insecure context): the full path is already
+    // rendered, so the user can select and copy it manually.
+  }
+}
+
 async function connectAll() {
   for (const client of connectableClients.value) {
     await connect(client.id)
@@ -381,6 +437,8 @@ async function connectAll() {
 
 function close() {
   resultMessage.value = ''
+  resultBackupPath.value = undefined
+  copiedBackup.value = false
   emit('close')
 }
 
@@ -392,6 +450,8 @@ watch(() => props.show, (newVal) => {
     fetchClients()
     void onboarding.fetchState()
     resultMessage.value = ''
+    resultBackupPath.value = undefined
+    copiedBackup.value = false
   }
 })
 </script>

--- a/frontend/src/components/OnboardingWizard.vue
+++ b/frontend/src/components/OnboardingWizard.vue
@@ -68,6 +68,9 @@
                 :key="c.id"
                 :client="c"
                 :busy="busyClients[c.id]"
+                :backup-path="connectBackups[c.id]"
+                :copied-backup="copiedBackupClient === c.id"
+                @copy-backup="copyBackupPath"
                 @connect="connectOne"
               />
             </div>
@@ -80,6 +83,9 @@
                 :key="c.id"
                 :client="c"
                 :busy="busyClients[c.id]"
+                :backup-path="connectBackups[c.id]"
+                :copied-backup="copiedBackupClient === c.id"
+                @copy-backup="copyBackupPath"
                 @connect="connectOne"
               />
             </div>
@@ -96,6 +102,9 @@
                   :key="c.id"
                   :client="c"
                   :busy="busyClients[c.id]"
+                  :backup-path="connectBackups[c.id]"
+                  :copied-backup="copiedBackupClient === c.id"
+                  @copy-backup="copyBackupPath"
                   @connect="connectOne"
                 />
               </div>
@@ -518,6 +527,11 @@ const clientsError = ref<string | null>(null)
 const busyClients = reactive<Record<string, boolean>>({})
 const connectMessage = ref('')
 const connectMessageOk = ref(true)
+// Spec 078 US2 / FR-006: backup path per client for connects performed in this
+// wizard session. string = timestamped backup created; null = success but no
+// prior file existed (nothing to back up); absent = no connect happened yet.
+const connectBackups = reactive<Record<string, string | null>>({})
+const copiedBackupClient = ref<string | null>(null)
 const addServerOpen = ref(false)
 const serverAddedJustNow = ref(false)
 
@@ -1028,6 +1042,9 @@ async function connectOne(clientId: string) {
     if (res.success && res.data) {
       connectMessageOk.value = true
       connectMessage.value = res.data.message || `Connected ${clientId}`
+      // Spec 078 US2: keep the backup path so the row can surface it; an
+      // empty/absent backup_path on success means no prior file existed.
+      connectBackups[clientId] = res.data.backup_path || null
       await fetchClients()
       // Spec 046 — record connect-step completion for telemetry funnel.
       // Only the first successful connect transitions the status; subsequent
@@ -1050,6 +1067,22 @@ async function connectOne(clientId: string) {
     connectMessage.value = (err as Error).message
   } finally {
     busyClients[clientId] = false
+  }
+}
+
+// Spec 078 US2: one-click copy of a row's backup path (same clipboard pattern
+// as ConnectModal's copy affordances).
+async function copyBackupPath(clientId: string) {
+  const path = connectBackups[clientId]
+  if (!path) return
+  try {
+    await navigator.clipboard.writeText(path)
+    copiedBackupClient.value = clientId
+    setTimeout(() => {
+      if (copiedBackupClient.value === clientId) copiedBackupClient.value = null
+    }, 2000)
+  } catch {
+    // Clipboard unavailable: the full path is already rendered in the row.
   }
 }
 
@@ -1111,14 +1144,14 @@ onMounted(() => {
 // --- ClientRow component ------------------------------------------------
 // Inlined as a functional component to keep this file self-contained while
 // the row layout stays consistent across all three lists.
-const ClientRow: FunctionalComponent<{ client: ClientStatus; busy?: boolean }, { connect: (id: string) => void }> = (props, { emit: rowEmit }) => {
+const ClientRow: FunctionalComponent<
+  { client: ClientStatus; busy?: boolean; backupPath?: string | null; copiedBackup?: boolean },
+  { connect: (id: string) => void; 'copy-backup': (id: string) => void }
+> = (props, { emit: rowEmit }) => {
   const c = props.client
-  return h(
+  const row = h(
     'div',
-    {
-      class: 'flex items-center justify-between p-2 rounded-lg border border-base-300',
-      'data-test': `client-row-${c.id}`,
-    },
+    { class: 'flex items-center justify-between' },
     [
       h('div', { class: 'min-w-0 flex-1' }, [
         h('div', { class: 'font-medium text-sm truncate' }, c.name),
@@ -1146,7 +1179,51 @@ const ClientRow: FunctionalComponent<{ client: ClientStatus; busy?: boolean }, {
       ]),
     ]
   )
+  // Spec 078 US2 / FR-006: after a connect performed in this wizard session,
+  // surface the timestamped backup (or the honest "no prior file" case) right
+  // in the row. undefined = no connect happened for this client yet.
+  const backupLine =
+    props.backupPath !== undefined
+      ? h(
+          'div',
+          {
+            class: 'mt-1 flex items-start justify-between gap-2 text-[11px] opacity-70',
+            'data-test': `client-backup-${c.id}`,
+          },
+          props.backupPath
+            ? [
+                h('span', { class: 'min-w-0 break-all leading-relaxed' }, [
+                  'A backup of your previous config was saved to ',
+                  h('code', { class: 'font-mono', title: props.backupPath }, props.backupPath),
+                ]),
+                h(
+                  'button',
+                  {
+                    class: 'btn btn-ghost btn-xs shrink-0',
+                    'data-test': `client-copy-backup-${c.id}`,
+                    title: 'Copy the backup path to the clipboard',
+                    onClick: () => rowEmit('copy-backup', c.id),
+                  },
+                  props.copiedBackup ? 'Copied ✓' : 'Copy path'
+                ),
+              ]
+            : 'No prior config file existed, so no backup was needed.'
+        )
+      : null
+  return h(
+    'div',
+    {
+      class: 'p-2 rounded-lg border border-base-300',
+      'data-test': `client-row-${c.id}`,
+    },
+    backupLine ? [row, backupLine] : [row]
+  )
 }
-ClientRow.props = { client: { type: Object, required: true }, busy: { type: Boolean, default: false } }
-ClientRow.emits = ['connect']
+ClientRow.props = {
+  client: { type: Object, required: true },
+  busy: { type: Boolean, default: false },
+  backupPath: { type: String, default: undefined },
+  copiedBackup: { type: Boolean, default: false },
+}
+ClientRow.emits = ['connect', 'copy-backup']
 </script>

--- a/frontend/src/components/OnboardingWizard.vue
+++ b/frontend/src/components/OnboardingWizard.vue
@@ -707,6 +707,10 @@ watch(() => props.show, async (open) => {
   if (open) {
     serverAddedJustNow.value = false
     connectMessage.value = ''
+    // Backup lines are session-scoped (Spec 078 US2): don't replay backup
+    // rows from connects performed in a previous wizard session.
+    for (const k of Object.keys(connectBackups)) delete connectBackups[k]
+    copiedBackupClient.value = null
     await onboarding.fetchState()
     await Promise.all([
       fetchClients(),
@@ -1160,7 +1164,11 @@ const ClientRow: FunctionalComponent<
       h('div', { class: 'shrink-0 ml-2' }, [
         !c.supported
           ? h('span', { class: 'badge badge-ghost badge-sm' }, c.reason || 'Not supported')
-          : !c.exists
+          // Bridge clients (e.g. Claude Desktop) are connectable even without
+          // an existing config file — Connect creates it (parity with
+          // ConnectModal's connectableClients gating; Spec 078 US2/FR-006:
+          // this is the path that produces the "no prior file" backup case).
+          : !c.exists && !c.bridge
             ? h('span', { class: 'text-xs opacity-40' }, 'Not installed')
             : c.connected
               ? h('span', { class: 'badge badge-success badge-sm' }, 'Connected')

--- a/frontend/tests/unit/connect-modal.spec.ts
+++ b/frontend/tests/unit/connect-modal.spec.ts
@@ -513,6 +513,103 @@ describe('ConnectModal', () => {
     expect(backup.text()).toContain('opencode.json.bak.20260702-110000')
   })
 
+  // Spec 078 US2 / SC-005: Connect All must surface EVERY successful client's
+  // backup outcome, not just the last one — 100% of successful connects that
+  // modified an existing config display their backup path.
+  it('Connect All surfaces a per-client backup line for every successful connect', async () => {
+    ;(api.getConnectStatus as any).mockResolvedValue({
+      success: true,
+      data: [
+        {
+          id: 'cursor',
+          name: 'Cursor',
+          config_path: '/Users/test/.cursor/mcp.json',
+          exists: true,
+          connected: false,
+          supported: true,
+          icon: 'cursor',
+        },
+        {
+          id: 'codex',
+          name: 'Codex CLI',
+          config_path: '/Users/test/.codex/config.toml',
+          exists: true,
+          connected: false,
+          supported: true,
+          icon: 'codex',
+        },
+        {
+          // Bridge client with no config file: connect creates it → no backup.
+          id: 'claude-desktop',
+          name: 'Claude Desktop',
+          config_path: '/Users/test/Library/Application Support/Claude/claude_desktop_config.json',
+          exists: false,
+          connected: false,
+          supported: true,
+          bridge: true,
+          icon: 'claude-desktop',
+        },
+      ],
+    })
+    ;(api.connectClient as any).mockImplementation((id: string) => {
+      const backups: Record<string, string | undefined> = {
+        cursor: '/Users/test/.cursor/mcp.json.bak.20260702-101530',
+        codex: '/Users/test/.codex/config.toml.bak.20260702-101531',
+        'claude-desktop': undefined,
+      }
+      return Promise.resolve({
+        success: true,
+        data: {
+          success: true,
+          client: id,
+          config_path: '',
+          backup_path: backups[id],
+          server_name: 'mcpproxy',
+          action: 'added',
+          message: `MCPProxy registered in ${id}`,
+        },
+      })
+    })
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+
+    const wrapper = mount(ConnectModal, {
+      props: { show: false },
+      global: { plugins: [pinia] },
+    })
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    const connectAllBtn = wrapper
+      .findAll('button')
+      .find(b => b.text().includes('Connect All'))!
+    expect(connectAllBtn).toBeTruthy()
+    await connectAllBtn.trigger('click')
+    await flushPromises()
+
+    expect(api.connectClient).toHaveBeenCalledTimes(3)
+
+    // Every modified-config client shows ITS backup path.
+    const cursorRow = wrapper.find('[data-test="connect-bulk-backup-cursor"]')
+    expect(cursorRow.exists()).toBe(true)
+    expect(cursorRow.text()).toContain('/Users/test/.cursor/mcp.json.bak.20260702-101530')
+    const codexRow = wrapper.find('[data-test="connect-bulk-backup-codex"]')
+    expect(codexRow.exists()).toBe(true)
+    expect(codexRow.text()).toContain('/Users/test/.codex/config.toml.bak.20260702-101531')
+    // The no-prior-file client states its case explicitly.
+    const desktopRow = wrapper.find('[data-test="connect-bulk-backup-claude-desktop"]')
+    expect(desktopRow.exists()).toBe(true)
+    expect(desktopRow.text()).toContain('No prior config file existed')
+
+    // The single-result backup line must not duplicate the last client's path.
+    expect(wrapper.find('[data-test="connect-backup-path"]').exists()).toBe(false)
+
+    // Per-row copy copies THAT client's path.
+    await wrapper.find('[data-test="connect-bulk-copy-cursor"]').trigger('click')
+    await flushPromises()
+    expect(writeText).toHaveBeenCalledWith('/Users/test/.cursor/mcp.json.bak.20260702-101530')
+  })
+
   // Spec 075 US1/US2: the explicit per-client "Check access" action reads one
   // client's config on demand (the only privacy-prompt-eligible call) and
   // resolves its access_state in-band, surfacing a denial without a full connect.

--- a/frontend/tests/unit/connect-modal.spec.ts
+++ b/frontend/tests/unit/connect-modal.spec.ts
@@ -371,6 +371,148 @@ describe('ConnectModal', () => {
     expect(wrapper.find('[data-test="connect-denied-banner"]').exists()).toBe(false)
   })
 
+  // Spec 078 US2 / FR-006: a successful connect must surface the timestamped
+  // backup path returned by the API — the strongest "you can undo this" signal.
+  it('surfaces the timestamped backup path after a successful connect', async () => {
+    ;(api.getConnectStatus as any).mockResolvedValue({
+      success: true,
+      data: [{
+        id: 'cursor',
+        name: 'Cursor',
+        config_path: '/Users/test/.cursor/mcp.json',
+        exists: true,
+        connected: false,
+        supported: true,
+        icon: 'cursor',
+      }],
+    })
+    ;(api.connectClient as any).mockResolvedValue({
+      success: true,
+      data: {
+        success: true,
+        client: 'cursor',
+        config_path: '/Users/test/.cursor/mcp.json',
+        backup_path: '/Users/test/.cursor/mcp.json.bak.20260702-101530',
+        server_name: 'mcpproxy',
+        action: 'added',
+        message: 'MCPProxy registered in Cursor as mcpproxy',
+      },
+    })
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+
+    const wrapper = mount(ConnectModal, {
+      props: { show: false },
+      global: { plugins: [pinia] },
+    })
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    await wrapper.find('button.btn-primary.btn-xs').trigger('click')
+    await flushPromises()
+
+    const backup = wrapper.find('[data-test="connect-backup-path"]')
+    expect(backup.exists()).toBe(true)
+    expect(backup.text()).toContain('A backup of your previous config was saved to')
+    expect(backup.text()).toContain('/Users/test/.cursor/mcp.json.bak.20260702-101530')
+    // The "no prior file" variant must not render simultaneously.
+    expect(wrapper.find('[data-test="connect-no-backup"]').exists()).toBe(false)
+
+    // One-click copy of the backup path (same affordance pattern as tccutil).
+    const copyBtn = wrapper.find('[data-test="connect-copy-backup"]')
+    expect(copyBtn.exists()).toBe(true)
+    await copyBtn.trigger('click')
+    await flushPromises()
+    expect(writeText).toHaveBeenCalledWith('/Users/test/.cursor/mcp.json.bak.20260702-101530')
+  })
+
+  // Spec 078 US2 acceptance 2: a connect that created a brand-new config file
+  // has nothing to back up — say so explicitly, never show a blank path.
+  it('states that there was no prior file to back up when connect created the config', async () => {
+    ;(api.getConnectStatus as any).mockResolvedValue({
+      success: true,
+      data: [{
+        id: 'claude-desktop',
+        name: 'Claude Desktop',
+        config_path: '/Users/test/Library/Application Support/Claude/claude_desktop_config.json',
+        exists: false,
+        connected: false,
+        supported: true,
+        bridge: true,
+        icon: 'claude-desktop',
+      }],
+    })
+    ;(api.connectClient as any).mockResolvedValue({
+      success: true,
+      data: {
+        success: true,
+        client: 'claude-desktop',
+        config_path: '/Users/test/Library/Application Support/Claude/claude_desktop_config.json',
+        // no backup_path: the file did not exist before the write
+        server_name: 'mcpproxy',
+        action: 'added',
+        message: 'MCPProxy registered in Claude Desktop as mcpproxy',
+      },
+    })
+
+    const wrapper = mount(ConnectModal, {
+      props: { show: false },
+      global: { plugins: [pinia] },
+    })
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    await wrapper.find('button.btn-primary.btn-xs').trigger('click')
+    await flushPromises()
+
+    const noBackup = wrapper.find('[data-test="connect-no-backup"]')
+    expect(noBackup.exists()).toBe(true)
+    expect(noBackup.text()).toContain('No prior config file existed, so no backup was needed.')
+    expect(wrapper.find('[data-test="connect-backup-path"]').exists()).toBe(false)
+  })
+
+  // Spec 078 US2: disconnect also writes a backup first — surface it too.
+  it('surfaces the backup path after a successful disconnect', async () => {
+    ;(api.getConnectStatus as any).mockResolvedValue({
+      success: true,
+      data: [{
+        id: 'opencode',
+        name: 'OpenCode',
+        config_path: '/Users/test/.config/opencode/opencode.json',
+        exists: true,
+        connected: true,
+        supported: true,
+        icon: 'opencode',
+      }],
+    })
+    ;(api.disconnectClient as any).mockResolvedValue({
+      success: true,
+      data: {
+        success: true,
+        client: 'opencode',
+        config_path: '/Users/test/.config/opencode/opencode.json',
+        backup_path: '/Users/test/.config/opencode/opencode.json.bak.20260702-110000',
+        server_name: 'mcpproxy',
+        action: 'removed',
+        message: 'MCPProxy removed from OpenCode',
+      },
+    })
+
+    const wrapper = mount(ConnectModal, {
+      props: { show: false },
+      global: { plugins: [pinia] },
+    })
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    await wrapper.find('button.btn-ghost.text-error').trigger('click')
+    await flushPromises()
+
+    const backup = wrapper.find('[data-test="connect-backup-path"]')
+    expect(backup.exists()).toBe(true)
+    expect(backup.text()).toContain('opencode.json.bak.20260702-110000')
+  })
+
   // Spec 075 US1/US2: the explicit per-client "Check access" action reads one
   // client's config on demand (the only privacy-prompt-eligible call) and
   // resolves its access_state in-band, surfacing a denial without a full connect.

--- a/frontend/tests/unit/onboarding-wizard-backup-path.spec.ts
+++ b/frontend/tests/unit/onboarding-wizard-backup-path.spec.ts
@@ -52,6 +52,23 @@ function cursorClient() {
   }
 }
 
+// Bridge client with NO config file on disk — the only real-world producer of
+// an empty backup_path (connect creates the file). Spec 078 US2's independent
+// test runs against exactly this shape.
+function bridgeClientNoConfig() {
+  return {
+    id: 'claude-desktop',
+    name: 'Claude Desktop',
+    config_path: '/Users/test/Library/Application Support/Claude/claude_desktop_config.json',
+    exists: false,
+    connected: false,
+    supported: true,
+    bridge: true,
+    note: 'Connects via an mcp-remote stdio bridge (npx -y mcp-remote). Requires Node.js.',
+    icon: 'claude-desktop',
+  }
+}
+
 async function openClientsTab(pinia: any) {
   const wrapper = mount(OnboardingWizard, {
     props: { show: false },
@@ -141,5 +158,91 @@ describe('OnboardingWizard backup path surfacing (Spec 078 US2)', () => {
     expect(backup.exists()).toBe(true)
     expect(backup.text()).toContain('No prior config file existed, so no backup was needed.')
     expect(backup.find('[data-test="client-copy-backup-cursor"]').exists()).toBe(false)
+  })
+
+  // Spec 078 US2 independent test / FR-006: a bridge client with no config file
+  // on disk MUST be connectable from the wizard (Connect creates the file) and
+  // the result MUST state the "no prior file to back up" case. Previously the
+  // wizard row rendered 'Not installed' for every exists=false client — making
+  // the no-prior-file branch unreachable from the wizard.
+  it('offers Connect for a bridge client with no config file and states no backup was needed', async () => {
+    ;(api.getConnectStatus as any).mockResolvedValue({
+      success: true,
+      data: [bridgeClientNoConfig()],
+    })
+    ;(api.connectClient as any).mockResolvedValue({
+      success: true,
+      data: {
+        success: true,
+        client: 'claude-desktop',
+        config_path: '/Users/test/Library/Application Support/Claude/claude_desktop_config.json',
+        // no backup_path: connect created the file
+        server_name: 'mcpproxy',
+        action: 'added',
+        message: 'MCPProxy registered in Claude Desktop as mcpproxy',
+      },
+    })
+
+    const wrapper = await openClientsTab(pinia)
+
+    const row = wrapper.find('[data-test="client-row-claude-desktop"]')
+    expect(row.exists()).toBe(true)
+    // Bridge clients are connectable even without an existing config file
+    // (parity with ConnectModal's connectableClients gating).
+    expect(row.text()).not.toContain('Not installed')
+    const connectBtn = wrapper.find('[data-test="connect-claude-desktop"]')
+    expect(connectBtn.exists()).toBe(true)
+
+    await connectBtn.trigger('click')
+    await flushPromises()
+
+    const backup = wrapper.find('[data-test="client-backup-claude-desktop"]')
+    expect(backup.exists()).toBe(true)
+    expect(backup.text()).toContain('No prior config file existed, so no backup was needed.')
+  })
+
+  // A non-bridge client that is simply not installed must still NOT offer Connect.
+  it('keeps Not installed (no Connect) for a non-bridge client without a config', async () => {
+    ;(api.getConnectStatus as any).mockResolvedValue({
+      success: true,
+      data: [{ ...cursorClient(), exists: false }],
+    })
+
+    const wrapper = await openClientsTab(pinia)
+
+    const row = wrapper.find('[data-test="client-row-cursor"]')
+    expect(row.exists()).toBe(true)
+    expect(row.text()).toContain('Not installed')
+    expect(wrapper.find('[data-test="connect-cursor"]').exists()).toBe(false)
+  })
+
+  // Backup lines are session-scoped: reopening the wizard must not replay
+  // backup rows from connects performed in a previous wizard session.
+  it('clears backup rows when the wizard is closed and reopened', async () => {
+    ;(api.connectClient as any).mockResolvedValue({
+      success: true,
+      data: {
+        success: true,
+        client: 'cursor',
+        config_path: '/Users/test/.cursor/mcp.json',
+        backup_path: '/Users/test/.cursor/mcp.json.bak.20260702-101530',
+        server_name: 'mcpproxy',
+        action: 'added',
+        message: 'MCPProxy registered in Cursor as mcpproxy',
+      },
+    })
+
+    const wrapper = await openClientsTab(pinia)
+    await wrapper.find('[data-test="connect-cursor"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-test="client-backup-cursor"]').exists()).toBe(true)
+
+    // Close and reopen the wizard: a fresh session must start clean.
+    await wrapper.setProps({ show: false })
+    await flushPromises()
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="client-backup-cursor"]').exists()).toBe(false)
   })
 })

--- a/frontend/tests/unit/onboarding-wizard-backup-path.spec.ts
+++ b/frontend/tests/unit/onboarding-wizard-backup-path.spec.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import OnboardingWizard from '@/components/OnboardingWizard.vue'
+import api from '@/services/api'
+
+// Spec 078 US2 / FR-006: the wizard's connect step must surface the timestamped
+// backup path after a successful connect (and explicitly represent the
+// "no prior file to back up" case) — the backend has always returned
+// ConnectResult.backup_path but the wizard previously dropped it.
+
+vi.mock('@/services/api', () => ({
+  default: {
+    getConnectStatus: vi.fn(),
+    getOnboardingState: vi.fn(),
+    markOnboardingState: vi.fn(),
+    getActivities: vi.fn(),
+    getConfig: vi.fn(),
+    getDockerStatus: vi.fn(),
+    getCanonicalConfigPaths: vi.fn(),
+    connectClient: vi.fn(),
+  },
+}))
+
+function onboardingState(connectedIds: string[]) {
+  return {
+    success: true,
+    data: {
+      has_connected_client: connectedIds.length > 0,
+      has_configured_server: true,
+      connected_client_count: connectedIds.length,
+      connected_client_ids: connectedIds,
+      configured_server_count: 1,
+      state: { engaged: false },
+      should_show_wizard: true,
+      first_mcp_client_ever: false,
+      mcp_clients_seen_ever: [],
+      incomplete_tab_count: 0,
+    },
+  }
+}
+
+function cursorClient() {
+  return {
+    id: 'cursor',
+    name: 'Cursor',
+    config_path: '/Users/test/.cursor/mcp.json',
+    exists: true,
+    connected: false,
+    supported: true,
+    icon: 'cursor',
+  }
+}
+
+async function openClientsTab(pinia: any) {
+  const wrapper = mount(OnboardingWizard, {
+    props: { show: false },
+    global: { plugins: [pinia] },
+  })
+  await wrapper.setProps({ show: true })
+  await flushPromises()
+  await wrapper.find('[data-test="tab-clients"]').trigger('click')
+  await flushPromises()
+  return wrapper
+}
+
+describe('OnboardingWizard backup path surfacing (Spec 078 US2)', () => {
+  let pinia: any
+
+  beforeEach(() => {
+    pinia = createPinia()
+    setActivePinia(pinia)
+    vi.clearAllMocks()
+    // Safe defaults for the wizard's open lifecycle.
+    ;(api.getActivities as any).mockResolvedValue({ success: true, data: { activities: [] } })
+    ;(api.getConfig as any).mockResolvedValue({ success: true, data: {} })
+    ;(api.getDockerStatus as any).mockResolvedValue({ success: true, data: { available: false } })
+    ;(api.getCanonicalConfigPaths as any).mockResolvedValue({ success: true, data: { paths: [] } })
+    ;(api.getOnboardingState as any).mockResolvedValue(onboardingState([]))
+    ;(api.markOnboardingState as any).mockResolvedValue(onboardingState([]))
+    ;(api.getConnectStatus as any).mockResolvedValue({ success: true, data: [cursorClient()] })
+  })
+
+  it('shows the backup path in the client row after a successful connect', async () => {
+    ;(api.connectClient as any).mockResolvedValue({
+      success: true,
+      data: {
+        success: true,
+        client: 'cursor',
+        config_path: '/Users/test/.cursor/mcp.json',
+        backup_path: '/Users/test/.cursor/mcp.json.bak.20260702-101530',
+        server_name: 'mcpproxy',
+        action: 'added',
+        message: 'MCPProxy registered in Cursor as mcpproxy',
+      },
+    })
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+
+    const wrapper = await openClientsTab(pinia)
+
+    // No backup info before any connect happened in this session.
+    expect(wrapper.find('[data-test="client-backup-cursor"]').exists()).toBe(false)
+
+    await wrapper.find('[data-test="connect-cursor"]').trigger('click')
+    await flushPromises()
+
+    const backup = wrapper.find('[data-test="client-backup-cursor"]')
+    expect(backup.exists()).toBe(true)
+    expect(backup.text()).toContain('A backup of your previous config was saved to')
+    expect(backup.text()).toContain('/Users/test/.cursor/mcp.json.bak.20260702-101530')
+
+    // One-click copy of the backup path.
+    const copyBtn = wrapper.find('[data-test="client-copy-backup-cursor"]')
+    expect(copyBtn.exists()).toBe(true)
+    await copyBtn.trigger('click')
+    await flushPromises()
+    expect(writeText).toHaveBeenCalledWith('/Users/test/.cursor/mcp.json.bak.20260702-101530')
+  })
+
+  it('states there was no prior file to back up when connect created the config', async () => {
+    ;(api.connectClient as any).mockResolvedValue({
+      success: true,
+      data: {
+        success: true,
+        client: 'cursor',
+        config_path: '/Users/test/.cursor/mcp.json',
+        // no backup_path: the file did not exist before the write
+        server_name: 'mcpproxy',
+        action: 'added',
+        message: 'MCPProxy registered in Cursor as mcpproxy',
+      },
+    })
+
+    const wrapper = await openClientsTab(pinia)
+
+    await wrapper.find('[data-test="connect-cursor"]').trigger('click')
+    await flushPromises()
+
+    const backup = wrapper.find('[data-test="client-backup-cursor"]')
+    expect(backup.exists()).toBe(true)
+    expect(backup.text()).toContain('No prior config file existed, so no backup was needed.')
+    expect(backup.find('[data-test="client-copy-backup-cursor"]').exists()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Motivation

Part of **Spec 078 (Connect Trust Preview)** — this PR implements the **backup-visibility slice** (User Story 2: "Always-created backup is visible and understood", FR-005/FR-006). The backend already creates a timestamped backup before modifying a client config and returns it as `ConnectResult.backup_path`; the Web UI silently dropped it. This slice surfaces it.

**This is a deliberate FIRST SLICE.** It does **not** include:
- US1 pre-connect change preview (FR-001–FR-004)
- US3 one-click undo (FR-007–FR-009)
- US4 plain-language trust copy / macOS prompt explanation (FR-010+)
- Any backend changes — `backup_path` was already in the API contract (`frontend/src/types/api.ts` needed no change)

## Implementation

- **`ConnectModal.vue`**: after a successful connect **or** disconnect, the result area shows "A backup of your previous config was saved to `<path>`" with a one-click **Copy path** button (reuses the existing `navigator.clipboard` pattern). A success with no `backup_path` renders an explicit "No prior config file existed, so no backup was needed." instead of nothing.
- **`OnboardingWizard.vue`**: the client row renders the same backup line (path + Copy path, or the no-prior-file message) after a connect performed in the wizard session — including per-client results from **Connect All** and connects where no config file existed. State tracked per-client in `connectBackups`; new `backupPath`/`copiedBackup` props + `copy-backup` emit on the functional `ClientRow`.
- Test hooks: `data-test="connect-backup-path" / "connect-no-backup" / "connect-copy-backup"` (modal); `"client-backup-<id>" / "client-copy-backup-<id>"` (wizard).
- Unit tests: `frontend/tests/unit/connect-modal.spec.ts`, `frontend/tests/unit/onboarding-wizard-backup-path.spec.ts`.

## Codex review

Reviewed by codex; findings **applied** in `543cb98c`:
1. Wizard rows missed the backup line when connect happened with no prior config (no-config connect path wasn't bridged into `connectBackups`) — fixed.
2. **Connect All** only recorded the last client's backup — now records per-client results.

No findings rebutted.

## Verification

All steps run in the worktree at HEAD `543cb98c` (on top of `3b339516`):
1. **Build**: `make build` exit 0 — frontend built and embedded, `go build` OK (v0.47.0-rc.1).
2. **Live API** against the built binary with an isolated HOME/config (port 18093, `/readyz` READY): `POST /api/v1/connect/claude-code` with a pre-existing `~/.claude.json` → success with a real timestamped `backup_path`; connect with no prior file → success without `backup_path` (drives the explicit no-backup message).
3. Frontend unit tests for both surfaces pass (modal + wizard, incl. Connect All and no-backup cases).

Part of specs/078-connect-trust-preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)
