### PR TITLE
fix: Update Dockerfile to go 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 RUN apk add --no-cache git nodejs npm make
 


### PR DESCRIPTION
# Pull Request

## Description
The `go.mod` file uses go 1.25, update the Dockerfile so it also uses go 1.25 for building.

## Testing
- [x] I have tested these changes locally
- [ ] I have added/updated tests that prove my fix is effective or my feature works
- [ ] All existing tests pass