### PR TITLE
feat(tokens): permanently delete agent tokens to free the name for reuse (#820)

### DIFF
--- a/cmd/mcpproxy/token_cmd.go
+++ b/cmd/mcpproxy/token_cmd.go
@@ -49,6 +49,7 @@ Examples:
 	tokenCmd.AddCommand(newTokenListCmd())
 	tokenCmd.AddCommand(newTokenShowCmd())
 	tokenCmd.AddCommand(newTokenRevokeCmd())
+	tokenCmd.AddCommand(newTokenDeleteCmd())
 	tokenCmd.AddCommand(newTokenRegenerateCmd())
 
 	return tokenCmd
@@ -392,6 +393,54 @@ func runTokenRevoke(_ *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Token %q has been revoked.\n", name)
+	return nil
+}
+
+func newTokenDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "delete <name>",
+		Aliases: []string{"rm", "remove"},
+		Short:   "Permanently delete an agent token",
+		Long: `Permanently delete an agent token, removing it entirely and freeing its
+name for reuse. Unlike revoke (a soft delete that keeps the record so the name
+stays reserved), delete removes the token completely.
+
+Examples:
+  mcpproxy token delete deploy-bot`,
+		Args: cobra.ExactArgs(1),
+		RunE: runTokenDelete,
+	}
+}
+
+func runTokenDelete(_ *cobra.Command, args []string) error {
+	client, _, err := newTokenCLIClient()
+	if err != nil {
+		return err
+	}
+
+	name := args[0]
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := client.DoRaw(ctx, http.MethodDelete, "/api/v1/tokens/"+name+"/permanent", nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("token %q not found", name)
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return parseAPIError(respBody, resp.StatusCode, "delete token")
+	}
+
+	fmt.Printf("Token %q has been permanently deleted.\n", name)
 	return nil
 }
 

--- a/cmd/mcpproxy/token_cmd_test.go
+++ b/cmd/mcpproxy/token_cmd_test.go
@@ -23,7 +23,32 @@ func TestGetTokenCommand(t *testing.T) {
 	assert.True(t, names["list"], "should have 'list' subcommand")
 	assert.True(t, names["show"], "should have 'show' subcommand")
 	assert.True(t, names["revoke"], "should have 'revoke' subcommand")
+	assert.True(t, names["delete"], "should have 'delete' subcommand")
 	assert.True(t, names["regenerate"], "should have 'regenerate' subcommand")
+}
+
+func TestGetTokenCommand_IncludesDelete(t *testing.T) {
+	cmd := GetTokenCommand()
+
+	// Find the delete subcommand
+	var deleteCmd *cobra.Command
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "delete" {
+			deleteCmd = sub
+			break
+		}
+	}
+
+	assert.NotNil(t, deleteCmd, "delete subcommand must exist")
+	assert.Equal(t, "delete <name>", deleteCmd.Use)
+	assert.Contains(t, deleteCmd.Short, "delete")
+	assert.NotEmpty(t, deleteCmd.Long)
+	assert.Contains(t, deleteCmd.Aliases, "rm", "delete should alias 'rm'")
+
+	// Verify it requires exactly 1 argument
+	assert.Error(t, deleteCmd.Args(deleteCmd, []string{}), "should reject zero args")
+	assert.NoError(t, deleteCmd.Args(deleteCmd, []string{"my-token"}), "should accept one arg")
+	assert.Error(t, deleteCmd.Args(deleteCmd, []string{"a", "b"}), "should reject two args")
 }
 
 func TestGetTokenCommand_IncludesRegenerate(t *testing.T) {
@@ -76,7 +101,7 @@ func TestGetMapString(t *testing.T) {
 
 	assert.Equal(t, "deploy-bot", getMapString(m, "name"))
 	assert.Equal(t, "", getMapString(m, "count"))       // not a string
-	assert.Equal(t, "", getMapString(m, "nonexistent"))  // missing key
+	assert.Equal(t, "", getMapString(m, "nonexistent")) // missing key
 }
 
 func TestJoinInterfaceSlice(t *testing.T) {

--- a/docs/features/agent-tokens.md
+++ b/docs/features/agent-tokens.md
@@ -231,10 +231,21 @@ mcpproxy token show deploy-bot
 
 ### Revoke a Token
 
-Immediately invalidates the token:
+Immediately invalidates the token. Revoke is a **soft delete**: the record is kept
+(so the token name stays reserved) and any further use is rejected:
 
 ```bash
 mcpproxy token revoke deploy-bot
+```
+
+### Delete a Token
+
+Permanently removes the token, freeing its name for reuse. Unlike revoke, delete
+removes the record entirely — after deleting, you can create a new token with the
+same name:
+
+```bash
+mcpproxy token delete deploy-bot   # aliases: rm, remove
 ```
 
 ### Regenerate a Token
@@ -280,7 +291,8 @@ Agent tokens can also be managed via the REST API (requires admin API key):
 | `POST` | `/api/v1/tokens` | Create a new agent token |
 | `GET` | `/api/v1/tokens` | List all tokens |
 | `GET` | `/api/v1/tokens/{name}` | Get token details |
-| `DELETE` | `/api/v1/tokens/{name}` | Revoke a token |
+| `DELETE` | `/api/v1/tokens/{name}` | Revoke a token (soft delete; name stays reserved) |
+| `DELETE` | `/api/v1/tokens/{name}/permanent` | Permanently delete a token (frees the name for reuse) |
 | `POST` | `/api/v1/tokens/{name}/regenerate` | Regenerate token secret |
 
 ### Create Token via API

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1101,6 +1101,13 @@ class APIService {
     })
   }
 
