### PR TITLE
fix(cli): honor global --data-dir flag in doctor, auth, call, code, and tools config loaders

### DIFF
--- a/cmd/mcpproxy/auth_cmd.go
+++ b/cmd/mcpproxy/auth_cmd.go
@@ -611,6 +611,11 @@ func loadAuthConfig() (*config.Config, error) {
 		return nil, fmt.Errorf("failed to load config from %s: %w", configFile, err)
 	}
 
+	// Respect global --data-dir flag
+	if dataDir != "" {
+		globalConfig.DataDir = dataDir
+	}
+
 	return globalConfig, nil
 }
 

--- a/cmd/mcpproxy/call_cmd.go
+++ b/cmd/mcpproxy/call_cmd.go
@@ -232,6 +232,11 @@ func loadCallConfig() (*config.Config, error) {
 		return nil, fmt.Errorf("failed to load config from %s: %w", configFilePath, err)
 	}
 
+	// Respect global --data-dir flag
+	if dataDir != "" {
+		globalConfig.DataDir = dataDir
+	}
+
 	return globalConfig, nil
 }
 

--- a/cmd/mcpproxy/code_cmd.go
+++ b/cmd/mcpproxy/code_cmd.go
@@ -420,6 +420,11 @@ func loadCodeConfig() (*config.Config, error) {
 		return nil, fmt.Errorf("failed to load config from %s: %w", configFilePath, err)
 	}
 
+	// Respect global --data-dir flag
+	if dataDir != "" {
+		globalConfig.DataDir = dataDir
+	}
+
 	return globalConfig, nil
 }
 

--- a/cmd/mcpproxy/datadir_flag_test.go
+++ b/cmd/mcpproxy/datadir_flag_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+)
+
+// TestLoadersHonorGlobalDataDirFlag verifies that every per-command config
+// loader applies the global --data-dir flag (bound to the package-level
+// dataDir variable) on top of the loaded config file. Without this, daemon
+// detection (socket.DetectSocketPath) probes the wrong directory and commands
+// like `mcpproxy doctor --data-dir D` falsely report that no daemon is
+// running (DOCTOR-DATADIR).
+//
+// These subtests mutate package-level globals (dataDir + per-command config
+// path vars), so they must not use t.Parallel.
+func TestLoadersHonorGlobalDataDirFlag(t *testing.T) {
+	cases := []struct {
+		name    string
+		setPath func(string) // sets the command's local --config path var
+		load    func() (*config.Config, error)
+	}{
+		{"doctor", func(p string) { doctorConfigPath = p }, loadDoctorConfig},
+		{"auth", func(p string) { authConfigPath = p }, loadAuthConfig},
+		{"call", func(p string) { callConfigPath = p }, loadCallConfig},
+		{"code", func(p string) { codeConfigPath = p }, loadCodeConfig},
+		{"tools", func(p string) { configPath = p }, loadToolsConfig},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			cfgDataDir := filepath.Join(tmp, "cfg-data")
+			cfgPath := filepath.Join(tmp, "cfg.json")
+			cfgJSON := fmt.Sprintf(`{"listen":"127.0.0.1:8080","data_dir":%q,"mcpServers":[]}`, cfgDataDir)
+			if err := os.WriteFile(cfgPath, []byte(cfgJSON), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			oldDataDir := dataDir
+			defer func() {
+				dataDir = oldDataDir
+				tc.setPath("")
+			}()
+			tc.setPath(cfgPath)
+
+			// 1) No flag: the config file's data_dir wins.
+			dataDir = ""
+			cfg, err := tc.load()
+			if err != nil {
+				t.Fatalf("load without --data-dir: %v", err)
+			}
+			if cfg.DataDir != cfgDataDir {
+				t.Errorf("no-flag DataDir = %q, want config data_dir %q", cfg.DataDir, cfgDataDir)
+			}
+
+			// 2) --data-dir flag overrides the config file (DOCTOR-DATADIR bug).
+			flagDir := filepath.Join(tmp, "flag-data")
+			dataDir = flagDir
+			cfg, err = tc.load()
+			if err != nil {
+				t.Fatalf("load with --data-dir: %v", err)
+			}
+			if cfg.DataDir != flagDir {
+				t.Errorf("DataDir = %q, want --data-dir %q", cfg.DataDir, flagDir)
+			}
+		})
+	}
+}

