### PR TITLE
docs(roadmap): true-up after v0.47.0-rc.2

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -94,7 +94,8 @@ graph TD
   end
   subgraph sg_upgrade_nudge["Upgrade awareness & guided update"]
     upgrade_nudge["Upgrade awareness & guided update"]
-    upgrade_nudge_surfacing["US1: universal awareness — status output, startup log, dismissible Web UI banner, update_check config block"]
+    upgrade_nudge_status_log["US1 slice: update availability in mcpproxy status + deduped startup log"]
+    upgrade_nudge_surfacing["US1 remainder: dismissible Web UI banner + update_check config block"]
     upgrade_nudge_channel["US2: channel-aware guided update command (brew/dmg/deb/rpm/docker/go-install detection, build-time channel marker)"]
     upgrade_nudge_quiet["US3: operator control + CI/offline quiet + no prerelease downgrade nudges"]
   end
@@ -151,6 +152,7 @@ graph TD
   scanner_simpl_unified_report --> scanner_simpl_deep_optin
   scanner_simpl_unified_report --> scanner_simpl_notifications
   scanner_simpl_deep_optin --> scanner_simpl_deepscan_fixes
+  upgrade_nudge_status_log --> upgrade_nudge_surfacing
   upgrade_nudge_surfacing --> upgrade_nudge_channel
   upgrade_nudge_surfacing --> upgrade_nudge_quiet
   telemetry_machineid_client --> telemetry_machineid_worker
@@ -162,10 +164,10 @@ graph TD
   classDef blocked fill:#a40e26,stroke:#5c0712,color:#ffffff;
   classDef todo fill:#6e7781,stroke:#3d4248,color:#ffffff;
   classDef parked fill:#30363d,stroke:#161b22,color:#9da7b3,stroke-dasharray:4 3;
