### PR TITLE
fix(082): stamp the work session on every tool call, not only the ones that remembered to

### DIFF
--- a/frontend/src/utils/sessionGrouping.ts
+++ b/frontend/src/utils/sessionGrouping.ts
@@ -1,0 +1,49 @@
+import type { ActivityRecord, MCPSession } from '@/types/api'
+
+/**
+ * Spec 082 — which session an activity row belongs to.
+ *
+ * The row we want to group by is the WORK session: one client, one project,
+ * across reconnects. But not every row carries one. A record written before the
+ * connection was attributed — or by an older build, or by a path that never
+ * marked the session as worked — has only its TRANSPORT session id.
+ *
+ * Falling back to the transport id per-row (`work_session_id || session_id`) is
+ * what produced the original bug: the orphaned rows of a connection landed in a
+ * bucket keyed by the transport id while the rest of that same connection landed
+ * in its work-session bucket, and one client showed up in the picker twice.
+ *
+ * So resolve the fallback through an index instead: a transport session belongs
+ * to whatever work session ANY of its rows (or the sessions API) names. Only a
+ * transport session with no known work session anywhere keys on itself.
+ */
+export type WorkSessionIndex = Map<string, string>
+
+export function buildWorkSessionIndex(
+  activities: readonly ActivityRecord[],
+  sessions: readonly MCPSession[] = [],
+): WorkSessionIndex {
+  const index: WorkSessionIndex = new Map()
+
+  // The sessions API is the more authoritative of the two: it is the connection's
+  // own record of the work session it was attributed to.
+  for (const s of sessions) {
+    if (s.id && s.work_session_id) index.set(s.id, s.work_session_id)
+  }
+
+  // Sibling rows fill the gaps — activity outlives sessions (90 days vs the 100
+  // most recent), so for older rows this is the only surviving evidence.
+  for (const a of activities) {
+    if (a.session_id && a.work_session_id && !index.has(a.session_id)) {
+      index.set(a.session_id, a.work_session_id)
+    }
+  }
+
+  return index
+}
+
+export function groupKeyOf(a: ActivityRecord, index: WorkSessionIndex): string {
+  if (a.work_session_id) return a.work_session_id
+  if (a.session_id) return index.get(a.session_id) ?? a.session_id
+  return ''
+}

--- a/frontend/src/views/Activity.vue
+++ b/frontend/src/views/Activity.vue
@@ -693,8 +693,9 @@ import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { useSystemStore } from '@/stores/system'
 import api from '@/services/api'
-import type { ActivityRecord, ActivitySummaryResponse } from '@/types/api'
+import type { ActivityRecord, ActivitySummaryResponse, MCPSession } from '@/types/api'
 import { buildSessionLabels } from '@/utils/sessionLabel'
+import { buildWorkSessionIndex, groupKeyOf as workSessionKeyOf } from '@/utils/sessionGrouping'
 import JsonViewer from '@/components/JsonViewer.vue'
 
 const route = useRoute()
