### PR TITLE
test(tray): make the merge-patch canary toolchain-agnostic

### DIFF
--- a/native/macos/MCPProxy/MCPProxyTests/MergePatchEncodingTests.swift
+++ b/native/macos/MCPProxy/MCPProxyTests/MergePatchEncodingTests.swift
@@ -4,20 +4,31 @@ import XCTest
 /// Pin the wire format of the JSON Merge Patch (RFC 7396) body the
 /// macOS tray sends to PATCH /api/v1/servers/{id}.
 ///
-/// The backend's delete signal is a literal JSON `null` value on the
-/// header / env key (`{"headers": {"X-Stale": null}}`). Swift's default
-/// `JSONEncoder` on `[String: String?]` drops nil entries from the output
-/// entirely — so a naive encoding would send `{"headers": {}}` and the
-/// backend would interpret that as "no headers changed", silently
-/// dropping the user's delete intent.
+/// The backend's delete signal is a literal JSON `null` value on the header /
+/// env key (`{"headers": {"X-Stale": null}}`), and RFC 7396 makes the
+/// distinction load-bearing: an ABSENT key means "leave it alone", `null` means
+/// "delete it". Getting that wrong silently destroys or silently preserves a
+/// user's setting.
 ///
-/// The fix is to build the patch dict as `[String: Any]` with `NSNull()`
-/// in place of Swift `nil`, and to encode via `JSONSerialization` which
-/// faithfully renders NSNull as the literal `null` token. These tests
-/// pin both:
-///   1. NSNull survives the encoder and lands on the wire as `null`.
-///   2. The simpler-but-wrong `[String: String?]` + `JSONEncoder` path
-///      DROPS the key, demonstrating why we use the manual approach.
+/// So the patch is built as `[String: Any]` with `NSNull()` in place of Swift
+/// `nil` and encoded via `JSONSerialization`, whose rendering of NSNull as the
+/// literal `null` token is specified and stable.
+///
+/// The tempting shortcut — `[String: String?]` + `JSONEncoder` — is avoided
+/// because Foundation does NOT specify how it encodes a nil map value, and the
+/// behaviour has already changed once under us: it used to DROP the key (turning
+/// a delete into "no change"), and current Foundation emits `null` (turning it
+/// into a delete). Same source, opposite meaning, decided by whichever toolchain
+/// happens to compile the app. That is the whole argument for the manual path.
+///
+/// These tests pin:
+///   1. NSNull survives the encoder and lands on the wire as `null` (the
+///      invariant that actually protects the feature).
+///   2. `""` (set-to-empty) stays `""` and is never confused with a delete.
+///   3. That `[String: String?]` + `JSONEncoder` remains unfit for purpose —
+///      asserted WITHOUT depending on which of the two known behaviours the
+///      current toolchain has, so CI cannot go red over a Foundation change that
+///      production is immune to.
 final class MergePatchEncodingTests: XCTestCase {
 
     /// JSONSerialization with NSNull renders the JSON null token.
@@ -57,21 +68,24 @@ final class MergePatchEncodingTests: XCTestCase {
         XCTAssertTrue(headers["X-Old"] is NSNull, "X-Old value must round-trip as NSNull, not be coerced to anything else")
     }
 
-    /// Tripwire on `[String: String?]` + `JSONEncoder` — the tempting shortcut
-    /// for building the patch, and the reason we don't take it.
+    /// Tripwire on `[String: String?]` + `JSONEncoder` — the tempting shortcut for
+    /// building the patch, and the reason we don't take it.
     ///
-    /// How Foundation encodes a nil map value is NOT stable across toolchains:
-    /// it used to DROP the key entirely (so a delete silently became "no change"),
-    /// and current Foundation emits `null` instead (so the same code would now
-    /// mean "delete"). Either way the meaning of a user's edit would be decided by
-    /// the Swift runtime rather than by us, and it flipped once already — which is
-    /// exactly why `saveEdits()` builds `[String: Any]` with `NSNull()` and encodes
-    /// through JSONSerialization, whose rendering is specified.
+    /// Deliberately does NOT assert which encoding the current toolchain produces.
+    /// Both behaviours have shipped (drop the key; emit `null`), they mean OPPOSITE
+    /// things under RFC 7396, and CI runs on a floating `macos-latest` image — so
+    /// pinning either one would make the suite go red on an Xcode bump over a
+    /// behaviour production does not depend on. Asserting "it is one of the two,
+    /// and we cannot tell which" is the honest, stable statement, and it is also
+    /// precisely the reason the shortcut is unusable.
     ///
-    /// This test therefore pins the observed behaviour rather than a preference.
-    /// If it fails, Foundation has changed AGAIN: re-audit saveEdits() (it should
-    /// still be immune, because it does not use this path) and update the comment.
-    func testDefaultJSONEncoderNilMapEncodingIsToolchainDefined() throws {
+    /// The invariant that actually protects the feature is asserted by the
+    /// JSONSerialization/NSNull tests above, which do not depend on the toolchain.
+    ///
+    /// If this ever fails, Foundation has invented a THIRD behaviour: re-audit
+    /// saveEdits() (it should still be immune — it never uses this path) before
+    /// touching anything else.
+    func testDefaultJSONEncoderIsUnfitForMergePatch() throws {
         struct Body: Encodable {
             let headers: [String: String?]
         }
@@ -80,13 +94,30 @@ final class MergePatchEncodingTests: XCTestCase {
 
         XCTAssertTrue(str.contains("X-Keep"), "a present value must always survive")
 
-        // Current Foundation: nil is emitted as an explicit null.
-        XCTAssertTrue(str.contains("\"X-Stale\":null") || str.contains("\"X-Stale\" : null"),
+        let dropsTheKey = !str.contains("X-Stale")
+        let emitsNull = str.contains("\"X-Stale\":null") || str.contains("\"X-Stale\" : null")
+
+        // Exactly one of the two known behaviours — we just don't get to choose it,
+        // which is the point.
+        XCTAssertTrue(dropsTheKey != emitsNull,
                       """
-                      Foundation's encoding of nil map values changed again (got: \(str)).
-                      saveEdits() does not use this path — verify that is still true — and \
-                      update this tripwire to the new behaviour.
+                      JSONEncoder produced a THIRD encoding for a nil map value (got: \(str)).
+                      Re-audit saveEdits() — it should still be immune, because it builds \
+                      [String: Any] with NSNull() and encodes via JSONSerialization — then \
+                      update this tripwire.
                       """)
+    }
+
+    /// The load-bearing distinction, stated directly: under RFC 7396 an ABSENT key
+    /// means "leave it alone" and `null` means "delete it". Our builder must be
+    /// able to express both, and JSONSerialization does — no matter the toolchain.
+    func testPatchCanExpressBothLeaveAloneAndDelete() throws {
+        let body: [String: Any] = ["headers": ["X-Delete": NSNull()]]  // X-Untouched deliberately absent
+        let str = String(data: try JSONSerialization.data(withJSONObject: body, options: [.sortedKeys]),
+                         encoding: .utf8)!
+
+        XCTAssertTrue(str.contains("\"X-Delete\":null"), "a delete must reach the wire as literal null")
+        XCTAssertFalse(str.contains("X-Untouched"), "an untouched key must be absent, not null")
     }
 
     /// Sanity: an empty-string value (set-to-empty) must NOT be treated


### PR DESCRIPTION
Follow-up to #848, from a Codex cross-model review of the merged change.

## The problem I introduced

#848 re-aimed the JSON Merge Patch canary at Foundation's **current** encoding of a nil map value (`"X-Stale":null`). Codex flagged that this trades one toolchain dependence for another: CI runs on a floating `macos-latest` image, so an Xcode bump that restores the old behaviour (**drop the key**) turns the entire native suite red — over a behaviour production is provably immune to.

That immunity is real and I re-verified it: `saveEdits()` builds `[String: Any]` with `NSNull()` and encodes via `JSONSerialization`; it never uses `[String: String?]` + `JSONEncoder`.

## The fix

The canary now asserts what is **actually true and stable**: `JSONEncoder` produces *one of the two known encodings*, we don't get to choose which, and the two mean **opposite** things under RFC 7396 —

| encoding | RFC 7396 meaning |
|---|---|
| drops the key | "leave it alone" |
| emits `null` | "delete it" |

— which is precisely why the shortcut is unusable. It fails only if Foundation invents a *third* behaviour, which is the one case that genuinely warrants a re-audit.

Verified the predicate against both known encodings and a hypothetical third:

```
PASS — old Foundation: drops the key
PASS — current Foundation: emits null
FAIL — hypothetical third behaviour
```

## Also

- **New `testPatchCanExpressBothLeaveAloneAndDelete`** — states the load-bearing rule directly (absent = leave alone, `null` = delete) and pins that our builder expresses both. This is the invariant that actually protects the feature, and it is toolchain-independent.
- **Fixed the file header**, which still claimed `JSONEncoder` "drops nil entries" and now contradicted the test beneath it — stale guidance for the next person auditing this.

Codex's clean checks on the rest of #848: the SSE parser fix is correct and complete (`sawDataField` set/cleared on every path, multi-line joins intact, `id`/`retry` persistence preserved), empty-data events cannot spam consumers, `decodePayload()` is consistent, and the `saveEdits()` immunity claim is true.