### PR TITLE
fix(release): inject httpapi.buildVersion everywhere + guard update check against non-semver versions

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -207,7 +207,7 @@ jobs:
           CGO_CFLAGS: "-mmacosx-version-min=13.0"
           CGO_LDFLAGS: "-mmacosx-version-min=13.0"
         run: |
-          LDFLAGS="-s -w -X mcpproxy-go/cmd/mcpproxy.version=${VERSION} -X main.version=${VERSION}"
+          LDFLAGS="-s -w -X main.version=${VERSION} -X github.com/smart-mcp-proxy/mcpproxy-go/internal/httpapi.buildVersion=${VERSION}"
 
           # Determine clean binary name
           if [ "${{ matrix.goos }}" = "windows" ]; then

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -205,7 +205,9 @@ jobs:
           fi
 
           echo "Building version: ${VERSION}"
-          LDFLAGS="-s -w -X mcpproxy-go/cmd/mcpproxy.version=${VERSION} -X main.version=${VERSION} -X mcpproxy-go/internal/httpapi.buildVersion=${VERSION}"
+          # -X paths must use the full module path (go.mod: github.com/smart-mcp-proxy/mcpproxy-go);
+          # a wrong path is silently ignored and the binary reports "development".
+          LDFLAGS="-s -w -X main.version=${VERSION} -X github.com/smart-mcp-proxy/mcpproxy-go/internal/httpapi.buildVersion=${VERSION}"
 
           # Determine clean binary name
           if [ "${{ matrix.goos }}" = "windows" ]; then

--- a/internal/updatecheck/checker.go
+++ b/internal/updatecheck/checker.go
@@ -334,6 +334,12 @@ func (c *Checker) compareVersions(current, latest string) bool {
 	currentSemver := ensureVPrefix(current)
 	latestSemver := ensureVPrefix(latest)
 
+	// semver.Compare ranks an invalid version below every valid one, which
+	// would flag any published release as an "update" for a dev build.
+	if !semver.IsValid(currentSemver) {
+		return false
+	}
+
 	// semver.Compare returns -1 if current < latest
 	return semver.Compare(currentSemver, latestSemver) < 0
 }
