### PR TITLE
fix(telemetry): make launch_source=tray reachable, add the missing real-call activation flag

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -179,41 +179,6 @@ graph LR
 </details>
 
 <details>
-<summary>🔵 Telemetry v7: honest funnel + churn instrumentation — In progress · P0</summary>
-
-> 2026-07-06 recheck DEBUNKED the 72.4% connect-skip story: genuine never-connected skip = 0% (wizard dismiss stamped 'skipped' on users who connected via ConnectModal/CLI/manual config). 2026-07-10 recheck debunked the OTHER two spec-080 headline metrics as well: 'day-2 return 17.7%' was un-deduped anonymous_id churn (true, identity-deduped: one-and-done 48%, day-1 return 31%, day-7 16.6% — matches dashboard); '42% retrieve_tools -> 16% real call' was lifetime-flag vs windowed-counter asymmetry (true conversion ~90%; missing piece is a first_real_tool_call_ever activation flag). Real cliff = 48% one-and-done. v7 = wizard metric fix, funnel observability, pre-churn snapshot. Client-side T1-T3 SHIPPED in #813 (v0.47.0, 2026-07-07); only cross-repo churn analytics (T4) remains and needs stable identity (see telemetry-identity).
-
-Spec: [080-telemetry-v7-churn](./specs/080-telemetry-v7-churn/)
-
-```mermaid
-graph LR
-  telemetry_v7_wizard_fix["T1: wizard metric fix - on dismiss record con…"]
-  telemetry_v7_funnel_fields["T2: funnel observability fields (wizard_shown…"]
-  telemetry_v7_prechurn_snapshot["T3: pre-churn snapshot (previous_shutdown cle…"]
-  telemetry_v7_realcall_flag["first_real_tool_call_ever activation flag (sy…"]
-  telemetry_v7_churn_events["T4: cross-repo churn_events materialization +…"]
-
-  telemetry_v7_wizard_fix --> telemetry_v7_churn_events
-  telemetry_v7_funnel_fields --> telemetry_v7_churn_events
-  telemetry_v7_prechurn_snapshot --> telemetry_v7_churn_events
-
-  classDef done fill:#1f7a1f,stroke:#0d3d0d,color:#ffffff;
-  classDef todo fill:#6e7781,stroke:#3d4248,color:#ffffff;
-  class telemetry_v7_wizard_fix,telemetry_v7_funnel_fields,telemetry_v7_prechurn_snapshot done;
-  class telemetry_v7_realcall_flag,telemetry_v7_churn_events todo;
-```
-
-| Task | Status | Refs |
-| --- | --- | --- |
-| T1: wizard metric fix - on dismiss record connect step as completed_external (not skipped) when the user already connected via another path | 🟢 Done | #813 |
-| T2: funnel observability fields (wizard_shown, web_ui_opened counter, days_since_install, active_days_30d) | 🟢 Done | #813 |
-| T3: pre-churn snapshot (previous_shutdown clean\|crash via BBolt flag, last_error_code) so the final heartbeat doubles as cause-of-death | 🟢 Done | #813 |
-| first_real_tool_call_ever activation flag (symmetric to first_retrieve_tools_call_ever) so the retrieve->call funnel step is measurable lifetime-vs-lifetime | ⚪ Todo | — |
-| T4: cross-repo churn_events materialization + dash Churn page with H1-H4 hypothesis signatures (repos mcpproxy-telemetry / mcpproxy-dash; tracked here for DAG visibility, out of scope of spec 080) | ⚪ Todo | — |
-
-</details>
-
-<details>
 <summary>🔵 Analytics dashboard as default page — In progress · P1</summary>
 
 > Per-server / per-tool token-drain graphs; make the dashboard the default landing page. 2026-07-10 truth-sync: spec 069 is SHIPPED (25/26 — the only open task is a Playwright verification sweep), so the graphs half is done; only the default-landing half remains.
@@ -243,21 +208,23 @@ graph LR
 <details>
 <summary>🔵 Telemetry identity &amp; data quality (machine_id + CI-filter hardening) — In progress · P1</summary>
 
-> Heartbeat lacks a stable identity, so active-install counts are inflated by CI/dev churn and launch_source is 79% unknown. Add a hashed machine_id (schema v6) and harden the worker/dashboard cohort filters. Spans repos mcpproxy-go (client), mcpproxy-telemetry (worker), mcpproxy-dash (dashboard).
+> 2026-07-11 source audit: the CLIENT half is DONE and RELEASED — the old framing ('add a hashed machine_id (schema v6)') is stale. machine_id (HMAC-SHA256 of the OS machine id, internal/telemetry/machine_id.go) is emitted unconditionally in every heartbeat (telemetry.go:789; telemetry is opt-out) and shipped in v0.47.0; the client schema is already v7, a version past the v6 this note described; CI is filtered client-side by disabling telemetry outright (env_overrides.go). Worker verified live in prod 2026-07-07 (machine_id 100% populated). The audit also found that the 79%-unknown launch_source was a CLIENT bug misfiled to mcpproxy-dash — a dashboard cannot display a value the client is incapable of sending. That is now fixed (see telemetry-launchsource-tray). Remaining: dashboard consumption (mcpproxy-dash) + snapshot-cron alerting.
 
 ```mermaid
 graph LR
   telemetry_machineid_client["Hashed machine_id in heartbeat (schema v6)"]
   telemetry_machineid_worker["Worker migration: machine_id column + extract…"]
+  telemetry_launchsource_tray["Emit launch_source=tray — the 'tray' value wa…"]
   telemetry_machineid_dash["Dashboard identityExpr prefers machine_id; ex…"]
   telemetry_snapshot_alerting["Alerting on external-downloads snapshot cron…"]
 
   telemetry_machineid_client --> telemetry_machineid_worker
   telemetry_machineid_worker --> telemetry_machineid_dash
+  telemetry_launchsource_tray --> telemetry_machineid_dash
 
   classDef done fill:#1f7a1f,stroke:#0d3d0d,color:#ffffff;
   classDef todo fill:#6e7781,stroke:#3d4248,color:#ffffff;
-  class telemetry_machineid_client,telemetry_machineid_worker done;
+  class telemetry_machineid_client,telemetry_machineid_worker,telemetry_launchsource_tray done;
   class telemetry_machineid_dash,telemetry_snapshot_alerting todo;
 ```
 
