### PR TITLE
feat(cli): add `mcpproxy version` subcommand with -o json/yaml support

### DIFF
--- a/cmd/mcpproxy/main.go
+++ b/cmd/mcpproxy/main.go
@@ -29,7 +29,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"runtime"
 	"strings"
 	"sync/atomic"
 	"syscall"
@@ -102,7 +101,7 @@ func main() {
 		Short:   "Smart MCP Proxy - Intelligent tool discovery and proxying for Model Context Protocol servers",
 		Version: version,
 	}
-	rootCmd.SetVersionTemplate(fmt.Sprintf("MCPProxy %s (%s) %s/%s\n", version, Edition, runtime.GOOS, runtime.GOARCH))
+	rootCmd.SetVersionTemplate(versionLine())
 
 	// Add global flags
 	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "", "Configuration file path")
@@ -212,6 +211,7 @@ func main() {
 	rootCmd.AddCommand(securityCmd)
 	rootCmd.AddCommand(connectCmd)
 	rootCmd.AddCommand(disconnectCmd)
+	rootCmd.AddCommand(GetVersionCommand())
 
 	// Server-edition-only commands (e.g. `credential`). No-op in personal edition.
 	registerServerEditionCommands(rootCmd)

--- a/cmd/mcpproxy/version_cmd.go
+++ b/cmd/mcpproxy/version_cmd.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"runtime"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -45,22 +46,23 @@ func newVersionInfo() VersionInfo {
 }
 
 func printVersionOutput(w io.Writer, info VersionInfo, format string) error {
-	switch format {
-	case "json", "yaml":
-		formatter, err := clioutput.NewFormatter(format)
-		if err != nil {
-			return err
-		}
-		out, err := formatter.Format(info)
-		if err != nil {
-			return err
-		}
-		fmt.Fprintln(w, out)
-		return nil
-	default:
+	// Table output is the shared human-readable line (byte-identical to
+	// --version), not the generic table formatter.
+	if f := strings.ToLower(format); f == "" || f == "table" {
 		fmt.Fprint(w, versionLine())
 		return nil
 	}
+	// NewFormatter is case-insensitive and rejects unknown formats.
+	formatter, err := clioutput.NewFormatter(format)
+	if err != nil {
+		return err
+	}
+	out, err := formatter.Format(info)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(w, out)
+	return nil
 }
 
 // GetVersionCommand returns the `version` subcommand.

--- a/cmd/mcpproxy/version_cmd.go
+++ b/cmd/mcpproxy/version_cmd.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"runtime"
+
+	"github.com/spf13/cobra"
+
+	clioutput "github.com/smart-mcp-proxy/mcpproxy-go/internal/cli/output"
+)
+
+// Injected via -ldflags "-X main.commit=… -X main.date=…" (Makefile, scripts/build.sh).
+// CI release workflows only set main.version, so these may be empty.
+var (
+	commit = ""
+	date   = ""
+)
+
+// versionLine returns the human-readable version string shared by
+// `mcpproxy version` and the root command's --version flag.
+func versionLine() string {
+	return fmt.Sprintf("MCPProxy %s (%s) %s/%s\n", version, Edition, runtime.GOOS, runtime.GOARCH)
+}
+
+// VersionInfo is the machine-readable version payload for -o json/yaml.
+type VersionInfo struct {
+	Version string `json:"version" yaml:"version"`
+	Edition string `json:"edition" yaml:"edition"`
+	OS      string `json:"os" yaml:"os"`
+	Arch    string `json:"arch" yaml:"arch"`
+	Commit  string `json:"commit,omitempty" yaml:"commit,omitempty"`
+	Date    string `json:"date,omitempty" yaml:"date,omitempty"`
+}
+
+func newVersionInfo() VersionInfo {
+	return VersionInfo{
+		Version: version,
+		Edition: Edition,
+		OS:      runtime.GOOS,
+		Arch:    runtime.GOARCH,
+		Commit:  commit,
+		Date:    date,
+	}
+}
+
+func printVersionOutput(w io.Writer, info VersionInfo, format string) error {
+	switch format {
+	case "json", "yaml":
+		formatter, err := clioutput.NewFormatter(format)
+		if err != nil {
+			return err
+		}
+		out, err := formatter.Format(info)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(w, out)
+		return nil
+	default:
+		fmt.Fprint(w, versionLine())
+		return nil
+	}
+}
+
+// GetVersionCommand returns the `version` subcommand.
+func GetVersionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print MCPProxy version, edition, and platform",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			format := clioutput.ResolveFormat(globalOutputFormat, globalJSONOutput)
+			return printVersionOutput(cmd.OutOrStdout(), newVersionInfo(), format)
+		},
+	}
+}

