### PR TITLE
chore(roadmap): regenerate — add the missing 082-work-sessions row

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -751,3 +751,4 @@ Legend: `shipped` ≥95% checked · `in-flight` 1–94% · `drafted` 0% · `—`
 | [079-upgrade-nudge](./specs/079-upgrade-nudge/) | — | — |
 | [080-telemetry-v7-churn](./specs/080-telemetry-v7-churn/) | — | — |
 | [081-release-qa-gate](./specs/081-release-qa-gate/) | — | — |
+| [082-work-sessions](./specs/082-work-sessions/) | — | — |


### PR DESCRIPTION
ROADMAP.md was out of date **on main**: spec 082 landed without refreshing the generated table, so `scripts/gen-roadmap.py --check` fails on main and on every PR that runs the roadmap gate. It surfaced while getting the Dependabot PRs green ahead of v0.50.0.

Regenerated with the script. The only change is the one missing row:

```
+| [082-work-sessions](./specs/082-work-sessions/) | — | — |
```