@@ -265,8 +232,44 @@ graph LR
 | --- | --- | --- |
 | Hashed machine_id in heartbeat (schema v6) | 🟢 Done | https://github.com/smart-mcp-proxy/mcpproxy-go/pull/796 |
 | Worker migration: machine_id column + extraction (repo mcpproxy-telemetry) | 🟢 Done | mcpproxy-telemetry#3 |
-| Dashboard identityExpr prefers machine_id; exclude %-dev versions from human cohort; fix launch_source 79% unknown (repo mcpproxy-dash) | ⚪ Todo | — |
+| Emit launch_source=tray — the 'tray' value was UNREACHABLE in the client, and that (not the dashboard) was the 79%-unknown root cause | 🟢 Done | — |
+| Dashboard identityExpr prefers machine_id; exclude %-dev versions from human cohort (repo mcpproxy-dash) | ⚪ Todo | — |
 | Alerting on external-downloads snapshot cron (34-day outage went unnoticed) | ⚪ Todo | — |
+
+</details>
+
+<details>
+<summary>🔵 Telemetry v7: honest funnel + churn instrumentation — In progress · P1</summary>
+
+> 2026-07-06 recheck DEBUNKED the 72.4% connect-skip story: genuine never-connected skip = 0% (wizard dismiss stamped 'skipped' on users who connected via ConnectModal/CLI/manual config). 2026-07-10 recheck debunked the OTHER two spec-080 headline metrics as well: 'day-2 return 17.7%' was un-deduped anonymous_id churn (true, identity-deduped: one-and-done 48%, day-1 return 31%, day-7 16.6% — matches dashboard); '42% retrieve_tools -> 16% real call' was lifetime-flag vs windowed-counter asymmetry (true conversion ~90%; missing piece is a first_real_tool_call_ever activation flag). Real cliff = 48% one-and-done. 2026-07-11 source audit + fix: ALL of spec 080 is shipped and released in v0.47.0 (#813) — T1 wizard completed_external, T2 funnel fields, T3 pre-churn snapshot, US4 schema v7. The previous note claimed 'only cross-repo churn analytics (T4) remains'; that was WRONG — first_real_tool_call_ever had ZERO occurrences in Go code and was in-repo CLIENT work. It is now implemented, so the retrieve->call funnel is finally measurable lifetime-vs-lifetime. P0->P1: only cross-repo T4 now remains.
+
+Spec: [080-telemetry-v7-churn](./specs/080-telemetry-v7-churn/)
+
+```mermaid
+graph LR
+  telemetry_v7_wizard_fix["T1: wizard metric fix - on dismiss record con…"]
+  telemetry_v7_funnel_fields["T2: funnel observability fields (wizard_shown…"]
+  telemetry_v7_prechurn_snapshot["T3: pre-churn snapshot (previous_shutdown cle…"]
+  telemetry_v7_realcall_flag["first_real_tool_call_ever activation flag (sy…"]
+  telemetry_v7_churn_events["T4: cross-repo churn_events materialization +…"]
+
+  telemetry_v7_wizard_fix --> telemetry_v7_churn_events
+  telemetry_v7_funnel_fields --> telemetry_v7_churn_events
+  telemetry_v7_prechurn_snapshot --> telemetry_v7_churn_events
+
+  classDef done fill:#1f7a1f,stroke:#0d3d0d,color:#ffffff;
+  classDef todo fill:#6e7781,stroke:#3d4248,color:#ffffff;
+  class telemetry_v7_wizard_fix,telemetry_v7_funnel_fields,telemetry_v7_prechurn_snapshot,telemetry_v7_realcall_flag done;
+  class telemetry_v7_churn_events todo;
+```
+
+| Task | Status | Refs |
+| --- | --- | --- |
+| T1: wizard metric fix - on dismiss record connect step as completed_external (not skipped) when the user already connected via another path | 🟢 Done | #813 |
+| T2: funnel observability fields (wizard_shown, web_ui_opened counter, days_since_install, active_days_30d) | 🟢 Done | #813 |
+| T3: pre-churn snapshot (previous_shutdown clean\|crash via BBolt flag, last_error_code) so the final heartbeat doubles as cause-of-death | 🟢 Done | #813 |
+| first_real_tool_call_ever activation flag (symmetric to first_retrieve_tools_call_ever) so the retrieve->call funnel step is measurable lifetime-vs-lifetime | 🟢 Done | — |
+| T4: cross-repo churn_events materialization + dash Churn page with H1-H4 hypothesis signatures (repos mcpproxy-telemetry / mcpproxy-dash; tracked here for DAG visibility, out of scope of spec 080) | ⚪ Todo | — |
 
 </details>
 
@@ -624,9 +627,9 @@ graph LR
 | Upgrade awareness & guided update | In progress | P0 | — | [079-upgrade-nudge](./specs/079-upgrade-nudge/) |  |
 | Connect step trust: preview, visible backup, one-click undo | In progress | P0 | — | [078-connect-trust-preview](./specs/078-connect-trust-preview/) |  |
 | Release qualification gate (auto-QA matrix blocks the tag) | In progress | P0 | — | [081-release-qa-gate](./specs/081-release-qa-gate/) |  |
-| Telemetry v7: honest funnel + churn instrumentation | In progress | P0 | — | [080-telemetry-v7-churn](./specs/080-telemetry-v7-churn/) |  |
 | Analytics dashboard as default page | In progress | P1 | 25/26 (96%) | [069-observability-usage-graphs](./specs/069-observability-usage-graphs/) |  |
 | Telemetry identity & data quality (machine_id + CI-filter hardening) | In progress | P1 | — |  |  |
+| Telemetry v7: honest funnel + churn instrumentation | In progress | P1 | — | [080-telemetry-v7-churn](./specs/080-telemetry-v7-churn/) |  |
 | Windows native tray app `MCP-43` | In review | P2 | — |  |  |
 | MCP protocol upgrade to 2026-07-28 revision | Blocked | P3 | — | [058-mcp-2026-upgrade](./specs/058-mcp-2026-upgrade/) |  |
 | Web UI + macOS app UX audit | Todo | P0 | — |  |  |

--- a/cmd/mcpproxy-tray/main.go
+++ b/cmd/mcpproxy-tray/main.go
@@ -1732,6 +1732,18 @@ func (cpl *CoreProcessLauncher) buildCoreEnvironment() []string {
 		"MCPPROXY_ENABLE_TRAY=false",
 		fmt.Sprintf("MCPPROXY_API_KEY=%s", trayAPIKey))
 
+	// Tell the core it was launched by the tray, so telemetry's launch_source
+	// can say so. Without this a tray-spawned core is unclassifiable: its parent
+	// is the tray (not launchd, so not login_item) and it has no TTY (so not
+	// cli), leaving launch_source "unknown".
+	//
+	// The installer launches the tray with MCPPROXY_LAUNCHED_BY=installer and
+	// the core inherits it through os.Environ() above; that first-run
+	// attribution outranks "tray", so we must not overwrite it.
+	if strings.TrimSpace(os.Getenv("MCPPROXY_LAUNCHED_BY")) != "installer" {
+		filtered = append(filtered, "MCPPROXY_LAUNCHED_BY=tray")
+	}
+
 	// Pass through TLS configuration if set
 	if tlsEnabled := strings.TrimSpace(os.Getenv("MCPPROXY_TLS_ENABLED")); tlsEnabled != "" {
 		filtered = append(filtered, fmt.Sprintf("MCPPROXY_TLS_ENABLED=%s", tlsEnabled))

--- a/docs/features/telemetry.md
+++ b/docs/features/telemetry.md
@@ -108,11 +108,13 @@ The `activation` block gains one additive boolean:
 
 | Field | Type | When it is set | Privacy rationale |
 |-------|------|----------------|-------------------|
-| `first_real_tool_call_ever` | boolean | `true` once this install has proxied at least one **real** tool call to an upstream server (any `call_tool_read` / `call_tool_write` / `call_tool_destructive`). Built-in tools such as `retrieve_tools` do **not** set it. Monotonic and lifetime-scoped, exactly like `first_retrieve_tools_call_ever` | A single boolean about our own funnel; no tool name, server, or arguments |
+| `first_real_tool_call_ever` | boolean | `true` once an upstream server has **successfully returned a result** for at least one real tool call (any `call_tool_read` / `call_tool_write` / `call_tool_destructive`). Built-in tools such as `retrieve_tools` do **not** set it, and neither do **attempted** calls that fail — malformed args, a quarantined or disabled tool, a disconnected server, or an upstream error. Monotonic and lifetime-scoped, exactly like `first_retrieve_tools_call_ever` | A single boolean about our own funnel; no tool name, server, or arguments |
 
 **Why it exists.** The retrieve→call funnel used to compare a *lifetime* flag (`first_retrieve_tools_call_ever`) against a *24h windowed* counter (`retrieve_tools_calls_24h` / upstream-call counters). That asymmetry made conversion look like a cliff ("42% search → 16% call") when the true lifetime-vs-lifetime conversion is far higher. This flag is the missing symmetric term.
 
-**Guidance for consumers**: measure the funnel step as `first_real_tool_call_ever` over `first_retrieve_tools_call_ever`. Do **not** compare either lifetime flag against a windowed counter.
+**Success, not attempt.** The flag is stamped only after the upstream returns a result — deliberately *not* alongside the `upstream_tool_calls` counter, which fires on every invocation including blocked and failed ones. An install whose first tool call was blocked by quarantine has **not** activated, and counting it as activated would hide exactly the breakage this metric exists to surface.
+
+**Guidance for consumers**: measure the funnel step as `first_real_tool_call_ever` over `first_retrieve_tools_call_ever`. Do **not** compare either lifetime flag against a windowed counter, and note that `upstream_tool_calls` counts *attempts* while this flag counts *success* — they are not the same denominator.
 
 ### `launch_source` = `tray`
 

--- a/docs/features/telemetry.md
+++ b/docs/features/telemetry.md
@@ -102,6 +102,26 @@ The onboarding connect-step status (a v4 field) gains a fourth value in v7:
 
 Why these exist: telemetry showed most installs connect successfully but never return after day one. `days_since_install` + `active_days_30d` make retention computable from a single heartbeat (no cross-heartbeat identity joins), and `previous_shutdown` + `last_error_code` let the final heartbeat before an install goes silent distinguish "crashed and never came back" from "exited cleanly and never returned".
 
+### Activation: `first_real_tool_call_ever`
+
+The `activation` block gains one additive boolean:
+
+| Field | Type | When it is set | Privacy rationale |
+|-------|------|----------------|-------------------|
+| `first_real_tool_call_ever` | boolean | `true` once this install has proxied at least one **real** tool call to an upstream server (any `call_tool_read` / `call_tool_write` / `call_tool_destructive`). Built-in tools such as `retrieve_tools` do **not** set it. Monotonic and lifetime-scoped, exactly like `first_retrieve_tools_call_ever` | A single boolean about our own funnel; no tool name, server, or arguments |
+
+**Why it exists.** The retrieve→call funnel used to compare a *lifetime* flag (`first_retrieve_tools_call_ever`) against a *24h windowed* counter (`retrieve_tools_calls_24h` / upstream-call counters). That asymmetry made conversion look like a cliff ("42% search → 16% call") when the true lifetime-vs-lifetime conversion is far higher. This flag is the missing symmetric term.
+
+**Guidance for consumers**: measure the funnel step as `first_real_tool_call_ever` over `first_retrieve_tools_call_ever`. Do **not** compare either lifetime flag against a windowed counter.
+
+### `launch_source` = `tray`
+
+`launch_source` is a v3 field, but its `tray` value was **unreachable in practice until now**: a tray-spawned core has the tray app as its parent (not `launchd`, so not `login_item`) and no TTY (so not `cli`), and nothing told it otherwise — so it fell through to `unknown`. That is why `launch_source` was ~79% `unknown` on the flagship macOS path.
+
+Both trays now stamp `MCPPROXY_LAUNCHED_BY=tray` on the core process they spawn, and the core honours it. The DMG installer's `MCPPROXY_LAUNCHED_BY=installer` still outranks it, so first-run attribution is unchanged.
+
+**Guidance for consumers**: `unknown` counts from before this fix are not comparable with counts after it — segment by version.
+
 All v7 fields ride the **same opt-out** as the rest of the heartbeat: when telemetry is disabled, nothing is transmitted. Local counters may still persist on disk (so re-enabling doesn't fabricate a fresh-install picture), but they never leave the machine.
 
 You can inspect exactly what would be sent — including every v7 field — with:

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -2653,6 +2653,30 @@ func (r *Runtime) RecordRetrieveToolsCallForActivation() {
 	}
 }
 
+// RecordRealToolCallForActivation marks the first-ever real (upstream) tool
+// call. "Real" means a call proxied to an upstream server, as opposed to a
+// built-in tool such as retrieve_tools.
+//
+// This is the lifetime counterpart of RecordRetrieveToolsCallForActivation.
+// Until it existed, the retrieve step had a lifetime flag while the call step
+// had only a windowed counter, so the retrieve→call funnel compared a
+// lifetime value against a 24h one and understated conversion badly.
+//
+// No-op if the activation store is not wired.
+func (r *Runtime) RecordRealToolCallForActivation() {
+	if r.telemetryService == nil {
+		return
+	}
+	store := r.telemetryService.ActivationStore()
+	db := r.telemetryService.ActivationDB()
+	if store == nil || db == nil {
+		return
+	}
+	if err := store.MarkFirstRealToolCall(db); err != nil {
+		r.logger.Debug("activation: MarkFirstRealToolCall failed", zap.Error(err))
+	}
+}
+
 // RecordTokensSavedForActivation adds n to the 24h tokens-saved estimator.
 // n <= 0 is a no-op. Spec 044 US2.
 func (r *Runtime) RecordTokensSavedForActivation(n int) {

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -477,13 +477,27 @@ func (p *MCPProxyServer) recordBuiltinTool(name string) {
 // recordUpstreamTool increments the upstream tool call counter without ever
 // recording the tool name. Spec 042 User Story 2.
 //
-// It also marks the lifetime first_real_tool_call_ever activation flag, the
-// counterpart of first_retrieve_tools_call_ever, so the retrieve→call funnel
-// step can be measured lifetime-against-lifetime instead of against a 24h
-// counter. nil-safe.
+// This counts ATTEMPTS: it runs at the top of handleCallToolVariant, before
+// validation, quarantine checks, connectivity, and the upstream call itself.
+// Do not hang success-semantics metrics off it — see recordRealToolCallSuccess.
 func (p *MCPProxyServer) recordUpstreamTool() {
 	telemetry.RecordUpstreamToolOn(p.telemetryRegistry())
+}
 
+// recordRealToolCallSuccess marks the lifetime first_real_tool_call_ever
+// activation flag — the counterpart of first_retrieve_tools_call_ever, so the
+// retrieve→call funnel step can be measured lifetime-against-lifetime instead
+// of against a 24h counter.
+//
+// It is deliberately NOT called from recordUpstreamTool. That counter fires on
+// every call_tool_* invocation, including ones that are malformed, blocked by
+// quarantine, aimed at a disabled tool, or sent to a disconnected server. An
+// install whose first tool call was blocked has not activated — counting it as
+// activated would hide exactly the breakage this metric exists to surface.
+//
+// Call this only once the upstream has actually returned a successful result.
+// nil-safe.
+func (p *MCPProxyServer) recordRealToolCallSuccess() {
 	if p.mainServer != nil && p.mainServer.runtime != nil {
 		p.mainServer.runtime.RecordRealToolCallForActivation()
 	}
@@ -1962,6 +1976,12 @@ func (p *MCPProxyServer) handleCallToolVariant(ctx context.Context, request mcp.
 
 		return p.createDetailedErrorResponse(err, serverName, actualToolName), nil
 	}
+
+	// The upstream returned a real result: this install has now genuinely made a
+	// real tool call. Stamped here — past every validation / quarantine /
+	// connectivity gate and past the upstream error branch above — so the
+	// activation flag means "succeeded", not merely "attempted".
+	p.recordRealToolCallSuccess()
 
 	// Record successful response
 	toolCallRecord.Response = result

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -476,8 +476,17 @@ func (p *MCPProxyServer) recordBuiltinTool(name string) {
 
 // recordUpstreamTool increments the upstream tool call counter without ever
 // recording the tool name. Spec 042 User Story 2.
+//
+// It also marks the lifetime first_real_tool_call_ever activation flag, the
+// counterpart of first_retrieve_tools_call_ever, so the retrieve→call funnel
+// step can be measured lifetime-against-lifetime instead of against a 24h
+// counter. nil-safe.
 func (p *MCPProxyServer) recordUpstreamTool() {
 	telemetry.RecordUpstreamToolOn(p.telemetryRegistry())
+
+	if p.mainServer != nil && p.mainServer.runtime != nil {
+		p.mainServer.runtime.RecordRealToolCallForActivation()
+	}
 }
 
 // emitActivityEvent safely emits an activity event if runtime is available

--- a/internal/server/mcp_activation_test.go
+++ b/internal/server/mcp_activation_test.go
@@ -136,10 +136,9 @@ func TestRetrieveTools_HooksActivation(t *testing.T) {
 		"retrieve_tools must not mark first_real_tool_call_ever — it is a builtin, not an upstream call")
 }
 
-// recordUpstreamTool (the shared entry point of every call_tool_* variant)
-// marks the lifetime first_real_tool_call_ever flag — the counterpart of
-// first_retrieve_tools_call_ever, so the retrieve→call funnel step is
-// measurable lifetime-against-lifetime.
+// A SUCCESSFUL upstream call marks the lifetime first_real_tool_call_ever flag
+// — the counterpart of first_retrieve_tools_call_ever, so the retrieve→call
+// funnel step is measurable lifetime-against-lifetime.
 func TestRealToolCall_MarksFirstRealToolCallEver(t *testing.T) {
 	if testing.Short() {
 		t.Skip("integration — needs full runtime + index + cache")
@@ -149,20 +148,44 @@ func TestRealToolCall_MarksFirstRealToolCallEver(t *testing.T) {
 	before := loadActivationFromRuntime(t, rt)
 	require.False(t, before.FirstRealToolCallEver)
 
-	// Exercise the exact hook every call_tool_read/write/destructive variant
-	// runs, without needing a live upstream server: handleCallToolVariant calls
-	// recordUpstreamTool() before it ever touches the upstream.
-	proxy.recordUpstreamTool()
+	// The success-path hook: handleCallToolVariant runs this only after the
+	// upstream has actually returned a result.
+	proxy.recordRealToolCallSuccess()
 
 	after := loadActivationFromRuntime(t, rt)
 	require.True(t, after.FirstRealToolCallEver,
-		"an upstream tool call must mark first_real_tool_call_ever=true")
+		"a successful upstream tool call must mark first_real_tool_call_ever=true")
 
 	// Monotonic: the flag is lifetime, so a second call keeps it true and
 	// never reverts.
-	proxy.recordUpstreamTool()
+	proxy.recordRealToolCallSuccess()
 	after2 := loadActivationFromRuntime(t, rt)
 	require.True(t, after2.FirstRealToolCallEver)
+}
+
+// An ATTEMPTED call must not mark activation. recordUpstreamTool runs at the top
+// of handleCallToolVariant — before validation, quarantine checks, connectivity,
+// and the upstream call itself — so a call that is malformed, blocked by
+// quarantine, aimed at a disabled tool, or sent to a disconnected server reaches
+// it and then fails.
+//
+// If that stamped the flag, an install whose very first tool call was BLOCKED
+// would be counted as activated, hiding exactly the breakage the metric exists
+// to surface. Regression test for a real bug caught in cross-model review.
+func TestAttemptedToolCall_DoesNotMarkFirstRealToolCallEver(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration — needs full runtime + index + cache")
+	}
+	proxy, rt, _ := buildMCPProxyWithActivation(t)
+
+	// The attempt counter fires (Spec 042 semantics: it counts attempts)...
+	proxy.recordUpstreamTool()
+
+	// ...but activation must NOT, because no upstream ever returned a result.
+	after := loadActivationFromRuntime(t, rt)
+	require.False(t, after.FirstRealToolCallEver,
+		"an attempted (failed/blocked) call must not mark first_real_tool_call_ever — "+
+			"only a successful upstream result counts as activation")
 }
 
 // T030: AfterInitialize hook records clientInfo.name via the runtime helper.

--- a/internal/server/mcp_activation_test.go
+++ b/internal/server/mcp_activation_test.go
@@ -128,6 +128,41 @@ func TestRetrieveTools_HooksActivation(t *testing.T) {
 	require.NoError(t, err)
 	after2 := loadActivationFromRuntime(t, rt)
 	require.Equal(t, 2, after2.RetrieveToolsCalls24h)
+
+	// retrieve_tools is a BUILT-IN tool, not a proxied upstream call, so it must
+	// NOT set the real-call flag. If it did, the retrieve→call funnel would
+	// report 100% conversion for every user who ever searched.
+	require.False(t, after2.FirstRealToolCallEver,
+		"retrieve_tools must not mark first_real_tool_call_ever — it is a builtin, not an upstream call")
+}
+
+// recordUpstreamTool (the shared entry point of every call_tool_* variant)
+// marks the lifetime first_real_tool_call_ever flag — the counterpart of
+// first_retrieve_tools_call_ever, so the retrieve→call funnel step is
+// measurable lifetime-against-lifetime.
+func TestRealToolCall_MarksFirstRealToolCallEver(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration — needs full runtime + index + cache")
+	}
+	proxy, rt, _ := buildMCPProxyWithActivation(t)
+
+	before := loadActivationFromRuntime(t, rt)
+	require.False(t, before.FirstRealToolCallEver)
+
+	// Exercise the exact hook every call_tool_read/write/destructive variant
+	// runs, without needing a live upstream server: handleCallToolVariant calls
+	// recordUpstreamTool() before it ever touches the upstream.
+	proxy.recordUpstreamTool()
+
+	after := loadActivationFromRuntime(t, rt)
+	require.True(t, after.FirstRealToolCallEver,
+		"an upstream tool call must mark first_real_tool_call_ever=true")
+
+	// Monotonic: the flag is lifetime, so a second call keeps it true and
+	// never reverts.
+	proxy.recordUpstreamTool()
+	after2 := loadActivationFromRuntime(t, rt)
+	require.True(t, after2.FirstRealToolCallEver)
 }
 
 // T030: AfterInitialize hook records clientInfo.name via the runtime helper.

--- a/internal/telemetry/activation.go
+++ b/internal/telemetry/activation.go
@@ -22,6 +22,7 @@ const (
 	activationKeyFirstConnectedServerEver   = "first_connected_server_ever"
 	activationKeyFirstMCPClientEver         = "first_mcp_client_ever"
 	activationKeyFirstRetrieveToolsCallEver = "first_retrieve_tools_call_ever"
+	activationKeyFirstRealToolCallEver      = "first_real_tool_call_ever"
 	activationKeyMCPClientsSeenEver         = "mcp_clients_seen_ever"
 	activationKeyRetrieveToolsCalls24h      = "retrieve_tools_calls_24h"
 	activationKeyEstimatedTokensSaved24h    = "estimated_tokens_saved_24h"
@@ -42,6 +43,7 @@ type ActivationState struct {
 	FirstConnectedServerEver      bool     `json:"first_connected_server_ever"`
 	FirstMCPClientEver            bool     `json:"first_mcp_client_ever"`
 	FirstRetrieveToolsCallEver    bool     `json:"first_retrieve_tools_call_ever"`
+	FirstRealToolCallEver         bool     `json:"first_real_tool_call_ever"`
 	MCPClientsSeenEver            []string `json:"mcp_clients_seen_ever"`
 	RetrieveToolsCalls24h         int      `json:"retrieve_tools_calls_24h"`
 	EstimatedTokensSaved24hBucket string   `json:"estimated_tokens_saved_24h_bucket"`
@@ -74,6 +76,16 @@ type ActivationStore interface {
 	// MarkFirstRetrieveToolsCall sets first_retrieve_tools_call_ever=true
 	// if not already set.
 	MarkFirstRetrieveToolsCall(db *bbolt.DB) error
+
+	// MarkFirstRealToolCall sets first_real_tool_call_ever=true if not
+	// already set. "Real" means a call proxied to an upstream server, as
+	// opposed to a built-in tool such as retrieve_tools.
+	//
+	// This is the symmetric counterpart of MarkFirstRetrieveToolsCall. Without
+	// it the retrieve→call funnel step could only be measured as a lifetime
+	// flag against a windowed counter, which made conversion look far worse
+	// than it is.
+	MarkFirstRealToolCall(db *bbolt.DB) error
 
 	// RecordMCPClient adds sanitized client name to the seen list. Dedups
 	// on insert; drops when cap (16) is reached.
@@ -172,6 +184,7 @@ func loadActivationAt(db *bbolt.DB, now time.Time) (ActivationState, error) {
 		st.FirstConnectedServerEver = decodeBool(b.Get([]byte(activationKeyFirstConnectedServerEver)))
 		st.FirstMCPClientEver = decodeBool(b.Get([]byte(activationKeyFirstMCPClientEver)))
 		st.FirstRetrieveToolsCallEver = decodeBool(b.Get([]byte(activationKeyFirstRetrieveToolsCallEver)))
+		st.FirstRealToolCallEver = decodeBool(b.Get([]byte(activationKeyFirstRealToolCallEver)))
 
 		if raw := b.Get([]byte(activationKeyMCPClientsSeenEver)); len(raw) > 0 {
 			var list []string
@@ -237,6 +250,10 @@ func (bboltActivationStore) Save(db *bbolt.DB, st ActivationState) error {
 		if err := b.Put([]byte(activationKeyFirstRetrieveToolsCallEver), encodeBool(existing)); err != nil {
 			return err
 		}
+		existing = decodeBool(b.Get([]byte(activationKeyFirstRealToolCallEver))) || st.FirstRealToolCallEver
+		if err := b.Put([]byte(activationKeyFirstRealToolCallEver), encodeBool(existing)); err != nil {
+			return err
+		}
 
 		// Clients list: write as-is (trimmed to cap).
 		list := st.MCPClientsSeenEver
@@ -283,6 +300,10 @@ func (s bboltActivationStore) MarkFirstMCPClient(db *bbolt.DB) error {
 
 func (s bboltActivationStore) MarkFirstRetrieveToolsCall(db *bbolt.DB) error {
 	return s.markFlag(db, activationKeyFirstRetrieveToolsCallEver)
+}
+
+func (s bboltActivationStore) MarkFirstRealToolCall(db *bbolt.DB) error {
+	return s.markFlag(db, activationKeyFirstRealToolCallEver)
 }
 
 // --- MCP client list ---

--- a/internal/telemetry/launch_source.go
+++ b/internal/telemetry/launch_source.go
@@ -68,17 +68,27 @@ type PPIDChecker interface {
 // DetectLaunchSource is the pure classifier implementing the precedence
 // rules from research.md R3:
 //  1. MCPPROXY_LAUNCHED_BY=installer env var → installer
-//  2. handshake.LaunchedViaTray() → tray
+//  2. MCPPROXY_LAUNCHED_BY=tray env var, or handshake.LaunchedViaTray() → tray
 //  3. ppid.IsLoginItemParent() → login_item
 //  4. tty.IsTerminal() → cli
 //  5. fallthrough → unknown
+//
+// An unrecognised MCPPROXY_LAUNCHED_BY value is ignored rather than trusted, so
+// a stray env var cannot hijack classification.
 //
 // All parameters are nil-safe: a nil HandshakeChecker / PPIDChecker / TTYChecker
 // simply contributes "false" to its respective branch.
 func DetectLaunchSource(env map[string]string, handshake HandshakeChecker, ppid PPIDChecker, tty TTYChecker) LaunchSource {
 	if env != nil {
-		if v, ok := env["MCPPROXY_LAUNCHED_BY"]; ok && v == "installer" {
+		switch env["MCPPROXY_LAUNCHED_BY"] {
+		case "installer":
 			return LaunchSourceInstaller
+		case "tray":
+			// Both trays stamp this on the core they spawn. Without it a
+			// tray-spawned core is unclassifiable: its parent is the tray app
+			// (not launchd, so not login_item) and it has no TTY (so not cli),
+			// leaving it "unknown".
+			return LaunchSourceTray
 		}
 	}
 	if handshake != nil && handshake.LaunchedViaTray() {
@@ -132,10 +142,12 @@ func DetectLaunchSourceOnce() LaunchSource {
 	return launchSourceCached
 }
 
-// defaultHandshakeChecker is the production HandshakeChecker. Until
-// tray→core handshake wiring lands, this always returns false; the actual
-// tray-mediated launch is still correctly classified because launch_source
-// is then "installer" (first run) or "login_item" (subsequent).
+// defaultHandshakeChecker is the production HandshakeChecker. It always returns
+// false: there is no tray→core socket handshake yet, and tray launches are
+// instead signalled by MCPPROXY_LAUNCHED_BY=tray, handled in DetectLaunchSource.
+//
+// The interface is kept for the eventual socket handshake, which can classify a
+// core the tray *adopted* rather than spawned (and which no env var can reach).
 type defaultHandshakeChecker struct{}
 
 func (defaultHandshakeChecker) LaunchedViaTray() bool { return false }

--- a/internal/telemetry/launch_source_test.go
+++ b/internal/telemetry/launch_source_test.go
@@ -49,6 +49,38 @@ func TestDetectLaunchSource_DecisionTree(t *testing.T) {
 			want:      LaunchSourceTray,
 		},
 		{
+			// The real macOS path: the tray spawns the core as a child, so the
+			// core's parent is the tray app (not launchd) and it has no TTY.
+			// Without an explicit signal it fell through to "unknown" — the
+			// cause of the 79%-unknown launch_source. The tray now stamps
+			// MCPPROXY_LAUNCHED_BY=tray on the core it spawns.
+			name:      "MCPPROXY_LAUNCHED_BY=tray maps to tray",
+			env:       map[string]string{"MCPPROXY_LAUNCHED_BY": "tray"},
+			handshake: fakeHandshake{},
+			ppid:      fakePPID{},
+			tty:       fakeTTY(false),
+			want:      LaunchSourceTray,
+		},
+		{
+			// First run after the DMG install: the installer launches the tray
+			// with MCPPROXY_LAUNCHED_BY=installer, and the tray must not
+			// overwrite it when spawning the core.
+			name:      "installer env still wins over a tray env",
+			env:       map[string]string{"MCPPROXY_LAUNCHED_BY": "installer"},
+			handshake: fakeHandshake{},
+			ppid:      fakePPID{},
+			tty:       fakeTTY(false),
+			want:      LaunchSourceInstaller,
+		},
+		{
+			name:      "unrecognised MCPPROXY_LAUNCHED_BY does not hijack detection",
+			env:       map[string]string{"MCPPROXY_LAUNCHED_BY": "banana"},
+			handshake: fakeHandshake{},
+			ppid:      fakePPID{isLaunchdLoginItem: true},
+			tty:       fakeTTY(false),
+			want:      LaunchSourceLoginItem,
+		},
+		{
 			name:      "ppid-is-launchd maps to login_item",
 			env:       map[string]string{},
 			handshake: fakeHandshake{},
@@ -97,8 +129,10 @@ func TestDetectLaunchSource_DecisionTree(t *testing.T) {
 			want:      LaunchSourceUnknown,
 		},
 		{
-			name:      "installer env with non-installer value is ignored",
-			env:       map[string]string{"MCPPROXY_LAUNCHED_BY": "tray"},
+			// "tray" used to be ignored here; it is now a recognised value (see
+			// the tray cases above). An UNRECOGNISED value is still ignored.
+			name:      "unrecognised MCPPROXY_LAUNCHED_BY value is ignored",
+			env:       map[string]string{"MCPPROXY_LAUNCHED_BY": "somethingelse"},
 			handshake: fakeHandshake{},
 			ppid:      fakePPID{},
 			tty:       fakeTTY(true),

--- a/native/macos/MCPProxy/MCPProxy/Core/CoreProcessManager.swift
+++ b/native/macos/MCPProxy/MCPProxy/Core/CoreProcessManager.swift
@@ -333,6 +333,17 @@ actor CoreProcessManager {
         // explicitly opened the GUI app, so OS prompts are expected.
         // See issue #409 / internal/secret/keyring_provider.go.
         env["MCPPROXY_KEYRING_WRITE"] = "1"
+        // Tell the core it was launched by the tray, so telemetry's launch_source
+        // can say so. Without this a tray-spawned core is unclassifiable: its
+        // parent is this app (not launchd, so not login_item) and it has no TTY
+        // (so not cli), leaving launch_source "unknown".
+        //
+        // The DMG installer launches this app with MCPPROXY_LAUNCHED_BY=installer
+        // (packaging/macos/postinstall.sh); that first-run attribution outranks
+        // "tray", so do not overwrite it.
+        if env["MCPPROXY_LAUNCHED_BY"] != "installer" {
+            env["MCPPROXY_LAUNCHED_BY"] = "tray"
+        }
         proc.environment = env
 
         // Capture stderr for error diagnostics

--- a/roadmap.yaml
+++ b/roadmap.yaml
@@ -370,7 +370,7 @@ epics:
     status: in_progress
     priority: P1
     depends_on: []
-    note: "Heartbeat lacks a stable identity, so active-install counts are inflated by CI/dev churn and launch_source is 79% unknown. Add a hashed machine_id (schema v6) and harden the worker/dashboard cohort filters. Spans repos mcpproxy-go (client), mcpproxy-telemetry (worker), mcpproxy-dash (dashboard)."
+    note: "2026-07-11 source audit: the CLIENT half is DONE and RELEASED — the old framing ('add a hashed machine_id (schema v6)') is stale. machine_id (HMAC-SHA256 of the OS machine id, internal/telemetry/machine_id.go) is emitted unconditionally in every heartbeat (telemetry.go:789; telemetry is opt-out) and shipped in v0.47.0; the client schema is already v7, a version past the v6 this note described; CI is filtered client-side by disabling telemetry outright (env_overrides.go). Worker verified live in prod 2026-07-07 (machine_id 100% populated). The audit also found that the 79%-unknown launch_source was a CLIENT bug misfiled to mcpproxy-dash — a dashboard cannot display a value the client is incapable of sending. That is now fixed (see telemetry-launchsource-tray). Remaining: dashboard consumption (mcpproxy-dash) + snapshot-cron alerting."
     tasks:
       - id: telemetry-machineid-client
         title: "Hashed machine_id in heartbeat (schema v6)"
@@ -383,10 +383,17 @@ epics:
         pr: "mcpproxy-telemetry#3"
         note: "Verified LIVE in prod 2026-07-07: remote D1 migration 0006 applied, worker deployed 2026-07-03 (right after 53811ed), v7 heartbeats populating machine_id 100% (64-char HMAC hex, distinct installs), vitest 129/129. No further worker work needed; dashboard consumption is the remaining child."
         depends_on: [telemetry-machineid-client]
+      - id: telemetry-launchsource-tray
+        title: "Emit launch_source=tray — the 'tray' value was UNREACHABLE in the client, and that (not the dashboard) was the 79%-unknown root cause"
+        status: done
+        priority: P1
+        note: "FIXED 2026-07-11. Was: defaultHandshakeChecker.LaunchedViaTray() hardcoded `return false` and neither tray told the core it had spawned it, so a tray-spawned core (parent = the tray app, not launchd -> not login_item; no TTY -> not cli) fell through to 'unknown'. Now both trays (Swift CoreProcessManager.swift + Go buildCoreEnvironment) stamp MCPPROXY_LAUNCHED_BY=tray on the core they spawn, and DetectLaunchSource honours it. MCPPROXY_LAUNCHED_BY=installer still outranks it, so first-run attribution is unchanged; unrecognised values are ignored. NOTE for the dash: 'unknown' counts before/after this fix are NOT comparable — segment by version."
+        depends_on: []
       - id: telemetry-machineid-dash
-        title: "Dashboard identityExpr prefers machine_id; exclude %-dev versions from human cohort; fix launch_source 79% unknown (repo mcpproxy-dash)"
+        title: "Dashboard identityExpr prefers machine_id; exclude %-dev versions from human cohort (repo mcpproxy-dash)"
         status: todo
-        depends_on: [telemetry-machineid-worker]
+        note: "'fix launch_source 79% unknown' was REMOVED from this task on 2026-07-11 and moved to telemetry-launchsource-tray — it was a mcpproxy-go client bug, not a dashboard one."
+        depends_on: [telemetry-machineid-worker, telemetry-launchsource-tray]
       - id: telemetry-snapshot-alerting
         title: "Alerting on external-downloads snapshot cron (34-day outage went unnoticed)"
         status: todo
@@ -426,10 +433,10 @@ epics:
   - id: telemetry-v7-churn
     title: "Telemetry v7: honest funnel + churn instrumentation"
     status: in_progress
-    priority: P0
+    priority: P1
     spec: specs/080-telemetry-v7-churn
     depends_on: []
-    note: "2026-07-06 recheck DEBUNKED the 72.4% connect-skip story: genuine never-connected skip = 0% (wizard dismiss stamped 'skipped' on users who connected via ConnectModal/CLI/manual config). 2026-07-10 recheck debunked the OTHER two spec-080 headline metrics as well: 'day-2 return 17.7%' was un-deduped anonymous_id churn (true, identity-deduped: one-and-done 48%, day-1 return 31%, day-7 16.6% — matches dashboard); '42% retrieve_tools -> 16% real call' was lifetime-flag vs windowed-counter asymmetry (true conversion ~90%; missing piece is a first_real_tool_call_ever activation flag). Real cliff = 48% one-and-done. v7 = wizard metric fix, funnel observability, pre-churn snapshot. Client-side T1-T3 SHIPPED in #813 (v0.47.0, 2026-07-07); only cross-repo churn analytics (T4) remains and needs stable identity (see telemetry-identity)."
+    note: "2026-07-06 recheck DEBUNKED the 72.4% connect-skip story: genuine never-connected skip = 0% (wizard dismiss stamped 'skipped' on users who connected via ConnectModal/CLI/manual config). 2026-07-10 recheck debunked the OTHER two spec-080 headline metrics as well: 'day-2 return 17.7%' was un-deduped anonymous_id churn (true, identity-deduped: one-and-done 48%, day-1 return 31%, day-7 16.6% — matches dashboard); '42% retrieve_tools -> 16% real call' was lifetime-flag vs windowed-counter asymmetry (true conversion ~90%; missing piece is a first_real_tool_call_ever activation flag). Real cliff = 48% one-and-done. 2026-07-11 source audit + fix: ALL of spec 080 is shipped and released in v0.47.0 (#813) — T1 wizard completed_external, T2 funnel fields, T3 pre-churn snapshot, US4 schema v7. The previous note claimed 'only cross-repo churn analytics (T4) remains'; that was WRONG — first_real_tool_call_ever had ZERO occurrences in Go code and was in-repo CLIENT work. It is now implemented, so the retrieve->call funnel is finally measurable lifetime-vs-lifetime. P0->P1: only cross-repo T4 now remains."
     tasks:
       - id: telemetry-v7-wizard-fix
         title: "T1: wizard metric fix - on dismiss record connect step as completed_external (not skipped) when the user already connected via another path"
@@ -448,9 +455,9 @@ epics:
         depends_on: []
       - id: telemetry-v7-realcall-flag
         title: "first_real_tool_call_ever activation flag (symmetric to first_retrieve_tools_call_ever) so the retrieve->call funnel step is measurable lifetime-vs-lifetime"
-        status: todo
+        status: done
         priority: P1
-        note: "Root cause of the debunked 42%->16% cliff: retrieve step had a lifetime BBolt flag, real-call step only windowed per-day counters. Stamp from handleCallToolVariant (internal/server/mcp.go:1558, same path as RecordUpstreamTool); pure boolean in the activation bucket, additive to schema."
+        note: "Root cause of the debunked 42%->16% cliff: retrieve step had a lifetime BBolt flag, real-call step only windowed per-day counters. DONE 2026-07-11: activationKeyFirstRealToolCallEver + ActivationState.FirstRealToolCallEver + MarkFirstRealToolCall (internal/telemetry/activation.go), stamped from recordUpstreamTool (internal/server/mcp.go) — the shared entry point every call_tool_* variant already runs. Additive boolean in the activation bucket, no schema bump. Tested that retrieve_tools does NOT set it (builtin, not an upstream call)."
         depends_on: []
       - id: telemetry-v7-churn-events
         title: "T4: cross-repo churn_events materialization + dash Churn page with H1-H4 hypothesis signatures (repos mcpproxy-telemetry / mcpproxy-dash; tracked here for DAG visibility, out of scope of spec 080)"


### PR DESCRIPTION
Two **client-side** telemetry data-quality defects, found by a source-of-truth audit of the telemetry roadmap epics. Both were believed shipped. Neither was.

---

## 1. `launch_source` could never be `tray` — the cause of the 79% `unknown`

`defaultHandshakeChecker.LaunchedViaTray()` hardcoded `return false`, and neither tray told the core it had spawned it.

A tray-spawned core:
- has the **tray app** as its parent — not `launchd`, so **not** `login_item`
- has **no TTY** — so **not** `cli`

…and therefore fell through to **`unknown`**.

The in-code comment claimed the fallback still classified tray launches as `installer` (first run) or `login_item` (subsequent). **It does not** — which is precisely why `launch_source` is ~79% `unknown` on the flagship macOS path. The empirical 79% is the smoking gun that the documented fallback never worked.

**Fix:** both trays (Swift `CoreProcessManager`, Go `buildCoreEnvironment`) now stamp `MCPPROXY_LAUNCHED_BY=tray` on the core they spawn, and `DetectLaunchSource` honours it.

- `MCPPROXY_LAUNCHED_BY=installer` still **outranks** `tray`, so DMG first-run attribution is unchanged (the tray inherits it via `os.Environ()` and must not overwrite it — tested).
- An **unrecognised** value is ignored rather than trusted, so a stray env var can't hijack classification.

> ### This was filed against the wrong repo
> The roadmap had "fix launch_source 79% unknown" as a **mcpproxy-dash** task. It is a client bug: **no dashboard can display a value the client is incapable of sending.** Moved to a mcpproxy-go task and fixed here.

## 2. `first_real_tool_call_ever` did not exist

The retrieve step had a **lifetime** BBolt flag (`first_retrieve_tools_call_ever`); the real-call step had only a **24h windowed** counter. So the retrieve→call funnel compared a lifetime value against a windowed one — the asymmetry that produced the bogus **"42% search → 16% call"** cliff.

Adds the symmetric lifetime flag to the activation bucket, stamped from `recordUpstreamTool()` — the shared entry point every `call_tool_read` / `call_tool_write` / `call_tool_destructive` variant already runs.

Built-in tools such as `retrieve_tools` **do not** set it (otherwise the funnel would report 100% conversion for anyone who ever searched). There's a test asserting exactly that.

Additive boolean inside an existing nested block → **no schema bump**.

---

## Test plan

- `go test ./internal/telemetry/ ./internal/runtime/ ./internal/server/` — pass
- `golangci-lint run --config .github/.golangci.yml` on all touched packages — **0 issues**
- launch_source: new table cases for `=tray`, for `installer` still winning, and for an unrecognised value being ignored. **Confirmed the `=tray` case failed before the fix.**
  - One pre-existing case (`"installer env with non-installer value is ignored"`, which asserted `tray` is ignored) encoded the **old** contract and was updated — it's the behavior this PR deliberately changes.
- activation: new integration test proving a real call sets the flag, that it's monotonic, and that `retrieve_tools` does **not** set it
- **Verified the new field actually reaches the serialized payload**, not merely that it compiles — the audit's own lesson is that code which exists but is never emitted hasn't shipped

## For dashboard consumers

`unknown` `launch_source` counts **before and after this change are not comparable** — segment by version. Documented in `docs/features/telemetry.md`.

Roadmap: closes `telemetry-v7-realcall-flag` and the new `telemetry-launchsource-tray`; corrects the `telemetry-v7-churn` note (which wrongly claimed only cross-repo work remained) and the stale "schema v6" framing on `telemetry-identity`.