+  // Permanently delete a token, freeing its name for reuse (unlike revoke, a soft delete).
+  async deleteAgentToken(name: string): Promise<APIResponse<void>> {
+    return this.request<void>(`/api/v1/tokens/${encodeURIComponent(name)}/permanent`, {
+      method: 'DELETE',
+    })
+  }
+
   async regenerateAgentToken(name: string): Promise<APIResponse<{ name: string; token: string }>> {
     return this.request<{ name: string; token: string }>(`/api/v1/tokens/${encodeURIComponent(name)}/regenerate`, {
       method: 'POST',

--- a/frontend/src/views/AgentTokens.vue
+++ b/frontend/src/views/AgentTokens.vue
@@ -198,6 +198,17 @@
                   </svg>
                   Revoke
                 </button>
+                <button
+                  v-if="token.revoked || isExpired(token)"
+                  @click="handleDelete(token.name)"
+                  class="btn btn-xs btn-error"
+                  title="Permanently delete token and free its name for reuse"
+                >
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                  Delete
+                </button>
               </div>
             </td>
           </tr>
@@ -639,6 +650,38 @@ async function handleRevoke(name: string) {
       type: 'error',
       title: 'Revoke Failed',
       message: err.message || 'Failed to revoke token',
+    })
+  }
+}
+
+// Permanently delete a (revoked or expired) token, freeing its name for reuse
+async function handleDelete(name: string) {
+  if (!confirm(`Permanently delete token "${name}"? This removes it completely and frees the name for reuse. This action cannot be undone.`)) {
+    return
+  }
+
+  try {
+    const response = await apiClient.deleteAgentToken(name)
+    if (response.success || !response.error) {
+      await loadTokens()
+
+      systemStore.addToast({
+        type: 'success',
+        title: 'Token Deleted',
+        message: `Token "${name}" has been permanently deleted`,
+      })
+    } else {
+      systemStore.addToast({
+        type: 'error',
+        title: 'Delete Failed',
+        message: response.error || 'Failed to delete token',
+      })
+    }
+  } catch (err: any) {
+    systemStore.addToast({
+      type: 'error',
+      title: 'Delete Failed',
+      message: err.message || 'Failed to delete token',
     })
   }
 }

