### PR TITLE
fix(storage): stop MCP sessions and user logins destroying each other in a shared bucket

### DIFF
--- a/internal/serveredition/users/models.go
+++ b/internal/serveredition/users/models.go
@@ -95,3 +95,14 @@ func (s *Session) Validate() error {
 	}
 	return nil
 }
+
+// isLoginSession reports whether this really is a user login session, rather
+// than a foreign record that merely unmarshalled without error.
+//
+// JSON unmarshalling accepts any shape and leaves unknown fields zero, so a
+// record belonging to someone else looks like a session with no user and a zero
+// expiry. Treating that as an expired session is how the sweep used to delete
+// data that was never its own.
+func (s *Session) isLoginSession() bool {
+	return s.UserID != "" && !s.ExpiresAt.IsZero()
+}

--- a/internal/serveredition/users/store.go
+++ b/internal/serveredition/users/store.go
@@ -15,7 +15,20 @@ import (
 const (
 	BucketUsers        = "users"
 	BucketUsersByEmail = "users_by_email"
-	BucketSessions     = "sessions"
+	// BucketSessions holds USER LOGIN sessions.
+	//
+	// The name stays "sessions" DELIBERATELY. The core used to share this bucket
+	// for MCP session records, and the two swept it believing each owned every
+	// key — core's retention evicted user logins, and the expiry sweep below
+	// deleted MCP records (they carry no expires_at, so a zero time reads as long
+	// expired). The core has moved out to "mcp_sessions"
+	// (internal/storage/sessions_migration.go); this bucket is now exclusively
+	// ours.
+	//
+	// Renaming it here as well would orphan every existing login and log the whole
+	// estate out on upgrade — the exact harm this fix exists to prevent. So it
+	// keeps its name, and the guards below make the sweep safe regardless.
+	BucketSessions = "sessions"
 )
 
 // UserStore provides CRUD operations for User and Session entities in BBolt.
@@ -391,7 +404,14 @@ func (s *UserStore) ListSessions() ([]*Session, error) {
 		return bucket.ForEach(func(_, v []byte) error {
 			var session Session
 			if err := json.Unmarshal(v, &session); err != nil {
-				return fmt.Errorf("failed to unmarshal session: %w", err)
+				return nil // not a login session — skip rather than fail the listing
+			}
+			// Defence in depth: only list records that actually look like login
+			// sessions. JSON unmarshalling happily accepts a foreign shape and
+			// leaves the fields zero, which is how MCP records used to appear here
+			// as phantom sessions with no user and a zero expiry.
+			if !session.isLoginSession() {
+				return nil
 			}
 			sessions = append(sessions, &session)
 			return nil
@@ -418,6 +438,13 @@ func (s *UserStore) CleanupExpiredSessions() (int, error) {
 			var session Session
 			if err := json.Unmarshal(v, &session); err != nil {
 				return nil // Skip malformed entries
+			}
+			// NEVER delete a record that is not a login session. A foreign record
+			// unmarshals without error and leaves ExpiresAt at the zero time, which
+			// reads as "long expired" — that is precisely how this sweep used to
+			// destroy every MCP session record sharing the bucket.
+			if !session.isLoginSession() {
+				return nil
 			}
 			if now.After(session.ExpiresAt) {
 				keyCopy := make([]byte, len(k))

--- a/internal/serveredition/users/store_bucket_safety_test.go
+++ b/internal/serveredition/users/store_bucket_safety_test.go
@@ -1,0 +1,96 @@
+//go:build server
+
+package users
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+)
+
+func openStore(t *testing.T) (*UserStore, *bbolt.DB) {
+	t.Helper()
+	db, err := bbolt.Open(t.TempDir()+"/test.db", 0o600, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists([]byte(BucketSessions))
+		return err
+	}))
+	return &UserStore{db: db}, db
+}
+
+// putForeign writes a record that is NOT a login session into the sessions
+// bucket — exactly what the core used to do with its MCP session records.
+func putForeign(t *testing.T, db *bbolt.DB, key string) {
+	t.Helper()
+	// An MCP session record: valid JSON, no user_id, no expires_at.
+	foreign := map[string]interface{}{
+		"id":          "mcp-session-abc",
+		"client_name": "claude-code",
+		"status":      "active",
+		"start_time":  time.Now().UTC().Format(time.RFC3339),
+	}
+	data, err := json.Marshal(foreign)
+	require.NoError(t, err)
+	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+		return tx.Bucket([]byte(BucketSessions)).Put([]byte(key), data)
+	}))
+}
+
+func keyCount(t *testing.T, db *bbolt.DB) int {
+	t.Helper()
+	n := 0
+	require.NoError(t, db.View(func(tx *bbolt.Tx) error {
+		return tx.Bucket([]byte(BucketSessions)).ForEach(func(_, _ []byte) error {
+			n++
+			return nil
+		})
+	}))
+	return n
+}
+
+// The expiry sweep must never delete a record that is not a login session.
+//
+// A foreign record unmarshals into Session without error — JSON simply ignores
+// the fields it does not know — leaving ExpiresAt at the zero time, which reads
+// as "expired long ago". That is precisely how this sweep used to destroy every
+// MCP session record that shared the bucket.
+func TestCleanupExpiredSessions_NeverDeletesForeignRecords(t *testing.T) {
+	store, db := openStore(t)
+
+	putForeign(t, db, "0001_mcp-session-abc")
+
+	live := NewSession("user-1", time.Hour)
+	require.NoError(t, store.CreateSession(live))
+
+	expired := NewSession("user-2", time.Hour)
+	expired.ExpiresAt = time.Now().UTC().Add(-time.Hour)
+	require.NoError(t, store.CreateSession(expired))
+
+	removed, err := store.CleanupExpiredSessions()
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, removed, "only the genuinely expired login is removed")
+	assert.Equal(t, 2, keyCount(t, db),
+		"the foreign record and the live login both survive — a zero expiry is not consent to delete")
+}
+
+// A foreign record must not be listed as a phantom login with no user.
+func TestListSessions_SkipsForeignRecords(t *testing.T) {
+	store, db := openStore(t)
+
+	putForeign(t, db, "0001_mcp-session-abc")
+	require.NoError(t, store.CreateSession(NewSession("user-1", time.Hour)))
+
+	sessions, err := store.ListSessions()
+	require.NoError(t, err)
+
+	require.Len(t, sessions, 1, "only real login sessions are listed")
+	assert.Equal(t, "user-1", sessions[0].UserID)
+}

