### PR TITLE
ci(codeql): finish the v4.37.0 bump — autobuild and analyze were left on v4.36.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,9 +48,9 @@ jobs:
 
       - name: Autobuild
         if: matrix.build-mode == 'autobuild'
-        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
+        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
         with:
           category: /language:${{ matrix.language }}


### PR DESCRIPTION
## The failure

CodeQL fails on **every** open PR, in **both** jobs — including the JavaScript analysis on PRs that touch no JavaScript:

```
We were unable to automatically build your code.
Loaded a configuration file for version '4.37.0', but running version '4.36.3'
CodeQL job status was configuration error.
```

## Root cause: main is half-bumped

Dependabot upgraded `codeql-action` in **separate PRs**, and only some steps came along:

| step | version on main | |
|---|---|---|
| `init` | **v4.37.0** | bumped by #827 |
| `autobuild` | v4.36.3 | ⚠️ left behind |
| `analyze` | v4.36.3 | ⚠️ left behind |
| `upload-sarif` (×2) | **v4.37.0** | bumped by #829 |

`init` at v4.37.0 writes a config for 4.37.0. `autobuild` at v4.36.3 then tries to load it and bails out. Hence the error naming both versions — it is telling us exactly this.

This also explains the standing warning: *"Not all workflow steps that use `github/codeql-action` actions use the same version."*

**Why main still looks green:** its last CodeQL run was on `cc2a749c`, which predates the Dependabot merges — that tree had all three steps consistently on v4.36.3. Every **PR** fails because `pull_request` analysis runs against the **merge ref**, which already contains main's half-bumped state. The next push to main would have failed too.

The "unable to automatically build your code" line is a red herring: the Go build is fine, the action just never got far enough to try.

## The fix

Bump `autobuild` and `analyze` to the **same commit main already pins** for `init` and `upload-sarif` (`99df26d4`, v4.37.0), so all five `codeql-action` steps in the repo are on one version and cannot drift apart again.

## Verification

CodeQL passing on this PR is itself the test — it is the check that was broken.