-  class profiles_v2,profiles_v2_indexes,profiles_v2_set_profile,profiles_v2_profile_pin,profiles_v2_tray_switcher,sandbox_isolation,sandbox_spike,sandbox_mode_config,sandbox_launcher,sandbox_scanner_parity,sandbox_snap_docker_it,ts_code_exec_ga,ts_code_exec_cookbook,scanner_v2,scanner_v2_foundation,scanner_v2_hard_checks,scanner_v2_soft_checks,scanner_v2_consensus,scanner_v2_eval_gate,scanner_v2_docs,registries_official_protocol,scanner_simpl_baseline,scanner_simpl_unified_report,scanner_simpl_notifications done;
-  class scanner_simplification,telemetry_identity in_progress;
-  class windows_tray,windows_tray_window,scanner_simpl_deep_optin,telemetry_machineid_client in_review;
-  class windows_tray_funnel_qa,ux_audit,ux_audit_webui_sweep,ux_audit_macos_sweep,action_log_transparency,action_log_glance_view,action_log_retention_tie_in,analytics_dashboard,analytics_token_drain_graphs,analytics_default_landing,registries_search_add,registries_search_ux,scanner_simpl_deepscan_fixes,upgrade_nudge,upgrade_nudge_surfacing,upgrade_nudge_channel,upgrade_nudge_quiet,connect_trust,connect_trust_preview,connect_trust_backup_visibility,connect_trust_undo,connect_trust_tcc_copy,telemetry_machineid_worker,telemetry_machineid_dash,telemetry_snapshot_alerting,planning_hygiene,hygiene_roadmap_github_check,hygiene_tasks_reconcile,hygiene_docs_facts,hygiene_quickstart_contract todo;
+  class profiles_v2,profiles_v2_indexes,profiles_v2_set_profile,profiles_v2_profile_pin,profiles_v2_tray_switcher,sandbox_isolation,sandbox_spike,sandbox_mode_config,sandbox_launcher,sandbox_scanner_parity,sandbox_snap_docker_it,ts_code_exec_ga,ts_code_exec_cookbook,scanner_v2,scanner_v2_foundation,scanner_v2_hard_checks,scanner_v2_soft_checks,scanner_v2_consensus,scanner_v2_eval_gate,scanner_v2_docs,registries_official_protocol,scanner_simplification,scanner_simpl_baseline,scanner_simpl_unified_report,scanner_simpl_deep_optin,scanner_simpl_notifications,scanner_simpl_deepscan_fixes,upgrade_nudge_status_log,connect_trust_preview,connect_trust_backup_visibility,telemetry_machineid_client,hygiene_roadmap_github_check done;
+  class upgrade_nudge,connect_trust,telemetry_identity in_progress;
+  class windows_tray,windows_tray_window in_review;
+  class windows_tray_funnel_qa,ux_audit,ux_audit_webui_sweep,ux_audit_macos_sweep,action_log_transparency,action_log_glance_view,action_log_retention_tie_in,analytics_dashboard,analytics_token_drain_graphs,analytics_default_landing,registries_search_add,registries_search_ux,upgrade_nudge_surfacing,upgrade_nudge_channel,upgrade_nudge_quiet,connect_trust_undo,connect_trust_tcc_copy,telemetry_machineid_worker,telemetry_machineid_dash,telemetry_snapshot_alerting,planning_hygiene,hygiene_tasks_reconcile,hygiene_docs_facts,hygiene_quickstart_contract todo;
   class marketplace,siem,paid_tier,sdk_v1_migration,sso parked;
 ```
 
@@ -173,13 +175,12 @@ graph TD
 
 | Epic | Status | Assignee | Priority | Progress | Spec | PR |
 | --- | --- | --- | --- | --- | --- | --- |
-| Scanner simplification (deterministic default, opt-in deep scan) | In progress | unassigned | P1 | 38/42 (90%) | [077-scanner-simplification](./specs/077-scanner-simplification/) |  |
+| Upgrade awareness & guided update | In progress | unassigned | P0 | — | [079-upgrade-nudge](./specs/079-upgrade-nudge/) |  |
+| Connect step trust: preview, visible backup, one-click undo | In progress | unassigned | P0 | — | [078-connect-trust-preview](./specs/078-connect-trust-preview/) |  |
 | Telemetry identity & data quality (machine_id + CI-filter hardening) | In progress | unassigned | P1 | — |  |  |
 | Windows native tray app `MCP-43` | In review | BackendEngineer | P2 | 25/60 (42%) | [002-windows-installer](./specs/002-windows-installer/) |  |
 | Web UI + macOS app UX audit | Todo | unassigned | P0 | — |  |  |
 | Action log / transparency — info at a glance | Todo | unassigned | P0 | — |  |  |
-| Upgrade awareness & guided update | Todo | unassigned | P0 | — | [079-upgrade-nudge](./specs/079-upgrade-nudge/) |  |
-| Connect step trust: preview, visible backup, one-click undo | Todo | unassigned | P0 | — | [078-connect-trust-preview](./specs/078-connect-trust-preview/) |  |
 | Analytics dashboard as default page | Todo | unassigned | P1 | 16/26 (62%) | [069-observability-usage-graphs](./specs/069-observability-usage-graphs/) |  |
 | Registries — easier search + add-server | Todo | unassigned | P1 | 3/24 (12%) | [070-registry-easy-upstream-add](./specs/070-registry-easy-upstream-add/) |  |
 | Planning/docs truth automation | Todo | unassigned | P2 | — |  |  |
@@ -191,6 +192,7 @@ graph TD
 | Profiles v2 (per-profile tool views) `MCP-33` | Done | BackendEngineer | P1 | — |  |  |
 | Non-Docker sandbox isolation (Landlock) `MCP-34` | Done | BackendEngineer | P1 | — |  |  |
 | Spec 076 deterministic offline tool-scanner `MCP-3574` | Done | BackendEngineer | P1 | 22/24 (92%) | [076-deterministic-tool-scanner](./specs/076-deterministic-tool-scanner/) |  |
+| Scanner simplification (deterministic default, opt-in deep scan) | Done | unassigned | P1 | 38/42 (90%) | [077-scanner-simplification](./specs/077-scanner-simplification/) |  |
 | TypeScript code-execution GA + cookbook `MCP-38` | Done | BackendEngineer | P2 | 19/19 (100%) | [033-typescript-code-execution](./specs/033-typescript-code-execution/) |  |
 
 ## Per-spec progress (recomputed from `specs/<NNN>/tasks.md`)

--- a/roadmap.yaml
+++ b/roadmap.yaml
@@ -296,12 +296,12 @@ epics:
 
   - id: scanner-simplification
     title: Scanner simplification (deterministic default, opt-in deep scan)
-    status: in_progress
+    status: done
     assignee: unassigned
     priority: P1
     spec: specs/077-scanner-simplification
     depends_on: [scanner-v2]
-    note: "Make the Spec 076 detect engine the always-on offline default; demote Docker scanners + source extraction to opt-in deep scan that never blocks/degrades the baseline; single unified report. US1/US2/US4 merged; US3 (deep-scan opt-in) in review as #793. Docs tasks T037-T039 treated as merge-blocking for PR #793 (docs still describe deleted legacy tpaRules / six-checks / auto_scan_quarantined). First of the 5 personal-edition polish verticals."
+    note: "Make the Spec 076 detect engine the always-on offline default; demote Docker scanners + source extraction to opt-in deep scan that never blocks/degrades the baseline; single unified report. COMPLETE: US1 #786, US2 #792, US4 #794, US3 + deep-scan trust fixes + docs truth sweep (T037-T039) #793 — all merged; shipped in v0.47.0-rc.2. Remaining 4 unchecked tasks in tasks.md are documented scope-outs. First of the 5 personal-edition polish verticals."
     tasks:
       - id: scanner-simpl-baseline
         title: "US1: deterministic offline baseline default + curated hard phrase_injection check (delete duplicate legacy rules)"
@@ -315,7 +315,7 @@ epics:
         depends_on: [scanner-simpl-baseline]
       - id: scanner-simpl-deep-optin
         title: "US3: opt-in deep scan (off by default), never blocks/degrades baseline; config migration"
-        status: in_review
+        status: done
         pr: "#793"
         depends_on: [scanner-simpl-baseline, scanner-simpl-unified-report]
       - id: scanner-simpl-notifications
@@ -325,24 +325,30 @@ epics:
         depends_on: [scanner-simpl-unified-report]
       - id: scanner-simpl-deepscan-fixes
         title: "Deep-scan trust fixes: nil-Security gating bug (source fetch runs with deep scan off on default configs), FR-014 verdict inversion (Dangerous deep finding < Warning), surface silently-skipped Docker scanners (non-nil deep_scan descriptor + CLI hint on security enable)"
-        status: todo
+        status: done
+        pr: "#793"
         priority: P1
         depends_on: [scanner-simpl-deep-optin]
 
   # ── TELEMETRY-DRIVEN REPLAN (2026-07-02) ──────────────────────────────────
   - id: upgrade-nudge
     title: Upgrade awareness & guided update
-    status: todo
+    status: in_progress
     assignee: unassigned
     priority: P0
     spec: specs/079-upgrade-nudge
     depends_on: []
     note: "Corrected CI-filtered telemetry (2026-07-02): ~60% of last-14d active installs run pre-v0.40; latest stable v0.46.0 only 18.7%. Turn the existing internal/updatecheck background poll into a universal, non-intrusive, channel-aware upgrade nudge across every surface. Never blocks/modals; silent offline/CI."
     tasks:
-      - id: upgrade-nudge-surfacing
-        title: "US1: universal awareness — status output, startup log, dismissible Web UI banner, update_check config block"
-        status: todo
+      - id: upgrade-nudge-status-log
+        title: "US1 slice: update availability in mcpproxy status + deduped startup log"
+        status: done
+        pr: "#798"
         depends_on: []
+      - id: upgrade-nudge-surfacing
+        title: "US1 remainder: dismissible Web UI banner + update_check config block"
+        status: todo
+        depends_on: [upgrade-nudge-status-log]
       - id: upgrade-nudge-channel
         title: "US2: channel-aware guided update command (brew/dmg/deb/rpm/docker/go-install detection, build-time channel marker)"
         status: todo
@@ -354,7 +360,7 @@ epics:
 
   - id: connect-trust
     title: "Connect step trust: preview, visible backup, one-click undo"
-    status: todo
+    status: in_progress
     assignee: unassigned
     priority: P0
     spec: specs/078-connect-trust-preview
@@ -363,11 +369,13 @@ epics:
     tasks:
       - id: connect-trust-preview
         title: "US1: preview API + wizard diff UI (exact entry, API-key masking)"
-        status: todo
+        status: done
+        pr: "#802"
         depends_on: []
       - id: connect-trust-backup-visibility
         title: "US1: surface backup_path in Web UI + retention policy"
-        status: todo
+        status: done
+        pr: "#799"
         depends_on: []
       - id: connect-trust-undo
         title: "US2: one-click undo/disconnect in wizard"
@@ -388,7 +396,7 @@ epics:
     tasks:
       - id: telemetry-machineid-client
         title: "Hashed machine_id in heartbeat (schema v6)"
-        status: in_review
+        status: done
         pr: "https://github.com/smart-mcp-proxy/mcpproxy-go/pull/796"
         depends_on: []
       - id: telemetry-machineid-worker
@@ -414,7 +422,8 @@ epics:
     tasks:
       - id: hygiene-roadmap-github-check
         title: "gen-roadmap --check-github: cross-check roadmap.yaml statuses vs gh PR state + dangling spec links"
-        status: todo
+        status: done
+        pr: "#800"
         depends_on: []
       - id: hygiene-tasks-reconcile
         title: "CI rule: PR touching specs/<id> implementation paths must update tasks.md"


### PR DESCRIPTION
Roadmap ground-truth sync following today's merges (#793/#798/#799/#800/#802) and the v0.47.0-rc.2 tag. `gen-roadmap --check-github` now reports 0 errors (2 known windows-tray warnings remain). Includes an honest split of the partially-shipped upgrade-nudge US1 task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)