### PR TITLE
fix(tray): green the native test suite — two skipped tests were hiding real bugs

### DIFF
--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -75,18 +75,12 @@ jobs:
         run: swift --version
       - name: Run native unit tests
         working-directory: native/macos/MCPProxy
-        # NOTE: the skip-set below are pre-existing/environmental failures
-        # tracked for repair (AutoStart UserDefaults first-run, SSE-parser
-        # edge cases, a JSONEncoder behavior canary). They are unrelated to the
-        # tray form logic. Remove skips as each is fixed so coverage grows.
-        # Tracked in the native-test-suite-green follow-up.
-        run: |
-          swift test \
-            --skip AutoStartTests \
-            --skip testDefaultJSONEncoderDropsOptionalNilFromMap \
-            --skip testSSEEventDecodeInvalidDataThrows \
-            --skip testFieldWithColonButNoValue \
-            --skip testFieldWithNoColon
+        # The whole suite runs. The former skip-set (AutoStart first-run, two
+        # SSE-parser edge cases, a JSONEncoder canary, SSE decode) is fixed — two
+        # of them were real bugs the skips were hiding — so there is nothing left
+        # to exclude. Do not reintroduce --skip: a skipped test is an untested
+        # code path that looks green.
+        run: swift test
 
   settings-parity:
     name: settings-parity

--- a/native/macos/MCPProxy/MCPProxy/API/Models.swift
+++ b/native/macos/MCPProxy/MCPProxy/API/Models.swift
@@ -767,11 +767,19 @@ struct SSEEvent: Equatable {
     }
 
     /// Convenience: decode the data payload as a JSON dictionary.
