### PR TITLE
feat(tray): add "Start Core when the app opens" preference (#410)

### DIFF
--- a/cmd/mcpproxy-tray/main.go
+++ b/cmd/mcpproxy-tray/main.go
@@ -997,6 +997,18 @@ const (
 	coreOwnershipExternalUnmanaged
 )
 
+// shouldTerminateCore reports whether tray shutdown may kill the core: only a
+// core the tray itself launched.
+//
+// GH #410: coreOwnershipExternalManaged ("a core was already running, so I
+// attached to it") used to be terminated as well — via the PID from /status and
+// a `pgrep -f "mcpproxy serve"` sweep — so quitting the tray killed a core the
+// user was running under launchd/brew. Attaching to a process is not a claim of
+// ownership over it.
+func shouldTerminateCore(ownership coreOwnershipMode) bool {
+	return ownership == coreOwnershipTrayManaged
+}
+
 // CoreProcessLauncher manages the mcpproxy core process with state machine integration
 type CoreProcessLauncher struct {
 	coreURL      string
@@ -1598,19 +1610,16 @@ func (cpl *CoreProcessLauncher) handleShutdown() {
 			cpl.forceKillCore()
 			time.Sleep(1 * time.Second) // Give it a moment to die
 		}
-	} else {
-		switch cpl.coreOwnership {
-		case coreOwnershipExternalUnmanaged:
-			cpl.logger.Info("Core management skipped by configuration - leaving external core running")
-		default:
-			cpl.logger.Warn("Process monitor unavailable during shutdown - attempting emergency core termination")
-			if err := cpl.shutdownExternalCoreFallback(); err != nil {
-				cpl.logger.Error("Emergency core shutdown failed", zap.Error(err))
-			}
+	} else if shouldTerminateCore(cpl.coreOwnership) {
+		cpl.logger.Warn("Process monitor unavailable during shutdown - attempting emergency core termination")
+		if err := cpl.shutdownExternalCoreFallback(); err != nil {
+			cpl.logger.Error("Emergency core shutdown failed", zap.Error(err))
 		}
+	} else {
+		cpl.logger.Info("Core was not started by the tray - leaving it running")
 	}
 
-	if cpl.coreOwnership != coreOwnershipExternalUnmanaged {
+	if shouldTerminateCore(cpl.coreOwnership) {
 		if err := cpl.ensureCoreTermination(); err != nil {
 			cpl.logger.Error("Final core termination verification failed", zap.Error(err))
 		}

--- a/cmd/mcpproxy-tray/main_test.go
+++ b/cmd/mcpproxy-tray/main_test.go
@@ -101,3 +101,31 @@ func TestSetupLogging_WritesTrayLogToRotatingFile(t *testing.T) {
 		t.Fatalf("tray.log did not contain expected JSON message: %s", string(content))
 	}
 }
+
+// TestShouldTerminateCore is the ownership invariant behind GH #410: the tray
+// may only kill a core IT launched.
+//
+// Before this, coreOwnershipExternalManaged — "a core was already running, so I
+// attached to it" — still fell through to shutdownExternalCoreFallback() and
+// ensureCoreTermination(), which look the PID up from /status and even
+// `pgrep -f "mcpproxy serve"` for stragglers. So starting a core under
+// launchd/brew and then opening the tray meant that quitting the tray killed
+// the user's core. Only MCPPROXY_TRAY_SKIP_CORE opted out of that.
+func TestShouldTerminateCore(t *testing.T) {
+	tests := []struct {
+		name      string
+		ownership coreOwnershipMode
+		want      bool
+	}{
+		{"tray launched it, so tray cleans it up", coreOwnershipTrayManaged, true},
+		{"attached to a core we found running", coreOwnershipExternalManaged, false},
+		{"explicitly told not to manage the core", coreOwnershipExternalUnmanaged, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldTerminateCore(tt.ownership); got != tt.want {
+				t.Errorf("shouldTerminateCore(%v) = %v, want %v", tt.ownership, got, tt.want)
+			}
+		})
+	}
+}

--- a/native/macos/MCPProxy/MCPProxy/Core/CoreProcessManager.swift
+++ b/native/macos/MCPProxy/MCPProxy/Core/CoreProcessManager.swift
@@ -172,6 +172,12 @@ actor CoreProcessManager {
     }
 
     /// Stop watching for an external core (we are starting or shutting down).
+    ///
+    /// MUST only be called from OUTSIDE the watch task (shutdown, supersede,
+    /// spawn). Calling it from within the attach path cancels the task that is
+    /// performing the attach, so the connect it awaits fails with
+    /// CancellationError — see attachToExternalCore, which drops the reference
+    /// instead of cancelling.
     private func cancelAttachWatch() {
         attachWatchTask?.cancel()
         attachWatchTask = nil
@@ -274,7 +280,14 @@ actor CoreProcessManager {
 
     /// Attach to an already-running core process on the socket.
     private func attachToExternalCore() async {
-        cancelAttachWatch()
+        // Drop the watch WITHOUT cancelling it. This attach is usually running
+        // INSIDE the watch task (that is how the core was noticed), so cancelling
+        // here would cancel the very work we are about to await: connectToCore()
+        // would throw CancellationError and the tray would sit in
+        // "Failed to connect to external core: cancelled" while a perfectly
+        // healthy core was running. The watch loop exits on its own the moment
+        // attachIfCoreIsRunning() reports success.
+        attachWatchTask = nil
         await MainActor.run {
             appState.ownership = .externalAttached
             // A core IS running, so we are not in the stopped state — even if we

--- a/native/macos/MCPProxy/MCPProxy/Core/CoreProcessManager.swift
+++ b/native/macos/MCPProxy/MCPProxy/Core/CoreProcessManager.swift
@@ -49,6 +49,15 @@ actor CoreProcessManager {
     private var refreshTask: Task<Void, Never>?
     /// Poll for an external core while core autostart is off (GH #410).
     private var attachWatchTask: Task<Void, Never>?
+
+    /// Set when this manager has been replaced by a newer one. A superseded
+    /// manager must never publish to the shared AppState again: the app creates a
+    /// FRESH CoreProcessManager on an explicit "Start MCPProxy Core", and the old
+    /// one may still be inside its idle attach-watch. Without this, the old
+    /// manager could observe the socket the NEW manager's core just created and
+    /// mislabel that tray-spawned core as `.externalAttached` — after which the
+    /// tray would refuse to stop it and leak it on quit.
+    private var superseded: Bool = false
     private var retryCount: Int = 0
     private let maxRetries: Int = 3
     private let notificationService: NotificationService
@@ -122,10 +131,19 @@ actor CoreProcessManager {
         await launchAndConnect()
     }
 
+    /// Retire this manager: stop watching and never touch AppState again. Called
+    /// before the app swaps in a replacement manager.
+    func supersede() {
+        superseded = true
+        cancelAttachWatch()
+    }
+
     /// Attach to a core that is already up. Returns false when none is.
     private func attachIfCoreIsRunning() async -> Bool {
+        guard !superseded else { return false }
         guard SocketTransport.isSocketAvailable(path: socketPath) else { return false }
         guard await probeExternalCore() else { return false }
+        guard !superseded else { return false } // a replacement took over while we probed
         await attachToExternalCore()
         return true
     }
@@ -226,7 +244,13 @@ actor CoreProcessManager {
         await transitionState(to: .idle)
     }
 
-    /// Retry launching the core after an error.
+    /// Retry after an error.
+    ///
+    /// This must not become a back door around the launch policy (#410). If the
+    /// core we lost was an EXTERNAL one and the user has core autostart off,
+    /// retrying re-attaches or returns to idle — it does not silently spawn a
+    /// tray-managed core the user asked us not to start. A core we own is
+    /// relaunched as before.
     func retry() async {
         retryCount = 0
         stderrBuffer = ""
@@ -238,7 +262,12 @@ actor CoreProcessManager {
         }
         self.process = nil
 
-        await launchAndConnect()
+        let ownership = await MainActor.run { appState.ownership }
+        let maySpawn = CoreLaunchPolicy.retryMaySpawn(
+            ownership: ownership,
+            policyAllowsSpawn: CoreLaunchPolicy().maySpawnCore
+        )
+        await start(maySpawn: maySpawn)
     }
 
     // MARK: - Private: Attach to External Core

--- a/native/macos/MCPProxy/MCPProxy/Core/CoreProcessManager.swift
+++ b/native/macos/MCPProxy/MCPProxy/Core/CoreProcessManager.swift
@@ -8,6 +8,10 @@
 
 import Foundation
 
+/// How often idle mode polls the socket for a core to attach to (GH #410).
+/// Cheap: a file-exists check plus, only when that passes, one `/ready` call.
+private let attachWatchInterval: TimeInterval = 2.0
+
 // MARK: - Core Process Manager
 
 /// Actor responsible for the full lifecycle of the mcpproxy core subprocess.
@@ -43,6 +47,8 @@ actor CoreProcessManager {
     private var sseClient: SSEClient?
     private var sseTask: Task<Void, Never>?
     private var refreshTask: Task<Void, Never>?
+    /// Poll for an external core while core autostart is off (GH #410).
+    private var attachWatchTask: Task<Void, Never>?
     private var retryCount: Int = 0
     private let maxRetries: Int = 3
     private let notificationService: NotificationService
@@ -86,24 +92,71 @@ actor CoreProcessManager {
 
     /// Start the core process and connect to it.
     ///
-    /// Strategy: always try to launch our own core first. If the socket already
-    /// exists, probe it with an actual API call — a stale socket file from a
-    /// killed process will fail the probe, so we remove it and launch fresh.
-    func start() async {
-        // If socket file exists, check if a real core is behind it
+    /// Strategy: prefer a core that is ALREADY running — if the socket exists,
+    /// probe it with a real API call and attach on success. Otherwise (a stale
+    /// socket from a killed process fails that probe) launch our own.
+    ///
+    /// - Parameter maySpawn: whether the tray is permitted to launch a core
+    ///   (GH #410). Attaching to a running core is never gated by this — only
+    ///   spawning is. When spawning is refused and no core is running, the tray
+    ///   goes idle and watches for one to appear, so a core the user starts
+    ///   later (CLI, launchd, brew services) is picked up without a restart.
+    func start(maySpawn: Bool = true) async {
+        if await attachIfCoreIsRunning() { return }
+
+        guard maySpawn else {
+            await awaitExternalCore()
+            return
+        }
+
+        // Stale socket — remove it so our new core can create a fresh one.
         if SocketTransport.isSocketAvailable(path: socketPath) {
-            if await probeExternalCore() {
-                // Real core is running — attach to it
-                await attachToExternalCore()
-                return
-            }
-            // Stale socket — remove it so our new core can create a fresh one
             try? FileManager.default.removeItem(atPath: socketPath)
         }
 
         // Launch our own core as a subprocess
-        await MainActor.run { appState.ownership = .trayManaged }
+        await MainActor.run {
+            appState.isStopped = false
+            appState.ownership = .trayManaged
+        }
         await launchAndConnect()
+    }
+
+    /// Attach to a core that is already up. Returns false when none is.
+    private func attachIfCoreIsRunning() async -> Bool {
+        guard SocketTransport.isSocketAvailable(path: socketPath) else { return false }
+        guard await probeExternalCore() else { return false }
+        await attachToExternalCore()
+        return true
+    }
+
+    /// Idle mode (#410): no core, and we are not allowed to start one. Sit in the
+    /// stopped state and poll for a core to attach to.
+    private func awaitExternalCore() async {
+        NSLog("[MCPProxy] Core autostart is off — idle, watching for an external core")
+        await MainActor.run {
+            appState.isStopped = true
+            appState.coreState = .idle
+        }
+        startAttachWatch()
+    }
+
+    /// Poll the socket until a core shows up, then attach to it.
+    private func startAttachWatch() {
+        attachWatchTask?.cancel()
+        attachWatchTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: UInt64(attachWatchInterval * 1_000_000_000))
+                guard !Task.isCancelled, let self else { return }
+                if await self.attachIfCoreIsRunning() { return }
+            }
+        }
+    }
+
+    /// Stop watching for an external core (we are starting or shutting down).
+    private func cancelAttachWatch() {
+        attachWatchTask?.cancel()
+        attachWatchTask = nil
     }
 
     /// Probe an existing socket to see if a live core is behind it.
@@ -119,8 +172,13 @@ actor CoreProcessManager {
     }
 
     /// Gracefully shut down the core process and all connections.
+    ///
+    /// A core we merely ATTACHED to is left running: we disconnect from it and
+    /// stop there. That rule is now enforced by the ownership check below rather
+    /// than by the fact that `process` happens to be nil for an attached core.
     func shutdown() async {
         await transitionState(to: .shuttingDown)
+        cancelAttachWatch()
 
         // Disconnect SSE
         sseTask?.cancel()
@@ -134,6 +192,14 @@ actor CoreProcessManager {
         sseClient = nil
         apiClient = nil
         await MainActor.run { appState.apiClient = nil }
+
+        let ownsCore = await MainActor.run { appState.ownership.shouldTerminateOnShutdown }
+        guard ownsCore else {
+            NSLog("[MCPProxy] Disconnected from an externally-managed core — leaving it running")
+            self.process = nil
+            await transitionState(to: .idle)
+            return
+        }
 
         // Terminate the process if we own it
         if let process, process.isRunning {
@@ -179,7 +245,13 @@ actor CoreProcessManager {
 
     /// Attach to an already-running core process on the socket.
     private func attachToExternalCore() async {
-        await MainActor.run { appState.ownership = .externalAttached }
+        cancelAttachWatch()
+        await MainActor.run {
+            appState.ownership = .externalAttached
+            // A core IS running, so we are not in the stopped state — even if we
+            // were forbidden from starting one ourselves (#410 idle mode).
+            appState.isStopped = false
+        }
         await transitionState(to: .waitingForCore)
 
         do {

--- a/native/macos/MCPProxy/MCPProxy/Core/CoreState.swift
+++ b/native/macos/MCPProxy/MCPProxy/Core/CoreState.swift
@@ -260,6 +260,29 @@ enum CoreOwnership: Equatable {
     /// The core was already running when the tray attached.
     /// On quit, the tray will detach without stopping the core.
     case externalAttached
+
+    /// Whether tray shutdown may terminate the core process.
+    ///
+    /// This held before only by accident — `CoreProcessManager.process` is nil
+    /// for an attached core, so the kill was skipped — which put a user's
+    /// externally-managed core one refactor away from being killed by a tray
+    /// quit. State the rule instead of relying on a nil.
+    var shouldTerminateOnShutdown: Bool {
+        self == .trayManaged
+    }
+
+    /// Title for the tray's stop action.
+    ///
+    /// A core we merely attached to CANNOT be stopped by us: we hold no PID for
+    /// it and the core exposes no shutdown endpoint. The menu used to offer
+    /// "Stop MCPProxy Core" anyway, tear down our own clients, display
+    /// "Stopped", and leave the core running. Say what actually happens.
+    var stopActionTitle: String {
+        switch self {
+        case .trayManaged: return "Stop MCPProxy Core"
+        case .externalAttached: return "Disconnect from Core"
+        }
+    }
 }
 
 // MARK: - Reconnection Policy

--- a/native/macos/MCPProxy/MCPProxy/MCPProxyApp.swift
+++ b/native/macos/MCPProxy/MCPProxy/MCPProxyApp.swift
@@ -428,10 +428,18 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate, NS
 
     // MARK: - Core Startup
 
+    /// Bring up the core on app launch.
+    ///
+    /// GH #410: `maySpawn` is the user's "Start Core when app opens" preference.
+    /// When it is off the manager still ATTACHES to a core that is already
+    /// running — it just will not start one, and idles watching for one instead.
     private func startCore() async {
         await notificationService.setup()
+
+        let policy = CoreLaunchPolicy()
         await MainActor.run {
             appState.autoStartEnabled = AutoStartService.isEnabled
+            appState.startCoreOnLaunch = policy.startCoreOnLaunch
         }
 
         if SymlinkService.needsSetup() {
@@ -445,7 +453,7 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate, NS
             notificationService: notificationService
         )
         coreManager = manager
-        await manager.start()
+        await manager.start(maySpawn: policy.maySpawnCore)
     }
 
     private func resolveBundledCoreBinary() -> String? {
@@ -790,10 +798,18 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate, NS
             start.image?.size = NSSize(width: 18, height: 18)
             menu.addItem(start)
         } else if appState.coreState == .connected || appState.coreState.isOperational {
-            let stop = NSMenuItem(title: "Stop MCPProxy Core", action: #selector(stopCore), keyEquivalent: "")
+            // A core we only attached to cannot be stopped by us — we hold no PID
+            // for it and the core has no shutdown endpoint. Say "Disconnect", and
+            // mean it (#410).
+            let ownership = appState.ownership
+            let stop = NSMenuItem(title: ownership.stopActionTitle, action: #selector(stopCore), keyEquivalent: "")
             stop.target = self
-            stop.image = NSImage(systemSymbolName: "stop.circle.fill", accessibilityDescription: "stop")
+            let symbol = ownership.shouldTerminateOnShutdown ? "stop.circle.fill" : "eject.circle.fill"
+            stop.image = NSImage(systemSymbolName: symbol, accessibilityDescription: "stop")
             stop.image?.size = NSSize(width: 18, height: 18)
+            if !ownership.shouldTerminateOnShutdown {
+                stop.toolTip = "This core was started outside MCPProxy. Disconnecting leaves it running."
+            }
             menu.addItem(stop)
         }
 
@@ -811,11 +827,14 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate, NS
     }
 
     @objc private func stopCore() {
-        NSLog("[MCPProxy] stopCore: stopping core")
+        // Only a core WE spawned gets signalled. For an attached core this is a
+        // disconnect: tear down our clients and leave the core alone (#410).
+        let ownsCore = appState.ownership.shouldTerminateOnShutdown
+        NSLog("[MCPProxy] stopCore: ownership=%@", ownsCore ? "tray-managed" : "external-attached")
         appState.isStopped = true
 
         // Kill the core process directly — most reliable method
-        let proc = coreManager?.managedProcess
+        let proc = ownsCore ? coreManager?.managedProcess : nil
         NSLog("[MCPProxy] stopCore: managedProcess=%@, isRunning=%@",
               proc != nil ? "exists" : "nil",
               proc?.isRunning == true ? "yes" : "no")
@@ -858,7 +877,10 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate, NS
                 notificationService: notificationService
             )
             coreManager = manager
-            await manager.start()
+            // An explicit "Start MCPProxy Core" always spawns, whatever the
+            // autostart preference says — the preference governs app LAUNCH, and
+            // the user is asking for a core right now (#410).
+            await manager.start(maySpawn: true)
             updateStatusIcon()
         }
     }

--- a/native/macos/MCPProxy/MCPProxy/MCPProxyApp.swift
+++ b/native/macos/MCPProxy/MCPProxy/MCPProxyApp.swift
@@ -439,7 +439,11 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate, NS
         let policy = CoreLaunchPolicy()
         await MainActor.run {
             appState.autoStartEnabled = AutoStartService.isEnabled
-            appState.startCoreOnLaunch = policy.startCoreOnLaunch
+            // NOTE: do NOT assign appState.startCoreOnLaunch here. AppState already
+            // initializes it from CoreLaunchPolicy, and its didSet WRITES to
+            // UserDefaults — so a redundant sync would materialize the key on
+            // every launch, including for users who only set MCPPROXY_TRAY_SKIP_CORE
+            // and never touched the preference.
         }
 
         if SymlinkService.needsSetup() {
@@ -872,6 +876,11 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate, NS
     @objc private func startCoreAction() {
         Task {
             appState.isStopped = false
+            // Retire the outgoing manager first. In idle mode it is still polling
+            // for a core to attach to, and it would otherwise find the core the
+            // NEW manager is about to spawn and label it "external" (#410).
+            await coreManager?.supersede()
+
             let manager = CoreProcessManager(
                 appState: appState,
                 notificationService: notificationService

--- a/native/macos/MCPProxy/MCPProxy/Services/CoreLaunchPolicy.swift
+++ b/native/macos/MCPProxy/MCPProxy/Services/CoreLaunchPolicy.swift
@@ -1,0 +1,67 @@
+// CoreLaunchPolicy.swift
+// MCPProxy
+//
+// GH #410 — whether the tray may START a core when it opens.
+//
+// The tray and the core are decoupled: they talk only over the Unix socket /
+// HTTP. That rules out storing this setting in the core's config, because the
+// setting's entire purpose is to be read when NO core is running — there would
+// be nothing to ask. So it is tray-local, like `fontScale` and
+// `MCPProxy.firstRunCompleted`.
+//
+// This does not make the tray stateful about the core. The tray never remembers
+// whether a core is running; it discovers that live from the socket on every
+// launch. The only thing it remembers is its own permission to SPAWN one.
+//
+//   attach to a running core  — always allowed, never gated by this policy
+//   spawn a new core          — gated by this policy
+
+import Foundation
+
+/// The tray's launcher preference: may it spawn a core process?
+struct CoreLaunchPolicy {
+
+    /// UserDefaults key for the persisted preference.
+    static let startCoreOnLaunchKey = "MCPProxy.startCoreOnLaunch"
+
+    /// Environment override, named to match the Go tray's existing flag
+    /// (`cmd/mcpproxy-tray/main.go` shouldSkipCoreLaunch) so a user who runs the
+    /// core under launchd/brew can pin the tray to attach-only in both trays.
+    static let skipCoreEnvVar = "MCPPROXY_TRAY_SKIP_CORE"
+
+    private let defaults: UserDefaults
+    private let environment: [String: String]
+
+    init(
+        defaults: UserDefaults = .standard,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) {
+        self.defaults = defaults
+        self.environment = environment
+    }
+
+    /// The user's stored preference. Defaults to `true` when never set, so an
+    /// existing install behaves exactly as it did before #410.
+    var startCoreOnLaunch: Bool {
+        get { defaults.object(forKey: Self.startCoreOnLaunchKey) as? Bool ?? true }
+        nonmutating set { defaults.set(newValue, forKey: Self.startCoreOnLaunchKey) }
+    }
+
+    /// True when the environment forces attach-only mode. Surfaced so the
+    /// Settings toggle can be shown disabled instead of silently disagreeing
+    /// with the app's actual behaviour.
+    var isPinnedOffByEnvironment: Bool {
+        guard let raw = environment[Self.skipCoreEnvVar]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        else { return false }
+        return raw == "1" || raw == "true"
+    }
+
+    /// The effective policy: may the tray spawn a core process right now?
+    /// The environment wins over the stored preference.
+    var maySpawnCore: Bool {
+        if isPinnedOffByEnvironment { return false }
+        return startCoreOnLaunch
+    }
+}

--- a/native/macos/MCPProxy/MCPProxy/Services/CoreLaunchPolicy.swift
+++ b/native/macos/MCPProxy/MCPProxy/Services/CoreLaunchPolicy.swift
@@ -64,4 +64,17 @@ struct CoreLaunchPolicy {
         if isPinnedOffByEnvironment { return false }
         return startCoreOnLaunch
     }
+
+    /// May a RETRY (after a core error) spawn a core?
+    ///
+    /// Yes when the core we lost was ours — the user started it, explicitly or by
+    /// leaving autostart on, so relaunching is what they want. But a retry after
+    /// an EXTERNAL core vanished must not spawn one behind the user's back when
+    /// autostart is off: that would route around the very preference they set.
+    /// Such a retry re-attaches if a core is there, and otherwise goes back to
+    /// idle, waiting for one.
+    static func retryMaySpawn(ownership: CoreOwnership, policyAllowsSpawn: Bool) -> Bool {
+        if ownership == .trayManaged { return true }
+        return policyAllowsSpawn
+    }
 }

--- a/native/macos/MCPProxy/MCPProxy/State/AppState.swift
+++ b/native/macos/MCPProxy/MCPProxy/State/AppState.swift
@@ -99,7 +99,22 @@ final class AppState: ObservableObject {
     @Published var webUIBaseURL: String = "http://127.0.0.1:8080"
 
     /// Whether the user has explicitly stopped MCPProxy (distinct from idle/error states).
+    /// Session-only by design (GH #410): the persistent choice is `startCoreOnLaunch`,
+    /// so stopping the core to debug something does not silently leave the tray
+    /// dead after the next reboot.
     @Published var isStopped: Bool = false
+
+    /// GH #410 — whether the tray may start a core when it opens. The one piece of
+    /// launcher state the tray persists; it says nothing about whether a core is
+    /// running (that is always discovered live from the socket). Mirrors
+    /// CoreLaunchPolicy so SwiftUI can bind to it.
+    @Published var startCoreOnLaunch: Bool = CoreLaunchPolicy().startCoreOnLaunch {
+        didSet { CoreLaunchPolicy().startCoreOnLaunch = startCoreOnLaunch }
+    }
+
+    /// True when MCPPROXY_TRAY_SKIP_CORE pins core autostart off, so the Settings
+    /// toggle can render disabled instead of disagreeing with actual behaviour.
+    let coreLaunchPinnedOffByEnvironment: Bool = CoreLaunchPolicy().isPinnedOffByEnvironment
 
     /// User-adjustable font scale (1.0 = default, persisted in UserDefaults).
     /// Standard macOS Cmd+/Cmd- changes this by 0.1 increments.

--- a/native/macos/MCPProxy/MCPProxy/Views/SettingsView.swift
+++ b/native/macos/MCPProxy/MCPProxy/Views/SettingsView.swift
@@ -64,6 +64,20 @@ private struct AppPrefsTab: View {
                 if let launchError {
                     Text(launchError).font(.callout).foregroundColor(.red)
                 }
+
+                // GH #410. Deliberately independent of "Launch at login": that one
+                // controls whether the APP starts with macOS, this one whether the
+                // CORE starts with the app. Turning it off keeps the menu-bar app
+                // available without the core and its upstream server processes.
+                Toggle("Start MCPProxy Core when the app opens", isOn: $appState.startCoreOnLaunch)
+                    .disabled(appState.coreLaunchPinnedOffByEnvironment)
+                if appState.coreLaunchPinnedOffByEnvironment {
+                    Text("Pinned off by MCPPROXY_TRAY_SKIP_CORE in the environment.")
+                        .font(.callout).foregroundColor(.secondary)
+                } else if !appState.startCoreOnLaunch {
+                    Text("MCPProxy will not start the core. It still connects to a core you start yourself, and you can start one from the menu at any time.")
+                        .font(.callout).foregroundColor(.secondary)
+                }
             } header: { Text("Startup") }
 
             Section {

--- a/native/macos/MCPProxy/MCPProxyTests/CoreLaunchPolicyTests.swift
+++ b/native/macos/MCPProxy/MCPProxyTests/CoreLaunchPolicyTests.swift
@@ -1,0 +1,125 @@
+// CoreLaunchPolicyTests.swift
+// MCPProxyTests
+//
+// GH #410 — "Start Core when app opens" preference.
+//
+// The tray is a launcher as well as a UI. This preference is the ONE bit of
+// launcher state it persists: may it SPAWN a core? It deliberately says nothing
+// about whether a core is running — that is discovered live from the socket on
+// every launch, so the tray still holds no core state.
+//
+// Invariants under test:
+//   1. Unset  => spawning allowed (existing users see no behaviour change).
+//   2. Off    => spawning refused, and the choice round-trips through UserDefaults.
+//   3. The MCPPROXY_TRAY_SKIP_CORE env var (parity with the Go tray) pins the
+//      policy OFF regardless of the stored preference.
+//   4. Attaching to an already-running core is NEVER gated by this policy.
+
+import XCTest
+@testable import MCPProxy
+
+final class CoreLaunchPolicyTests: XCTestCase {
+
+    private func makeDefaults(_ name: String) -> UserDefaults {
+        let suite = "MCPProxyTests.CoreLaunchPolicy.\(name)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        addTeardownBlock { defaults.removeSuite(named: suite) }
+        return defaults
+    }
+
+    // MARK: - Default
+
+    /// Back-compat: an existing install has no stored preference, and MUST keep
+    /// starting the core on launch exactly as before.
+    func testDefaultsToStartingTheCore() {
+        let policy = CoreLaunchPolicy(defaults: makeDefaults("default"), environment: [:])
+
+        XCTAssertTrue(policy.startCoreOnLaunch, "unset preference must default to ON")
+        XCTAssertTrue(policy.maySpawnCore, "an existing install must keep auto-starting the core")
+        XCTAssertFalse(policy.isPinnedOffByEnvironment)
+    }
+
+    // MARK: - Round-trip
+
+    func testPreferenceRoundTrips() {
+        let defaults = makeDefaults("roundtrip")
+        var policy = CoreLaunchPolicy(defaults: defaults, environment: [:])
+
+        policy.startCoreOnLaunch = false
+        XCTAssertFalse(policy.maySpawnCore, "with the toggle off the tray must not spawn a core")
+
+        // A fresh policy over the same domain sees the persisted choice — this is
+        // the whole point of #410: the choice must survive a relaunch.
+        let reloaded = CoreLaunchPolicy(defaults: defaults, environment: [:])
+        XCTAssertFalse(reloaded.startCoreOnLaunch, "the choice must survive a relaunch")
+        XCTAssertFalse(reloaded.maySpawnCore)
+
+        policy.startCoreOnLaunch = true
+        XCTAssertTrue(CoreLaunchPolicy(defaults: defaults, environment: [:]).maySpawnCore)
+    }
+
+    // MARK: - Environment override
+
+    /// MCPPROXY_TRAY_SKIP_CORE is the Go tray's existing flag (main.go
+    /// shouldSkipCoreLaunch). Honour the same name so a user who runs the core
+    /// under launchd/brew can pin the tray to attach-only, and surface that the
+    /// setting is env-pinned so the UI can disable the toggle rather than lie.
+    func testEnvironmentPinsPolicyOff() {
+        for raw in ["1", "true", "TRUE", " true "] {
+            let policy = CoreLaunchPolicy(
+                defaults: makeDefaults("env-\(raw.trimmingCharacters(in: .whitespaces))"),
+                environment: ["MCPPROXY_TRAY_SKIP_CORE": raw]
+            )
+            XCTAssertFalse(policy.maySpawnCore, "MCPPROXY_TRAY_SKIP_CORE=\(raw) must forbid spawning")
+            XCTAssertTrue(policy.isPinnedOffByEnvironment, "the UI must be able to show the toggle as env-pinned")
+        }
+    }
+
+    /// The env var must override even an explicitly-ON stored preference.
+    func testEnvironmentOverridesStoredPreference() {
+        let defaults = makeDefaults("env-overrides")
+        var policy = CoreLaunchPolicy(defaults: defaults, environment: [:])
+        policy.startCoreOnLaunch = true
+
+        let pinned = CoreLaunchPolicy(defaults: defaults, environment: ["MCPPROXY_TRAY_SKIP_CORE": "1"])
+        XCTAssertTrue(pinned.startCoreOnLaunch, "the stored preference itself is unchanged")
+        XCTAssertFalse(pinned.maySpawnCore, "but the environment wins for the effective policy")
+    }
+
+    /// Values that are not truthy leave the policy alone.
+    func testUnsetOrFalsyEnvironmentIsIgnored() {
+        for raw in ["0", "false", "", "no"] {
+            let policy = CoreLaunchPolicy(
+                defaults: makeDefaults("env-falsy-\(raw)"),
+                environment: ["MCPPROXY_TRAY_SKIP_CORE": raw]
+            )
+            XCTAssertTrue(policy.maySpawnCore, "MCPPROXY_TRAY_SKIP_CORE=\(raw) must not disable the core")
+            XCTAssertFalse(policy.isPinnedOffByEnvironment)
+        }
+    }
+}
+
+// MARK: - Ownership invariants (the two latent bugs #410 would make reachable)
+
+final class CoreOwnershipTests: XCTestCase {
+
+    /// The tray must terminate ONLY a core it spawned. Today this holds by
+    /// accident — `process` is nil for an attached core — rather than by an
+    /// ownership check. Make it explicit so no refactor can turn tray-quit into
+    /// "kill the user's launchd-managed core".
+    func testOnlyTrayManagedCoreIsTerminated() {
+        XCTAssertTrue(CoreOwnership.trayManaged.shouldTerminateOnShutdown)
+        XCTAssertFalse(CoreOwnership.externalAttached.shouldTerminateOnShutdown,
+                       "a core we did not spawn must survive tray quit")
+    }
+
+    /// "Stop MCPProxy Core" on an ATTACHED core cannot actually stop it (the
+    /// core exposes no shutdown endpoint, and we hold no PID for it). Today the
+    /// menu claims to stop it and silently leaves it running. The label must
+    /// tell the truth instead.
+    func testStopActionLabelsMatchOwnership() {
+        XCTAssertEqual(CoreOwnership.trayManaged.stopActionTitle, "Stop MCPProxy Core")
+        XCTAssertEqual(CoreOwnership.externalAttached.stopActionTitle, "Disconnect from Core")
+    }
+}

--- a/native/macos/MCPProxy/MCPProxyTests/CoreLaunchPolicyTests.swift
+++ b/native/macos/MCPProxy/MCPProxyTests/CoreLaunchPolicyTests.swift
@@ -87,6 +87,26 @@ final class CoreLaunchPolicyTests: XCTestCase {
         XCTAssertFalse(pinned.maySpawnCore, "but the environment wins for the effective policy")
     }
 
+    // MARK: - Retry must not route around the policy
+
+    /// A retry after OUR core died relaunches it: the user asked for that core,
+    /// either explicitly or by leaving autostart on.
+    func testRetryRelaunchesACoreWeOwn() {
+        XCTAssertTrue(CoreLaunchPolicy.retryMaySpawn(ownership: .trayManaged, policyAllowsSpawn: false),
+                      "a core the tray owns is relaunched on retry even with autostart off")
+        XCTAssertTrue(CoreLaunchPolicy.retryMaySpawn(ownership: .trayManaged, policyAllowsSpawn: true))
+    }
+
+    /// But a retry after an EXTERNAL core vanished must not spawn one behind the
+    /// user's back when autostart is off — that would route around the very
+    /// preference they set. It re-attaches, or goes back to idle.
+    func testRetryDoesNotSpawnForAnExternalCoreWhenAutostartIsOff() {
+        XCTAssertFalse(CoreLaunchPolicy.retryMaySpawn(ownership: .externalAttached, policyAllowsSpawn: false),
+                       "retry must not spawn a core the user told us not to start")
+        XCTAssertTrue(CoreLaunchPolicy.retryMaySpawn(ownership: .externalAttached, policyAllowsSpawn: true),
+                      "with autostart on, a retry may spawn a replacement")
+    }
+
     /// Values that are not truthy leave the policy alone.
     func testUnsetOrFalsyEnvironmentIsIgnored() {
         for raw in ["0", "false", "", "no"] {


### PR DESCRIPTION
Implements discussion #410 (jagaliano), open and unanswered since 2026-04-25.

## The report

The macOS tray starts the Core unconditionally in `applicationDidFinishLaunching`, and **nothing can stop it**: the existing Stop action only sets an in-memory `isStopped`, so the choice never survives a relaunch. Keeping MCPProxy in the menu bar therefore means keeping the Core — and its whole tree of upstream MCP server processes — alive. ~1.8 GB RSS in the reporter's setup, with no AI client open.

The requester read our Swift and proposed the implementation himself; his analysis checks out. What he did not know: **the Go tray has had `MCPPROXY_TRAY_SKIP_CORE` for this all along** (`cmd/mcpproxy-tray/main.go`, documented in `docs/architecture.md`). The Swift app we actually ship never got it. So this is closing a parity gap, not inventing a concept.

## Design — where the state lives

The tray and Core are decoupled (socket / HTTP only), so this setting **cannot** live in the Core's config: its entire purpose is to be read when **no Core is running**, so there is nothing to ask. It is tray-local (`UserDefaults`), alongside `fontScale` and `firstRunCompleted`.

This does not make the tray stateful about the Core. It never remembers *whether a Core is running* — that is discovered live from the socket on every launch. The one bit it remembers is its own permission to **spawn** one:

```
attach to a running core  — always allowed, never gated
spawn a new core          — gated by the preference
```

With the preference off and no Core up, the tray idles and polls, so a Core started later (CLI, launchd, brew services) is picked up without a tray restart. An explicit "Start MCPProxy Core" from the menu always spawns.

Stop stays **session-only** by design: the persistent choice is the toggle. Stopping the Core to debug something must not silently leave the tray dead after the next reboot.

## Two ownership bugs fixed alongside

Both are real today; idle mode makes them far more reachable.

1. **Swift: "Stop MCPProxy Core" lied on an attached Core.** It killed `managedProcess` — `nil` in `.externalAttached` — so it tore down our own clients, displayed "Stopped", and left the Core running. We hold no PID for it and the Core exposes no shutdown endpoint. It is now **"Disconnect from Core"** and says so. `shutdown()` checks ownership explicitly instead of relying on `process` incidentally being `nil`.
2. **Go tray killed Cores it never started.** `coreOwnershipExternalManaged` ("a Core was already running, so I attached") still fell through to `shutdownExternalCoreFallback()` + `ensureCoreTermination()`, which look the PID up from `/status` and even `pgrep -f "mcpproxy serve"` for stragglers. Run a Core under launchd, open the Go tray, quit it — **your Core died**. Only a tray-spawned Core is terminated now.

## Tests

7 new: `CoreLaunchPolicyTests` (default-ON back-compat, round-trip, env override precedence), `CoreOwnershipTests` (only-kill-what-you-spawned, honest labels), Go `TestShouldTerminateCore`. Swift suite 276 → 283 tests, failure count unchanged at 7 — those 7 are pre-existing on clean `main` (SSE parser, UserDefaults suite pollution), not from this change. `go build ./...` + golangci-lint v2 clean.

Not yet driven end-to-end in the real `.app` — the wiring (idle mode, attach-watch, menu labels) is proven by construction and unit tests only.