--- a/internal/httpapi/auth_middleware_test.go
+++ b/internal/httpapi/auth_middleware_test.go
@@ -24,10 +24,11 @@ type testTokenStore struct {
 	validateFunc func(rawToken string, hmacKey []byte) (*auth.AgentToken, error)
 }
 
-func (s *testTokenStore) CreateAgentToken(_ auth.AgentToken, _ string, _ []byte) error   { return nil }
-func (s *testTokenStore) ListAgentTokens() ([]auth.AgentToken, error)                    { return nil, nil }
-func (s *testTokenStore) GetAgentTokenByName(_ string) (*auth.AgentToken, error)          { return nil, nil }
-func (s *testTokenStore) RevokeAgentToken(_ string) error                                 { return nil }
+func (s *testTokenStore) CreateAgentToken(_ auth.AgentToken, _ string, _ []byte) error { return nil }
+func (s *testTokenStore) ListAgentTokens() ([]auth.AgentToken, error)                  { return nil, nil }
+func (s *testTokenStore) GetAgentTokenByName(_ string) (*auth.AgentToken, error)       { return nil, nil }
+func (s *testTokenStore) RevokeAgentToken(_ string) error                              { return nil }
+func (s *testTokenStore) DeleteAgentToken(_ string) error                              { return nil }
 func (s *testTokenStore) RegenerateAgentToken(_ string, _ string, _ []byte) (*auth.AgentToken, error) {
 	return nil, nil
 }
@@ -398,4 +399,3 @@ func TestAPIKeyAuth_NoTokenStore_RejectsAgentToken(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, w.Code,
 		"Agent token should be rejected when token store is not configured")
 }
-

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -761,6 +761,7 @@ func (s *Server) setupRoutes() {
 			r.Route("/{name}", func(r chi.Router) {
 				r.Get("/", s.handleGetToken)
 				r.Delete("/", s.handleRevokeToken)
+				r.Delete("/permanent", s.handleDeleteToken)
 				r.Post("/regenerate", s.handleRegenerateToken)
 			})
 		})

--- a/internal/httpapi/tokens.go
+++ b/internal/httpapi/tokens.go
@@ -22,6 +22,7 @@ type TokenStore interface {
 	ListAgentTokens() ([]auth.AgentToken, error)
 	GetAgentTokenByName(name string) (*auth.AgentToken, error)
 	RevokeAgentToken(name string) error
+	DeleteAgentToken(name string) error
 	RegenerateAgentToken(name string, newRawToken string, hmacKey []byte) (*auth.AgentToken, error)
 	ValidateAgentToken(rawToken string, hmacKey []byte) (*auth.AgentToken, error)
 	UpdateAgentTokenLastUsed(name string) error
@@ -286,6 +287,36 @@ func (s *Server) handleRevokeToken(w http.ResponseWriter, r *http.Request) {
 		}
 		s.logger.Errorf("Failed to revoke agent token: %v", err)
 		s.writeError(w, r, http.StatusInternalServerError, "Failed to revoke token")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleDeleteToken handles DELETE /api/v1/tokens/{name}/permanent
+// It permanently removes a token (unlike revoke, which is a soft delete),
+// freeing the name so it can be reused for a new token.
+func (s *Server) handleDeleteToken(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAdminAuth(w, r) {
+		return
+	}
+	if !s.requireTokenStore(w, r) {
+		return
+	}
+
+	name := chi.URLParam(r, "name")
+	if name == "" {
+		s.writeError(w, r, http.StatusBadRequest, "Token name is required")
+		return
+	}
+
+	if err := s.tokenStore.DeleteAgentToken(name); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			s.writeError(w, r, http.StatusNotFound, fmt.Sprintf("Token %q not found", name))
+			return
+		}
+		s.logger.Errorf("Failed to delete agent token: %v", err)
+		s.writeError(w, r, http.StatusInternalServerError, "Failed to delete token")
 		return
 	}
 

