### PR TITLE
fix(082): make Sessions → View Activity actually show the session's activity

### DIFF
--- a/frontend/src/utils/sessionGrouping.ts
+++ b/frontend/src/utils/sessionGrouping.ts
@@ -47,3 +47,35 @@ export function groupKeyOf(a: ActivityRecord, index: WorkSessionIndex): string {
   if (a.session_id) return index.get(a.session_id) ?? a.session_id
   return ''
 }
+
+/**
+ * Translate a session filter into the key the activity log is actually grouped
+ * by.
+ *
+ * The Sessions page links to `/activity?session=<transport id>` — that is what
+ * its table lists. But the log groups by work session, so the raw transport id
+ * matched no group and no entry in the Session dropdown: an empty log next to a
+ * blank picker. Anything already a work-session id, or unknown, passes through
+ * untouched.
+ */
+export function resolveSessionFilter(sessionKey: string, index: WorkSessionIndex): string {
+  if (!sessionKey) return ''
+  return index.get(sessionKey) ?? sessionKey
+}
+
+/**
+ * Whether a record belongs to the filtered session, accepting either id.
+ *
+ * The index is assembled from data that arrives asynchronously, so a deep link
+ * carrying a transport id must still match on that id alone until the index
+ * catches up — otherwise the log shows "no matching activities" for a moment
+ * before the rows appear.
+ */
+export function matchesSessionFilter(
+  a: ActivityRecord,
+  sessionKey: string,
+  index: WorkSessionIndex,
+): boolean {
+  if (!sessionKey) return true
+  return groupKeyOf(a, index) === resolveSessionFilter(sessionKey, index) || a.session_id === sessionKey
+}

--- a/frontend/src/views/Activity.vue
+++ b/frontend/src/views/Activity.vue
@@ -695,7 +695,12 @@ import { useSystemStore } from '@/stores/system'
 import api from '@/services/api'
 import type { ActivityRecord, ActivitySummaryResponse, MCPSession } from '@/types/api'
 import { buildSessionLabels } from '@/utils/sessionLabel'
-import { buildWorkSessionIndex, groupKeyOf as workSessionKeyOf } from '@/utils/sessionGrouping'
+import {
+  buildWorkSessionIndex,
+  groupKeyOf as workSessionKeyOf,
+  matchesSessionFilter,
+  resolveSessionFilter,
+} from '@/utils/sessionGrouping'
 import JsonViewer from '@/components/JsonViewer.vue'
 
 const route = useRoute()