--- a/cmd/mcpproxy/version_cmd_test.go
+++ b/cmd/mcpproxy/version_cmd_test.go
@@ -89,6 +89,36 @@ func TestPrintVersionOutputJSONWithBuildMeta(t *testing.T) {
 	}
 }
 
+func TestPrintVersionOutputCaseInsensitiveFormat(t *testing.T) {
+	var buf bytes.Buffer
+	info := VersionInfo{Version: "v1.2.3", Edition: "personal", OS: "darwin", Arch: "arm64"}
+
+	if err := printVersionOutput(&buf, info, "JSON"); err != nil {
+		t.Fatalf("printVersionOutput(JSON) error: %v", err)
+	}
+
+	var decoded map[string]string
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("-o JSON should produce JSON output, got: %s (err: %v)", buf.String(), err)
+	}
+	if decoded["version"] != "v1.2.3" {
+		t.Errorf("JSON version = %q, want %q", decoded["version"], "v1.2.3")
+	}
+}
+
+func TestPrintVersionOutputRejectsUnknownFormat(t *testing.T) {
+	var buf bytes.Buffer
+	info := VersionInfo{Version: "v1.2.3", Edition: "personal", OS: "darwin", Arch: "arm64"}
+
+	err := printVersionOutput(&buf, info, "xml")
+	if err == nil {
+		t.Fatalf("printVersionOutput(xml) should return an error, got output: %s", buf.String())
+	}
+	if !strings.Contains(err.Error(), "xml") {
+		t.Errorf("error should name the invalid format, got: %v", err)
+	}
+}
+
 func TestPrintVersionOutputYAML(t *testing.T) {
 	var buf bytes.Buffer
 	info := VersionInfo{Version: "v1.2.3", Edition: "personal", OS: "darwin", Arch: "arm64"}

--- a/cmd/mcpproxy/version_cmd_test.go
+++ b/cmd/mcpproxy/version_cmd_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestVersionCommandTableOutput(t *testing.T) {
+	t.Setenv("MCPPROXY_OUTPUT", "")
+
+	cmd := GetVersionCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs(nil)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	want := fmt.Sprintf("MCPProxy %s (%s) %s/%s\n", version, Edition, runtime.GOOS, runtime.GOARCH)
+	if got := buf.String(); got != want {
+		t.Errorf("table output mismatch:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestPrintVersionOutputJSON(t *testing.T) {
+	var buf bytes.Buffer
+	info := VersionInfo{Version: "v1.2.3", Edition: "personal", OS: "darwin", Arch: "arm64"}
+
+	if err := printVersionOutput(&buf, info, "json"); err != nil {
+		t.Fatalf("printVersionOutput() error: %v", err)
+	}
+
+	var decoded map[string]string
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, buf.String())
+	}
+
+	expected := map[string]string{
+		"version": "v1.2.3",
+		"edition": "personal",
+		"os":      "darwin",
+		"arch":    "arm64",
+	}
+	for key, want := range expected {
+		if got, ok := decoded[key]; !ok || got != want {
+			t.Errorf("JSON key %q = %q, want %q", key, got, want)
+		}
+	}
+
+	raw := buf.String()
+	if strings.Contains(raw, `"commit"`) {
+		t.Errorf("JSON output should omit empty commit, got: %s", raw)
+	}
+	if strings.Contains(raw, `"date"`) {
+		t.Errorf("JSON output should omit empty date, got: %s", raw)
+	}
+}
+
+func TestPrintVersionOutputJSONWithBuildMeta(t *testing.T) {
+	var buf bytes.Buffer
+	info := VersionInfo{
+		Version: "v1.2.3",
+		Edition: "server",
+		OS:      "linux",
+		Arch:    "amd64",
+		Commit:  "abc1234",
+		Date:    "2026-07-15T00:00:00Z",
+	}
+
+	if err := printVersionOutput(&buf, info, "json"); err != nil {
+		t.Fatalf("printVersionOutput() error: %v", err)
+	}
+
+	var decoded map[string]string
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, buf.String())
+	}
+
+	if decoded["commit"] != "abc1234" {
+		t.Errorf("JSON commit = %q, want %q", decoded["commit"], "abc1234")
+	}
+	if decoded["date"] != "2026-07-15T00:00:00Z" {
+		t.Errorf("JSON date = %q, want %q", decoded["date"], "2026-07-15T00:00:00Z")
+	}
+}
+
+func TestPrintVersionOutputYAML(t *testing.T) {
+	var buf bytes.Buffer
+	info := VersionInfo{Version: "v1.2.3", Edition: "personal", OS: "darwin", Arch: "arm64"}
+
+	if err := printVersionOutput(&buf, info, "yaml"); err != nil {
+		t.Fatalf("printVersionOutput() error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "version:") {
+		t.Errorf("YAML output missing version key: %s", out)
+	}
+	if !strings.Contains(out, "edition:") {
+		t.Errorf("YAML output missing edition key: %s", out)
+	}
+}
+
+func TestVersionCommandRejectsArgs(t *testing.T) {
+	cmd := GetVersionCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"extra"})
+
+	if err := cmd.Execute(); err == nil {
+		t.Error("Execute() with extra args should return an error")
+	}
+}

