### PR TITLE
fix(packaging): make /etc/mcpproxy writable by the service user

### DIFF
--- a/packaging/linux/postinstall.sh
+++ b/packaging/linux/postinstall.sh
@@ -6,6 +6,22 @@ set -e
 
 install -d -m 0750 -o mcpproxy -g mcpproxy /var/lib/mcpproxy
 
+# /etc/mcpproxy must be writable by the service, not just readable. Saving from
+# the web UI goes through config.SaveConfig -> atomicWriteFile, which creates
+# mcp_config.json.tmp.<hex> IN THIS DIRECTORY and renames it over the config —
+# so the mcpproxy user needs write+search on the directory itself, not merely
+# on the file. nfpm creates /etc/mcpproxy implicitly (root:root 0755) because
+# only the files inside it are declared, which left the service unable to
+# create the temp file. Adding /etc/mcpproxy to ReadWritePaths= in the unit
+# (PR #822) lifts systemd's ProtectSystem=strict namespace restriction; this
+# lifts the POSIX one. Both are required.
+#
+# 2770: group-writable so mcpproxy can write, setgid so files created here keep
+# the mcpproxy group, and no access for others (the config holds API keys).
+# Doing it here rather than as an nfpm dir entry also repairs the permissions
+# on hosts that installed an earlier package.
+install -d -m 2770 -o root -g mcpproxy /etc/mcpproxy
+
 if command -v systemctl >/dev/null 2>&1; then
     systemctl daemon-reload || true
     if [ -d /run/systemd/system ]; then


### PR DESCRIPTION
Companion to #822 (thanks @Eun for the report and the unit-file fix).

#822 added `/etc/mcpproxy` to `ReadWritePaths=`, lifting systemd's `ProtectSystem=strict` namespace restriction. That is **necessary but not sufficient** — POSIX permissions still apply.

`nfpm.yaml` declares only the *files* under `/etc/mcpproxy`, so the directory is created implicitly. Verified against a `.deb` built from this tree:

```
$ tar -tvf data.tar.gz | grep etc/mcpproxy/
drwxr-xr-x  root root      ./etc/mcpproxy/
-rw-r-----  root mcpproxy  ./etc/mcpproxy/mcp_config.json
```

The service runs as `User=mcpproxy`. Saving from the web UI goes through `config.SaveConfig` → `atomicWriteFile`, which creates `mcp_config.json.tmp.<hex>` **in this directory** and renames it over the config — so the service needs write+search on the *directory*, not just the file. Against `root:root 0755` that is `EACCES`, and `SaveConfig`'s `os.MkdirAll(dir, 0700)` is a no-op on an existing directory, so nothing repairs it at runtime.

`postinstall.sh` now runs:

```sh
install -d -m 2770 -o root -g mcpproxy /etc/mcpproxy
```

`2770`: group-writable so `mcpproxy` can write; setgid so files created there keep the `mcpproxy` group; no access for others (the config holds API keys). This mirrors the existing `install -d` for `/var/lib/mcpproxy`, and doing it in `postinstall` rather than as an nfpm dir entry also **repairs the permissions on hosts that installed an earlier package**.

Verification: `sh -n` and `shellcheck` clean; built the `.deb` with nfpm and confirmed the shipped `postinst` carries the line and that the unit file carries #822's `ReadWritePaths`.