### PR TITLE
ci(codeql): bump codeql-action to v4.37.0 to match the CodeQL 2.26.0 bundle

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,16 +41,16 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
+        uses: github/codeql-action/init@24ea975727876cf496b1eb0c5b36e96e01600b51  # v4.37.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
       - name: Autobuild
         if: matrix.build-mode == 'autobuild'
-        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
+        uses: github/codeql-action/autobuild@24ea975727876cf496b1eb0c5b36e96e01600b51  # v4.37.0
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
+        uses: github/codeql-action/analyze@24ea975727876cf496b1eb0c5b36e96e01600b51  # v4.37.0
         with:
           category: /language:${{ matrix.language }}

--- a/.github/workflows/scanner-images.yml
+++ b/.github/workflows/scanner-images.yml
@@ -179,7 +179,7 @@ jobs:
 
       - name: Upload SARIF
         if: github.event_name != 'pull_request' && !matrix.arch
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/upload-sarif@24ea975727876cf496b1eb0c5b36e96e01600b51 # v4.37.0
         with:
           sarif_file: trivy-results-${{ matrix.id }}.sarif
           category: trivy-${{ matrix.id }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -60,6 +60,6 @@ jobs:
           retention-days: 5
 
       - name: Upload SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/upload-sarif@24ea975727876cf496b1eb0c5b36e96e01600b51 # v4.37.0
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## The failure

CodeQL is failing on **every** open PR, in **both** jobs — including the JavaScript analysis on PRs that touch no JavaScript:

```
We were unable to automatically build your code.
Loaded a configuration file for version '4.37.0', but running version '4.36.3'
CodeQL job status was configuration error.
```

## Diagnosis

This is **not a code defect and not an alert** — it's a configuration error.

The runner's toolcache now carries CodeQL bundle **2.26.0** (`/opt/hostedtoolcache/CodeQL/2.26.0`), which pairs with `codeql-action` **v4.37.0**. The workflow pinned **v4.36.3**. The older action cannot read the newer bundle's config, so `init`/`autobuild` bail out before any analysis runs.

The "unable to automatically build your code" line is a red herring — the Go build is fine; the action never got far enough to try.

**Why main still looks green:** the rollout is mid-flight across the runner pool. Re-running an untouched `main` commit today still passes, because it happened to land on a runner with the old toolcache. It's a race that will hit any PR (and eventually main) regardless of content.

## The fix

Bumps all **five** `codeql-action` pins to v4.37.0 (`24ea9757`), matching the current bundle:

| workflow | step | was |
|---|---|---|
| `codeql.yml` | `init`, `autobuild`, `analyze` | v4.36.3 |
| `scanner-images.yml` | `upload-sarif` | v4.36.2 |
| `scorecard.yml` | `upload-sarif` | v4.36.2 |

The two `upload-sarif` steps were on a *third* version. Bringing everything to one version also clears the standing warning ("Not all workflow steps that use `github/codeql-action` actions use the same version") and stops them drifting apart again.

## Verification

CodeQL passing on this PR is itself the test — it's the check that was broken.