@@ -375,6 +381,14 @@ func (c *Checker) SetCheckFunc(fn func() (*GitHubRelease, error)) {
 func (c *Checker) CheckNow() *VersionInfo {
 	if !c.Enabled() {
 		c.logger.Debug("Immediate update check skipped: update checking disabled")
+		return nil
+	}
+	// Same guard as Start(): a non-semver current version (e.g. "development")
+	// cannot be meaningfully compared, and offering the latest stable release
+	// against it is a downgrade prompt, not an update.
+	if !c.isValidSemver() {
+		c.logger.Debug("Immediate update check skipped: non-semver version",
+			zap.String("version", c.version))
 		return nil
 	}
 	c.logger.Debug("Performing immediate update check")

--- a/internal/updatecheck/checker_test.go
+++ b/internal/updatecheck/checker_test.go
@@ -79,6 +79,35 @@ func TestChecker_CheckNow_NoUpdate(t *testing.T) {
 	}
 }
 
+// TestChecker_CheckNow_NonSemverVersionSkipsCheck verifies that the forced
+// refresh path has the same non-semver guard as Start(): a "development"
+// build must never run a check, because compareVersions would rank the
+// invalid current version below ANY published release and every surface
+// (Web UI banner, doctor, status) would offer a stable-version "update" —
+// a downgrade prompt on dev/misbuilt binaries.
+func TestChecker_CheckNow_NonSemverVersionSkipsCheck(t *testing.T) {
+	for _, version := range []string{"development", "dev", ""} {
+		t.Run("version_"+version, func(t *testing.T) {
+			checker := New(zaptest.NewLogger(t), version)
+
+			checked := false
+			checker.SetCheckFunc(func() (*GitHubRelease, error) {
+				checked = true
+				return &GitHubRelease{TagName: "v1.1.0", HTMLURL: "https://example.com"}, nil
+			})
+
+			info := checker.CheckNow()
+
+			if checked {
+				t.Error("CheckNow ran a network check for a non-semver version")
+			}
+			if info != nil && info.UpdateAvailable {
+				t.Errorf("UpdateAvailable = true for non-semver version %q", version)
+			}
+		})
+	}
+}
+
 // TestChecker_UpdateAvailableLoggedOncePerVersion verifies the "Update available"
 // Info log is emitted exactly once per detected latest version, not on every
 // periodic tick (FR-004 of specs/079-upgrade-nudge: no repeated log spam).
@@ -168,6 +197,10 @@ func TestChecker_CompareVersions(t *testing.T) {
 		{"1.0.0", "1.1.0", true}, // Without v prefix
 		{"v0.11.1", "v0.11.3", true},
 		{"v0.11.2", "v0.11.2", false},
+		// An invalid current version must never be treated as "older than
+		// everything" — that turns a dev build into a permanent downgrade nudge.
+		{"development", "v1.0.0", false},
+		{"", "v1.0.0", false},
 	}
 
 	for _, tc := range tests {

--- a/scripts/build-windows-installer.ps1
+++ b/scripts/build-windows-installer.ps1
@@ -48,7 +48,7 @@ Write-Host "  Building mcpproxy.exe..." -ForegroundColor White
 $env:CGO_ENABLED = "0"
 $CoreBinary = Join-Path $BinDir "mcpproxy.exe"
 $CoreCmd = Join-Path $RepoRoot "cmd/mcpproxy"
-go build -buildvcs=false -ldflags "-s -w -X main.version=$Version" -o $CoreBinary $CoreCmd
+go build -buildvcs=false -ldflags "-s -w -X main.version=$Version -X github.com/smart-mcp-proxy/mcpproxy-go/internal/httpapi.buildVersion=$Version" -o $CoreBinary $CoreCmd
 
 if ($LASTEXITCODE -ne 0) {
     Write-Host "  Failed to build mcpproxy.exe" -ForegroundColor Red
@@ -61,7 +61,7 @@ Write-Host "  Building mcpproxy-tray.exe..." -ForegroundColor White
 $env:CGO_ENABLED = "1"
 $TrayBinary = Join-Path $BinDir "mcpproxy-tray.exe"
 $TrayCmd = Join-Path $RepoRoot "cmd/mcpproxy-tray"
-go build -buildvcs=false -ldflags "-s -w -X main.version=$Version -H windowsgui" -o $TrayBinary $TrayCmd
+go build -buildvcs=false -ldflags "-s -w -X main.version=$Version -X github.com/smart-mcp-proxy/mcpproxy-go/internal/httpapi.buildVersion=$Version -H windowsgui" -o $TrayBinary $TrayCmd
 
 if ($LASTEXITCODE -ne 0) {
     Write-Host "  Failed to build mcpproxy-tray.exe" -ForegroundColor Red

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -42,7 +42,7 @@ Write-Host "Commit: $Commit" -ForegroundColor Green
 Write-Host "Date: $Date" -ForegroundColor Green
 Write-Host ""
 
-$LDFLAGS = "-X main.version=$Version -X main.commit=$Commit -X main.date=$Date -s -w"
+$LDFLAGS = "-X main.version=$Version -X main.commit=$Commit -X main.date=$Date -X github.com/smart-mcp-proxy/mcpproxy-go/internal/httpapi.buildVersion=$Version -s -w"
 
 # Array to track built binaries
 $BuiltBinaries = @()
@@ -96,7 +96,7 @@ if (!$OnlyCurrentPlatform) {
 if ($BuildTray) {
     Write-Host ""
     Write-Host "Building mcpproxy-tray binaries..." -ForegroundColor Magenta
-    
+
     # Build tray for current platform (Windows with CGO)
     Write-Host "Building tray for Windows..." -ForegroundColor Cyan
     $env:CGO_ENABLED = "1"
@@ -109,7 +109,7 @@ if ($BuildTray) {
         Write-Host "✓ Windows tray binary built successfully" -ForegroundColor Green
         $BuiltBinaries += "mcpproxy-tray.exe"
     }
-    
+
     if (!$OnlyCurrentPlatform) {
         # Build tray for macOS (requires macOS host for proper CGO compilation)
         Write-Host "Attempting to build tray for macOS..." -ForegroundColor Cyan
@@ -123,7 +123,7 @@ if ($BuildTray) {
             Write-Host "✓ macOS tray binary built successfully" -ForegroundColor Green
             $BuiltBinaries += "mcpproxy-tray-darwin-amd64"
         }
-        
+
         # Build tray for macOS ARM64
         Write-Host "Attempting to build tray for macOS ARM64..." -ForegroundColor Cyan
         $env:CGO_ENABLED = "1"
@@ -139,7 +139,7 @@ if ($BuildTray) {
     } else {
         Write-Host "Skipping cross-platform tray builds (OnlyCurrentPlatform flag is set)" -ForegroundColor Yellow
     }
-    
+
     # Reset environment variables
     Remove-Item Env:CGO_ENABLED -ErrorAction SilentlyContinue
     Remove-Item Env:GOOS -ErrorAction SilentlyContinue
@@ -172,4 +172,3 @@ if ($BuiltFiles.Count -gt 0) {
 Write-Host ""
 Write-Host "Test version info:" -ForegroundColor Cyan
 & .\mcpproxy.exe --version
-


### PR DESCRIPTION
## Summary

Release QA on **v0.47.0-rc.4** found the installed app reporting version `development` on every httpapi-backed surface: the Spec 079 update banner, `mcpproxy doctor` and `mcpproxy status` all offered **v0.46.0 — a downgrade prompt** — and telemetry heartbeats reported `development`, corrupting Spec 080 churn metrics for the whole RC channel.

### Root cause 1 — wrong/missing `-X` ldflags paths (silently ignored by Go)
Module is `github.com/smart-mcp-proxy/mcpproxy-go`:
- `prerelease.yml` used `mcpproxy-go/internal/httpapi.buildVersion` (ignored) + bogus `mcpproxy-go/cmd/mcpproxy.version` → **every RC binary** ships `buildVersion=development`
- `scripts/build-windows-installer.ps1` (used by **both** release.yml and prerelease.yml) never set `httpapi.buildVersion` → **stable Windows installer builds** have the same bug
- `scripts/build.ps1` and `pr-build.yml` aligned for consistency

### Root cause 2 — forced refresh bypasses the non-semver guard
`Checker.CheckNow()` (the `/api/v1/info` refresh path behind the Web UI banner and doctor) lacked the `isValidSemver()` guard that `Start()` has, and `compareVersions()` ranks an invalid current version below any release → a `development` build sees every stable release as an available "update". Both guarded now.

## Evidence (live rc.4)
- Web UI banner: *"Update available: v0.46.0 — you are running development"*
- `mcpproxy doctor`: *"Version: development (update available: v0.46.0)"*
- `/api/v1/info`: `{"version":"development","update":{"available":true,"latest_version":"v0.46.0"}}`
- MCP `initialize` serverInfo correctly says `v0.47.0-rc.4` (main.version IS injected) — isolating the bug to `httpapi.buildVersion` consumers

## Tests
- `TestChecker_CheckNow_NonSemverVersionSkipsCheck` (development/dev/empty)
- `TestChecker_CompareVersions` extended with invalid-current cases
- Full `./scripts/test-api-e2e.sh`: 65/65 PASS · `go test -race` green · golangci-lint v2: 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)