### PR TITLE
feat(webui): meaningful session names in the Activity Log + link the Sessions page

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -333,6 +333,7 @@ graph LR
 
 ```mermaid
 graph LR
+  sessions_web_ui["Sessions in the Web UI: meaningful session na…"]
   action_log_glance_view["At-a-glance action log view (top signals, hea…"]
   action_log_tray_menu["Activity in the tray menu (recent tool calls…"]
   tray_menu_open_telemetry["tray_menu_opened counter: Swift menuWillOpen…"]
@@ -341,12 +342,15 @@ graph LR
   action_log_glance_view --> action_log_tray_menu
   action_log_glance_view --> action_log_retention_tie_in
 
+  classDef done fill:#1f7a1f,stroke:#0d3d0d,color:#ffffff;
   classDef todo fill:#6e7781,stroke:#3d4248,color:#ffffff;
+  class sessions_web_ui done;
   class action_log_glance_view,action_log_tray_menu,tray_menu_open_telemetry,action_log_retention_tie_in todo;
 ```
 
 | Task | Status | Refs |
 | --- | --- | --- |
+| Sessions in the Web UI: meaningful session names in the Activity Log filter + the existing /sessions page linked in the sidebar | 🟢 Done | — |
 | At-a-glance action log view (top signals, health) | ⚪ Todo | — |
 | Activity in the tray menu (recent tool calls + security events, jump to full log) | ⚪ Todo | — |
 | tray_menu_opened counter: Swift menuWillOpen (MCPProxyApp.swift:192) -> lightweight POST /api/v1/telemetry/tray-menu-opened -> registry counter -> heartbeat tray_menu_opened_24h | ⚪ Todo | — |

--- a/frontend/src/components/SidebarNav.vue
+++ b/frontend/src/components/SidebarNav.vue
@@ -265,6 +265,18 @@
             </li>
             <li>
               <router-link
+                to="/sessions"
+                :class="{ 'active': isActiveRoute('/sessions') }"
+                class="rounded-lg font-medium"
+                :title="collapsed ? 'Sessions' : ''"
+                data-test="sidebar-sessions"
+              >
+                <IconSessions class="w-5 h-5 shrink-0" />
+                <span v-show="!collapsed">Sessions</span>
+              </router-link>
+            </li>
+            <li>
+              <router-link
                 to="/activity"
                 :class="{ 'active': isActiveRoute('/activity') }"
                 class="rounded-lg font-medium"