--- a/internal/storage/bbolt.go
+++ b/internal/storage/bbolt.go
@@ -97,12 +97,21 @@ func (b *BoltDB) initBuckets() error {
 			ScanReportsBucket,
 			IntegrityBaselinesBucket,
 			OnboardingBucket,
+			SessionsBucket,
 		}
 
 		for _, bucket := range buckets {
 			if _, err := tx.CreateBucketIfNotExists([]byte(bucket)); err != nil {
 				return fmt.Errorf("failed to create bucket %s: %w", bucket, err)
 			}
+		}
+
+		// Move MCP session records out of the shared "sessions" bucket, which the
+		// server edition also used for USER LOGIN sessions. Each side swept the
+		// bucket believing it owned every key, deleting the other's data.
+		// Idempotent; leaves auth sessions untouched, so nobody is logged out.
+		if err := migrateLegacySessions(tx); err != nil {
+			return fmt.Errorf("failed to migrate legacy sessions bucket: %w", err)
 		}
 
 		// Backfill the scan-job index for databases created before MCP-2205.

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -27,7 +27,27 @@ const (
 	MetaBucket            = "meta"
 	CacheBucket           = "cache"
 	CacheStatsBucket      = "cache_stats"
-	SessionsBucket        = "sessions"
+	// SessionsBucket holds MCP transport/work session records.
+	//
+	// It is NOT "sessions". The server edition stores USER LOGIN sessions in a
+	// bucket of that name, on the same BBolt database, and the two were silently
+	// destroying each other:
+	//
+	//   - enforceSessionRetention (here) keeps the 100 newest keys and deletes the
+	//     rest by raw key order, with no type check — evicting user auth sessions
+	//     and logging people out at random.
+	//   - the server edition's CleanupExpiredSessions unmarshals every value as an
+	//     auth session; an MCP record has no expires_at, so its zero time reads as
+	//     long expired and the record is deleted.
+	//
+	// Namespacing the bucket is what makes each side's sweep safe.
+	SessionsBucket = "mcp_sessions"
+
+	// LegacySessionsBucket is the pre-namespacing bucket. In the personal edition
+	// it holds only MCP records; in the server edition it holds a mix of those and
+	// user login sessions. migrateLegacySessions moves the MCP records out and
+	// leaves the auth sessions where they are, so nobody is logged out.
+	LegacySessionsBucket = "sessions"
 
 	// Security scanner buckets (Spec 039)
 	ScannersBucket           = "security_scanners"

--- a/internal/storage/server_identity.go
+++ b/internal/storage/server_identity.go
@@ -58,24 +58,24 @@ type TokenMetrics struct {
 
 // ToolCallRecord represents a tool call with server context
 type ToolCallRecord struct {
-	ID               string                 `json:"id"`                          // UUID
-	ServerID         string                 `json:"server_id"`                   // Server identity
-	ServerName       string                 `json:"server_name"`                 // For quick reference
-	ToolName         string                 `json:"tool_name"`                   // Original tool name (without server prefix)
-	Arguments        map[string]interface{} `json:"arguments"`                   // Tool arguments
-	Response         interface{}            `json:"response"`                    // Tool response
-	Error            string                 `json:"error"`                       // Error if failed
-	Duration         int64                  `json:"duration"`                    // Duration in nanoseconds
-	Timestamp        time.Time              `json:"timestamp"`                   // When the call was made
-	ConfigPath       string                 `json:"config_path"`                 // Which config was active
-	RequestID        string                 `json:"request_id"`                  // For correlation
-	Metrics          *TokenMetrics          `json:"metrics,omitempty"`           // Token usage metrics (nil for older records)
-	ParentCallID     string                 `json:"parent_call_id,omitempty"`    // Links nested calls to parent code_execution
-	ExecutionType    string                 `json:"execution_type,omitempty"`    // "direct" or "code_execution"
-	MCPSessionID     string                    `json:"mcp_session_id,omitempty"`    // MCP session identifier
-	MCPClientName    string                    `json:"mcp_client_name,omitempty"`   // MCP client name from InitializeRequest
-	MCPClientVersion string                    `json:"mcp_client_version,omitempty"` // MCP client version
-	Annotations      *config.ToolAnnotations   `json:"annotations,omitempty"`       // Tool behavior hints snapshot
+	ID               string                  `json:"id"`                           // UUID
+	ServerID         string                  `json:"server_id"`                    // Server identity
+	ServerName       string                  `json:"server_name"`                  // For quick reference
+	ToolName         string                  `json:"tool_name"`                    // Original tool name (without server prefix)
+	Arguments        map[string]interface{}  `json:"arguments"`                    // Tool arguments
+	Response         interface{}             `json:"response"`                     // Tool response
+	Error            string                  `json:"error"`                        // Error if failed
+	Duration         int64                   `json:"duration"`                     // Duration in nanoseconds
+	Timestamp        time.Time               `json:"timestamp"`                    // When the call was made
+	ConfigPath       string                  `json:"config_path"`                  // Which config was active
+	RequestID        string                  `json:"request_id"`                   // For correlation
+	Metrics          *TokenMetrics           `json:"metrics,omitempty"`            // Token usage metrics (nil for older records)
+	ParentCallID     string                  `json:"parent_call_id,omitempty"`     // Links nested calls to parent code_execution
+	ExecutionType    string                  `json:"execution_type,omitempty"`     // "direct" or "code_execution"
+	MCPSessionID     string                  `json:"mcp_session_id,omitempty"`     // MCP session identifier
+	MCPClientName    string                  `json:"mcp_client_name,omitempty"`    // MCP client name from InitializeRequest
+	MCPClientVersion string                  `json:"mcp_client_version,omitempty"` // MCP client version
+	Annotations      *config.ToolAnnotations `json:"annotations,omitempty"`        // Tool behavior hints snapshot
 }
 
 // DiagnosticRecord represents a diagnostic event for a server

--- a/internal/storage/sessions_migration.go
+++ b/internal/storage/sessions_migration.go
@@ -1,0 +1,106 @@
+package storage
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"go.etcd.io/bbolt"
+)
+
+// migrateLegacySessions moves MCP session records out of the shared "sessions"
+// bucket and into the namespaced one.
+//
+// Both editions used a bucket literally named "sessions" on the same database:
+// the core for MCP transport/work sessions, the server edition for USER LOGIN
+// sessions. Each side swept the bucket believing it owned every key, so they
+// deleted each other's data — core's retention evicted user logins, and the
+// server edition's expiry sweep deleted MCP records (they carry no expires_at,
+// so a zero time read as long expired).
+//
+// This moves only the records that are unmistakably ours and leaves everything
+// else exactly where it is. Auth sessions are never touched, so nobody is logged
+// out by the upgrade. Idempotent, and safe to run on a personal-edition database
+// where the legacy bucket contains nothing but MCP records.
+func migrateLegacySessions(tx *bbolt.Tx) error {
+	legacy := tx.Bucket([]byte(LegacySessionsBucket))
+	if legacy == nil {
+		return nil // fresh database, or already migrated
+	}
+
+	target, err := tx.CreateBucketIfNotExists([]byte(SessionsBucket))
+	if err != nil {
+		return fmt.Errorf("failed to create %s bucket: %w", SessionsBucket, err)
+	}
+
+	type movedEntry struct {
+		key   []byte
+		value []byte
+	}
+	var moved []movedEntry
+
+	if err := legacy.ForEach(func(k, v []byte) error {
+		if !isMCPSessionRecord(v) {
+			return nil // not ours — a user login session, or something unknown
+		}
+		// Copy: the key and value are only valid for the life of the iteration.
+		key := make([]byte, len(k))
+		copy(key, k)
+		val := make([]byte, len(v))
+		copy(val, v)
+		moved = append(moved, movedEntry{key: key, value: val})
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to scan legacy sessions bucket: %w", err)
+	}
+
+	for _, e := range moved {
+		if err := target.Put(e.key, e.value); err != nil {
+			return fmt.Errorf("failed to move session record: %w", err)
+		}
+		if err := legacy.Delete(e.key); err != nil {
+			return fmt.Errorf("failed to remove legacy session record: %w", err)
+		}
+	}
+
+	// Only drop the legacy bucket once it is genuinely empty. In the server
+	// edition it still holds user login sessions and MUST survive.
+	//
+	// Emptiness is checked with a cursor, not Stats(): Stats() reports page-level
+	// counts that do not reflect deletions made inside this same transaction, so
+	// it would still report the records we just moved out.
+	if k, _ := legacy.Cursor().First(); k == nil {
+		if err := tx.DeleteBucket([]byte(LegacySessionsBucket)); err != nil {
+			return fmt.Errorf("failed to delete empty legacy sessions bucket: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// isMCPSessionRecord reports whether a stored value is one of OUR session
+// records, as opposed to a server-edition user login session sharing the bucket.
+//
+// The two are told apart by the fields only one of them has. A user login session
+// carries user_id / expires_at / bearer_token; an MCP session record carries
+// start_time and status and none of those. We require the positive signal AND the
+// absence of the negative one, so an unrecognised value is left alone rather than
+// moved or deleted on a guess.
+func isMCPSessionRecord(value []byte) bool {
+	var probe struct {
+		// Ours.
+		StartTime *string `json:"start_time"`
+		Status    *string `json:"status"`
+		// Theirs — the presence of any of these means hands off.
+		UserID      *string `json:"user_id"`
+		ExpiresAt   *string `json:"expires_at"`
+		BearerToken *string `json:"bearer_token"`
+	}
+	if err := json.Unmarshal(value, &probe); err != nil {
+		return false // unparseable: not ours to move
+	}
+
+	if probe.UserID != nil || probe.ExpiresAt != nil || probe.BearerToken != nil {
+		return false // a user login session
+	}
+	return probe.StartTime != nil && probe.Status != nil
+}

--- a/internal/storage/sessions_migration_test.go
+++ b/internal/storage/sessions_migration_test.go
@@ -1,0 +1,202 @@
+package storage
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+	"go.uber.org/zap"
+)
+
+// authSession mirrors the server edition's user login session (users.Session).
+// Duplicated here on purpose: internal/storage must not import the server
+// edition (it is behind a build tag), but it must still be able to prove it
+// leaves that shape alone.
+type authSession struct {
+	ID          string    `json:"id"`
+	UserID      string    `json:"user_id"`
+	BearerToken string    `json:"bearer_token"`
+	CreatedAt   time.Time `json:"created_at"`
+	ExpiresAt   time.Time `json:"expires_at"`
+}
+
+func openTempDB(t *testing.T) *bbolt.DB {
+	t.Helper()
+	db, err := bbolt.Open(t.TempDir()+"/test.db", 0o600, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func putJSON(t *testing.T, db *bbolt.DB, bucket, key string, v interface{}) {
+	t.Helper()
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists([]byte(bucket))
+		if err != nil {
+			return err
+		}
+		return b.Put([]byte(key), data)
+	}))
+}
+
+func keysIn(t *testing.T, db *bbolt.DB, bucket string) []string {
+	t.Helper()
+	var keys []string
+	require.NoError(t, db.View(func(tx *bbolt.Tx) error {
+		b := tx.Bucket([]byte(bucket))
+		if b == nil {
+			return nil
+		}
+		return b.ForEach(func(k, _ []byte) error {
+			keys = append(keys, string(k))
+			return nil
+		})
+	}))
+	return keys
+}
+
+// The core bucket must not be the one the server edition uses for user logins.
+// This is the whole bug in one assertion: they were both literally "sessions",
+// on the same database, and each side's sweep deleted the other's records.
+func TestSessionsBucketDoesNotCollideWithUserLogins(t *testing.T) {
+	// The server edition's bucket name, hardcoded rather than imported (that
+	// package is behind a build tag). If someone renames it, this test is the
+	// tripwire.
+	const serverEditionLoginBucket = "sessions"
+
+	assert.NotEqual(t, serverEditionLoginBucket, SessionsBucket,
+		"MCP session records must not share a bucket with user login sessions — "+
+			"each side sweeps the bucket believing it owns every key")
+	assert.Equal(t, serverEditionLoginBucket, LegacySessionsBucket,
+		"the legacy bucket is the one the server edition still owns")
+}
+
+// The migration must move OUR records out and leave user logins exactly where
+// they are. A logged-in user must not be logged out by upgrading.
+func TestMigrateLegacySessions_MovesMCPRecordsAndSparesUserLogins(t *testing.T) {
+	db := openTempDB(t)
+
+	mcpRecord := SessionRecord{
+		ID:           "mcp-session-abc",
+		ClientName:   "claude-code",
+		Status:       "active",
+		StartTime:    time.Now().UTC(),
+		LastActivity: time.Now().UTC(),
+	}
+	login := authSession{
+		ID:          "login-1",
+		UserID:      "user-123",
+		BearerToken: "jwt...",
+		CreatedAt:   time.Now().UTC(),
+		ExpiresAt:   time.Now().UTC().Add(24 * time.Hour),
+	}
+
+	putJSON(t, db, LegacySessionsBucket, "0001_mcp-session-abc", mcpRecord)
+	putJSON(t, db, LegacySessionsBucket, "login-1", login)
+
+	require.NoError(t, db.Update(migrateLegacySessions))
+
+	assert.Equal(t, []string{"0001_mcp-session-abc"}, keysIn(t, db, SessionsBucket),
+		"the MCP record must move into the namespaced bucket")
+	assert.Equal(t, []string{"login-1"}, keysIn(t, db, LegacySessionsBucket),
+		"the user login must be left exactly where it is — upgrading must not log anyone out")
+}
+
+// A personal-edition database has nothing but MCP records. Once they are moved,
+// the legacy bucket is empty and can go.
+func TestMigrateLegacySessions_DropsLegacyBucketWhenEmptied(t *testing.T) {
+	db := openTempDB(t)
+
+	putJSON(t, db, LegacySessionsBucket, "0001_a", SessionRecord{
+		ID: "a", Status: "active", StartTime: time.Now().UTC(),
+	})
+
+	require.NoError(t, db.Update(migrateLegacySessions))
+
+	require.NoError(t, db.View(func(tx *bbolt.Tx) error {
+		assert.Nil(t, tx.Bucket([]byte(LegacySessionsBucket)),
+			"an emptied legacy bucket should be removed")
+		return nil
+	}))
+	assert.Equal(t, []string{"0001_a"}, keysIn(t, db, SessionsBucket))
+}
+
+func TestMigrateLegacySessions_IsIdempotent(t *testing.T) {
+	db := openTempDB(t)
+	putJSON(t, db, LegacySessionsBucket, "0001_a", SessionRecord{
+		ID: "a", Status: "active", StartTime: time.Now().UTC(),
+	})
+	putJSON(t, db, LegacySessionsBucket, "login-1", authSession{
+		ID: "login-1", UserID: "u1", ExpiresAt: time.Now().Add(time.Hour),
+	})
+
+	require.NoError(t, db.Update(migrateLegacySessions))
+	require.NoError(t, db.Update(migrateLegacySessions))
+	require.NoError(t, db.Update(migrateLegacySessions))
+
+	assert.Equal(t, []string{"0001_a"}, keysIn(t, db, SessionsBucket))
+	assert.Equal(t, []string{"login-1"}, keysIn(t, db, LegacySessionsBucket))
+}
+
+func TestMigrateLegacySessions_NoLegacyBucketIsFine(t *testing.T) {
+	db := openTempDB(t)
+	assert.NoError(t, db.Update(migrateLegacySessions))
+}
+
+// The discriminator is the safety property: anything we are not certain is ours
+// gets left alone rather than moved (or, in the sweeps, deleted).
+func TestIsMCPSessionRecord(t *testing.T) {
+	mcp, err := json.Marshal(SessionRecord{
+		ID: "x", Status: "active", StartTime: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	assert.True(t, isMCPSessionRecord(mcp))
+
+	login, err := json.Marshal(authSession{
+		ID: "l", UserID: "u", ExpiresAt: time.Now().Add(time.Hour),
+	})
+	require.NoError(t, err)
+	assert.False(t, isMCPSessionRecord(login), "a user login is never ours to move")
+
+	assert.False(t, isMCPSessionRecord([]byte("not json")))
+	assert.False(t, isMCPSessionRecord([]byte(`{"something":"else"}`)),
+		"an unrecognised record is left alone rather than moved on a guess")
+
+	// The nasty one: a record carrying BOTH shapes. Hands off — we only move what
+	// is unambiguously ours.
+	both := []byte(`{"start_time":"2026-07-12T10:00:00Z","status":"active","user_id":"u1"}`)
+	assert.False(t, isMCPSessionRecord(both))
+}
+
+// Retention keeps the newest 100 by raw key order with no type check. That is
+// safe now only because the bucket is exclusively ours — this test pins the
+// behaviour the namespacing depends on.
+func TestEnforceSessionRetention_OnlyTouchesItsOwnBucket(t *testing.T) {
+	db := openTempDB(t)
+
+	// A user login lives in the LEGACY bucket, where the server edition keeps it.
+	putJSON(t, db, LegacySessionsBucket, "login-1", authSession{
+		ID: "login-1", UserID: "u1", ExpiresAt: time.Now().Add(24 * time.Hour),
+	})
+
+	// Fill our own bucket past the retention limit.
+	for i := 0; i < 130; i++ {
+		putJSON(t, db, SessionsBucket, string(rune('a'+i%26))+string(rune('a'+i/26)), SessionRecord{
+			ID: "s", Status: "active", StartTime: time.Now().UTC(),
+		})
+	}
+
+	m := &Manager{logger: zap.NewNop().Sugar()}
+	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+		return m.enforceSessionRetention(tx.Bucket([]byte(SessionsBucket)), 100)
+	}))
+
+	assert.Len(t, keysIn(t, db, SessionsBucket), 100, "retention trims our own bucket")
+	assert.Equal(t, []string{"login-1"}, keysIn(t, db, LegacySessionsBucket),
+		"and cannot reach a user login, which is what used to log people out")
+}


### PR DESCRIPTION
Found while reviewing #840. Not caused by it — this is pre-existing.

## The bug

The core stores MCP session records in a BBolt bucket named **`"sessions"`**.
The server edition stores **user login sessions** in a bucket of the **same name**, on the **same database** — `serveredition_wire.go` hands it the core's `*bbolt.DB` directly.

Both sides then sweep that bucket believing they own every key:

| | what it does | what it destroyed |
|---|---|---|
| `enforceSessionRetention` (core) | keeps the 100 newest keys, deletes the rest **by raw key order, no type check** | **user auth sessions → people logged out at random** |
| `CleanupExpiredSessions` (server edition) | unmarshals every value as a login session | **every MCP session record in the bucket** |
| `listSessions` (server edition) | lists everything in the bucket | MCP records shown as **phantom logins** with no user |

The expiry sweep is the nastiest. JSON unmarshalling **accepts a foreign shape without error** and leaves unknown fields zero — so an MCP record parses cleanly as a `Session` with `ExpiresAt` at the **zero time**, which reads as *"expired long ago"*. It gets deleted. A zero expiry is not consent to delete.

## The fix

**The core moves out.** `SessionsBucket` is now `"mcp_sessions"`, with an idempotent migration that relocates the records which are unmistakably ours and **leaves everything else exactly where it is**.

**The server edition keeps its bucket name — deliberately.** Renaming it as well would orphan every existing login and **log the whole estate out on upgrade**: precisely the harm this fix exists to prevent. It is now exclusively theirs.

## Defence in depth

Namespacing alone would fix today's bug and leave the trap armed for the next person. So both sweeps are now guarded:

- The migration moves a record **only** if it carries `start_time` + `status` **and not** `user_id` / `expires_at` / `bearer_token`. A record with *both* shapes, or an unrecognised one, is **left alone** rather than moved on a guess.
- The server edition now **refuses to list or delete anything that is not a real login session** (`UserID != "" && !ExpiresAt.IsZero()`).

A test asserts the two bucket names differ, so this cannot silently regress.

## Verification

Run against a **real database** carrying existing sessions:

- **101 MCP sessions migrated** into `mcp_sessions` and still readable through `/api/v1/sessions` — zero loss.
- The emptied legacy bucket was dropped (personal edition has no logins to preserve).
- Confirmed by reading the BBolt file's actual top-level buckets, not a byte-grep — `"sessions"` is a substring of `"mcp_sessions"`, which makes the naive check useless.

Tests cover: the migration, its idempotency, a **mixed** bucket where the login must survive, retention being unable to reach a login, and both server-edition sweeps refusing to touch foreign records.

Both editions build. `golangci-lint` 0 issues. `internal/storage`, `internal/server`, `internal/runtime` and the server-edition suites all pass.