### PR TITLE
fix(packaging): allow web-UI config saves on linux by adding /etc/mcpproxy to ReadWritePaths

### DIFF
--- a/packaging/linux/mcpproxy.service
+++ b/packaging/linux/mcpproxy.service
@@ -23,7 +23,7 @@ ProtectKernelModules=true
 ProtectControlGroups=true
 RestrictSUIDSGID=true
 LockPersonality=true
-ReadWritePaths=/var/lib/mcpproxy
+ReadWritePaths=/var/lib/mcpproxy /etc/mcpproxy
 
 # Allow binding to privileged ports if user reconfigures listen address
 AmbientCapabilities=CAP_NET_BIND_SERVICE


### PR DESCRIPTION
# Pull Request

## Description
When saving the configuration, the backend creates a new file at `/etc/mcpproxy/mcp_config.json.tmp.<suffix>`. However, when systemd starts the process, it restricts write access to the `/etc/mcpproxy` directory. This pull request modifies the service file to enable write permissions for the `/etc/mcpproxy` directory.

## Testing
- [x] I have tested these changes locally
- [ ] I have added/updated tests that prove my fix is effective or my feature works
- [ ] All existing tests pass