### PR TITLE
fix(tray): delete dead config-file read in the OAuth login path

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -67,7 +67,6 @@ graph LR
 - 🔵 **Release qualification gate (auto-QA matrix blocks the tag)** — In progress · P0
 - 🟡 **Windows native tray app** — In review · P2
 - 🔴 **MCP protocol upgrade to 2026-07-28 revision** — Blocked · P3
-- ⚪ **Tray↔core decoupling: socket/REST API only, no config-file reads** — Todo · P2
 - ⚪ **Planning/docs truth automation** — Todo · P2
 - ⚫ **Server marketplace** — Todo · P3 · parked
 - ⚫ **Audit SIEM integration** — Todo · P3 · parked
@@ -77,6 +76,7 @@ graph LR
 - ⚪ **Security gateway Tracks C/D (per-arg least-privilege + signature provenance)** — Todo · P3
 - ⚪ **Discovery-quality eval harness (Spec 065 second half)** — Todo · P3
 - 🟢 **Registries — easier search + add-server** — Done · P1
+- 🟢 **Tray↔core decoupling: socket/REST API only, no config-file reads** — Done · P2
 
 ## Epic details
 
@@ -381,26 +381,6 @@ graph LR
 </details>
 
 <details>
-<summary>⚪ Tray↔core decoupling: socket/REST API only, no config-file reads — Todo · P2</summary>
-
-> Architecture rule (CLAUDE.md): the tray holds no state and talks to the core only via socket/REST + SSE. 2026-07-03 audit: Swift tray clean (opens config in editor only, never parses); Go tray's update-check gate was caught reading mcp_config.json in PR #805 review and reworked to core-API gating — but one pre-existing violation remains.
-
-```mermaid
-graph LR
-  tray_oauth_config_read["Go tray OAuth login path loads mcp_config.jso…"]
-
-
-  classDef todo fill:#6e7781,stroke:#3d4248,color:#ffffff;
-  class tray_oauth_config_read todo;
-```
-
-| Task | Status | Refs |
-| --- | --- | --- |
-| Go tray OAuth login path loads mcp_config.json directly (internal/tray/tray.go:~1734 config.LoadFromFile via GetConfigPath) — replace with REST (server config / OAuth endpoints), then remove GetConfigPath from the tray server interface if no consumers remain | ⚪ Todo | — |
-
-</details>
-
-<details>
 <summary>⚪ Planning/docs truth automation — Todo · P2</summary>
 
 > Automate the consistency checks this very audit had to do by hand: roadmap vs GitHub PR state, tasks.md updates on implementation PRs, volatile CLAUDE.md/README facts, and quickstart contract tests.
@@ -617,6 +597,29 @@ graph LR
 
 </details>
 