--- a/internal/httpapi/tokens_test.go
+++ b/internal/httpapi/tokens_test.go
@@ -24,6 +24,7 @@ type mockTokenStore struct {
 	tokens     map[string]auth.AgentToken
 	createErr  error
 	revokeErr  error
+	deleteErr  error
 	regenToken *auth.AgentToken
 	regenErr   error
 }
@@ -72,6 +73,17 @@ func (m *mockTokenStore) RevokeAgentToken(name string) error {
 	}
 	t.Revoked = true
 	m.tokens[name] = t
+	return nil
+}
+
+func (m *mockTokenStore) DeleteAgentToken(name string) error {
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+	if _, ok := m.tokens[name]; !ok {
+		return fmt.Errorf("agent token %q not found", name)
+	}
+	delete(m.tokens, name)
 	return nil
 }
 
@@ -626,6 +638,59 @@ func TestRevokeToken_NotFound(t *testing.T) {
 
 	w := doRequest(t, srv, http.MethodDelete, "/api/v1/tokens/nonexistent", nil)
 	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestDeleteToken(t *testing.T) {
+	store := newMockTokenStore()
+	srv := newTestTokenServer(t, store, nil)
+
+	// Create a token
+	body := createTokenRequest{
+		Name:        "delete-me",
+		Permissions: []string{"read"},
+	}
+	w := doRequest(t, srv, http.MethodPost, "/api/v1/tokens", body)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	// Permanently delete it
+	w = doRequest(t, srv, http.MethodDelete, "/api/v1/tokens/delete-me/permanent", nil)
+	assert.Equal(t, http.StatusNoContent, w.Code)
+
+	// Verify it's gone
+	stored, err := store.GetAgentTokenByName("delete-me")
+	require.NoError(t, err)
+	assert.Nil(t, stored)
+}
+
+func TestDeleteToken_NotFound(t *testing.T) {
+	store := newMockTokenStore()
+	srv := newTestTokenServer(t, store, nil)
+
+	w := doRequest(t, srv, http.MethodDelete, "/api/v1/tokens/nonexistent/permanent", nil)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestDeleteToken_FreesNameForReuse verifies the issue #820 flow end-to-end at
+// the API layer: revoke reserves the name, delete frees it for reuse.
+func TestDeleteToken_FreesNameForReuse(t *testing.T) {
+	store := newMockTokenStore()
+	srv := newTestTokenServer(t, store, nil)
+
+	body := createTokenRequest{Name: "reusable", Permissions: []string{"read"}}
+	w := doRequest(t, srv, http.MethodPost, "/api/v1/tokens", body)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	// Revoke keeps the name reserved -> re-create conflicts.
+	w = doRequest(t, srv, http.MethodDelete, "/api/v1/tokens/reusable", nil)
+	require.Equal(t, http.StatusNoContent, w.Code)
+	w = doRequest(t, srv, http.MethodPost, "/api/v1/tokens", body)
+	assert.Equal(t, http.StatusConflict, w.Code)
+
+	// Permanent delete frees the name -> re-create succeeds.
+	w = doRequest(t, srv, http.MethodDelete, "/api/v1/tokens/reusable/permanent", nil)
+	require.Equal(t, http.StatusNoContent, w.Code)
+	w = doRequest(t, srv, http.MethodPost, "/api/v1/tokens", body)
+	assert.Equal(t, http.StatusCreated, w.Code)
 }
 
 func TestRegenerateToken(t *testing.T) {

--- a/internal/serveredition/api/user_handlers.go
+++ b/internal/serveredition/api/user_handlers.go
@@ -33,6 +33,7 @@ type tokenStore interface {
 	ListAgentTokens() ([]auth.AgentToken, error)
 	GetAgentTokenByName(name string) (*auth.AgentToken, error)
 	RevokeAgentToken(name string) error
+	DeleteAgentToken(name string) error
 	RegenerateAgentToken(name string, newRawToken string, hmacKey []byte) (*auth.AgentToken, error)
 }
 
@@ -61,6 +62,7 @@ func (h *UserHandlers) RegisterRoutes(r chi.Router) {
 		r.Get("/", h.listUserTokens)
 		r.Post("/", h.createUserToken)
 		r.Delete("/{name}", h.revokeUserToken)
+		r.Delete("/{name}/permanent", h.deleteUserToken)
 		r.Post("/{name}/regenerate", h.regenerateUserToken)
 	})
 }
@@ -76,6 +78,7 @@ func (h *UserHandlers) RegisterRoutesWithPrefix(r chi.Router, prefix string) {
 	r.Get(prefix+"/user/tokens", h.listUserTokens)
 	r.Post(prefix+"/user/tokens", h.createUserToken)
 	r.Delete(prefix+"/user/tokens/{name}", h.revokeUserToken)
+	r.Delete(prefix+"/user/tokens/{name}/permanent", h.deleteUserToken)
 	r.Post(prefix+"/user/tokens/{name}/regenerate", h.regenerateUserToken)
 }
 
@@ -659,6 +662,52 @@ func (h *UserHandlers) revokeUserToken(w http.ResponseWriter, r *http.Request) {
 
 	h.logger.Infow("user token revoked", "user_id", userID, "name", name)
 	writeJSON(w, http.StatusOK, map[string]string{"message": fmt.Sprintf("Token %q revoked", name)})
+}
+
+// deleteUserToken permanently removes an agent token owned by the authenticated
+// user, freeing its name for reuse (unlike revoke, which is a soft delete).
+func (h *UserHandlers) deleteUserToken(w http.ResponseWriter, r *http.Request) {
+	userID, err := getUserID(r)
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "Authentication required")
+		return
+	}
+
+	if h.tokenStore == nil {
+		writeError(w, http.StatusInternalServerError, "Token store not available")
+		return
+	}
+
+	name := chi.URLParam(r, "name")
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "Token name is required")
+		return
+	}
+
+	// Verify the token belongs to this user.
+	existing, err := h.tokenStore.GetAgentTokenByName(name)
+	if err != nil {
+		h.logger.Errorw("failed to get token for delete", "user_id", userID, "name", name, "error", err)
+		writeError(w, http.StatusInternalServerError, "Failed to get token")
+		return
+	}
+	if existing == nil {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("Token %q not found", name))
+		return
+	}
+	if existing.UserID != userID {
+		writeError(w, http.StatusForbidden, "Cannot delete another user's token")
+		return
+	}
+
+	if err := h.tokenStore.DeleteAgentToken(name); err != nil {
+		h.logger.Errorw("failed to delete token", "user_id", userID, "name", name, "error", err)
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to delete token: %v", err))
+		return
+	}
+
+	h.logger.Infow("user token deleted", "user_id", userID, "name", name)
+	writeJSON(w, http.StatusOK, map[string]string{"message": fmt.Sprintf("Token %q deleted", name)})
 }
 
 // regenerateUserToken regenerates an agent token owned by the authenticated user.

