### PR TITLE
fix(runtime): stop reporting spurious docker_isolation in config PATCH changed_fields

### DIFF
--- a/internal/httpapi/server_config_patch_test.go
+++ b/internal/httpapi/server_config_patch_test.go
@@ -24,6 +24,11 @@ type mockPatchConfigController struct {
 	live         *config.Config
 	captured     *config.Config
 	changedField string
+	// detectChanges routes ApplyConfig through the real
+	// runtime.DetectConfigChanges(live, merged) so tests can assert the
+	// changed_fields the real change detector would compute for the
+	// handler's deep-merge output.
+	detectChanges bool
 	// validationErrs, when non-empty, is returned from ApplyConfig so a test
 	// can assert that invalid values surface as validation errors rather than
 	// corrupting config.
@@ -43,6 +48,9 @@ func (m *mockPatchConfigController) GetConfigPath() string { return "/tmp/mcp_co
 func (m *mockPatchConfigController) ApplyConfig(cfg *config.Config, _ string) (*runtime.ConfigApplyResult, error) {
 	clone := *cfg
 	m.captured = &clone
+	if m.detectChanges {
+		return runtime.DetectConfigChanges(m.live, cfg), nil
+	}
 	if len(m.validationErrs) > 0 {
 		return &runtime.ConfigApplyResult{
 			Success:          false,
@@ -167,6 +175,35 @@ func TestHandlePatchConfig_ChangedFields(t *testing.T) {
 	changed, _ := result["changed_fields"].([]interface{})
 	require.NotEmpty(t, changed, "changed_fields must be populated, got %v", result)
 	assert.Contains(t, changed, "quarantine_enabled")
+}
+
+// TestHandlePatchConfig_NoSpuriousDockerIsolation (QA API-PATCH): patching only
+// the toon fields must not report docker_isolation in changed_fields. The
+// handler's JSON round-trip drops DockerIsolation.ExtraArgs []string{} via
+// omitempty; change detection must treat that as unchanged.
+func TestHandlePatchConfig_NoSpuriousDockerIsolation(t *testing.T) {
+	logger := zap.NewNop().Sugar()
+	mockCtrl := &mockPatchConfigController{
+		apiKey:        "test-key",
+		live:          &config.Config{DockerIsolation: config.DefaultDockerIsolationConfig()},
+		detectChanges: true, // route through real runtime.DetectConfigChanges
+	}
+	srv := NewServer(mockCtrl, logger, nil)
+
+	body := []byte(`{"toon_output":"always","toon_min_savings_pct":1}`)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/config", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", "test-key")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	result := decodePatchResult(t, w.Body.Bytes())
+	changed, _ := result["changed_fields"].([]interface{})
+	assert.Contains(t, changed, "toon_output")
+	assert.Contains(t, changed, "toon_min_savings_pct")
+	assert.NotContains(t, changed, "docker_isolation",
+		"docker_isolation was not in the PATCH body and its effective value did not change")
 }
 
 // TestHandlePatchConfig_EmptyBody rejects an empty object with 400.

--- a/internal/runtime/config_hotreload.go
+++ b/internal/runtime/config_hotreload.go
@@ -1,9 +1,12 @@
 package runtime
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
-	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 	"reflect"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 )
 
 // ConfigApplyResult represents the result of applying a configuration
@@ -139,8 +142,11 @@ func DetectConfigChanges(oldCfg, newCfg *config.Config) *ConfigApplyResult {
 		result.ChangedFields = append(result.ChangedFields, "logging")
 	}
 
-	// Docker isolation configuration (can be hot-reloaded for new servers)
-	if !reflect.DeepEqual(oldCfg.DockerIsolation, newCfg.DockerIsolation) {
+	// Docker isolation configuration (can be hot-reloaded for new servers).
+	// Compared via jsonEqual, not reflect.DeepEqual: the PATCH /api/v1/config
+	// round-trip collapses ExtraArgs []string{} to nil (omitempty), which
+	// DeepEqual would spuriously report as a change.
+	if !jsonEqual(oldCfg.DockerIsolation, newCfg.DockerIsolation) {
 		result.ChangedFields = append(result.ChangedFields, "docker_isolation")
 	}
 
@@ -201,6 +207,23 @@ func DetectConfigChanges(oldCfg, newCfg *config.Config) *ConfigApplyResult {
 	}
 
 	return result
+}
+
+// jsonEqual reports whether a and b marshal to identical JSON. Config
+// sub-structs round-trip through JSON on the PATCH /api/v1/config path,
+// where `omitempty` collapses empty slices to absent keys; comparing the
+// JSON form treats nil and []T{} as the same effective value, unlike
+// reflect.DeepEqual (which spuriously reported "docker_isolation" as
+// changed because DefaultDockerIsolationConfig's ExtraArgs: []string{}
+// round-trips to nil). json.Marshal sorts map keys, so the comparison is
+// deterministic.
+func jsonEqual(a, b interface{}) bool {
+	ab, errA := json.Marshal(a)
+	bb, errB := json.Marshal(b)
+	if errA != nil || errB != nil {
+		return false // conservative: unmarshalable => treat as changed
+	}
+	return bytes.Equal(ab, bb)
 }
 
 // FormatChangedFields returns a human-readable string of changed fields

--- a/internal/runtime/config_hotreload_test.go
+++ b/internal/runtime/config_hotreload_test.go
@@ -1,9 +1,11 @@
 package runtime
 
 import (
-	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+	"encoding/json"
 	"testing"
 	"time"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -455,6 +457,38 @@ func TestDetectConfigChanges_ToonOutput(t *testing.T) {
 		assert.NotContains(t, result.ChangedFields, "toon_output")
 		assert.NotContains(t, result.ChangedFields, "toon_min_savings_pct")
 	})
+}
+
+// TestDetectConfigChanges_DockerIsolationRoundTripNoFalsePositive (QA API-PATCH):
+// the PATCH /api/v1/config handler round-trips the live config through JSON,
+// which collapses DefaultDockerIsolationConfig's ExtraArgs []string{} to nil
+// via omitempty. That artifact must not surface as a "docker_isolation" change.
+func TestDetectConfigChanges_DockerIsolationRoundTripNoFalsePositive(t *testing.T) {
+	old := &config.Config{DockerIsolation: config.DefaultDockerIsolationConfig()}
+
+	b, err := json.Marshal(old) // simulate handlePatchConfig's round-trip
+	require.NoError(t, err)
+	var next config.Config
+	require.NoError(t, json.Unmarshal(b, &next))
+	next.ToonOutput = "always"
+	next.ToonMinSavingsPct = 1
+
+	result := DetectConfigChanges(old, &next)
+	require.True(t, result.Success)
+	assert.NotContains(t, result.ChangedFields, "docker_isolation",
+		"docker_isolation was not patched — nil vs []string{} ExtraArgs is a JSON round-trip artifact, not a change")
+	assert.ElementsMatch(t, []string{"toon_output", "toon_min_savings_pct"}, result.ChangedFields)
+}
+
+// TestDetectConfigChanges_DockerIsolationRealChangeStillDetected: real
+// docker_isolation edits must still be detected through jsonEqual.
+func TestDetectConfigChanges_DockerIsolationRealChangeStillDetected(t *testing.T) {
+	old := &config.Config{DockerIsolation: config.DefaultDockerIsolationConfig()}
+	next := &config.Config{DockerIsolation: config.DefaultDockerIsolationConfig()}
+	next.DockerIsolation.Enabled = true
+	result := DetectConfigChanges(old, next)
+	require.True(t, result.Success)
+	assert.Contains(t, result.ChangedFields, "docker_isolation")
 }
 
 // TestDetectConfigChanges_ToolResponseMode (Spec 085 T015, ⟲#1a): an API


### PR DESCRIPTION
## Problem

Every `PATCH /api/v1/config` request reported `docker_isolation` in `changed_fields`, even when the patch never touched Docker isolation (e.g. patching only `toon_output`). Found by v0.51.0-rc.1 QA (2026-07-15), finding API-PATCH.

## Root cause

- `handlePatchConfig` (`internal/httpapi/server.go:3949-4003`) round-trips the live config through JSON before deep-merging the patch.
- `DefaultDockerIsolationConfig()` sets `ExtraArgs: []string{}` (`internal/config/config.go:1322`), but the field is tagged `json:"extra_args,omitempty"` (`config.go:564`), so the empty slice is omitted on marshal and comes back as `nil`.
- `DetectConfigChanges` (`internal/runtime/config_hotreload.go:143`) compared `DockerIsolation` with `reflect.DeepEqual`, which distinguishes `nil` from `[]string{}` — so the round-trip artifact surfaced as a spurious "docker_isolation" change.

## Fix

Compare `docker_isolation` by JSON serialization instead of `reflect.DeepEqual`: new `jsonEqual` helper in `internal/runtime/config_hotreload.go` marshals both sides and byte-compares (deterministic — `json.Marshal` sorts map keys). Identical JSON means identical effective value, so nil-vs-empty artifacts are invisible while real edits are still detected. A PATCH touching nothing effective now correctly returns "No configuration changes detected".

Note: the same nil-vs-empty DeepEqual hazard theoretically exists for other clauses in `DetectConfigChanges` (notably `Servers`, where a live `Args: []string{}` would spuriously report `mcpServers`); this PR deliberately fixes only the confirmed `docker_isolation` finding — `jsonEqual` makes a follow-up trivial.

## Tests

TDD — both new tests failed pre-fix with `docker_isolation` present, pass post-fix:

- `TestDetectConfigChanges_DockerIsolationRoundTripNoFalsePositive` + `TestDetectConfigChanges_DockerIsolationRealChangeStillDetected` (`internal/runtime/config_hotreload_test.go`) — unit-level: JSON round-trip artifact suppressed, real edits still detected.
- `TestHandlePatchConfig_NoSpuriousDockerIsolation` (`internal/httpapi/server_config_patch_test.go`) — handler-level regression: the mock's `ApplyConfig` now optionally routes through the real `runtime.DetectConfigChanges`, exercising the actual PATCH deep-merge output.

Commands run:
- `go test -race ./internal/runtime/ ./internal/httpapi/` — ok
- `go build ./cmd/mcpproxy` and `go build -tags server ./cmd/mcpproxy` — ok
- `golangci-lint run --config .github/.golangci.yml ./internal/runtime/... ./internal/httpapi/...` (v2) — 0 issues