### PR TITLE
fix(cli): read real upstream_stats keys in mcpproxy status server counts

### DIFF
--- a/cmd/mcpproxy/status_cmd.go
+++ b/cmd/mcpproxy/status_cmd.go
@@ -269,19 +269,36 @@ func collectStatusFromConfig(cfg *config.Config, socketPath, configPath string) 
 func extractServerCounts(stats map[string]interface{}) *ServerCounts {
 	counts := &ServerCounts{}
 
-	if v, ok := stats["connected"].(float64); ok {
-		counts.Connected = int(v)
-	}
-	if v, ok := stats["quarantined"].(float64); ok {
-		counts.Quarantined = int(v)
-	}
-	if v, ok := stats["total"].(float64); ok {
-		counts.Total = int(v)
+	// The daemon emits connected_servers/quarantined_servers/total_servers
+	// (see the GetStats builders in internal/server and internal/upstream);
+	// bare connected/quarantined/total are accepted for older daemons.
+	counts.Connected = statsInt(stats, "connected_servers", "connected")
+	counts.Quarantined = statsInt(stats, "quarantined_servers", "quarantined")
+	if v, ok := statsIntOK(stats, "total_servers", "total"); ok {
+		counts.Total = v
 	} else {
 		counts.Total = counts.Connected + counts.Quarantined
 	}
 
 	return counts
+}
+
+// statsInt returns the first of the given keys present in stats as an int.
+func statsInt(stats map[string]interface{}, keys ...string) int {
+	v, _ := statsIntOK(stats, keys...)
+	return v
+}
+
+func statsIntOK(stats map[string]interface{}, keys ...string) (int, bool) {
+	for _, key := range keys {
+		switch v := stats[key].(type) {
+		case float64:
+			return int(v), true
+		case int:
+			return v, true
+		}
+	}
+	return 0, false
 }
 
 // extractStatusUpdate pulls the `update` object out of the /api/v1/info

--- a/cmd/mcpproxy/status_cmd_test.go
+++ b/cmd/mcpproxy/status_cmd_test.go
@@ -374,6 +374,29 @@ func TestFormatDuration(t *testing.T) {
 }
 
 func TestExtractServerCounts(t *testing.T) {
+	// Real /api/v1/status upstream_stats shape (see internal/server/server.go
+	// and internal/upstream/manager.go GetStats builders).
+	stats := map[string]interface{}{
+		"connected_servers":   float64(14),
+		"quarantined_servers": float64(2),
+		"total_servers":       float64(28),
+	}
+
+	counts := extractServerCounts(stats)
+
+	if counts.Connected != 14 {
+		t.Errorf("expected Connected=14, got %d", counts.Connected)
+	}
+	if counts.Quarantined != 2 {
+		t.Errorf("expected Quarantined=2, got %d", counts.Quarantined)
+	}
+	if counts.Total != 28 {
+		t.Errorf("expected Total=28, got %d", counts.Total)
+	}
+}
+
+func TestExtractServerCountsLegacyKeys(t *testing.T) {
+	// Older daemons emitted bare connected/quarantined/total keys.
 	stats := map[string]interface{}{
 		"connected":   float64(5),
 		"quarantined": float64(2),
@@ -395,8 +418,8 @@ func TestExtractServerCounts(t *testing.T) {
 
 func TestExtractServerCountsNoTotal(t *testing.T) {
 	stats := map[string]interface{}{
-		"connected":   float64(3),
-		"quarantined": float64(1),
+		"connected_servers":   float64(3),
+		"quarantined_servers": float64(1),
 	}
 
 	counts := extractServerCounts(stats)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -733,6 +733,7 @@ func (s *Server) GetUpstreamStats() map[string]interface{} {
 
 			connectedCount := 0
 			connectingCount := 0
+			quarantinedCount := 0
 			totalTools := 0
 
 			serverStats := make(map[string]interface{}, len(snapshot.Servers))
@@ -819,17 +820,21 @@ func (s *Server) GetUpstreamStats() map[string]interface{} {
 				if connecting {
 					connectingCount++
 				}
+				if status.Quarantined {
+					quarantinedCount++
+				}
 				totalTools += status.ToolCount
 
 				serverStats[name] = entry
 			}
 
 			return map[string]interface{}{
-				"connected_servers":  connectedCount,
-				"connecting_servers": connectingCount,
-				"total_servers":      len(snapshot.Servers),
-				"servers":            serverStats,
-				"total_tools":        totalTools,
+				"connected_servers":   connectedCount,
+				"connecting_servers":  connectingCount,
+				"quarantined_servers": quarantinedCount,
+				"total_servers":       len(snapshot.Servers),
+				"servers":             serverStats,
+				"total_tools":         totalTools,
 			}
 		}
 	}

--- a/internal/upstream/manager.go
+++ b/internal/upstream/manager.go
@@ -1526,6 +1526,7 @@ func (m *Manager) GetStats() map[string]interface{} {
 	// Now process clients without holding lock to avoid deadlock
 	connectedCount := 0
 	connectingCount := 0
+	quarantinedCount := 0
 	serverStatus := make(map[string]interface{})
 
 	for id, client := range clientsCopy {
@@ -1542,6 +1543,9 @@ func (m *Manager) GetStats() map[string]interface{} {
 		name, url, protocol := "", "", ""
 		if cfg := client.GetConfig(); cfg != nil {
 			name, url, protocol = cfg.Name, cfg.URL, cfg.Protocol
+			if cfg.Quarantined {
+				quarantinedCount++
+			}
 		}
 
 		status := map[string]interface{}{
@@ -1595,11 +1599,12 @@ func (m *Manager) GetStats() map[string]interface{} {
 	totalTools := m.GetTotalToolCount()
 
 	return map[string]interface{}{
-		"connected_servers":  connectedCount,
-		"connecting_servers": connectingCount,
-		"total_servers":      totalCount,
-		"servers":            serverStatus,
-		"total_tools":        totalTools,
+		"connected_servers":   connectedCount,
+		"connecting_servers":  connectingCount,
+		"quarantined_servers": quarantinedCount,
+		"total_servers":       totalCount,
+		"servers":             serverStatus,
+		"total_tools":         totalTools,
 	}
 }
 


### PR DESCRIPTION
## Summary

`mcpproxy status` always printed **"Servers: 0 connected, 0 quarantined"** because `extractServerCounts` (cmd/mcpproxy/status_cmd.go) read `connected`/`quarantined`/`total` while the daemon's GetStats builders emit `connected_servers`/`total_servers` — and no quarantined count existed at all.

Found in v0.47.0-rc.4 release QA: live daemon had 14 connected + 2 quarantined; CLI showed 0/0.

## Changes
- `extractServerCounts` reads `connected_servers`/`quarantined_servers`/`total_servers`, with fallback to the bare legacy keys for older daemons
- Both GetStats builders (stateview path in `internal/server`, manager fallback in `internal/upstream`) now emit `quarantined_servers` (stateview `ServerStatus.Quarantined` / `ServerConfig.Quarantined`)

## Tests
- `TestExtractServerCounts` rewritten against the real payload shape (was red before the fix), legacy-keys case kept
- `./scripts/test-api-e2e.sh`: 65/65 PASS · `go test -race ./cmd/mcpproxy` green · golangci-lint v2: 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)