@@ -857,6 +862,17 @@ const refreshSessionsIfUnknown = () => {
 // splitting one client into two entries in the picker.
 const workSessionIndex = computed(() => buildWorkSessionIndex(activities.value, sessionsRaw.value))
 
+// A deep link from the Sessions page arrives with a TRANSPORT session id (see
+// Sessions.vue), while the picker's options are keyed by work session. Rewrite
+// the filter to the work session as soon as the index can tell us what it is —
+// otherwise the filter works but the dropdown shows blank, because no option
+// equals the value it is bound to.
+watch(workSessionIndex, index => {
+  if (!filterSession.value) return
+  const resolved = resolveSessionFilter(filterSession.value, index)
+  if (resolved !== filterSession.value) filterSession.value = resolved
+})
+
 // The key an activity row is grouped and filtered by: its WORK session (Spec
 // 082) — one client, one project, across reconnects. Rows for which no work
 // session is known anywhere still fall back to the transport session.
@@ -932,9 +948,10 @@ const filteredActivities = computed(() => {
     result = result.filter(a => a.server_name === filterServer.value)
   }
   // Session filter — a WORK session (Spec 082), falling back to the transport
-  // session for rows written before it.
+  // session for rows written before it. Accepts either id, so a deep link from
+  // the Sessions page (which knows only transport ids) still finds the rows.
   if (filterSession.value) {
-    result = result.filter(a => groupKeyOf(a) === filterSession.value)
+    result = result.filter(a => matchesSessionFilter(a, filterSession.value, workSessionIndex.value))
   }
   if (filterStatus.value) {
     result = result.filter(a => a.status === filterStatus.value)

--- a/frontend/src/views/Sessions.vue
+++ b/frontend/src/views/Sessions.vue
@@ -109,8 +109,11 @@
                   <div class="text-xs text-base-content/60">{{ formatRelativeTime(session.last_activity) }}</div>
                 </td>
                 <td>
+                  <!-- Link by WORK session (Spec 082) — that is what the Activity
+                       Log groups by. Falling back to the transport id keeps rows
+                       written before 082 reachable; the log accepts either. -->
                   <router-link
-                    :to="{ name: 'activity', query: { session: session.id } }"
+                    :to="{ name: 'activity', query: { session: session.work_session_id || session.id } }"
                     class="btn btn-xs btn-primary"
                     title="View activity for this session"
                   >

--- a/frontend/tests/unit/session-grouping.spec.ts
+++ b/frontend/tests/unit/session-grouping.spec.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { buildWorkSessionIndex, groupKeyOf } from '@/utils/sessionGrouping'
+import {
+  buildWorkSessionIndex,
+  groupKeyOf,
+  resolveSessionFilter,
+  matchesSessionFilter,
+} from '@/utils/sessionGrouping'
 import type { ActivityRecord, MCPSession } from '@/types/api'
 
 const rec = (p: Partial<ActivityRecord>): ActivityRecord =>
@@ -76,5 +81,54 @@ describe('work-session grouping', () => {
   it('tolerates records with no session id at all', () => {
     const index = buildWorkSessionIndex([rec({ tool_name: 'echo' })], [])
     expect(groupKeyOf(rec({ tool_name: 'echo' }), index)).toBe('')
+  })
+})
+
+// Sessions page → "View Activity" links with the row's TRANSPORT id, because
+// that is what the Sessions table is a list of. The Activity page groups and
+// filters by WORK session. So the link arrived carrying an id that matched no
+// group and no dropdown option: an empty log and a blank Session picker, even
+// though the session plainly had activity.
+describe('session filter from a deep link', () => {
+  const SID = 'mcp-session-edb5dc8a-84a6-48d0-a0a6-b03b3aa08ebd'
+  const WSID = 'ws-3c571af4004fba33'
+
+  const rows: ActivityRecord[] = [
+    rec({ session_id: SID, work_session_id: WSID, tool_name: 'retrieve_tools' }),
+    rec({ session_id: SID, work_session_id: WSID, tool_name: 'call_tool_read' }),
+  ]
+  const index = buildWorkSessionIndex(rows, [])
+
+  it('translates a transport id into the work session the picker is keyed by', () => {
+    expect(resolveSessionFilter(SID, index)).toBe(WSID)
+  })
+
+  it('leaves a work-session id alone (the dropdown’s own values must survive)', () => {
+    expect(resolveSessionFilter(WSID, index)).toBe(WSID)
+  })
+
+  it('leaves an unknown id alone rather than dropping the filter', () => {
+    expect(resolveSessionFilter('sess-never-seen', index)).toBe('sess-never-seen')
+    expect(resolveSessionFilter('', index)).toBe('')
+  })
+
+  it('matches the session’s rows whether the filter is the transport or work id', () => {
+    for (const filter of [SID, WSID]) {
+      expect(rows.filter(a => matchesSessionFilter(a, filter, index))).toHaveLength(2)
+    }
+  })
+
+  // The index is built from data that arrives asynchronously. Before it lands,
+  // a transport-id filter must still show the connection's rows rather than an
+  // empty log that then blinks into existence.
+  it('matches on the raw transport id even before the index is populated', () => {
+    const empty = new Map<string, string>()
+    expect(rows.filter(a => matchesSessionFilter(a, SID, empty))).toHaveLength(2)
+  })
+
+  it('does not match rows from a different session', () => {
+    const other = rec({ session_id: 'sess-other', work_session_id: 'ws-other' })
+    expect(matchesSessionFilter(other, SID, index)).toBe(false)
+    expect(matchesSessionFilter(other, WSID, index)).toBe(false)
   })
 })


### PR DESCRIPTION
Found testing v0.49.0-rc.3. On the **Sessions** page, *Actions → View Activity* lands on an **empty** Activity Log with a **blank** Session dropdown — for a session that visibly has tool calls.

## Cause

The two pages disagree about what a "session" is — the same two-namespace split as #843, in a different place.

- `Sessions.vue:113` links with `session.id` — the **transport** session id, which is what its table lists.
- `Activity.vue:937` filters with `groupKeyOf(a)` — the **work** session id (Spec 082).

So the id in the link matches no group (empty log) and no option in the picker (blank dropdown, because `<select>` is bound to a value none of its options have).

## Fix — three parts, because the link is only half of it

1. **`Sessions.vue`** links by `work_session_id || id`, so new links carry the id the log is keyed by.
2. **The filter accepts either id** (`matchesSessionFilter`), so links and bookmarks already in the wild keep working, and rows show even before the async session index has loaded.
3. **The filter is rewritten to the work session** once the index resolves it (`resolveSessionFilter`). Without this the rows appear but the dropdown still reads blank.

## Verification

Reproduced and then re-tested in the browser against a real MCP session on a scratch instance:

| | before | after |
|---|---|---|
| URL | `?session=mcp-session-edb5dc8a-…` | `?session=ws-aab3bb26b40285c9` |
| Session picker | *(blank)* | `opencode · 10:29 AM` |
| Active filter badge | `Session: …08ebd` | `Session: opencode · 10:29 AM` |
| Rows | **No matching activities** | the session's 2 records |

An old `?session=mcp-session-…` URL resolves to the same view, confirming the back-compat path.

6 new unit tests in `frontend/tests/unit/session-grouping.spec.ts` (transport→work translation, work id passthrough, unknown id passthrough, matching on either id, matching before the index loads, and not matching a different session). Full frontend suite: 297 passed. `vue-tsc` clean.