### PR TITLE
fix(activity): persist the MCP client name on each record so it survives session eviction

### DIFF
--- a/frontend/src/views/Activity.vue
+++ b/frontend/src/views/Activity.vue
@@ -835,9 +835,11 @@ const availableSessions = computed((): SessionOption[] => {
     if (a.session_id && !seen.has(a.session_id)) {
       const info = sessionInfo.value.get(a.session_id)
       seen.set(a.session_id, {
-        // Prefer the session record; fall back to metadata for records that
-        // carry it, then to nothing (→ id suffix).
-        clientName: info?.clientName ?? (a.metadata?.client_name as string | undefined),
+        // Prefer the name persisted ON the record: it is that row's own truth and
+        // never expires. The /api/v1/sessions lookup is only a fallback for rows
+        // written before the name was persisted — and it decays, because just the
+        // 100 most recent sessions are kept while activity lives for 90 days.
+        clientName: (a.metadata?.client_name as string | undefined) ?? info?.clientName,
         startTime: info?.startTime ?? a.timestamp,
       })
     }

--- a/internal/runtime/activity_service.go
+++ b/internal/runtime/activity_service.go
@@ -32,11 +32,29 @@ type SensitiveDataEventEmitter interface {
 	EmitSensitiveDataDetected(activityID string, detectionCount int, maxSeverity string, detectionTypes []string)
 }
 
+// SessionClientResolver maps an MCP session id to the client that opened it
+// (clientInfo.name / clientInfo.version from the initialize handshake).
+// Returns empty strings when the session is unknown.
+type SessionClientResolver func(sessionID string) (name, version string)
+
 // ActivityService subscribes to activity events and persists them to storage.
 // It runs as a background goroutine and handles activity recording non-blocking.
 type ActivityService struct {
 	storage *storage.Manager
 	logger  *zap.Logger
+
+	// clientResolver stamps the MCP client onto each activity record at WRITE
+	// time. Read-time joining against the sessions API is not viable: the core
+	// retains only the 100 most recent sessions, while activity is retained for
+	// 90 days — and an IDE that reconnects every few minutes burns through 100
+	// sessions in about a day. Any name resolved by lookup therefore decays back
+	// to a bare session id. Denormalizing it here makes it permanent, and it
+	// costs nothing: the resolver reads the in-memory session store (O(1)) and
+	// the session is by definition still open when its activity is emitted.
+	//
+	// nil until wired via SetSessionClientResolver; the records simply carry no
+	// client name in that case.
+	clientResolver SessionClientResolver
 
 	// Channel for receiving events
 	eventCh chan Event
@@ -98,6 +116,37 @@ func NewActivityService(storage *storage.Manager, logger *zap.Logger) *ActivityS
 	}
 	s.usagePersistIntervalNs.Store(int64(DefaultUsagePersistInterval))
 	return s
+}
+
+// SetSessionClientResolver wires the session -> MCP client lookup. Safe to leave
+// unset (records then carry no client name).
+func (s *ActivityService) SetSessionClientResolver(r SessionClientResolver) {
+	s.clientResolver = r
+}
+
+// withClientInfo stamps client_name / client_version onto an activity record's
+// metadata, so the Activity Log can name the client that made the call long
+// after the session record itself has been evicted.
+//
+// Returns the metadata map to assign; it allocates one only when there is
+// something to add, so records for sessionless events stay exactly as they were.
+func (s *ActivityService) withClientInfo(metadata map[string]interface{}, sessionID string) map[string]interface{} {
+	if sessionID == "" || s.clientResolver == nil {
+		return metadata
+	}
+	name, version := s.clientResolver(sessionID)
+	if name == "" {
+		return metadata // unknown session (e.g. already closed) — nothing to add
+	}
+
+	if metadata == nil {
+		metadata = make(map[string]interface{})
+	}
+	metadata["client_name"] = name
+	if version != "" {
+		metadata["client_version"] = version
+	}
+	return metadata
 }
 
 // SetDetector sets the sensitive data detector for async scanning (Spec 026).
@@ -383,6 +432,8 @@ func (s *ActivityService) handleToolCallCompleted(evt Event) {
 			metadata["profile"] = profileSlug
 		}
 	}
+	// Name the MCP client on the record itself, so it survives session eviction.
+	metadata = s.withClientInfo(metadata, sessionID)
 
 	// Spec 069 A1: byte sizes measured pre-truncation by the emitter.
 	requestBytes := int(getInt64Payload(evt.Payload, "request_bytes"))