+<details>
+<summary>🟢 Tray↔core decoupling: socket/REST API only, no config-file reads — Done · P2</summary>
+
+> Architecture rule (CLAUDE.md): the tray holds no state and talks to the core only via socket/REST + SSE. 2026-07-11 source-of-truth re-audit + fix: Swift tray was already clean (MCPProxyApp.swift opens the config in an external editor, never parses it); the Go tray's update-check gate was already reworked to core-API gating (#805). The last violation — config.LoadFromFile in the Go tray's OAuth login path, live since ff03db92 (2026-05-18, #477) — turned out to be FUNCTIONALLY DEAD: the loaded config fed only two debug log lines, while the actual trigger was already the core-API TriggerOAuthLogin. Deleted rather than ported to REST. Bootstrap reads (socket path, config PATH without parsing, CA cert) are allowed and remain. Now enforced by a test so the rule cannot silently rot.
+
+```mermaid
+graph LR
+  tray_oauth_config_read["Delete the dead config read in the Go tray OA…"]
+  tray_config_import_guard["Test guard (internal/tray/config_import_guard…"]
+
+  tray_oauth_config_read --> tray_config_import_guard
+
+  classDef done fill:#1f7a1f,stroke:#0d3d0d,color:#ffffff;
+  class tray_oauth_config_read,tray_config_import_guard done;
+```
+
+| Task | Status | Refs |
+| --- | --- | --- |
+| Delete the dead config read in the Go tray OAuth path (config.LoadFromFile) + drop the now-unused internal/config import. GetConfigPath stays on the interface — openConfigDir still needs the path to reveal the dir in the file manager. | 🟢 Done | — |
+| Test guard (internal/tray/config_import_guard_test.go) failing any tray-side call to config.LoadFromFile/Load/SaveConfig/... Parses source on disk, so a violation cannot hide behind an inactive build tag. Bans config FILE I/O, not the config package — cmd/mcpproxy-tray legitimately references the config.LogConfig type for its own logger. | 🟢 Done | — |
+
+</details>
+
 ## Epics
 
 | Epic | Status | Priority | Progress | Spec | PR |
@@ -632,7 +635,6 @@ graph LR
 | Web UI + macOS app UX audit | Todo | P0 | — |  |  |
 | Action log / transparency — info at a glance | Todo | P1 | — |  |  |
 | tpa-db: versioned TPA signature database for the offline scanner | Todo | P1 | — |  |  |
-| Tray↔core decoupling: socket/REST API only, no config-file reads | Todo | P2 | — |  |  |
 | Planning/docs truth automation | Todo | P2 | — |  |  |
 | Security gateway Tracks C/D (per-arg least-privilege + signature provenance) | Todo | P3 | — | [054-mcp-security-gateway](./specs/054-mcp-security-gateway/) |  |
 | Discovery-quality eval harness (Spec 065 second half) | Todo | P3 | — | [065-evaluation-foundation](./specs/065-evaluation-foundation/) |  |
@@ -645,6 +647,7 @@ graph LR
 | Spec 076 deterministic offline tool-scanner `MCP-3574` | Done | P1 | 22/24 (92%) | [076-deterministic-tool-scanner](./specs/076-deterministic-tool-scanner/) |  |
 | Registries — easier search + add-server | Done | P1 | 21/24 (88%) | [070-registry-easy-upstream-add](./specs/070-registry-easy-upstream-add/) |  |
 | Scanner simplification (deterministic default, opt-in deep scan) | Done | P1 | 38/42 (90%) | [077-scanner-simplification](./specs/077-scanner-simplification/) |  |
+| Tray↔core decoupling: socket/REST API only, no config-file reads | Done | P2 | — |  |  |
 
 ## Shipped (archived)
 

--- a/cmd/mcpproxy-tray/internal/api/adapter.go
+++ b/cmd/mcpproxy-tray/internal/api/adapter.go
@@ -310,9 +310,14 @@ func (a *ServerAdapter) ReloadConfiguration() error {
 
 // GetConfigPath returns the configuration file path core is running with.
 // The tray passes MCPPROXY_TRAY_CONFIG_PATH to core as --config (see
-// buildCoreArgs in main.go), so tray-side config consumers — e.g. the Spec 079
-// update_check gate — must resolve to that same override, not a hardcoded
-// default. Falls back to the default ~/.mcpproxy path when unset.
+// buildCoreArgs in main.go), so a tray-side consumer of this path must resolve
+// to that same override, not a hardcoded default. Falls back to the default
+// ~/.mcpproxy path when unset.
+//
+// This returns a PATH ONLY — the tray never parses the config file. Its sole
+// consumer is openConfigDir (internal/tray/tray.go), which reveals the
+// directory in the file manager. See TestTrayDoesNotReadConfigFile for the
+// enforced rule.
 func (a *ServerAdapter) GetConfigPath() string {
 	if cfg := strings.TrimSpace(os.Getenv("MCPPROXY_TRAY_CONFIG_PATH")); cfg != "" {
 		return cfg

--- a/internal/tray/config_import_guard_test.go
+++ b/internal/tray/config_import_guard_test.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -13,94 +14,113 @@ import (
 // configPkg is the import path of the config package.
 const configPkg = "github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 
-// forbiddenConfigIO are the config-package entry points that touch mcp_config.json.
+// allowedConfigSymbols are the ONLY config-package symbols tray-side code may
+// reference.
 //
 // The architectural rule (CLAUDE.md) is that the tray holds no state and talks
-// to the core only over socket/REST + SSE. Loading or saving the config file
+// to the core only over socket/REST + SSE. Loading or saving mcp_config.json
 // makes the tray a second, competing source of truth — the class of bug that
 // produced the dead OAuth-path config read this guard was added alongside.
 //
-// The rule bans config *file I/O*, not the config package outright: referencing
-// a pure type such as config.LogConfig (the tray's own logger settings, built
-// in memory — see cmd/mcpproxy-tray/main.go) reads nothing and is fine.
-var forbiddenConfigIO = map[string]bool{
-	"LoadFromFile":        true,
-	"Load":                true,
-	"LoadOrCreateConfig":  true,
-	"SaveConfig":          true,
-	"SaveConfigToDataDir": true,
+// This is an ALLOWLIST, not a denylist, and that is deliberate: it fails CLOSED.
+// A file-I/O helper added to the config package tomorrow is caught here by
+// default, whereas a denylist of today's loader names would silently miss it.
+// (An earlier denylist did miss config.CreateSampleConfig, which writes a
+// config file via SaveConfig.)
+//
+// LogConfig is a plain struct type describing the tray's OWN logger, built in
+// memory from logs.DefaultLogConfig() — see cmd/mcpproxy-tray/main.go. It reads
+// nothing from disk, so it is allowed.
+var allowedConfigSymbols = map[string]bool{
+	"LogConfig": true,
 }
 
-// trayDirs are the tray-side packages the rule applies to.
+// trayRoots are the tray-side trees the rule applies to. Both are walked
+// RECURSIVELY: cmd/mcpproxy-tray has subpackages (internal/api, internal/monitor,
+// internal/state) that are every bit as tray-side as its root.
 //
-// Bootstrap reads are deliberately out of scope: resolving the socket path, the
-// config *path* (without parsing it), or the CA cert are how the tray finds the
-// core in the first place, and none of them call the functions above.
-var trayDirs = []string{
+// Bootstrap reads stay out of scope by construction: resolving the socket path,
+// the config *path* (without parsing it), or the CA cert touches none of the
+// config package.
+var trayRoots = []string{
 	".",
 	filepath.Join("..", "..", "cmd", "mcpproxy-tray"),
 }
 
-// TestTrayDoesNotReadConfigFile fails if any tray-side source file calls a
-// config-file loader or saver. It parses the files on disk rather than relying
-// on the compiler, so a violation cannot hide behind a build tag that happens
-// not to be active on the machine running the test.
+// TestTrayDoesNotReadConfigFile fails if any tray-side source file uses the
+// config package for anything but the allowlisted pure types.
+//
+// It parses sources on disk rather than relying on the compiler, so a violation
+// cannot hide behind a build tag that happens to be inactive on the machine
+// running the test.
 func TestTrayDoesNotReadConfigFile(t *testing.T) {
 	fset := token.NewFileSet()
+	scanned := 0
 
-	for _, dir := range trayDirs {
-		// parser.ParseDir ignores build constraints — every file is checked on
-		// every platform, which is the point.
-		pkgs, err := parser.ParseDir(fset, dir, nil, 0)
-		if err != nil {
-			t.Fatalf("parse %s: %v", dir, err)
-		}
-
-		scanned := 0
-		for _, pkg := range pkgs {
-			for path, file := range pkg.Files {
-				if strings.HasSuffix(path, "_test.go") {
-					continue // this guard names the symbols itself
-				}
-				scanned++
-
-				// Find the local alias for the config package in this file, if
-				// it is imported at all. Without it, a `config.Load` selector
-				// cannot refer to the config package.
-				alias := configAlias(file)
-				if alias == "" {
-					continue
-				}
-
-				ast.Inspect(file, func(n ast.Node) bool {
-					sel, ok := n.(*ast.SelectorExpr)
-					if !ok {
-						return true
-					}
-					ident, ok := sel.X.(*ast.Ident)
-					if !ok || ident.Name != alias {
-						return true
-					}
-					if !forbiddenConfigIO[sel.Sel.Name] {
-						return true
-					}
-					t.Errorf(
-						"%s calls config.%s.\n\n"+
-							"The tray must not read or write mcp_config.json — it holds no state and "+
-							"talks to the core over socket/REST + SSE (CLAUDE.md). Fetch what you need "+
-							"from the core API instead.",
-						fset.Position(sel.Pos()), sel.Sel.Name,
-					)
-					return true
-				})
+	for _, root := range trayRoots {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
 			}
-		}
+			if d.IsDir() {
+				if d.Name() == "testdata" || d.Name() == "node_modules" {
+					return fs.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil // this guard names the symbols itself
+			}
 
-		// Guard the guard: a typo'd path would silently scan nothing and pass.
-		if scanned == 0 {
-			t.Fatalf("no non-test Go files found in %s — the guard is not scanning anything", dir)
+			file, perr := parser.ParseFile(fset, path, nil, 0)
+			if perr != nil {
+				return perr
+			}
+			scanned++
+
+			// Without an import of the config package, a `config.X` selector in
+			// this file cannot refer to it — it is a local variable named config
+			// (cmd/mcpproxy-tray/internal/monitor has several).
+			alias := configAlias(file)
+			if alias == "" {
+				return nil
+			}
+
+			ast.Inspect(file, func(n ast.Node) bool {
+				sel, ok := n.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				ident, ok := sel.X.(*ast.Ident)
+				if !ok || ident.Name != alias {
+					return true
+				}
+				if allowedConfigSymbols[sel.Sel.Name] {
+					return true
+				}
+				t.Errorf(
+					"%s uses config.%s.\n\n"+
+						"Tray-side code must not read or write mcp_config.json — the tray holds no "+
+						"state and talks to the core over socket/REST + SSE (CLAUDE.md). Fetch what "+
+						"you need from the core API instead.\n"+
+						"If config.%s is genuinely a pure in-memory type that touches no file, add it "+
+						"to allowedConfigSymbols with a comment saying why.",
+					fset.Position(sel.Pos()), sel.Sel.Name, sel.Sel.Name,
+				)
+				return true
+			})
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", root, err)
 		}
 	}
+
+	// Guard the guard: a typo'd root would silently scan nothing and pass.
+	if scanned == 0 {
+		t.Fatal("no non-test Go files found — the guard is not scanning anything")
+	}
+	t.Logf("scanned %d tray-side source files", scanned)
 }
 
 // configAlias returns the name the config package is bound to in this file
@@ -113,8 +133,7 @@ func configAlias(file *ast.File) string {
 		}
 		if imp.Name != nil {
 			if imp.Name.Name == "_" || imp.Name.Name == "." {
-				// Blank/dot imports cannot produce a `config.Load` selector we
-				// could attribute; nothing to check.
+				// Blank/dot imports produce no attributable `config.X` selector.
 				return ""
 			}
 			return imp.Name.Name

--- a/internal/tray/config_import_guard_test.go
+++ b/internal/tray/config_import_guard_test.go
@@ -1,0 +1,125 @@
+package tray
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// configPkg is the import path of the config package.
+const configPkg = "github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+
+// forbiddenConfigIO are the config-package entry points that touch mcp_config.json.
+//
+// The architectural rule (CLAUDE.md) is that the tray holds no state and talks
+// to the core only over socket/REST + SSE. Loading or saving the config file
+// makes the tray a second, competing source of truth — the class of bug that
+// produced the dead OAuth-path config read this guard was added alongside.
+//
+// The rule bans config *file I/O*, not the config package outright: referencing
+// a pure type such as config.LogConfig (the tray's own logger settings, built
+// in memory — see cmd/mcpproxy-tray/main.go) reads nothing and is fine.
+var forbiddenConfigIO = map[string]bool{
+	"LoadFromFile":        true,
+	"Load":                true,
+	"LoadOrCreateConfig":  true,
+	"SaveConfig":          true,
+	"SaveConfigToDataDir": true,
+}
+
+// trayDirs are the tray-side packages the rule applies to.
+//
+// Bootstrap reads are deliberately out of scope: resolving the socket path, the
+// config *path* (without parsing it), or the CA cert are how the tray finds the
+// core in the first place, and none of them call the functions above.
+var trayDirs = []string{
+	".",
+	filepath.Join("..", "..", "cmd", "mcpproxy-tray"),
+}
+
+// TestTrayDoesNotReadConfigFile fails if any tray-side source file calls a
+// config-file loader or saver. It parses the files on disk rather than relying
+// on the compiler, so a violation cannot hide behind a build tag that happens
+// not to be active on the machine running the test.
+func TestTrayDoesNotReadConfigFile(t *testing.T) {
+	fset := token.NewFileSet()
+
+	for _, dir := range trayDirs {
+		// parser.ParseDir ignores build constraints — every file is checked on
+		// every platform, which is the point.
+		pkgs, err := parser.ParseDir(fset, dir, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", dir, err)
+		}
+
+		scanned := 0
+		for _, pkg := range pkgs {
+			for path, file := range pkg.Files {
+				if strings.HasSuffix(path, "_test.go") {
+					continue // this guard names the symbols itself
+				}
+				scanned++
+
+				// Find the local alias for the config package in this file, if
+				// it is imported at all. Without it, a `config.Load` selector
+				// cannot refer to the config package.
+				alias := configAlias(file)
+				if alias == "" {
+					continue
+				}
+
+				ast.Inspect(file, func(n ast.Node) bool {
+					sel, ok := n.(*ast.SelectorExpr)
+					if !ok {
+						return true
+					}
+					ident, ok := sel.X.(*ast.Ident)
+					if !ok || ident.Name != alias {
+						return true
+					}
+					if !forbiddenConfigIO[sel.Sel.Name] {
+						return true
+					}
+					t.Errorf(
+						"%s calls config.%s.\n\n"+
+							"The tray must not read or write mcp_config.json — it holds no state and "+
+							"talks to the core over socket/REST + SSE (CLAUDE.md). Fetch what you need "+
+							"from the core API instead.",
+						fset.Position(sel.Pos()), sel.Sel.Name,
+					)
+					return true
+				})
+			}
+		}
+
+		// Guard the guard: a typo'd path would silently scan nothing and pass.
+		if scanned == 0 {
+			t.Fatalf("no non-test Go files found in %s — the guard is not scanning anything", dir)
+		}
+	}
+}
+
+// configAlias returns the name the config package is bound to in this file
+// ("config", or an explicit alias), or "" if the file does not import it.
+func configAlias(file *ast.File) string {
+	for _, imp := range file.Imports {
+		path, err := strconv.Unquote(imp.Path.Value)
+		if err != nil || path != configPkg {
+			continue
+		}
+		if imp.Name != nil {
+			if imp.Name.Name == "_" || imp.Name.Name == "." {
+				// Blank/dot imports cannot produce a `config.Load` selector we
+				// could attribute; nothing to check.
+				return ""
+			}
+			return imp.Name.Name
+		}
+		return "config"
+	}
+	return ""
+}

--- a/internal/tray/tray.go
+++ b/internal/tray/tray.go
@@ -26,7 +26,6 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/mod/semver"
 
-	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 	internalRuntime "github.com/smart-mcp-proxy/mcpproxy-go/internal/runtime"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/server"
 	// "github.com/smart-mcp-proxy/mcpproxy-go/internal/upstream/cli" // replaced by in-process OAuth
@@ -1755,47 +1754,6 @@ func (a *App) handleOAuthLogin(serverName string) error {
 	a.logger.Info("Found server for OAuth",
 		zap.String("server", serverName),
 		zap.Any("server_data", targetServer))
-
-	// Load the config file that mcpproxy is using
-	configPath := a.server.GetConfigPath()
-	if configPath == "" {
-		err := fmt.Errorf("config path not available")
-		a.logger.Error("Failed to get config path for OAuth login",
-			zap.String("server", serverName),
-			zap.Error(err))
-		return err
-	}
-
-	a.logger.Info("Loading config file for OAuth",
-		zap.String("server", serverName),
-		zap.String("config_path", configPath))
-
-	globalConfig, err := config.LoadFromFile(configPath)
-	if err != nil {
-		a.logger.Error("Failed to load server configuration for OAuth login",
-			zap.String("server", serverName),
-			zap.String("config_path", configPath),
-			zap.Error(err))
-		return fmt.Errorf("failed to load server configuration: %w", err)
-	}
-
-	// Debug: Check if server exists in config
-	var serverFound bool
-	for _, server := range globalConfig.Servers {
-		if server.Name == serverName {
-			serverFound = true
-			break
-		}
-	}
-
-	a.logger.Info("Server lookup in config",
-		zap.String("server", serverName),
-		zap.Bool("found_in_config", serverFound),
-		zap.String("config_path", configPath))
-
-	a.logger.Info("Config loaded for OAuth",
-		zap.String("server", serverName),
-		zap.Int("total_servers", len(globalConfig.Servers)))
 
 	// Trigger OAuth inside the running daemon to avoid DB lock conflicts
 	a.logger.Info("Triggering in-process OAuth from tray", zap.String("server", serverName))

--- a/roadmap.yaml
+++ b/roadmap.yaml
@@ -459,16 +459,21 @@ epics:
 
   - id: tray-api-purity
     title: "Tray↔core decoupling: socket/REST API only, no config-file reads"
-    status: todo
+    status: done
     priority: P2
     depends_on: []
-    note: "Architecture rule (CLAUDE.md): the tray holds no state and talks to the core only via socket/REST + SSE. 2026-07-03 audit: Swift tray clean (opens config in editor only, never parses); Go tray's update-check gate was caught reading mcp_config.json in PR #805 review and reworked to core-API gating — but one pre-existing violation remains."
+    note: "Architecture rule (CLAUDE.md): the tray holds no state and talks to the core only via socket/REST + SSE. 2026-07-11 source-of-truth re-audit + fix: Swift tray was already clean (MCPProxyApp.swift opens the config in an external editor, never parses it); the Go tray's update-check gate was already reworked to core-API gating (#805). The last violation — config.LoadFromFile in the Go tray's OAuth login path, live since ff03db92 (2026-05-18, #477) — turned out to be FUNCTIONALLY DEAD: the loaded config fed only two debug log lines, while the actual trigger was already the core-API TriggerOAuthLogin. Deleted rather than ported to REST. Bootstrap reads (socket path, config PATH without parsing, CA cert) are allowed and remain. Now enforced by a test so the rule cannot silently rot."
     tasks:
       - id: tray-oauth-config-read
-        title: "Go tray OAuth login path loads mcp_config.json directly (internal/tray/tray.go:~1734 config.LoadFromFile via GetConfigPath) — replace with REST (server config / OAuth endpoints), then remove GetConfigPath from the tray server interface if no consumers remain"
-        status: todo
+        title: "Delete the dead config read in the Go tray OAuth path (config.LoadFromFile) + drop the now-unused internal/config import. GetConfigPath stays on the interface — openConfigDir still needs the path to reveal the dir in the file manager."
+        status: done
         priority: P2
         depends_on: []
+      - id: tray-config-import-guard
+        title: "Test guard (internal/tray/config_import_guard_test.go) failing any tray-side call to config.LoadFromFile/Load/SaveConfig/... Parses source on disk, so a violation cannot hide behind an inactive build tag. Bans config FILE I/O, not the config package — cmd/mcpproxy-tray legitimately references the config.LogConfig type for its own logger."
+        status: done
+        priority: P2
+        depends_on: [tray-oauth-config-read]
 
   - id: planning-hygiene
     title: Planning/docs truth automation


### PR DESCRIPTION
## What

The Go tray loaded `mcp_config.json` inside `handleOAuthLogin`, violating the architecture rule that **the tray holds no state and talks to the core only over socket/REST + SSE** (CLAUDE.md).

Found by a source-of-truth audit of the `tray-api-purity` roadmap epic. The roadmap said "one pre-existing violation remains" — it was still there, untouched since `ff03db92` (2026-05-18, #477).

## The interesting part: the read was already dead

The loaded config fed **nothing but two debug log lines** (`found_in_config`, `total_servers`). The actual OAuth trigger was already the core-API call `TriggerOAuthLogin`.

So this **deletes** the read rather than porting it to REST. The roadmap task assumed a REST rewrite was needed; it wasn't.

## Behavior change (an improvement)

A missing config path or an unreadable config file used to **abort the OAuth login with an error**. It no longer can — the tray doesn't need the file to trigger OAuth. This removes a spurious failure mode rather than adding one.

## Not removed

`GetConfigPath` stays on the tray server interface: `openConfigDir` still uses it to reveal the directory in the file manager, and that never parses the file. Bootstrap reads (socket path, CA cert) are likewise untouched — they're how the tray finds the core, not state.

## Regression guard

`TestTrayDoesNotReadConfigFile` fails any tray-side call to `config.LoadFromFile` / `Load` / `SaveConfig` / …

Two deliberate design choices:
- It **parses sources on disk** rather than relying on the compiler, so a violation can't hide behind a build tag that's inactive on the machine running the test.
- It bans config **file I/O**, not the config package. `cmd/mcpproxy-tray/main.go` legitimately references the `config.LogConfig` *type* for its own logger, which reads nothing. (A blanket import ban flagged this as a false positive — verified while writing the guard.)

Verified the guard actually fails when the violation is reintroduced, not just that it passes today.

## Test plan

- `go build ./...` + `go build ./cmd/mcpproxy-tray` (tray is behind a build tag — compiled explicitly)
- `go test ./internal/tray/...` — pass
- `golangci-lint run --config .github/.golangci.yml ./internal/tray/... ./cmd/mcpproxy-tray/...` — 0 issues
- Negative test: reintroduced `config.LoadFromFile`, confirmed the guard fails at the exact line; restored, confirmed it passes

Closes the `tray-api-purity` epic in `roadmap.yaml`.