--- a/internal/storage/agent_tokens.go
+++ b/internal/storage/agent_tokens.go
@@ -12,7 +12,7 @@ import (
 // Bucket names for agent token storage.
 const (
 	AgentTokensBucket     = "agent_tokens"      //nolint:gosec // bucket name, not a credential
-	AgentTokenNamesBucket = "agent_token_names"  //nolint:gosec // bucket name, not a credential
+	AgentTokenNamesBucket = "agent_token_names" //nolint:gosec // bucket name, not a credential
 )
 
 // CreateAgentToken stores a new agent token. It hashes the raw token using
@@ -222,6 +222,47 @@ func (m *Manager) RevokeAgentToken(name string) error {
 		}
 
 		return tokenBucket.Put(hash, updatedData)
+	})
+}
+
+// DeleteAgentToken permanently removes an agent token, deleting both the record
+// in the "agent_tokens" bucket and the name->hash mapping in "agent_token_names".
+// Unlike RevokeAgentToken (a soft delete that keeps the record), this frees the
+// name so a new token can be created with the same name. Returns an error if the
+// token does not exist.
+func (m *Manager) DeleteAgentToken(name string) error {
+	if name == "" {
+		return fmt.Errorf("agent token name cannot be empty")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.db.db.Update(func(tx *bbolt.Tx) error {
+		nameBucket := tx.Bucket([]byte(AgentTokenNamesBucket))
+		if nameBucket == nil {
+			return fmt.Errorf("agent token %q not found", name)
+		}
+
+		hash := nameBucket.Get([]byte(name))
+		if hash == nil {
+			return fmt.Errorf("agent token %q not found", name)
+		}
+
+		// Delete the name->hash mapping first so the name is freed even if the
+		// record is somehow missing.
+		if err := nameBucket.Delete([]byte(name)); err != nil {
+			return fmt.Errorf("failed to delete agent token name mapping: %w", err)
+		}
+
+		tokenBucket := tx.Bucket([]byte(AgentTokensBucket))
+		if tokenBucket != nil {
+			if err := tokenBucket.Delete(hash); err != nil {
+				return fmt.Errorf("failed to delete agent token: %w", err)
+			}
+		}
+
+		return nil
 	})
 }
 

--- a/internal/storage/agent_tokens_test.go
+++ b/internal/storage/agent_tokens_test.go
@@ -162,6 +162,79 @@ func TestAgentTokenRevoke_NotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found")
 }
 