--- a/docs/cli-output-formatting.md
+++ b/docs/cli-output-formatting.md
@@ -187,6 +187,30 @@ mcpproxy upstream list -o json | jq -r '.[] | select(.connected) | .name'
 mcpproxy upstream list -o json | jq '[.[].tool_count] | add'
 ```
 
+### Show version information
+
+```bash
+# Human-readable (same output as `mcpproxy --version`)
+mcpproxy version
+# MCPProxy v0.51.0 (personal) darwin/arm64
+
+# JSON for scripting
+mcpproxy version -o json
+```
+
+JSON payload (`commit` and `date` appear only when injected at build time, e.g. `make build`):
+
+```json
+{
+  "version": "v0.51.0",
+  "edition": "personal",
+  "os": "darwin",
+  "arch": "arm64",
+  "commit": "15458bd5",
+  "date": "2026-07-15T00:00:00Z"
+}
+```
+
 ### Discover commands for AI agents
 
 ```bash


### PR DESCRIPTION
## Problem

CLAUDE.md and `docs/errors/MCPX_UNKNOWN_UNCLASSIFIED.md` instruct users and agents to run `mcpproxy version`, but no such subcommand exists — Cobra rejects it with `unknown command "version"`. Only the `--version` flag works, so the docs promise a command that errors. Found by v0.51.0-rc.1 QA (2026-07-15).

## Root cause

Version output was wired only through Cobra's built-in `--version` flag: `cmd/mcpproxy/main.go:103` sets `Version: version` and `main.go:105` sets the version template. Because rootCmd has subcommands, Cobra's legacyArgs rejects `mcpproxy version`. Additionally, Makefile:61 and scripts/build.sh:13 inject `-X main.commit`/`-X main.date` into symbols that were never declared, so the linker silently dropped them.

## Fix

- New `version` subcommand in `cmd/mcpproxy/version_cmd.go`; table output is byte-identical to `--version` via a shared `versionLine()` helper (the root version template now uses it too).
- Supports `-o json`/`-o yaml`/`--json`/`MCPPROXY_OUTPUT` via the inherited global output flags and `clioutput.ResolveFormat`.
- Declares the `main.commit`/`main.date` ldflags targets; they appear in JSON/YAML output with `omitempty` (CI release builds only inject `main.version`).
- Automatically discoverable via `--help-json`.
- Documented the command + JSON payload in `docs/cli-output-formatting.md`. `CLAUDE.md:38` and `docs/errors/MCPX_UNKNOWN_UNCLASSIFIED.md:37` become true without edits.

## Tests

Added `cmd/mcpproxy/version_cmd_test.go` (TDD, red→green): table-output parity with `--version`, JSON key/value assertions + commit/date omitempty, JSON with build metadata, YAML output, `cobra.NoArgs` rejection.

Commands run:
- `go test -race ./cmd/mcpproxy/` — pass (all package tests, incl. 5 new)
- `go build ./cmd/mcpproxy` and `go build -tags server ./cmd/mcpproxy` — both compile
- End-to-end: plain build (no commit/date in JSON), ldflags build (`commit`/`date` present), server-edition binary (`.edition == "server"`), `--json` alias, `MCPPROXY_OUTPUT=json`, `--help-json` lists the command, `diff <(mcpproxy version) <(mcpproxy --version)` identical
- `/opt/homebrew/bin/golangci-lint run --config .github/.golangci.yml ./cmd/mcpproxy/...` — 0 issues