--- a/cmd/mcpproxy/doctor_cmd.go
+++ b/cmd/mcpproxy/doctor_cmd.go
@@ -536,9 +536,25 @@ func outputDiagnostics(diag map[string]interface{}, info map[string]interface{},
 
 func loadDoctorConfig() (*config.Config, error) {
 	if doctorConfigPath != "" {
-		return config.LoadFromFile(doctorConfigPath)
+		cfg, err := config.LoadFromFile(doctorConfigPath)
+		if err != nil {
+			return nil, err
+		}
+		// Respect global --data-dir flag
+		if dataDir != "" {
+			cfg.DataDir = dataDir
+		}
+		return cfg, nil
 	}
-	return config.Load()
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, err
+	}
+	// Respect global --data-dir flag
+	if dataDir != "" {
+		cfg.DataDir = dataDir
+	}
+	return cfg, nil
 }
 
 func createDoctorLogger(level string) (*zap.Logger, error) {

--- a/cmd/mcpproxy/tools_cmd.go
+++ b/cmd/mcpproxy/tools_cmd.go
@@ -476,6 +476,11 @@ func loadToolsConfig() (*config.Config, error) {
 		return nil, fmt.Errorf("failed to load config from %s: %w", configFilePath, err)
 	}
 
+	// Respect global --data-dir flag
+	if dataDir != "" {
+		globalConfig.DataDir = dataDir
+	}
+
 	return globalConfig, nil
 }
 


### PR DESCRIPTION
## Problem

`mcpproxy doctor --config C --data-dir D` falsely reports "doctor requires running daemon. Start with: mcpproxy serve" even when a daemon is running with data dir `D`. The same command class works via `mcpproxy upstream list --data-dir D`. Auth, call, code, and tools suffer the identical bug. Found by v0.51.0-rc.1 QA (2026-07-15).

## Root cause

The root command binds `--data-dir`/`-d` to the package-level `dataDir` var (`cmd/mcpproxy/main.go:109`), but five per-command loaders never apply it after loading the config:

- `loadDoctorConfig` — `cmd/mcpproxy/doctor_cmd.go:537`
- `loadAuthConfig` — `cmd/mcpproxy/auth_cmd.go:597`
- `loadCallConfig` — `cmd/mcpproxy/call_cmd.go:210`
- `loadCodeConfig` — `cmd/mcpproxy/code_cmd.go:398`
- `loadToolsConfig` — `cmd/mcpproxy/tools_cmd.go:454`

Daemon detection is `shouldUse*Daemon(cfg.DataDir)` → `socket.DetectSocketPath`, so the socket probe looked at `~/.mcpproxy/mcpproxy.sock` instead of `D/mcpproxy.sock`. `loadUpstreamConfig` (`upstream_cmd.go:642-655`) already applies the override, which is why `upstream list` worked.

## Fix

Replicate the existing `loadUpstreamConfig` pattern in each broken loader: after a successful load, `if dataDir != "" { cfg.DataDir = dataDir }`. Resulting precedence: `--data-dir` flag > config-file `data_dir` > `~/.mcpproxy` default — matching `doctor fix` and the already-correct loaders. No signature changes, no new helpers.

## Tests

- New `cmd/mcpproxy/datadir_flag_test.go`: `TestLoadersHonorGlobalDataDirFlag`, table-driven over all five loaders, asserting (1) config-file `data_dir` wins with no flag (regression guard) and (2) `--data-dir` overrides the config file. Written TDD-first: assertion 2 failed for all five loaders before the fix, all pass after.
- `go test -race ./cmd/mcpproxy/` — full package pass.
- `/opt/homebrew/bin/golangci-lint run --config .github/.golangci.yml ./cmd/mcpproxy/...` — 0 issues.
- Manual E2E: scratch daemon on `127.0.0.1:18099` with a temp `--data-dir`; before the fix `doctor --data-dir D` returned the false "requires running daemon" error, after the fix `doctor --data-dir D`, `doctor --config C --data-dir D`, and `auth status --data-dir D --all` all reach the daemon.
- Both editions compile: `go build ./cmd/mcpproxy` and `go build -tags server ./cmd/mcpproxy`.