@@ -461,10 +512,10 @@ func (s *ActivityService) handlePolicyDecision(evt Event) {
 		ServerName: serverName,
 		ToolName:   toolName,
 		Status:     decision,
-		Metadata: map[string]interface{}{
+		Metadata: s.withClientInfo(map[string]interface{}{
 			"decision": decision,
 			"reason":   reason,
-		},
+		}, sessionID),
 		Timestamp: evt.Timestamp,
 		SessionID: sessionID,
 	}
@@ -635,6 +686,10 @@ func (s *ActivityService) handleInternalToolCall(evt Event) {
 	if contentTrust != "" {
 		metadata["content_trust"] = contentTrust
 	}
+	// Name the MCP client on the record itself, so it survives session eviction.
+	// retrieve_tools calls arrive here, and they are the bulk of session-bearing
+	// activity — without this they would be the rows left showing a bare id.
+	metadata = s.withClientInfo(metadata, sessionID)
 
 	record := &storage.ActivityRecord{
 		Type:         storage.ActivityTypeInternalToolCall,

--- a/internal/runtime/activity_service_test.go
+++ b/internal/runtime/activity_service_test.go
@@ -486,6 +486,77 @@ func setupTestStorage(t *testing.T) (*storage.Manager, func()) {
 	}
 }
 
+// TestActivityRecordsCarryClientName verifies that the MCP client is stamped onto
+// the activity record at WRITE time.
+//
+// This must not be a read-time lookup: activity is retained for 90 days but only
+// the 100 most recent sessions are, and an IDE reconnecting every few minutes
+// burns through 100 sessions in about a day. A name resolved by joining against
+// the session store therefore decays back to a bare session id — which is exactly
+// the bug this fixes. Persisting it on the record makes it permanent.
+func TestActivityRecordsCarryClientName(t *testing.T) {
+	store, cleanup := setupTestStorage(t)
+	defer cleanup()
+
+	svc := NewActivityService(store, zap.NewNop())
+	svc.SetSessionClientResolver(func(sessionID string) (string, string) {
+		if sessionID == "mcp-session-abc" {
+			return "claude-code", "1.0.60"
+		}
+		return "", ""
+	})
+
+	// A retrieve_tools call — an internal tool call, which is the bulk of
+	// session-bearing activity.
+	svc.handleEvent(Event{
+		Type:      EventTypeActivityInternalToolCall,
+		Timestamp: time.Now().UTC(),
+		Payload: map[string]any{
+			"internal_tool_name": "retrieve_tools",
+			"session_id":         "mcp-session-abc",
+			"request_id":         "req-1",
+			"status":             "success",
+			"duration_ms":        int64(20),
+		},
+	})
+
+	records, _, err := store.ListActivities(storage.DefaultActivityFilter())
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+
+	assert.Equal(t, "claude-code", records[0].Metadata["client_name"],
+		"the client name must be persisted on the record, not looked up later")
+	assert.Equal(t, "1.0.60", records[0].Metadata["client_version"])
+}
+
+// TestActivityRecordsUnknownSessionHasNoClientName verifies we add nothing when
+// the session cannot be resolved (already closed, or no resolver wired), rather
+// than writing an empty key the UI would have to special-case.
+func TestActivityRecordsUnknownSessionHasNoClientName(t *testing.T) {
+	store, cleanup := setupTestStorage(t)
+	defer cleanup()
+
+	svc := NewActivityService(store, zap.NewNop())
+	svc.SetSessionClientResolver(func(string) (string, string) { return "", "" })
+
+	svc.handleEvent(Event{
+		Type:      EventTypeActivityInternalToolCall,
+		Timestamp: time.Now().UTC(),
+		Payload: map[string]any{
+			"internal_tool_name": "retrieve_tools",
+			"session_id":         "mcp-session-gone",
+			"status":             "success",
+		},
+	})
+
+	records, _, err := store.ListActivities(storage.DefaultActivityFilter())
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+
+	_, hasName := records[0].Metadata["client_name"]
+	assert.False(t, hasName, "an unresolvable session must not add an empty client_name")
+}
+
 // TestHandleToolCallCompleted_UserIdentityExtraction verifies that handleToolCallCompleted
 // extracts UserID and UserEmail from _auth_ prefixed arguments and sets them on the record.
 func TestHandleToolCallCompleted_UserIdentityExtraction(t *testing.T) {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -2653,6 +2653,16 @@ func (r *Runtime) RecordRetrieveToolsCallForActivation() {
 	}
 }
 
+// SetSessionClientResolver wires the session -> MCP client lookup that stamps
+// client_name / client_version onto every activity record at write time.
+// No-op if the activity service is not wired.
+func (r *Runtime) SetSessionClientResolver(resolver SessionClientResolver) {
+	if r.activityService == nil {
+		return
+	}
+	r.activityService.SetSessionClientResolver(resolver)
+}
+
 // RecordRealToolCallForActivation marks the first-ever real (upstream) tool
 // call. "Real" means a call proxied to an upstream server, as opposed to a
 // built-in tool such as retrieve_tools.

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -213,6 +213,21 @@ func NewMCPProxyServer(
 	// Wire up storage manager for session persistence
 	sessionStore.SetStorageManager(storage)
 
+	// Let the activity log name the MCP client on every record it writes.
+	// Activity is retained for 90 days but only the 100 most recent SESSIONS are
+	// kept — and an IDE that reconnects every few minutes burns through 100
+	// sessions in about a day. So the client name must be stamped on the record
+	// at write time; resolving it later against the session store works for a
+	// day and then decays back to a bare session id.
+	if mainServer != nil && mainServer.runtime != nil {
+		mainServer.runtime.SetSessionClientResolver(func(sessionID string) (name, version string) {
+			if info := sessionStore.GetSession(sessionID); info != nil {
+				return info.ClientName, info.ClientVersion
+			}
+			return "", ""
+		})
+	}
+
 	// Create hooks to capture session information
 	hooks := &mcpserver.Hooks{}
 	// Update session activity on every MCP message to prevent premature cleanup.


### PR DESCRIPTION
Reported after installing **v0.49.0-rc.1**: the Activity Log Session filter *still* showed bare ids (`...139c9`, `...851e1`) for most rows.

## The read-time join in #836 was the wrong architecture

It resolved a row's client by looking its session up in `GET /api/v1/sessions`. But:

- activity is retained for **90 days**
- only the **100 most recent sessions** are retained
- an IDE that reconnects every few minutes burns through 100 sessions in **about a day**

On the reporter's install there were **101 session records, all from today**, while every session-bearing activity row was **four days old**. Not one of them could be joined.

So the join worked for *live* sessions and decayed to a hash for everything else. It looked fine in my testing precisely because my test sessions were always fresh.

> Cross-model review flagged this exact retention mismatch. I dismissed it as a rare edge case that "degrades gracefully to the previous behaviour." **It is not rare — it is the steady state**, and it makes the feature useless on a real install after a day. That call was mine and it was wrong.

## The fix: stamp the name at write time

`ActivityService` now takes a `SessionClientResolver` and writes `client_name` / `client_version` into the record's metadata **when the record is created**, covering:

- `tool_call` (completed)
- `internal_tool_call` — `retrieve_tools`, which is the **bulk** of session-bearing activity
- `policy_decision`

The resolver reads the **in-memory** session store, so it's an O(1) map hit on a path that already does BBolt writes — and the session is *by definition* still open when its own activity is emitted, so it always resolves.

An unresolvable session adds **no** key at all (rather than an empty one the UI would have to special-case).

The frontend now **prefers** the name persisted on the record — that row's own truth, which never expires — and keeps the sessions lookup only as a fallback for rows written before this change.

## Caveat, stated plainly

**Historical rows cannot be backfilled.** The sessions they referenced are already evicted, so the name is simply not recoverable. Existing rows keep their hashes until activity retention ages them out. Only rows written from this build onward are named.

## Verification

Reproduced the exact production failure against a live instance:

1. Emit activity from `claude-code` and `opencode`.
2. Burn through the 100-session cap (101 filler `initialize` calls) so both session records are **evicted** — confirmed absent from `/api/v1/sessions`.
3. Load the Activity Log.

**Result:** filter reads `Claude Code · 04:46 PM` and `opencode · 04:46 PM`, and selecting one narrows to exactly its rows with the chip `Session: opencode · 04:46 PM`. Under the shipped RC these are bare hashes.

Backend tests cover both the persisted name and the unresolvable-session case. `go build` + `go test ./internal/runtime/ ./internal/server/` pass, golangci-lint 0 issues, `vue-tsc` clean, 282/282 frontend tests.

## Follow-up worth considering (not in this PR)

The 100-session cap is *very* low given real churn — 101 sessions accumulated in a single day on the reporter's machine. Worth revisiting so the **Sessions page** itself shows more than ~a day of history.