@@ -776,6 +777,10 @@ interface SessionOption {
 // show "Claude Code · 14:32" instead of an opaque "...139c9".
 const sessionInfo = ref(new Map<string, { clientName?: string; startTime?: string; workspace?: string }>())
 
+// The raw session records behind that map. Kept because they carry the
+// transport -> work session link that groupKeyOf needs (see workSessionIndex).
+const sessionsRaw = ref<MCPSession[]>([])
+
 // Session ids we have already tried and failed to resolve. The core keeps only
 // the 100 most recent sessions, so an old session's activity rows can outlive
 // its record and never become resolvable. Without this set, every refresh would
@@ -791,8 +796,10 @@ const loadSessions = async () => {
   sessionsInFlight = (async () => {
     try {
       const response = await api.getSessions(100)
+      const sessions = response.data?.sessions ?? []
+      sessionsRaw.value = sessions
       const next = new Map<string, { clientName?: string; startTime?: string; workspace?: string }>()
-      for (const s of response.data?.sessions ?? []) {
+      for (const s of sessions) {
         const info = {
           clientName: s.client_name,
           startTime: s.start_time,
@@ -844,10 +851,16 @@ const refreshSessionsIfUnknown = () => {
   if (hasUnknown) void loadSessions()
 }
 
+// Transport session -> work session, learned from the sessions API and from any
+// sibling row that does carry one. A row with no work session of its own is
+// folded into its connection's, rather than keying on the raw transport id and
+// splitting one client into two entries in the picker.
+const workSessionIndex = computed(() => buildWorkSessionIndex(activities.value, sessionsRaw.value))
+
 // The key an activity row is grouped and filtered by: its WORK session (Spec
-// 082) — one client, one project, across reconnects. Rows written before 082
-// have none, so they fall back to the transport session and behave as before.
-const groupKeyOf = (a: ActivityRecord): string => a.work_session_id || a.session_id || ''
+// 082) — one client, one project, across reconnects. Rows for which no work
+// session is known anywhere still fall back to the transport session.
+const groupKeyOf = (a: ActivityRecord): string => workSessionKeyOf(a, workSessionIndex.value)
 
 const availableSessions = computed((): SessionOption[] => {
   const seen = new Map<string, { clientName?: string; startTime?: string; workspace?: string }>()

--- a/frontend/tests/unit/session-grouping.spec.ts
+++ b/frontend/tests/unit/session-grouping.spec.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { buildWorkSessionIndex, groupKeyOf } from '@/utils/sessionGrouping'
+import type { ActivityRecord, MCPSession } from '@/types/api'
+
+const rec = (p: Partial<ActivityRecord>): ActivityRecord =>
+  ({ status: 'success', timestamp: '2026-07-13T05:30:00Z', ...p }) as ActivityRecord
+
+// The bug this file exists for (Spec 082 SC-002).
+//
+// One opencode connection, transport session `mcp-session-…858cea`, wrote four
+// activity records. The first two named built-ins that did not mark the session
+// as worked, so they carry no work_session_id; the last two carry `ws-…000abe`.
+// Grouping by `work_session_id || session_id` put them in two different buckets
+// and the session picker showed ONE connection as TWO sessions — labelled with
+// the tails of two different ids, `58cea` and `00abe`.
+describe('work-session grouping', () => {
+  const SID = 'mcp-session-9958d45e-015f-4c16-8d9a-74792c858cea'
+  const WSID = 'ws-a3f505743e000abe'
+
+  const opencodeRun: ActivityRecord[] = [
+    rec({ session_id: SID, tool_name: 'list_registries' }), // no work_session_id
+    rec({ session_id: SID, tool_name: 'upstream_servers' }), // no work_session_id
+    rec({ session_id: SID, work_session_id: WSID, tool_name: 'retrieve_tools' }),
+    rec({ session_id: SID, work_session_id: WSID, tool_name: 'echo' }),
+  ]
+
+  it('folds records with no work session into their connection’s work session', () => {
+    const index = buildWorkSessionIndex(opencodeRun, [])
+    const keys = new Set(opencodeRun.map(a => groupKeyOf(a, index)))
+
+    expect(keys).toEqual(new Set([WSID]))
+  })
+
+  it('learns the mapping from the sessions API too, not only from sibling records', () => {
+    // The orphaned rows on their own — the work session is only known because
+    // /api/v1/sessions reports it for this transport session.
+    const orphans = opencodeRun.slice(0, 2)
+    const sessions = [{ id: SID, work_session_id: WSID } as MCPSession]
+
+    const index = buildWorkSessionIndex(orphans, sessions)
+
+    expect(orphans.map(a => groupKeyOf(a, index))).toEqual([WSID, WSID])
+  })
+
+  it('falls back to the transport session when no work session is known anywhere', () => {
+    // Pre-082 rows, and clients whose work session was never resolved.
+    const legacy = [rec({ session_id: 'sess-legacy', tool_name: 'echo' })]
+    const index = buildWorkSessionIndex(legacy, [])
+
+    expect(groupKeyOf(legacy[0], index)).toBe('sess-legacy')
+  })
+
+  it('keeps genuinely different work sessions apart', () => {
+    // Same client reconnecting into DIFFERENT work (e.g. a different project):
+    // two transport sessions, two work sessions. These must not be merged.
+    const rows = [
+      rec({ session_id: 'sess-a', work_session_id: 'ws-project-one' }),
+      rec({ session_id: 'sess-b', work_session_id: 'ws-project-two' }),
+    ]
+    const index = buildWorkSessionIndex(rows, [])
+
+    expect(rows.map(a => groupKeyOf(a, index))).toEqual(['ws-project-one', 'ws-project-two'])
+  })
+
+  it('groups a work session that spans several connections (the reconnect case)', () => {
+    const rows = [
+      rec({ session_id: 'sess-1', work_session_id: 'ws-same' }),
+      rec({ session_id: 'sess-2', work_session_id: 'ws-same' }),
+      rec({ session_id: 'sess-2' }), // orphan on the second connection
+    ]
+    const index = buildWorkSessionIndex(rows, [])
+
+    expect(new Set(rows.map(a => groupKeyOf(a, index)))).toEqual(new Set(['ws-same']))
+  })
+
+  it('tolerates records with no session id at all', () => {
+    const index = buildWorkSessionIndex([rec({ tool_name: 'echo' })], [])
+    expect(groupKeyOf(rec({ tool_name: 'echo' }), index)).toBe('')
+  })
+})

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -27,6 +27,7 @@ import (
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/outputvalidation"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/registries"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/reqcontext"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/runtime"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/security"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/server/tokens"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/shellwrap"
@@ -117,6 +118,11 @@ type MCPProxyServer struct {
 	logger               *zap.Logger
 	mainServer           *Server        // Reference to main server for config persistence
 	config               *config.Config // Add config reference for security checks
+
+	// workSessionResolver maps an identity to a work session (Spec 082). Normally
+	// nil, and the runtime's tracker is used; tests inject a stub so they do not
+	// have to stand up a whole Runtime to exercise session attribution.
+	workSessionResolver func(runtime.WorkSessionIdentity) string
 
 	// Routing mode MCP server instances (Spec 031)
 	// Each instance has different tools registered for its routing mode.
@@ -235,10 +241,12 @@ func NewMCPProxyServer(
 		})
 	}
 
-	// Forward handle to the MCP server, which is constructed below but is needed
-	// by the hooks above it (to send a roots request back to the client).
-	// Atomic because the hooks run on client goroutines.
+	// Forward handles to the MCP server and the proxy, both constructed below but
+	// needed by the hooks above them (to send a roots request back to the client,
+	// and to attribute work to a session). Atomic because the hooks run on client
+	// goroutines.
 	var mcpSrvRef atomic.Pointer[mcpserver.MCPServer]
+	var proxyRef atomic.Pointer[MCPProxyServer]
 
 	// Create hooks to capture session information
 	hooks := &mcpserver.Hooks{}
@@ -269,6 +277,14 @@ func NewMCPProxyServer(
 		// answer simply has no workspace.
 		if method != mcp.MethodInitialize && sessionStore.TryClaimWorkspaceFetch(session.SessionID()) {
 			go fetchWorkspaceRoot(ctx, mcpSrvRef.Load(), sessionStore, logger)
+		}
+
+		// Spec 082: attribute this request to a work session before the handler
+		// runs, so every activity record the handler writes carries it. Kicked off
+		// AFTER the roots fetch above, which it may wait on briefly — the fetch is
+		// already in flight by then.
+		if proxy := proxyRef.Load(); proxy != nil {
+			proxy.markWorkIfToolCall(ctx, method)
 		}
 	})
 
@@ -431,6 +447,9 @@ func NewMCPProxyServer(
 		sessionStore:         sessionStore,
 		hooks:                hooks,
 	}
+
+	// Let the hooks (registered before the proxy existed) reach it.
+	proxyRef.Store(proxy)
 
 	// Register proxy tools for the default (retrieve_tools) server
 	proxy.registerTools(debugSearch)

--- a/internal/server/worksession_hook_test.go
+++ b/internal/server/worksession_hook_test.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/runtime"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
+)
+
+// newWorkSessionProxy builds the smallest MCPProxyServer that can resolve a work
+// session: a real session store (persistence needs a storage manager) and a stub
+// resolver, so the test does not have to stand up a whole Runtime.
+func newWorkSessionProxy(t *testing.T) (*MCPProxyServer, *SessionStore) {
+	t.Helper()
+
+	logger := zap.NewNop()
+	sm, err := storage.NewManager(t.TempDir(), logger.Sugar())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sm.Close() })
+
+	store := NewSessionStore(logger)
+	store.SetStorageManager(sm)
+
+	p := &MCPProxyServer{
+		logger:       logger,
+		sessionStore: store,
+		workSessionResolver: func(id runtime.WorkSessionIdentity) string {
+			return "ws-" + id.ClientName
+		},
+	}
+	return p, store
+}
+
+func workSessionCtx(sessionID string) context.Context {
+	helper := mcpserver.NewMCPServer("test", "1.0.0")
+	return helper.WithContext(context.Background(), &fakeClientSession{id: sessionID})
+}
+
+// The regression: EVERY tools/call is work, whichever tool it names.
+//
+// Work used to be stamped inside individual handlers (retrieve_tools, the
+// call_tool_* variants, code_execution). The other built-ins — list_registries,
+// upstream_servers, quarantine_security, … — never marked the session, so the
+// activity they wrote carried an empty work_session_id. The Web UI then grouped
+// those rows under the raw TRANSPORT session id while the rest of the same
+// connection grouped under its work-session id, and one opencode connection
+// appeared in the session picker as two sessions (Spec 082 SC-002).
+func TestWorkSession_AnyToolCallMarksWork(t *testing.T) {
+	p, store := newWorkSessionProxy(t)
+	store.SetSession("s1", "opencode", "1.17.18", false, false, nil)
+
+	// A tools/call naming a built-in that never called markSessionWorked itself.
+	got := p.markWorkIfToolCall(workSessionCtx("s1"), mcp.MethodToolsCall)
+
+	assert.Equal(t, "ws-opencode", got,
+		"a tools/call must resolve a work session regardless of which tool it names")
+	assert.Equal(t, "ws-opencode", store.WorkSessionID("s1"),
+		"the work session must be cached on the connection, so every later record agrees")
+}
+
+// The counterweight, and the reason this is a method allow-list rather than
+// "mark on any request": a connection that only shakes hands and lists tools has
+// done no work and must leave nothing behind. On a real machine 99 of 100
+// session records were background agents doing exactly this, every ~15 minutes.
+func TestWorkSession_HandshakeAndListingAreNotWork(t *testing.T) {
+	p, store := newWorkSessionProxy(t)
+	store.SetSession("s1", "background-agent", "1.0", false, false, nil)
+
+	for _, method := range []mcp.MCPMethod{
+		mcp.MethodInitialize,
+		mcp.MethodToolsList,
+		mcp.MethodPing,
+	} {
+		assert.Empty(t, p.markWorkIfToolCall(workSessionCtx("s1"), method),
+			"%s is not work and must not persist a session", method)
+	}
+
+	assert.Empty(t, store.WorkSessionID("s1"),
+		"a session that only handshook and listed must have no work session")
+}
+
+// No client session in the context (internal calls, tests, odd transports) must
+// be a no-op rather than a panic.
+func TestWorkSession_NoClientSessionIsNoop(t *testing.T) {
+	p, _ := newWorkSessionProxy(t)
+	assert.Empty(t, p.markWorkIfToolCall(context.Background(), mcp.MethodToolsCall))
+}

--- a/internal/server/workspace.go
+++ b/internal/server/workspace.go
@@ -167,14 +167,55 @@ func (p *MCPProxyServer) markSessionWorked(ctx context.Context, sessionID string
 	principal := principalFromContext(ctx)
 
 	return p.sessionStore.EnsurePersisted(sessionID, func(info *SessionInfo) string {
-		if p.mainServer == nil || p.mainServer.runtime == nil {
+		resolve := p.resolveWorkSession()
+		if resolve == nil {
 			return ""
 		}
-		return p.mainServer.runtime.ResolveWorkSession(runtime.WorkSessionIdentity{
+		return resolve(runtime.WorkSessionIdentity{
 			Principal:     principal,
 			ClientName:    info.ClientName,
 			ClientVersion: info.ClientVersion,
 			WorkspaceRoot: info.Workspace,
 		})
 	})
+}
+
+// resolveWorkSession is the runtime's work-session tracker, or the stub a test
+// injected in its place. Nil when neither is available.
+func (p *MCPProxyServer) resolveWorkSession() func(runtime.WorkSessionIdentity) string {
+	if p.workSessionResolver != nil {
+		return p.workSessionResolver
+	}
+	if p.mainServer == nil || p.mainServer.runtime == nil {
+		return nil
+	}
+	return p.mainServer.runtime.ResolveWorkSession
+}
+
+// markWorkIfToolCall attributes a request to a work session when — and only when
+// — it is real work (Spec 082).
+//
+// This runs from the beforeAny hook, which every MCP method passes through on
+// every server instance (direct / code-exec / call-tool all share these hooks).
+// That placement is the point: work used to be marked inside individual tool
+// handlers, and the built-ins that did not bother — list_registries,
+// upstream_servers, quarantine_security — wrote activity with no work session on
+// it. The Web UI grouped those orphaned rows under the raw transport session id
+// while the rest of the same connection grouped under its work-session id, so a
+// single client appeared as two sessions in the picker. Marking here means a new
+// built-in cannot reintroduce that by forgetting a call.
+//
+// A tools/call is the boundary of "work", deliberately: a connection that only
+// initializes and lists tools has done nothing, and persisting it would bury the
+// user's real sessions under background agents that connect every few minutes,
+// do nothing, and leave.
+func (p *MCPProxyServer) markWorkIfToolCall(ctx context.Context, method mcp.MCPMethod) string {
+	if method != mcp.MethodToolsCall {
+		return ""
+	}
+	session := mcpserver.ClientSessionFromContext(ctx)
+	if session == nil {
+		return ""
+	}
+	return p.markSessionWorked(ctx, session.SessionID())
 }


### PR DESCRIPTION
Found while testing v0.49.0-rc.2. One `opencode` connection appeared in the Activity Log session picker as **two** sessions ~20 seconds apart.

## What was actually happening

Both entries were the same connection. Its four activity records:

| time | tool | work_session_id |
|---|---|---|
| 05:30:39 | `list_registries` | *null* |
| 05:30:41 | `upstream_servers` | *null* |
| 05:30:45 | `retrieve_tools` | `ws-a3f505743e000abe` |
| 05:30:46 | `echo` | `ws-a3f505743e000abe` |

The two labels in the picker were the tails of two different **id namespaces**: `58cea` from the transport session id `mcp-session-…74792c858cea`, and `00abe` from the work session id. Not two sessions — one connection, split across two grouping keys.

## Backend

Work was marked inside individual tool handlers: `retrieve_tools`, the `call_tool_*` variants, `code_execution`, direct routing. Every **other** built-in — `list_registries`, `upstream_servers`, `quarantine_security` — wrote activity without ever resolving a work session, so anything a client did before its first "work" call was orphaned.

Marking now happens in the `beforeAny` hook, which every MCP method passes through on every server instance (direct / code-exec / call-tool all share these hooks). A new built-in can no longer reintroduce this by forgetting a call.

`tools/call` remains the boundary of "work", deliberately: a connection that only initializes and lists tools still persists nothing — that property is what keeps background agents (which connect every few minutes, do nothing, and leave) from burying real sessions under the 100-session retention cap.

## Frontend

Grouping by `work_session_id || session_id` is what turned an orphaned row into a phantom session. The fallback now resolves through an index — transport session → work session, learned from the sessions API and from any sibling row that carries one — so a row with no work session of its own folds into its connection's rather than keying on the raw transport id. This also **heals rows already in the database**, which the backend fix alone cannot do.

## Verification

- `internal/server/worksession_hook_test.go`: any `tools/call` marks work; `initialize`/`tools/list`/`ping` still do not; no client session is a no-op.
- `frontend/tests/unit/session-grouping.spec.ts`: 6 cases, including the exact `858cea`/`00abe` shape observed above, plus the cases that must NOT merge (different projects) and the reconnect case that must.
- Driven over **real MCP** against a scratch instance: a connection calling `upstream_servers` then `retrieve_tools` now emits two records sharing one `work_session_id`, and the Web UI picker shows **one** entry.
- `go test -race ./internal/server/... ./internal/runtime/...` green; `golangci-lint` (CI v2 config) 0 issues; 291 frontend unit tests green.

Closes the SC-002 violation in Spec 082 ("a user … sees one session for that hour, not one per reconnect").

> Note for the release: this is **not** the same bug as #841 (shared BBolt bucket). That one *destroys* session records and only bites the server edition; this one *duplicates* them. rc.3 wants both.