@@ -541,6 +553,10 @@ const IconTokens = makeIcon(
 )
 const IconActivity = makeIcon(
   'M4 12h3l3-8 4 16 3-8h3'
+)
+// Two chat bubbles — a session is one AI client's conversation with the proxy.
+const IconSessions = makeIcon(
+  'M8 10h8M8 14h5M4 5a1 1 0 011-1h14a1 1 0 011 1v10a1 1 0 01-1 1H9l-5 4V5z'
 )
 const IconShield = makeIcon(
   'M12 3l8 3v6c0 5-3.5 8.5-8 9-4.5-.5-8-4-8-9V6l8-3zm-3 9l2 2 4-4'

--- a/frontend/src/utils/sessionLabel.ts
+++ b/frontend/src/utils/sessionLabel.ts
@@ -24,22 +24,41 @@ const KNOWN_CLIENTS: Array<[needle: string, display: string]> = [
 ]
 
 /**
+ * Max rendered length of an unrecognised client name.
+ *
+ * `clientInfo.name` is attacker-controllable: any MCP client can send an
+ * arbitrary string at initialize and the core stores it verbatim. Vue escapes it
+ * on render, so there is no XSS — but an unbounded name would still be dumped
+ * into a `<select>` option and blow out the filter layout. Bound it.
+ */
+const MAX_CLIENT_NAME = 32
+
+/** Shortest id suffix we ever show. Grows on demand to stay unique. */
+const MIN_SUFFIX = 5
+
+/**
  * Map a raw MCP clientInfo.name to a display name. Unknown clients are shown
- * verbatim — a name we don't recognise is still far better than a hash.
+ * verbatim but length-bounded — a name we don't recognise is still far better
+ * than a hash.
  */
 export function prettyClientName(raw?: string): string {
   const name = (raw ?? '').trim()
   if (!name) return ''
+
   const lower = name.toLowerCase()
   for (const [needle, display] of KNOWN_CLIENTS) {
     if (lower.includes(needle)) return display
   }
-  return name
+
+  // Unrecognised, and therefore untrusted: collapse whitespace (a newline would
+  // break the option label) and truncate.
+  const flat = name.replace(/\s+/g, ' ')
+  return flat.length > MAX_CLIENT_NAME ? `${flat.slice(0, MAX_CLIENT_NAME - 1)}…` : flat
 }
 
-/** Last 5 chars of a session id — the legacy label, now only ever a fallback. */
-export function sessionIdSuffix(sessionId: string): string {
-  return sessionId.slice(-5)
+/** Last `len` chars of a session id. */
+export function sessionIdSuffix(sessionId: string, len: number = MIN_SUFFIX): string {
+  return sessionId.slice(-len)
 }
 
 function clockTime(iso?: string): string {
@@ -55,11 +74,14 @@ export interface SessionLabelInput {
   clientName?: string
   /** ISO start time, used to tell two sessions of the same client apart. */
   startTime?: string
-  /**
-   * True when another session in the same list would render an identical label.
-   * Callers compute this across the whole list; we then disambiguate with the id.
-   */
-  ambiguous?: boolean
+}
+
+/** The label with no disambiguating suffix. "" when there is no client name. */
+function baseLabel(input: SessionLabelInput): string {
+  const pretty = prettyClientName(input.clientName)
+  if (!pretty) return '' // no client name → the id is all we have
+  const time = clockTime(input.startTime)
+  return time ? `${pretty} · ${time}` : pretty
 }
 
 /**
@@ -67,38 +89,71 @@ export interface SessionLabelInput {
  *
  *   "Claude Code · 14:32"          — the common case
  *   "Claude Code · 14:32 (139c9)"  — two Claude Code sessions started the same minute
- *   "...139c9"                     — no clientInfo (pre-initialize or a stale session)
+ *   "...139c9"                     — no clientInfo (pre-initialize, or an evicted session)
+ *
+ * `suffixLen` is chosen by buildSessionLabels so the suffix is long enough to
+ * actually disambiguate — a fixed-width suffix can itself collide.
  */
-export function formatSessionLabel(input: SessionLabelInput): string {
-  const pretty = prettyClientName(input.clientName)
-  if (!pretty) {
-    // Unchanged legacy behaviour: without a client name there is nothing better to show.
-    return `...${sessionIdSuffix(input.sessionId)}`
-  }
+export function formatSessionLabel(
+  input: SessionLabelInput,
+  opts: { ambiguous?: boolean; suffixLen?: number } = {}
+): string {
+  const len = opts.suffixLen ?? MIN_SUFFIX
+  const base = baseLabel(input)
 
-  const time = clockTime(input.startTime)
-  const base = time ? `${pretty} · ${time}` : pretty
-  return input.ambiguous ? `${base} (${sessionIdSuffix(input.sessionId)})` : base
+  // No client name: the id suffix IS the label (unchanged legacy behaviour).
+  if (!base) return `...${sessionIdSuffix(input.sessionId, len)}`
+
+  return opts.ambiguous ? `${base} (${sessionIdSuffix(input.sessionId, len)})` : base
 }
 
 /**
- * Label a whole list at once, resolving collisions so no two sessions share a
- * label. Returns a Map keyed by session id.
+ * Shortest suffix length that tells every id in `ids` apart.
+ *
+ * A fixed 5-char suffix is NOT guaranteed unique — two ids can share their last
+ * five characters — so grow it until the ids are distinguished, falling back to
+ * the longest id. Session ids are unique, so this always terminates.
  */
-export function buildSessionLabels(
-  sessions: Array<Omit<SessionLabelInput, 'ambiguous'>>
-): Map<string, string> {
-  const counts = new Map<string, number>()
+function uniqueSuffixLen(ids: string[]): number {
+  const maxLen = Math.max(...ids.map(id => id.length))
+  for (let len = MIN_SUFFIX; len < maxLen; len++) {
+    if (new Set(ids.map(id => id.slice(-len))).size === ids.length) return len
+  }
+  return maxLen
+}
+
+/**
+ * Label a whole list at once, resolving collisions so no two sessions ever share
+ * a label. Returns a Map keyed by session id.
+ */
+export function buildSessionLabels(sessions: SessionLabelInput[]): Map<string, string> {
+  // Group by the label they would get with no disambiguation. Sessions with no
+  // client name all share the "" group: their label is the id suffix, which must
+  // be unique among themselves too.
+  const groups = new Map<string, SessionLabelInput[]>()
   for (const s of sessions) {
-    const provisional = formatSessionLabel(s)
-    counts.set(provisional, (counts.get(provisional) ?? 0) + 1)
+    const key = baseLabel(s)
+    const group = groups.get(key)
+    if (group) group.push(s)
+    else groups.set(key, [s])
   }
 
   const labels = new Map<string, string>()
-  for (const s of sessions) {
-    const provisional = formatSessionLabel(s)
-    const ambiguous = (counts.get(provisional) ?? 0) > 1
-    labels.set(s.sessionId, formatSessionLabel({ ...s, ambiguous }))
+  for (const [key, group] of groups) {
+    const named = key !== ''
+
+    // A named session alone in its group needs no suffix at all.
+    if (named && group.length === 1) {
+      labels.set(group[0].sessionId, formatSessionLabel(group[0]))
+      continue
+    }
+
+    // Otherwise every member gets a suffix, long enough to be unique within the
+    // group. (Unnamed sessions always carry one — it is their whole label.)
+    const suffixLen = group.length > 1 ? uniqueSuffixLen(group.map(s => s.sessionId)) : MIN_SUFFIX
+    for (const s of group) {
+      labels.set(s.sessionId, formatSessionLabel(s, { ambiguous: named, suffixLen }))
+    }
   }
   return labels
 }

--- a/frontend/src/utils/sessionLabel.ts
+++ b/frontend/src/utils/sessionLabel.ts
@@ -1,0 +1,104 @@
+/**
+ * Human-meaningful labels for MCP sessions.
+ *
+ * A session is one AI client's conversation with the proxy. The raw session id
+ * is an opaque uuid, so surfacing it (`...139c9`) tells the user nothing. The
+ * MCP `initialize` handshake already gives us `clientInfo.name`, which the core
+ * persists on the session record and serves on `GET /api/v1/sessions` — that is
+ * the name we show.
+ *
+ * Display names mirror the macOS tray (DashboardView.swift `connectedClientNames`)
+ * so the two surfaces agree on what a client is called.
+ */
+
+/** Known clients, matched case-insensitively as substrings of clientInfo.name. */
+const KNOWN_CLIENTS: Array<[needle: string, display: string]> = [
+  ['claude', 'Claude Code'],
+  ['cursor', 'Cursor'],
+  ['vscode', 'VS Code'],
+  ['copilot', 'VS Code'],
+  ['codex', 'Codex'],
+  ['gemini', 'Gemini'],
+  ['antigravity', 'Antigravity'],
+  ['windsurf', 'Windsurf'],
+]
+
+/**
+ * Map a raw MCP clientInfo.name to a display name. Unknown clients are shown
+ * verbatim — a name we don't recognise is still far better than a hash.
+ */
+export function prettyClientName(raw?: string): string {
+  const name = (raw ?? '').trim()
+  if (!name) return ''
+  const lower = name.toLowerCase()
+  for (const [needle, display] of KNOWN_CLIENTS) {
+    if (lower.includes(needle)) return display
+  }
+  return name
+}
+
+/** Last 5 chars of a session id — the legacy label, now only ever a fallback. */
+export function sessionIdSuffix(sessionId: string): string {
+  return sessionId.slice(-5)
+}
+
+function clockTime(iso?: string): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+}
+
+export interface SessionLabelInput {
+  sessionId: string
+  /** Raw clientInfo.name, e.g. "claude-code". Absent for sessions we never saw initialize. */
+  clientName?: string
+  /** ISO start time, used to tell two sessions of the same client apart. */
+  startTime?: string
+  /**
+   * True when another session in the same list would render an identical label.
+   * Callers compute this across the whole list; we then disambiguate with the id.
+   */
+  ambiguous?: boolean
+}
+
+/**
+ * Build the label shown in the Activity Log session filter.
+ *
+ *   "Claude Code · 14:32"          — the common case
+ *   "Claude Code · 14:32 (139c9)"  — two Claude Code sessions started the same minute
+ *   "...139c9"                     — no clientInfo (pre-initialize or a stale session)
+ */
+export function formatSessionLabel(input: SessionLabelInput): string {
+  const pretty = prettyClientName(input.clientName)
+  if (!pretty) {
+    // Unchanged legacy behaviour: without a client name there is nothing better to show.
+    return `...${sessionIdSuffix(input.sessionId)}`
+  }
+
+  const time = clockTime(input.startTime)
+  const base = time ? `${pretty} · ${time}` : pretty
+  return input.ambiguous ? `${base} (${sessionIdSuffix(input.sessionId)})` : base
+}
+
+/**
+ * Label a whole list at once, resolving collisions so no two sessions share a
+ * label. Returns a Map keyed by session id.
+ */
+export function buildSessionLabels(
+  sessions: Array<Omit<SessionLabelInput, 'ambiguous'>>
+): Map<string, string> {
+  const counts = new Map<string, number>()
+  for (const s of sessions) {
+    const provisional = formatSessionLabel(s)
+    counts.set(provisional, (counts.get(provisional) ?? 0) + 1)
+  }
+
+  const labels = new Map<string, string>()
+  for (const s of sessions) {
+    const provisional = formatSessionLabel(s)
+    const ambiguous = (counts.get(provisional) ?? 0) > 1
+    labels.set(s.sessionId, formatSessionLabel({ ...s, ambiguous }))
+  }
+  return labels
+}

--- a/frontend/src/views/Activity.vue
+++ b/frontend/src/views/Activity.vue
@@ -694,6 +694,7 @@ import { useRoute } from 'vue-router'
 import { useSystemStore } from '@/stores/system'
 import api from '@/services/api'
 import type { ActivityRecord, ActivitySummaryResponse } from '@/types/api'
+import { buildSessionLabels } from '@/utils/sessionLabel'
 import JsonViewer from '@/components/JsonViewer.vue'
 
 const route = useRoute()
@@ -766,27 +767,58 @@ interface SessionOption {
   id: string
   label: string
   clientName?: string
+  startTime?: string
 }
+
+// Client identity lives on the session record, not the activity record — an
+// activity row only carries session_id. We join the two here so the filter can
+// show "Claude Code · 14:32" instead of an opaque "...139c9".
+const sessionInfo = ref(new Map<string, { clientName?: string; startTime?: string }>())
+
+const loadSessions = async () => {
+  try {
+    const response = await api.getSessions(100)
+    const next = new Map<string, { clientName?: string; startTime?: string }>()
+    for (const s of response.data?.sessions ?? []) {
+      next.set(s.id, { clientName: s.client_name, startTime: s.start_time })
+    }
+    sessionInfo.value = next
+  } catch {
+    // Non-fatal: without session metadata the filter degrades to id suffixes,
+    // which is exactly the previous behaviour. Never block the activity log.
+  }
+}
+
 const availableSessions = computed((): SessionOption[] => {
-  const sessionsMap = new Map<string, { clientName?: string }>()
+  const seen = new Map<string, { clientName?: string; startTime?: string }>()
   activities.value.forEach(a => {
-    if (a.session_id && !sessionsMap.has(a.session_id)) {
-      // Try to get client name from metadata or any available source
-      const clientName = a.metadata?.client_name as string | undefined
-      sessionsMap.set(a.session_id, { clientName })
+    if (a.session_id && !seen.has(a.session_id)) {
+      const info = sessionInfo.value.get(a.session_id)
+      seen.set(a.session_id, {
+        // Prefer the session record; fall back to metadata for records that
+        // carry it, then to nothing (→ id suffix).
+        clientName: info?.clientName ?? (a.metadata?.client_name as string | undefined),
+        startTime: info?.startTime ?? a.timestamp,
+      })
     }
   })
 
-  return Array.from(sessionsMap.entries())
-    .map(([sessionId, info]) => {
-      // Format: "ClientName ...12345" or "...12345" if no client name
-      const suffix = sessionId.slice(-5)
-      const label = info.clientName
-        ? `${info.clientName} ...${suffix}`
-        : `...${suffix}`
-      return { id: sessionId, label, clientName: info.clientName }
-    })
-    .sort((a, b) => a.label.localeCompare(b.label))
+  const entries = Array.from(seen.entries()).map(([sessionId, info]) => ({
+    sessionId,
+    clientName: info.clientName,
+    startTime: info.startTime,
+  }))
+  const labels = buildSessionLabels(entries)
+
+  return entries
+    .map(e => ({
+      id: e.sessionId,
+      label: labels.get(e.sessionId) ?? `...${e.sessionId.slice(-5)}`,
+      clientName: e.clientName,
+      startTime: e.startTime,
+    }))
+    // Most recent session first — in a session picker, recency beats alphabet.
+    .sort((a, b) => (b.startTime ?? '').localeCompare(a.startTime ?? ''))
 })
 
 // Get session label by ID for display in Active Filters
@@ -1191,6 +1223,7 @@ onMounted(() => {
   }
 
   loadActivities()
+  loadSessions()
 
   // Listen for SSE activity events
   window.addEventListener('mcpproxy:activity', handleActivityEvent as EventListener)

--- a/frontend/src/views/Activity.vue
+++ b/frontend/src/views/Activity.vue
@@ -775,18 +775,58 @@ interface SessionOption {
 // show "Claude Code · 14:32" instead of an opaque "...139c9".
 const sessionInfo = ref(new Map<string, { clientName?: string; startTime?: string }>())
 
+// Session ids we have already tried and failed to resolve. The core keeps only
+// the 100 most recent sessions, so an old session's activity rows can outlive
+// its record and never become resolvable. Without this set, every refresh would
+// see them as "unknown" and refetch forever.
+const unresolvableSessions = ref(new Set<string>())
+
+let sessionsInFlight: Promise<void> | null = null
+
 const loadSessions = async () => {
-  try {
-    const response = await api.getSessions(100)
-    const next = new Map<string, { clientName?: string; startTime?: string }>()
-    for (const s of response.data?.sessions ?? []) {
-      next.set(s.id, { clientName: s.client_name, startTime: s.start_time })
+  // Coalesce: a burst of SSE events must not fan out into N parallel fetches.
+  if (sessionsInFlight) return sessionsInFlight
+
+  sessionsInFlight = (async () => {
+    try {
+      const response = await api.getSessions(100)
+      const next = new Map<string, { clientName?: string; startTime?: string }>()
+      for (const s of response.data?.sessions ?? []) {
+        next.set(s.id, { clientName: s.client_name, startTime: s.start_time })
+      }
+      sessionInfo.value = next
+
+      // Anything still unknown after a fresh fetch is gone for good (evicted by
+      // the 100-session cap). Remember it so we stop asking.
+      for (const a of activities.value) {
+        if (a.session_id && !next.has(a.session_id)) {
+          unresolvableSessions.value.add(a.session_id)
+        }
+      }
+    } catch {
+      // Non-fatal: without session metadata the filter degrades to id suffixes,
+      // which is exactly the previous behaviour. Never block the activity log.
+      // Deliberately NOT marked unresolvable — a transient failure should be
+      // retried the next time an unknown session shows up.
+    } finally {
+      sessionsInFlight = null
     }
-    sessionInfo.value = next
-  } catch {
-    // Non-fatal: without session metadata the filter degrades to id suffixes,
-    // which is exactly the previous behaviour. Never block the activity log.
-  }
+  })()
+
+  return sessionsInFlight
+}
+
+// The Activity Log is a live page: a client can connect while it is open, and
+// SSE will deliver its rows. Those sessions were not in the map we fetched on
+// mount, so refresh the join whenever a genuinely new session id appears.
+const refreshSessionsIfUnknown = () => {
+  const hasUnknown = activities.value.some(
+    a =>
+      a.session_id &&
+      !sessionInfo.value.has(a.session_id) &&
+      !unresolvableSessions.value.has(a.session_id)
+  )
+  if (hasUnknown) void loadSessions()
 }
 
 const availableSessions = computed((): SessionOption[] => {
@@ -818,8 +858,19 @@ const availableSessions = computed((): SessionOption[] => {
       startTime: e.startTime,
     }))
     // Most recent session first — in a session picker, recency beats alphabet.
-    .sort((a, b) => (b.startTime ?? '').localeCompare(a.startTime ?? ''))
+    // Compare epoch ms, not the ISO strings: those carry a timezone offset
+    // ("...+03:00"), so lexical order is not chronological order across offsets.
+    // A missing or unparseable start time sorts last; id breaks ties so the
+    // order is stable rather than dependent on Map insertion.
+    .sort((a, b) => epochOf(b.startTime) - epochOf(a.startTime) || a.id.localeCompare(b.id))
 })
+
+/** Epoch ms for sorting; -Infinity for missing/unparseable, so it sorts last. */
+const epochOf = (iso?: string): number => {
+  if (!iso) return -Infinity
+  const t = new Date(iso).getTime()
+  return Number.isNaN(t) ? -Infinity : t
+}
 
 // Get session label by ID for display in Active Filters
 const getSessionLabel = (sessionId: string): string => {
@@ -1213,6 +1264,12 @@ const handleKeydown = (event: KeyboardEvent) => {
     closeDetailDrawer()
   }
 }
+
+// Keep the session join fresh no matter how activities arrived — polling,
+// manual refresh, or an SSE event for a client that connected just now. Watching
+// the list covers every mutation path; refreshSessionsIfUnknown is a no-op
+// unless a genuinely new session id showed up, and coalesces concurrent fetches.
+watch(activities, refreshSessionsIfUnknown)
 
 // Lifecycle
 onMounted(() => {

--- a/frontend/tests/unit/session-label.spec.ts
+++ b/frontend/tests/unit/session-label.spec.ts
@@ -42,12 +42,10 @@ describe('formatSessionLabel', () => {
   })
 
   it('disambiguates with the id suffix when the label would collide', () => {
-    const label = formatSessionLabel({
-      sessionId: 'abc-def-139c9',
-      clientName: 'claude-code',
-      startTime,
-      ambiguous: true,
-    })
+    const label = formatSessionLabel(
+      { sessionId: 'abc-def-139c9', clientName: 'claude-code', startTime },
+      { ambiguous: true }
+    )
     expect(label).toContain('Claude Code')
     expect(label).toContain('139c9')
   })
@@ -80,5 +78,62 @@ describe('buildSessionLabels', () => {
   it('keeps the hash fallback for sessions with no client name', () => {
     const labels = buildSessionLabels([{ sessionId: 'abc-def-139c9' }])
     expect(labels.get('abc-def-139c9')).toBe('...139c9')
+  })
+
+  // Regression: a fixed 5-char suffix is not guaranteed unique. Two same-client
+  // sessions started in the same minute whose ids END IN THE SAME 5 CHARACTERS
+  // used to produce byte-identical labels. Caught in cross-model review.
+  it('grows the suffix when the last 5 chars also collide', () => {
+    const labels = buildSessionLabels([
+      { sessionId: 'sess-a-12345', clientName: 'claude-code', startTime: '2026-07-11T14:32:00Z' },
+      { sessionId: 'sess-b-12345', clientName: 'claude-code', startTime: '2026-07-11T14:32:00Z' },
+    ])
+    const a = labels.get('sess-a-12345')!
+    const b = labels.get('sess-b-12345')!
+    expect(a).not.toBe(b)
+    expect(a).toContain('Claude Code')
+    expect(b).toContain('Claude Code')
+  })
+
+  // Same trap, on the no-client-name path: those labels are ONLY the id suffix.
+  it('grows the suffix for unnamed sessions sharing the last 5 chars', () => {
+    const labels = buildSessionLabels([
+      { sessionId: 'sess-a-12345' },
+      { sessionId: 'sess-b-12345' },
+    ])
+    expect(labels.get('sess-a-12345')).not.toBe(labels.get('sess-b-12345'))
+  })
+
+  it('never emits duplicate labels across a realistic mixed list', () => {
+    const labels = buildSessionLabels([
+      { sessionId: 's1-aaaaa', clientName: 'claude-code', startTime: '2026-07-11T14:32:00Z' },
+      { sessionId: 's2-aaaaa', clientName: 'claude-code', startTime: '2026-07-11T14:32:00Z' },
+      { sessionId: 's3-bbbbb', clientName: 'cursor', startTime: '2026-07-11T14:05:00Z' },
+      { sessionId: 's4-ccccc' },
+      { sessionId: 's5-ccccc' },
+    ])
+    const all = [...labels.values()]
+    expect(new Set(all).size).toBe(all.length)
+  })
+})
+
+describe('prettyClientName — untrusted input', () => {
+  // clientInfo.name is attacker-controllable: any MCP client can send anything
+  // at initialize and the core stores it verbatim. Vue escapes it (no XSS), but
+  // an unbounded name would still be dumped into a <select> option and wreck the
+  // filter layout. Caught in cross-model review.
+  it('bounds the length of an unrecognised client name', () => {
+    const hostile = 'A'.repeat(10_000)
+    const out = prettyClientName(hostile)
+    expect(out.length).toBeLessThanOrEqual(32)
+    expect(out.endsWith('…')).toBe(true)
+  })
+
+  it('collapses newlines and tabs that would break the option label', () => {
+    expect(prettyClientName('evil\n\nname\twith\nbreaks')).toBe('evil name with breaks')
+  })
+
+  it('does not truncate recognised clients (they map to a short display name)', () => {
+    expect(prettyClientName('claude-code-' + 'x'.repeat(500))).toBe('Claude Code')
   })
 })

--- a/frontend/tests/unit/session-label.spec.ts
+++ b/frontend/tests/unit/session-label.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import {
+  prettyClientName,
+  formatSessionLabel,
+  buildSessionLabels,
+} from '@/utils/sessionLabel'
+
+describe('prettyClientName', () => {
+  it('maps known clients to their display names', () => {
+    expect(prettyClientName('claude-code')).toBe('Claude Code')
+    expect(prettyClientName('Claude Desktop')).toBe('Claude Code')
+    expect(prettyClientName('cursor-vscode')).toBe('Cursor')
+    expect(prettyClientName('codex-cli')).toBe('Codex')
+    expect(prettyClientName('windsurf')).toBe('Windsurf')
+  })
+
+  it('shows an unknown client verbatim rather than hiding it', () => {
+    expect(prettyClientName('acme-agent')).toBe('acme-agent')
+  })
+
+  it('returns empty string when there is no client name', () => {
+    expect(prettyClientName(undefined)).toBe('')
+    expect(prettyClientName('   ')).toBe('')
+  })
+})
+
+describe('formatSessionLabel', () => {
+  const startTime = '2026-07-11T14:32:00Z'
+
+  it('renders client name and start time instead of a hash', () => {
+    const label = formatSessionLabel({
+      sessionId: 'abc-def-139c9',
+      clientName: 'claude-code',
+      startTime,
+    })
+    expect(label).toContain('Claude Code')
+    expect(label).not.toContain('139c9')
+  })
+
+  it('falls back to the id suffix when clientInfo is absent', () => {
+    expect(formatSessionLabel({ sessionId: 'abc-def-139c9' })).toBe('...139c9')
+  })
+
+  it('disambiguates with the id suffix when the label would collide', () => {
+    const label = formatSessionLabel({
+      sessionId: 'abc-def-139c9',
+      clientName: 'claude-code',
+      startTime,
+      ambiguous: true,
+    })
+    expect(label).toContain('Claude Code')
+    expect(label).toContain('139c9')
+  })
+})
+
+describe('buildSessionLabels', () => {
+  it('gives every session a distinct label when two clients collide', () => {
+    const labels = buildSessionLabels([
+      { sessionId: 'aaaaa-11111', clientName: 'claude-code', startTime: '2026-07-11T14:32:00Z' },
+      { sessionId: 'bbbbb-22222', clientName: 'claude-code', startTime: '2026-07-11T14:32:00Z' },
+    ])
+    const a = labels.get('aaaaa-11111')!
+    const b = labels.get('bbbbb-22222')!
+    expect(a).not.toBe(b)
+    expect(a).toContain('11111')
+    expect(b).toContain('22222')
+  })
+
+  it('leaves a unique label clean, with no id suffix', () => {
+    const labels = buildSessionLabels([
+      { sessionId: 'aaaaa-11111', clientName: 'claude-code', startTime: '2026-07-11T14:32:00Z' },
+      { sessionId: 'bbbbb-22222', clientName: 'cursor', startTime: '2026-07-11T14:05:00Z' },
+    ])
+    expect(labels.get('aaaaa-11111')).toContain('Claude Code')
+    expect(labels.get('aaaaa-11111')).not.toContain('11111')
+    expect(labels.get('bbbbb-22222')).toContain('Cursor')
+    expect(labels.get('bbbbb-22222')).not.toContain('22222')
+  })
+
+  it('keeps the hash fallback for sessions with no client name', () => {
+    const labels = buildSessionLabels([{ sessionId: 'abc-def-139c9' }])
+    expect(labels.get('abc-def-139c9')).toBe('...139c9')
+  })
+})

--- a/roadmap.yaml
+++ b/roadmap.yaml
@@ -188,6 +188,12 @@ epics:
     depends_on: [ux-audit]
     note: "Surface the most important activity/security/connection signals at a glance; reduce digging. Vision pillar 'feel control → transparency' — the activity log is a headline feature, polish it and bring it to the tray menu. Builds on the shipped activity-log backend + retention (spec 024, 95% shipped — this epic is the at-a-glance UX on top, not the backend, so 024 is not the progress driver)."
     tasks:
+      - id: sessions-web-ui
+        title: "Sessions in the Web UI: meaningful session names in the Activity Log filter + the existing /sessions page linked in the sidebar"
+        status: done
+        priority: P1
+        note: "DONE 2026-07-11. Two-sided miss: Activity.vue already read a.metadata?.client_name, but the backend never wrote that field, so the Session filter always fell back to the id suffix ('...139c9'). Meanwhile the client name (MCP initialize clientInfo) has always existed on the session record and is already served by GET /api/v1/sessions. Fixed by joining the two at read time (activity rows already carry session_id as a foreign key) rather than denormalizing the name into the tool-call hot path. Also: a full Sessions.vue page + /sessions route already existed and were simply never linked in the personal-edition sidebar (only the Teams admin menu) — the fix was to unhide a page, not build one. New frontend/src/utils/sessionLabel.ts (+9 tests) handles display names and collision suffixes."
+        depends_on: []
       - id: action-log-glance-view
         title: At-a-glance action log view (top signals, health)
         status: todo


### PR DESCRIPTION
The Activity Log's **Session** filter showed opaque id suffixes — `...139c9`, `...851e1`, `...93be3` — which tell you nothing about *which AI client* a session was.

## Root cause: a two-sided miss

`Activity.vue:775` already read `a.metadata?.client_name`.
**The backend never writes that field.** So the label always fell through to the id suffix.

Meanwhile the client name has existed all along — captured from the MCP `initialize` handshake's `clientInfo`, persisted on the session record, and **already served by `GET /api/v1/sessions`**. Nobody was joining the two.

## The fix: join at read time, don't denormalize

Activity rows already carry `session_id` as a foreign key, and the session record is the canonical home for the client name. So the frontend joins them.

The alternative — writing `client_name` into every activity record's metadata — was rejected:
- it puts a storage lookup + cache in the **tool-call hot path** (and `EmitActivityToolCallCompleted` already takes **17 parameters**)
- it only fixes records written *after* the change, leaving existing rows showing hashes for the length of the retention window

## Result

| before | after |
|---|---|
| `...139c9` | `Claude Code · 07:33 AM (0cd9b)` |
| `...851e1` | `Cursor · 07:33 AM` |

- Two sessions of the **same client in the same minute** get a disambiguating id suffix; a unique one stays clean.
- A session with **no clientInfo** keeps the old id-suffix fallback — so this is **never worse** than before.
- Display names mirror the macOS tray's `connectedClientNames`, so the two surfaces agree on what a client is called.

## Also: the Sessions page already existed

A complete `Sessions.vue` **and** a `/sessions` route were already shipped — they were simply **never linked in the personal-edition sidebar** (only in the Teams admin menu). This unhides a page rather than building one.

Placed **above** Activity Log, because a session is the *parent* of activity records.

## Verification

Validated against a live instance with three real MCP sessions (two `claude-code` — deliberately exercising the collision path — and one `cursor-vscode`), driven through the real MCP `initialize` + `tools/call` handshake:

- Session dropdown renders the names above ✅
- Selecting one filters to exactly its records; the active-filter chip reads `Session: Cursor · 07:33 AM` ✅
- Sessions page loads from the new sidebar item ✅
- Confirmed via the API that activity rows have `session_id` but `metadata.client_name` is `null` — reproducing the bug before fixing it

`vue-tsc` clean · **276/276** frontend tests pass (9 new, in `frontend/tests/unit/session-label.spec.ts`).

> Note: new tests live in `frontend/tests/unit/*.spec.ts`. The `src/**/__tests__/*.test.ts` files in this repo match neither the directory nor the suffix in `vitest.config.ts`'s `include`, so they never run.

## Not in this PR

The Dashboard "Connected clients" card and a rework of the `Sessions.vue` table itself — both are follow-ups; this is the minimal fix for the reported problem.