+    ///
+    /// Always throws `SSEError.invalidData` on bad input. The `try` on
+    /// JSONSerialization used to let Foundation's own NSError escape — so an
+    /// event with an empty or malformed payload threw a raw Cocoa error instead
+    /// of the SSEError this function documents, and any caller matching on
+    /// SSEError missed it.
     func decodePayload() throws -> [String: Any] {
-        guard let jsonData = data.data(using: .utf8) else {
+        guard let jsonData = data.data(using: .utf8), !jsonData.isEmpty else {
             throw SSEError.invalidData
         }
-        guard let dict = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
+        guard let object = try? JSONSerialization.jsonObject(with: jsonData),
+              let dict = object as? [String: Any]
+        else {
             throw SSEError.invalidData
         }
         return dict

--- a/native/macos/MCPProxy/MCPProxy/API/SSEClient.swift
+++ b/native/macos/MCPProxy/MCPProxy/API/SSEClient.swift
@@ -11,6 +11,16 @@ import Foundation
 struct SSEParser {
     private var eventType: String = ""
     private var dataBuffer: String = ""
+    /// Whether a `data` field appeared in the event being assembled.
+    ///
+    /// The spec appends a LINE FEED to the data buffer for EVERY data field and
+    /// then dispatches whenever the buffer is non-empty (stripping one trailing
+    /// LF). We join data lines with "\n" instead, which is equivalent for content
+    /// — but it loses the one thing the spec's trailing LF encodes: that a data
+    /// field was seen at all. Without this flag, a lone `data:` (empty value)
+    /// leaves the buffer "" and is indistinguishable from an event carrying no
+    /// data field, so a spec-valid empty-data event was silently dropped.
+    private var sawDataField: Bool = false
     private var lastEventId: String?
     private var retryMs: Int?
 
@@ -49,10 +59,11 @@ struct SSEParser {
         case "event":
             eventType = value
         case "data":
-            if !dataBuffer.isEmpty {
+            if sawDataField {
                 dataBuffer += "\n"
             }
             dataBuffer += value
+            sawDataField = true
         case "id":
             // Per spec, id must not contain null
             if !value.contains("\0") {
@@ -72,8 +83,12 @@ struct SSEParser {
 
     /// Assemble and return the current buffered event, then reset buffers.
     private mutating func dispatchEvent() -> SSEEvent? {
-        // If data buffer is empty, no event to dispatch (per spec)
-        guard !dataBuffer.isEmpty else {
+        // An event is dispatched iff a `data` field was seen — NOT merely when the
+        // buffer is non-empty. Per spec, `data:` with an empty value still yields
+        // an event (with empty data); only an event carrying no data field at all
+        // is dropped. Testing the buffer alone conflated the two and swallowed
+        // spec-valid empty-data events.
+        guard sawDataField else {
             // Still reset event type for next event
             eventType = ""
             return nil
@@ -89,6 +104,7 @@ struct SSEParser {
         // Reset per-event state; id and retry persist across events per spec
         eventType = ""
         dataBuffer = ""
+        sawDataField = false
         // Note: retryMs and lastEventId intentionally NOT reset (they persist)
 
         return event
@@ -98,6 +114,7 @@ struct SSEParser {
     mutating func reset() {
         eventType = ""
         dataBuffer = ""
+        sawDataField = false
         lastEventId = nil
         retryMs = nil
     }

--- a/native/macos/MCPProxy/MCPProxyTests/AutoStartTests.swift
+++ b/native/macos/MCPProxy/MCPProxyTests/AutoStartTests.swift
@@ -30,7 +30,17 @@ final class AutoStartTests: XCTestCase {
     func testFirstRunFlagRoundTrip() {
         let suite = "MCPProxyTests.AutoStartTests.firstRun"
         let defaults = UserDefaults(suiteName: suite)!
-        defer { defaults.removeSuite(named: suite) }
+
+        // removeSuite() only drops the suite from THIS instance's search list — it
+        // does not erase the persisted domain, so the `true` written below survived
+        // on disk and the next run of this test saw a "fresh" suite that already
+        // reported firstRunCompleted=true. Purge the domain on both ends instead,
+        // so the test is hermetic no matter what earlier runs left behind.
+        defaults.removePersistentDomain(forName: suite)
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suite)
+            defaults.removeSuite(named: suite)
+        }
 
         // Fresh domain → not completed.
         XCTAssertFalse(defaults.bool(forKey: firstRunCompletedKey),

--- a/native/macos/MCPProxy/MCPProxyTests/MergePatchEncodingTests.swift
+++ b/native/macos/MCPProxy/MCPProxyTests/MergePatchEncodingTests.swift
@@ -57,24 +57,36 @@ final class MergePatchEncodingTests: XCTestCase {
         XCTAssertTrue(headers["X-Old"] is NSNull, "X-Old value must round-trip as NSNull, not be coerced to anything else")
     }
 
-    /// Demonstrate the WRONG path so a future refactor can't tell itself
-    /// "JSONEncoder should be fine, let's switch". `[String: String?]`
-    /// run through the default encoder strips nil values silently.
-    func testDefaultJSONEncoderDropsOptionalNilFromMap() throws {
+    /// Tripwire on `[String: String?]` + `JSONEncoder` — the tempting shortcut
+    /// for building the patch, and the reason we don't take it.
+    ///
+    /// How Foundation encodes a nil map value is NOT stable across toolchains:
+    /// it used to DROP the key entirely (so a delete silently became "no change"),
+    /// and current Foundation emits `null` instead (so the same code would now
+    /// mean "delete"). Either way the meaning of a user's edit would be decided by
+    /// the Swift runtime rather than by us, and it flipped once already — which is
+    /// exactly why `saveEdits()` builds `[String: Any]` with `NSNull()` and encodes
+    /// through JSONSerialization, whose rendering is specified.
+    ///
+    /// This test therefore pins the observed behaviour rather than a preference.
+    /// If it fails, Foundation has changed AGAIN: re-audit saveEdits() (it should
+    /// still be immune, because it does not use this path) and update the comment.
+    func testDefaultJSONEncoderNilMapEncodingIsToolchainDefined() throws {
         struct Body: Encodable {
             let headers: [String: String?]
         }
         let body = Body(headers: ["X-Keep": "v", "X-Stale": nil])
-        let data = try JSONEncoder().encode(body)
-        let str = String(data: data, encoding: .utf8)!
+        let str = String(data: try JSONEncoder().encode(body), encoding: .utf8)!
 
-        // X-Stale must NOT appear in the encoded JSON — which is exactly
-        // why we don't use this approach. If a future change makes the
-        // encoder start emitting nil as `null`, this test fails and the
-        // author has to update both the test and the saveEdits() path.
-        XCTAssertFalse(str.contains("X-Stale"),
-                       "documented pitfall: default JSONEncoder drops nil map values; if this changes, audit saveEdits()")
-        XCTAssertTrue(str.contains("X-Keep"))
+        XCTAssertTrue(str.contains("X-Keep"), "a present value must always survive")
+
+        // Current Foundation: nil is emitted as an explicit null.
+        XCTAssertTrue(str.contains("\"X-Stale\":null") || str.contains("\"X-Stale\" : null"),
+                      """
+                      Foundation's encoding of nil map values changed again (got: \(str)).
+                      saveEdits() does not use this path — verify that is still true — and \
+                      update this tripwire to the new behaviour.
+                      """)
     }
 
     /// Sanity: an empty-string value (set-to-empty) must NOT be treated

--- a/native/macos/MCPProxy/MCPProxyTests/SSEParserTests.swift
+++ b/native/macos/MCPProxy/MCPProxyTests/SSEParserTests.swift
@@ -339,4 +339,42 @@ final class SSEParserTests: XCTestCase {
         XCTAssertEqual(events[2].event, "config.reloaded")
         XCTAssertEqual(events[2].id, "3")
     }
+
+    // MARK: - Empty-data events (native-test-suite-green)
+
+    /// An event carrying a `data` field with an EMPTY value must still be
+    /// dispatched — only an event with no data field at all is dropped.
+    ///
+    /// The parser used to decide this by looking at the data buffer alone, which
+    /// cannot tell "data: (empty)" from "no data field", so it silently swallowed
+    /// spec-valid empty-data events. The two tests above pinned exactly this and
+    /// were being SKIPPED in CI, which is how the bug survived.
+    func testEmptyDataFieldStillDispatchesAnEvent() {
+        var parser = SSEParser()
+        XCTAssertNil(parser.feed("event: ping"))
+        XCTAssertNil(parser.feed("data:"))
+
+        let event = parser.feed("")
+        XCTAssertNotNil(event, "a data field with an empty value must still produce an event")
+        XCTAssertEqual(event?.event, "ping")
+        XCTAssertEqual(event?.data, "")
+    }
+
+    /// ...while an event with NO data field is still dropped, per spec.
+    func testEventWithoutAnyDataFieldIsDropped() {
+        var parser = SSEParser()
+        XCTAssertNil(parser.feed("event: ping"))
+        XCTAssertNil(parser.feed(""), "no data field => no event")
+    }
+
+    /// The empty-data path must not corrupt the NEXT event's buffer.
+    func testEmptyDataEventDoesNotLeakIntoTheNextEvent() {
+        var parser = SSEParser()
+        _ = parser.feed("data:")
+        _ = parser.feed("")
+
+        XCTAssertNil(parser.feed("data: {\"ok\":true}"))
+        let next = parser.feed("")
+        XCTAssertEqual(next?.data, "{\"ok\":true}", "a stale empty data field must not prepend a newline")
+    }
 }


### PR DESCRIPTION
Follow-up to #847. CI ran `swift test` with five tests excluded:

```
swift test --skip AutoStartTests --skip testDefaultJSONEncoderDropsOptionalNilFromMap \
           --skip testSSEEventDecodeInvalidDataThrows --skip testFieldWithColonButNoValue --skip testFieldWithNoColon
```

annotated *"pre-existing/environmental failures tracked for repair"*. **Two of them were not environmental — the code was wrong, and the skip is what kept it invisible.**

## The real bugs

**1. `SSEParser` silently dropped spec-valid empty-data events.**
Per the [SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html), an event is dispatched whenever a `data` field appeared: `data:` with an empty value produces an event with empty data, and only an event with *no* data field is dropped. The parser decided this by testing whether the data buffer was empty — which cannot distinguish `data:` *(empty value)* from *no data field at all* — so it swallowed the former. Now it tracks whether a data field was seen. `testFieldWithNoColon` and `testFieldWithColonButNoValue` were right all along; they were skipped instead of believed.

**2. `SSEEvent.decodePayload()` leaked Foundation's error.**
It documents throwing `SSEError`, but the bare `try JSONSerialization…` let a raw Cocoa `NSError` escape for an empty or malformed payload — so any caller matching on `SSEError` missed it. It now always throws `SSEError.invalidData`.

## The two that really were environmental

**3. The `JSONEncoder` merge-patch canary** asserted a Foundation behaviour that has since changed: encoding a nil map value used to **drop** the key, and now emits **`null`** — which in JSON Merge Patch means *delete*. The canary's own message said "if this changes, audit `saveEdits()`", so I did: **it is immune**, because it builds `[String: Any]` with `NSNull()` and encodes via `JSONSerialization`, never `[String: String?]` + `JSONEncoder`. The tripwire is re-aimed at the observed behaviour, noting that it has flipped once and is therefore not something to depend on.

**4. `AutoStartTests` was not hermetic.** `removeSuite()` drops a suite from the search list but does **not** erase the persisted domain, so the `true` it wrote survived on disk and the next run saw a "fresh" suite that already reported `firstRunCompleted=true`. It now purges the persistent domain on both ends.

## CI

The workflow runs the whole suite — no `--skip`. A skipped test is an untested code path that looks green.

**288 tests, 0 failures**, including three new regression tests for the empty-data event path.