### PR TITLE
refactor(webui): split the sidebar's observability pages out of Workspace

### DIFF
--- a/frontend/src/components/SidebarNav.vue
+++ b/frontend/src/components/SidebarNav.vue
@@ -263,6 +263,32 @@
                 <span v-show="!collapsed">Agent Tokens</span>
               </router-link>
             </li>
+          </ul>
+
+          <!-- Section: Observability
+               Workspace is what you CONFIGURE (servers, tools, secrets);
+               these are what you OBSERVE. Keeping them apart stops the two
+               kinds of page reading as one undifferentiated list. -->
+          <div
+            v-if="!collapsed"
+            class="mt-5 mb-1 px-3 text-[10px] font-semibold uppercase tracking-[0.12em] text-base-content/40"
+          >
+            Observability
+          </div>
+          <div v-else class="mt-3 mb-1 mx-auto w-6 h-px bg-base-300"></div>
+
+          <ul class="menu menu-sm w-full gap-0.5 p-0">
+            <li>
+              <router-link
+                to="/activity"
+                :class="{ 'active': isActiveRoute('/activity') }"
+                class="rounded-lg font-medium"
+                :title="collapsed ? 'Activity Log' : ''"
+              >
+                <IconActivity class="w-5 h-5 shrink-0" />
+                <span v-show="!collapsed">Activity Log</span>
+              </router-link>
+            </li>
             <li>
               <router-link
                 to="/sessions"
@@ -273,17 +299,6 @@
               >
                 <IconSessions class="w-5 h-5 shrink-0" />
                 <span v-show="!collapsed">Sessions</span>
-              </router-link>
-            </li>
-            <li>
-              <router-link
-                to="/activity"
-                :class="{ 'active': isActiveRoute('/activity') }"
-                class="rounded-lg font-medium"
-                :title="collapsed ? 'Activity Log' : ''"
-              >
-                <IconActivity class="w-5 h-5 shrink-0" />
-                <span v-show="!collapsed">Activity Log</span>
               </router-link>
             </li>
             <li>


### PR DESCRIPTION
The **WORKSPACE** group was doing two jobs: things you *configure* (Servers, Tools, Secrets, Agent Tokens) sat in the same list as things you *observe* (Sessions, Activity Log, Security Scanners). Nine items read as one undifferentiated column, and Sessions in particular looked misfiled sitting next to Secrets.

```
  before                          after
  ──────────────────────          ──────────────────────
  WORKSPACE                       WORKSPACE
    Servers          28             Servers          28
    Tools           961             Tools           961
    Secrets           6             Secrets           6
      Agent Tokens                    Agent Tokens
    Sessions
    Activity Log                  OBSERVABILITY
    Security Scanners               Activity Log
                                    Sessions
  SYSTEM                            Security Scanners
    Repositories
    Configuration                 SYSTEM
                                    Repositories
                                    Configuration
```

Activity Log leads, with Sessions beneath it: they are two lenses on the same data, and the Sessions page's only action is to open the Activity Log filtered to one session.

Considered and rejected: nesting Sessions *under* Activity Log as a sub-item (like Agent Tokens under Secrets). The nesting precedent works because a token genuinely *is a kind of* secret — a session is not a kind of activity log, and if anything the containment runs the other way. It would also hide the entry point the Dashboard's "Recent Sessions" link points at.

Sidebar grouping only — no routes, no components, no behaviour changed. Collapsed mode keeps working (each section renders its divider rule). Frontend suite green, `vue-tsc` clean.

Verified in the browser.