+func TestAgentTokenDelete(t *testing.T) {
+	mgr, cleanup := setupTestStorageForAgentTokens(t)
+	defer cleanup()
+
+	token, rawToken := makeTestToken("delete-me")
+	err := mgr.CreateAgentToken(token, rawToken, testHMACKey)
+	require.NoError(t, err)
+
+	// Delete permanently.
+	err = mgr.DeleteAgentToken("delete-me")
+	require.NoError(t, err)
+
+	// Record is gone (both by name and by hash).
+	retrieved, err := mgr.GetAgentTokenByName("delete-me")
+	require.NoError(t, err)
+	assert.Nil(t, retrieved, "deleted token should not be retrievable by name")
+
+	hash := auth.HashToken(rawToken, testHMACKey)
+	byHash, err := mgr.GetAgentTokenByHash(hash)
+	require.NoError(t, err)
+	assert.Nil(t, byHash, "deleted token should not be retrievable by hash")
+
+	// Not listed anymore.
+	tokens, err := mgr.ListAgentTokens()
+	require.NoError(t, err)
+	assert.Empty(t, tokens)
+}
+
+func TestAgentTokenDelete_NotFound(t *testing.T) {
+	mgr, cleanup := setupTestStorageForAgentTokens(t)
+	defer cleanup()
+
+	err := mgr.DeleteAgentToken("nonexistent")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestAgentTokenDelete_FreesNameForReuse is the crux of issue #820: after a
+// token is revoked and deleted, its name must be available for a new token.
+func TestAgentTokenDelete_FreesNameForReuse(t *testing.T) {
+	mgr, cleanup := setupTestStorageForAgentTokens(t)
+	defer cleanup()
+
+	token1, rawToken1 := makeTestToken("reusable")
+	err := mgr.CreateAgentToken(token1, rawToken1, testHMACKey)
+	require.NoError(t, err)
+
+	// Revoke — name is still reserved (revoke is a soft delete).
+	err = mgr.RevokeAgentToken("reusable")
+	require.NoError(t, err)
+
+	// Creating with the same name still fails while the revoked record exists.
+	token2, rawToken2 := makeTestToken("reusable")
+	err = mgr.CreateAgentToken(token2, rawToken2, testHMACKey)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+
+	// Delete the revoked token — this frees the name.
+	err = mgr.DeleteAgentToken("reusable")
+	require.NoError(t, err)
+
+	// Now the same name can be reused.
+	token3, rawToken3 := makeTestToken("reusable")
+	err = mgr.CreateAgentToken(token3, rawToken3, testHMACKey)
+	require.NoError(t, err)
+
+	retrieved, err := mgr.GetAgentTokenByName("reusable")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	assert.False(t, retrieved.Revoked, "reused name should map to the fresh, non-revoked token")
+	assert.Equal(t, auth.TokenPrefix(rawToken3), retrieved.TokenPrefix)
+}
+
 func TestAgentTokenRegenerate(t *testing.T) {
 	mgr, cleanup := setupTestStorageForAgentTokens(t)
 	defer cleanup()

--- a/specs/028-agent-tokens/contracts/agent-tokens-api.yaml
+++ b/specs/028-agent-tokens/contracts/agent-tokens-api.yaml
@@ -95,6 +95,32 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /api/v1/tokens/{name}/permanent:
+    parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Agent token name
+
+    delete:
+      summary: Permanently delete an agent token
+      description: >-
+        Permanently removes the agent token, deleting its record entirely and
+        freeing its name for reuse. Unlike revoke (a soft delete that keeps the
+        record so the name stays reserved), delete removes the token completely.
+      operationId: deleteAgentToken
+      security:
+        - apiKey: []
+      responses:
+        '204':
+          description: Token deleted successfully
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /api/v1/tokens/{name}/regenerate:
     parameters:
       - name: name


### PR DESCRIPTION
## Summary

Closes #820.

Revoking an agent token is a **soft delete** — the record is kept so the token name stays reserved, which blocks creating a new token with the same name. This adds a **permanent delete** that removes the token record and its `name → hash` mapping, freeing the name for reuse.

## Changes

| Layer | Change |
|-------|--------|
| **Storage** | `DeleteAgentToken(name)` removes both the `agent_tokens` record and the `agent_token_names` mapping in one BBolt tx (revoke leaves both intact). |
| **REST** | `DELETE /api/v1/tokens/{name}/permanent` — distinct from the existing revoke `DELETE /api/v1/tokens/{name}`. Admin-only, `204` on success, `404` if not found. |
| **Server edition** | Parallel `DELETE /api/v1/user/tokens/{name}/permanent`, scoped to the authenticated user. |
| **CLI** | `mcpproxy token delete <name>` (aliases `rm`, `remove`). |
| **Web UI** | A **Delete** button on revoked/expired tokens (active tokens must be revoked first), with a confirm dialog. |
| **Docs / contract** | `docs/features/agent-tokens.md` + `specs/028-agent-tokens/contracts/agent-tokens-api.yaml`. |

## Design notes

- **Separate route** (`/permanent`) rather than overloading the revoke `DELETE` or a query param — keeps revoke (soft) and delete (hard) unambiguous and independently testable.
- **API/CLI allow deleting any token**; only the Web UI gates Delete to revoked/expired tokens. Delete is a legitimate admin action (like `rm`); requiring revoke-first would add friction for automation, while the UI keeps the interactive path safe.
- Revoke semantics are unchanged (still soft) so `ValidateAgentToken` keeps rejecting revoked tokens with "token has been revoked".

## Testing

- **Unit**: storage delete + delete-not-found + **name-reuse-after-delete** (the crux); API delete/404/name-reuse; CLI subcommand wiring. All packages green with `-race`; server edition green.
- **Lint**: `golangci-lint` v2 (CI config) clean; frontend `type-check` clean.
- **Live E2E**: verified the full loop on a running binary via REST (create → revoke → recreate `409` → permanent delete → recreate `201`) and end-to-end through the **Web UI** (Delete button removes a revoked token, then the freed name is reused successfully).