### PR TITLE
fix(cli): route human banners/progress to stderr so -o json emits clean stdout

### DIFF
--- a/cmd/mcpproxy/call_cmd.go
+++ b/cmd/mcpproxy/call_cmd.go
@@ -373,17 +373,18 @@ func runCallToolVariant(toolVariant, operationType string) error {
 		return fmt.Errorf("failed to create logger: %w", err)
 	}
 
-	// Display intent information
-	fmt.Printf("🚀 Intent-Based Tool Call\n")
-	fmt.Printf("   Tool: %s\n", callToolName)
-	fmt.Printf("   Variant: %s (operation_type=%s)\n", toolVariant, operationType)
+	// Display intent information on stderr so machine formats (-o json)
+	// keep stdout parseable (see docs/cli-output-formatting.md).
+	fmt.Fprintf(os.Stderr, "🚀 Intent-Based Tool Call\n")
+	fmt.Fprintf(os.Stderr, "   Tool: %s\n", callToolName)
+	fmt.Fprintf(os.Stderr, "   Variant: %s (operation_type=%s)\n", toolVariant, operationType)
 	if callIntentSensitivity != "" {
-		fmt.Printf("   Sensitivity: %s\n", callIntentSensitivity)
+		fmt.Fprintf(os.Stderr, "   Sensitivity: %s\n", callIntentSensitivity)
 	}
 	if callIntentReason != "" {
-		fmt.Printf("   Reason: %s\n", callIntentReason)
+		fmt.Fprintf(os.Stderr, "   Reason: %s\n", callIntentReason)
 	}
-	fmt.Printf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n")
+	fmt.Fprintf(os.Stderr, "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n")
 
 	// Detect daemon (socket first, then TCP fallback) and use client mode if available
 	if client, ok := newDaemonClient(globalConfig, logger.Sugar()); ok {
@@ -413,7 +414,7 @@ func runCallToolVariantClientMode(client *cliclient.Client, toolVariant string, 
 	fmt.Fprintf(os.Stderr, "ℹ️  Using daemon mode - fast execution\n")
 
 	// Call tool via daemon
-	fmt.Printf("🔗 Calling %s via daemon socket...\n", toolVariant)
+	fmt.Fprintf(os.Stderr, "🔗 Calling %s via daemon socket...\n", toolVariant)
 	callCtx, callCancel := context.WithTimeout(context.Background(), callTimeout)
 	defer callCancel()
 
@@ -432,7 +433,7 @@ func runCallToolVariantClientMode(client *cliclient.Client, toolVariant string, 
 	case outputFormatPretty, "":
 		fallthrough
 	default:
-		fmt.Printf("✅ Tool call completed successfully!\n\n")
+		fmt.Fprintf(os.Stderr, "✅ Tool call completed successfully!\n\n")
 		outputCallResultPretty(result)
 	}
 
@@ -493,7 +494,7 @@ func runCallToolVariantStandalone(ctx context.Context, toolVariant string, args 
 		nil, // standalone one-shot: no runtime-owned signature cache
 	)
 
-	fmt.Printf("🛠️  Calling %s...\n", toolVariant)
+	fmt.Fprintf(os.Stderr, "🛠️  Calling %s...\n", toolVariant)
 
 	// Call the tool variant through the proxy server's public method
 	result, err := mcpProxy.CallBuiltInTool(ctx, toolVariant, args)
@@ -508,7 +509,7 @@ func runCallToolVariantStandalone(ctx context.Context, toolVariant string, args 
 	case outputFormatPretty, "":
 		fallthrough
 	default:
-		fmt.Printf("✅ Tool call completed successfully!\n\n")
+		fmt.Fprintf(os.Stderr, "✅ Tool call completed successfully!\n\n")
 		outputCallResultPretty(result)
 	}
 

--- a/cmd/mcpproxy/security_cmd.go
+++ b/cmd/mcpproxy/security_cmd.go
@@ -774,8 +774,10 @@ func runSecurityScan(_ *cobra.Command, args []string) error {
 			progress += fmt.Sprintf(" (running: %s)", strings.Join(runningNames, ", "))
 		}
 		// Erase previous line on TTY for a clean rolling display; on a pipe
-		// just print one progress line per tick.
-		if stdoutIsTTY() {
+		// just print one progress line per tick. Progress is written to
+		// stderr, so the TTY check must follow stderr (not stdout) — else
+		// `2>scan.log` on a terminal would fill the log with \r frames.
+		if stderrIsTTY() {
 			pad := ""
 			if lastProgressLen > len(progress) {
 				pad = strings.Repeat(" ", lastProgressLen-len(progress))
@@ -788,13 +790,13 @@ func runSecurityScan(_ *cobra.Command, args []string) error {
 
 		switch jobStatus {
 		case "completed":
-			if stdoutIsTTY() {
+			if stderrIsTTY() {
 				fmt.Fprintln(os.Stderr)
 			}
 			fmt.Fprintf(os.Stderr, "  Scan completed in %s\n", elapsed)
 			return printScanSummary(client, ctx, serverName)
 		case "failed":
-			if stdoutIsTTY() {
+			if stderrIsTTY() {
 				fmt.Fprintln(os.Stderr)
 			}
 			fmt.Fprintf(os.Stderr, "  Scan failed after %s\n", elapsed)
@@ -804,7 +806,7 @@ func runSecurityScan(_ *cobra.Command, args []string) error {
 			}
 			return fmt.Errorf("scan failed for %q", serverName)
 		case "cancelled":
-			if stdoutIsTTY() {
+			if stderrIsTTY() {
 				fmt.Fprintln(os.Stderr)
 			}
 			fmt.Fprintf(os.Stderr, "  Scan cancelled after %s\n", elapsed)
@@ -2313,6 +2315,13 @@ func scannerStatusColor(status string) (open, reset string) {
 // Used to gate ANSI escapes (colors, cursor moves) so piped output stays clean.
 func stdoutIsTTY() bool {
 	return term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+// stderrIsTTY returns true when stderr is connected to an interactive
+// terminal. Used to gate the rolling (\r) progress display, which is written
+// to stderr so machine formats keep stdout parseable.
+func stderrIsTTY() bool {
+	return term.IsTerminal(int(os.Stderr.Fd()))
 }
 
 // normalizeOverviewLastScan replaces a Go zero-time `last_scan_at` value with

--- a/cmd/mcpproxy/security_cmd.go
+++ b/cmd/mcpproxy/security_cmd.go
@@ -698,7 +698,9 @@ func runSecurityScan(_ *cobra.Command, args []string) error {
 	//   2. Use a 750ms ticker (no tight loop, no 2s lag).
 	//   3. Honor a hard timeout based on the configured per-scanner timeout.
 	//   4. Print one progress line per tick with run/running/failed counts.
-	fmt.Printf("Scanning %q (timeout %s, job %s)...\n", serverName, hardTimeout, jobID)
+	// Progress goes to stderr so stdout stays clean for machine formats
+	// (see docs/cli-output-formatting.md).
+	fmt.Fprintf(os.Stderr, "Scanning %q (timeout %s, job %s)...\n", serverName, hardTimeout, jobID)
 	scanStart := time.Now()
 
 	ticker := time.NewTicker(750 * time.Millisecond)
@@ -708,7 +710,7 @@ func runSecurityScan(_ *cobra.Command, args []string) error {
 	for {
 		select {
 		case <-ctx.Done():
-			fmt.Println()
+			fmt.Fprintln(os.Stderr)
 			return fmt.Errorf("scan timed out after %s for %q (job %s); use 'mcpproxy security status %s' to inspect", hardTimeout, serverName, jobID, serverName)
 		case <-ticker.C:
 		}
@@ -778,24 +780,24 @@ func runSecurityScan(_ *cobra.Command, args []string) error {
 			if lastProgressLen > len(progress) {
 				pad = strings.Repeat(" ", lastProgressLen-len(progress))
 			}
-			fmt.Print("\r" + progress + pad)
+			fmt.Fprint(os.Stderr, "\r"+progress+pad)
 			lastProgressLen = len(progress)
 		} else {
-			fmt.Println(progress)
+			fmt.Fprintln(os.Stderr, progress)
 		}
 
 		switch jobStatus {
 		case "completed":
 			if stdoutIsTTY() {
-				fmt.Println()
+				fmt.Fprintln(os.Stderr)
 			}
-			fmt.Printf("  Scan completed in %s\n", elapsed)
+			fmt.Fprintf(os.Stderr, "  Scan completed in %s\n", elapsed)
 			return printScanSummary(client, ctx, serverName)
 		case "failed":
 			if stdoutIsTTY() {
-				fmt.Println()
+				fmt.Fprintln(os.Stderr)
 			}
-			fmt.Printf("  Scan failed after %s\n", elapsed)
+			fmt.Fprintf(os.Stderr, "  Scan failed after %s\n", elapsed)
 			errMsg := getMapString(status, "error")
 			if errMsg != "" {
 				return fmt.Errorf("scan failed: %s", errMsg)
@@ -803,9 +805,9 @@ func runSecurityScan(_ *cobra.Command, args []string) error {
 			return fmt.Errorf("scan failed for %q", serverName)
 		case "cancelled":
 			if stdoutIsTTY() {
-				fmt.Println()
+				fmt.Fprintln(os.Stderr)
 			}
-			fmt.Printf("  Scan cancelled after %s\n", elapsed)
+			fmt.Fprintf(os.Stderr, "  Scan cancelled after %s\n", elapsed)
 			return fmt.Errorf("scan was cancelled for %q", serverName)
 		}
 		// pending or running: continue polling

--- a/cmd/mcpproxy/tools_cmd.go
+++ b/cmd/mcpproxy/tools_cmd.go
@@ -241,9 +241,9 @@ func runToolsList(_ *cobra.Command, _ []string) error {
 	// Enable transport tracing if requested
 	if traceTransport {
 		transport.GlobalTraceEnabled = true
-		fmt.Println("HTTP/SSE TRANSPORT TRACING ENABLED")
-		fmt.Println("   All HTTP requests/responses and SSE frames will be logged")
-		fmt.Println()
+		fmt.Fprintln(os.Stderr, "HTTP/SSE TRANSPORT TRACING ENABLED")
+		fmt.Fprintln(os.Stderr, "   All HTTP requests/responses and SSE frames will be logged")
+		fmt.Fprintln(os.Stderr)
 	}
 
 	// Load configuration
@@ -617,10 +617,12 @@ func runToolsListStandalone(ctx context.Context, serverName string, globalConfig
 			serverName, getAvailableServerNames(globalConfig))
 	}
 
-	fmt.Printf("MCP Tools List - Server: %s\n", serverName)
-	fmt.Printf("Log Level: %s\n", toolsLogLevel)
-	fmt.Printf("Timeout: %v\n", timeout)
-	fmt.Printf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n")
+	// Human banner/progress goes to stderr so machine formats (-o json|yaml)
+	// keep stdout parseable (see docs/cli-output-formatting.md).
+	fmt.Fprintf(os.Stderr, "MCP Tools List - Server: %s\n", serverName)
+	fmt.Fprintf(os.Stderr, "Log Level: %s\n", toolsLogLevel)
+	fmt.Fprintf(os.Stderr, "Timeout: %v\n", timeout)
+	fmt.Fprintf(os.Stderr, "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n")
 
 	// Create storage (optional, for OAuth persistence)
 	var db *storage.BoltDB
@@ -652,14 +654,14 @@ func runToolsListStandalone(ctx context.Context, serverName string, globalConfig
 	}
 
 	// Connect to server
-	fmt.Printf("Connecting to server '%s'...\n", serverName)
+	fmt.Fprintf(os.Stderr, "Connecting to server '%s'...\n", serverName)
 	if err := managedClient.Connect(ctx); err != nil {
 		return fmt.Errorf("failed to connect to server '%s': %w", serverName, err)
 	}
 
 	// Ensure cleanup on exit
 	defer func() {
-		fmt.Printf("Disconnecting from server...\n")
+		fmt.Fprintf(os.Stderr, "Disconnecting from server...\n")
 		if disconnectErr := managedClient.Disconnect(); disconnectErr != nil {
 			fmt.Fprintf(os.Stderr, "Warning: Failed to disconnect cleanly: %v\n", disconnectErr)
 		}

--- a/cmd/mcpproxy/tools_cmd_test.go
+++ b/cmd/mcpproxy/tools_cmd_test.go
@@ -2,17 +2,20 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/socket"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestToolsDaemonDetection_NoDaemon(t *testing.T) {
@@ -303,6 +306,85 @@ func TestToolsEnableCmd_ArgValidation(t *testing.T) {
 	require.NotNil(t, disableCmd)
 	assert.Error(t, disableCmd.Args(disableCmd, []string{}), "disable must reject zero args")
 	assert.NoError(t, disableCmd.Args(disableCmd, []string{"server:tool"}), "disable must accept one arg")
+}
+
+// ---------------------------------------------------------------------------
+// CLI-JSON (v0.51.0-rc.1 QA): standalone mode must keep stdout clean for
+// machine formats — banners/progress go to stderr.
+// ---------------------------------------------------------------------------
+
+// runStandaloneCapture runs runToolsListStandalone against a server whose
+// command does not exist (Connect fails fast, no live MCP server needed) and
+// returns everything written to stdout and stderr. The banner prints before
+// Connect, so it is exercised regardless of the connection failure.
+func runStandaloneCapture(t *testing.T, format string) (stdoutStr, stderrStr string) {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	rOut, wOut, err := os.Pipe()
+	require.NoError(t, err)
+	rErr, wErr, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = wOut
+	os.Stderr = wErr
+
+	oldFormat := globalOutputFormat
+	oldJSON := globalJSONOutput
+	globalOutputFormat = format
+	globalJSONOutput = false
+	t.Cleanup(func() {
+		globalOutputFormat = oldFormat
+		globalJSONOutput = oldJSON
+	})
+
+	cfg := &config.Config{Servers: []*config.ServerConfig{{
+		Name:     "everything",
+		Command:  "/nonexistent-mcpproxy-test-cmd",
+		Protocol: "stdio",
+		Enabled:  true,
+	}}} // DataDir empty → bbolt storage is skipped
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	// Connect fails (command does not exist); the returned error is irrelevant
+	// here — we only assert on where the banner/progress text landed.
+	_ = runToolsListStandalone(ctx, "everything", cfg, zap.NewNop())
+
+	wOut.Close()
+	wErr.Close()
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+
+	var bufOut, bufErr bytes.Buffer
+	_, _ = bufOut.ReadFrom(rOut)
+	_, _ = bufErr.ReadFrom(rErr)
+	return bufOut.String(), bufErr.String()
+}
+
+// TestRunToolsListStandalone_MachineModeStdoutClean is the QA finding: with
+// -o json, stdout must contain only the JSON payload — no human banner or
+// progress text.
+func TestRunToolsListStandalone_MachineModeStdoutClean(t *testing.T) {
+	stdoutStr, stderrStr := runStandaloneCapture(t, "json")
+
+	assert.NotContains(t, stdoutStr, "MCP Tools List", "banner must not pollute stdout in json mode")
+	assert.NotContains(t, stdoutStr, "Connecting to server", "progress must not pollute stdout in json mode")
+	assert.NotContains(t, stdoutStr, "Disconnecting from server", "progress must not pollute stdout in json mode")
+	assert.Contains(t, stderrStr, "MCP Tools List", "banner should move to stderr")
+}
+
+// TestRunToolsListStandalone_TableModeBannerOnStderr locks the
+// unconditional-stderr convention: banners go to stderr in table mode too, so
+// `-o table | tee file` stays clean.
+func TestRunToolsListStandalone_TableModeBannerOnStderr(t *testing.T) {
+	stdoutStr, stderrStr := runStandaloneCapture(t, "table")
+
+	assert.NotContains(t, stdoutStr, "MCP Tools List", "banner must not pollute stdout in table mode")
+	assert.NotContains(t, stdoutStr, "Connecting to server", "progress must not pollute stdout in table mode")
+	assert.Contains(t, stderrStr, "MCP Tools List", "banner should be on stderr")
+	assert.Contains(t, stderrStr, "Connecting to server", "progress should be on stderr")
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/mcpproxy/upstream_cmd.go
+++ b/cmd/mcpproxy/upstream_cmd.go
@@ -1261,13 +1261,35 @@ func runUpstreamAdd(cmd *cobra.Command, args []string) error {
 	return runUpstreamAddConfigMode(req, globalConfig)
 }
 
+// outputSkipNotice prints a human skip notice (for --if-not-exists /
+// --if-exists) to stderr and, in machine formats, emits a structured skip
+// object on stdout so `-o json` consumers always receive parseable output.
+func outputSkipNotice(notice string, payload map[string]interface{}) error {
+	fmt.Fprintln(os.Stderr, notice)
+	outputFormat := ResolveOutputFormat()
+	if outputFormat == "json" || outputFormat == "yaml" {
+		formatter, err := GetOutputFormatter()
+		if err != nil {
+			return err
+		}
+		formatted, err := formatter.Format(payload)
+		if err != nil {
+			return err
+		}
+		fmt.Println(formatted)
+	}
+	return nil
+}
+
 func runUpstreamAddDaemonMode(ctx context.Context, client *cliclient.Client, req *cliclient.AddServerRequest) error {
 	result, err := client.AddServer(ctx, req)
 	if err != nil {
 		// Check if it's "already exists" error and --if-not-exists is set
 		if upstreamAddIfNotExists && strings.Contains(err.Error(), "already exists") {
-			fmt.Printf("Server '%s' already exists (skipped)\n", req.Name)
-			return nil
+			return outputSkipNotice(
+				fmt.Sprintf("Server '%s' already exists (skipped)", req.Name),
+				map[string]interface{}{"name": req.Name, "skipped": true},
+			)
 		}
 		return outputError(output.NewStructuredError(output.ErrCodeOperationFailed, err.Error()).
 			WithGuidance("Check the server name and configuration"), output.ErrCodeOperationFailed)
@@ -1294,8 +1316,10 @@ func runUpstreamAddConfigMode(req *cliclient.AddServerRequest, globalConfig *con
 	for _, srv := range globalConfig.Servers {
 		if srv.Name == req.Name {
 			if upstreamAddIfNotExists {
-				fmt.Printf("Server '%s' already exists (skipped)\n", req.Name)
-				return nil
+				return outputSkipNotice(
+					fmt.Sprintf("Server '%s' already exists (skipped)", req.Name),
+					map[string]interface{}{"name": req.Name, "skipped": true},
+				)
 			}
 			return fmt.Errorf("server '%s' already exists", req.Name)
 		}
@@ -1382,8 +1406,10 @@ func runUpstreamRemoveDaemonMode(ctx context.Context, client *cliclient.Client, 
 	if err != nil {
 		// Check if it's "not found" error and --if-exists is set
 		if upstreamRemoveIfExists && strings.Contains(err.Error(), "not found") {
-			fmt.Printf("Server '%s' not found (skipped)\n", serverName)
-			return nil
+			return outputSkipNotice(
+				fmt.Sprintf("Server '%s' not found (skipped)", serverName),
+				map[string]interface{}{"name": serverName, "skipped": true},
+			)
 		}
 		return outputError(output.NewStructuredError(output.ErrCodeOperationFailed, err.Error()).
 			WithGuidance("Check the server name"), output.ErrCodeOperationFailed)
@@ -1419,8 +1445,10 @@ func runUpstreamRemoveConfigMode(serverName string, globalConfig *config.Config)
 
 	if !found {
 		if upstreamRemoveIfExists {
-			fmt.Printf("Server '%s' not found (skipped)\n", serverName)
-			return nil
+			return outputSkipNotice(
+				fmt.Sprintf("Server '%s' not found (skipped)", serverName),
+				map[string]interface{}{"name": serverName, "skipped": true},
+			)
 		}
 		return fmt.Errorf("server '%s' not found", serverName)
 	}

--- a/cmd/mcpproxy/upstream_cmd_test.go
+++ b/cmd/mcpproxy/upstream_cmd_test.go
@@ -819,24 +819,43 @@ func TestAddHTTPServerConfigMode(t *testing.T) {
 		upstreamAddIfNotExists = true
 		defer func() { upstreamAddIfNotExists = oldIfNotExists }()
 
-		// Capture output
+		// Pin table format so the structured skip payload is not emitted.
+		oldFormat := globalOutputFormat
+		oldJSON := globalJSONOutput
+		globalOutputFormat = "table"
+		globalJSONOutput = false
+		defer func() {
+			globalOutputFormat = oldFormat
+			globalJSONOutput = oldJSON
+		}()
+
+		// Capture output. Since the CLI-JSON fix, the human skip notice goes
+		// to stderr so machine formats keep stdout parseable.
 		oldStdout := os.Stdout
-		r, w, _ := os.Pipe()
-		os.Stdout = w
+		oldStderr := os.Stderr
+		rOut, wOut, _ := os.Pipe()
+		rErr, wErr, _ := os.Pipe()
+		os.Stdout = wOut
+		os.Stderr = wErr
 
 		err = runUpstreamAddConfigMode(req, cfg)
 
-		w.Close()
+		wOut.Close()
+		wErr.Close()
 		os.Stdout = oldStdout
-		var buf bytes.Buffer
-		buf.ReadFrom(r)
-		output := buf.String()
+		os.Stderr = oldStderr
+		var bufOut, bufErr bytes.Buffer
+		bufOut.ReadFrom(rOut)
+		bufErr.ReadFrom(rErr)
 
 		if err != nil {
 			t.Errorf("Expected no error with --if-not-exists, got: %v", err)
 		}
-		if !strings.Contains(output, "already exists") || !strings.Contains(output, "skipped") {
-			t.Error("Expected skip message for existing server")
+		if !strings.Contains(bufErr.String(), "already exists") || !strings.Contains(bufErr.String(), "skipped") {
+			t.Error("Expected skip message on stderr for existing server")
+		}
+		if bufOut.String() != "" {
+			t.Errorf("Expected empty stdout in table mode, got %q", bufOut.String())
 		}
 	})
 }
@@ -1110,24 +1129,43 @@ func TestRemoveServerConfigMode(t *testing.T) {
 		upstreamRemoveIfExists = true
 		defer func() { upstreamRemoveIfExists = oldIfExists }()
 
-		// Capture output
+		// Pin table format so the structured skip payload is not emitted.
+		oldFormat := globalOutputFormat
+		oldJSON := globalJSONOutput
+		globalOutputFormat = "table"
+		globalJSONOutput = false
+		defer func() {
+			globalOutputFormat = oldFormat
+			globalJSONOutput = oldJSON
+		}()
+
+		// Capture output. Since the CLI-JSON fix, the human skip notice goes
+		// to stderr so machine formats keep stdout parseable.
 		oldStdout := os.Stdout
-		r, w, _ := os.Pipe()
-		os.Stdout = w
+		oldStderr := os.Stderr
+		rOut, wOut, _ := os.Pipe()
+		rErr, wErr, _ := os.Pipe()
+		os.Stdout = wOut
+		os.Stderr = wErr
 
 		err = runUpstreamRemoveConfigMode("nonexistent", cfg)
 
-		w.Close()
+		wOut.Close()
+		wErr.Close()
 		os.Stdout = oldStdout
-		var buf bytes.Buffer
-		buf.ReadFrom(r)
-		output := buf.String()
+		os.Stderr = oldStderr
+		var bufOut, bufErr bytes.Buffer
+		bufOut.ReadFrom(rOut)
+		bufErr.ReadFrom(rErr)
 
 		if err != nil {
 			t.Errorf("Expected no error with --if-exists, got: %v", err)
 		}
-		if !strings.Contains(output, "not found") || !strings.Contains(output, "skipped") {
-			t.Error("Expected skip message for non-existent server")
+		if !strings.Contains(bufErr.String(), "not found") || !strings.Contains(bufErr.String(), "skipped") {
+			t.Error("Expected skip message on stderr for non-existent server")
+		}
+		if bufOut.String() != "" {
+			t.Errorf("Expected empty stdout in table mode, got %q", bufOut.String())
 		}
 	})
 }
@@ -1513,6 +1551,76 @@ func TestOutputError_WithoutRequestID(t *testing.T) {
 		// Verify "Request ID:" is NOT printed
 		if strings.Contains(output, "Request ID:") {
 			t.Errorf("Expected output to NOT contain 'Request ID:' for regular errors, got: %s", output)
+		}
+	})
+}
+
+// TestOutputSkipNotice verifies the CLI-JSON contract for --if-not-exists /
+// --if-exists skip paths: the human notice goes to stderr, and in json mode
+// stdout carries a structured skip object (parseable by jq); in table mode
+// stdout stays empty.
+func TestOutputSkipNotice(t *testing.T) {
+	capture := func(t *testing.T, format string) (stdoutStr, stderrStr string) {
+		t.Helper()
+		oldStdout := os.Stdout
+		oldStderr := os.Stderr
+		rOut, wOut, _ := os.Pipe()
+		rErr, wErr, _ := os.Pipe()
+		os.Stdout = wOut
+		os.Stderr = wErr
+
+		oldFormat := globalOutputFormat
+		oldJSON := globalJSONOutput
+		globalOutputFormat = format
+		globalJSONOutput = false
+		t.Cleanup(func() {
+			globalOutputFormat = oldFormat
+			globalJSONOutput = oldJSON
+		})
+
+		err := outputSkipNotice("Server 'foo' already exists (skipped)", map[string]interface{}{
+			"name":    "foo",
+			"skipped": true,
+		})
+
+		wOut.Close()
+		wErr.Close()
+		os.Stdout = oldStdout
+		os.Stderr = oldStderr
+
+		if err != nil {
+			t.Fatalf("outputSkipNotice returned error: %v", err)
+		}
+
+		var bufOut, bufErr bytes.Buffer
+		bufOut.ReadFrom(rOut)
+		bufErr.ReadFrom(rErr)
+		return bufOut.String(), bufErr.String()
+	}
+
+	t.Run("json mode emits structured object on stdout, notice on stderr", func(t *testing.T) {
+		stdoutStr, stderrStr := capture(t, "json")
+
+		var parsed map[string]interface{}
+		if err := json.Unmarshal([]byte(stdoutStr), &parsed); err != nil {
+			t.Fatalf("stdout must be valid JSON, got %q: %v", stdoutStr, err)
+		}
+		if parsed["name"] != "foo" || parsed["skipped"] != true {
+			t.Errorf("unexpected skip payload: %v", parsed)
+		}
+		if !strings.Contains(stderrStr, "already exists (skipped)") {
+			t.Errorf("human notice must be on stderr, got %q", stderrStr)
+		}
+	})
+
+	t.Run("table mode keeps stdout empty, notice on stderr", func(t *testing.T) {
+		stdoutStr, stderrStr := capture(t, "table")
+
+		if stdoutStr != "" {
+			t.Errorf("table-mode skip must not write to stdout, got %q", stdoutStr)
+		}
+		if !strings.Contains(stderrStr, "already exists (skipped)") {
+			t.Errorf("human notice must be on stderr, got %q", stderrStr)
 		}
 	})
 }


### PR DESCRIPTION
## Problem

Found by v0.51.0-rc.1 QA (2026-07-15). `mcpproxy tools list --server=X -o json` printed a human banner ("MCP Tools List - Server: ...", log level, timeout, rule) plus "Connecting to server..." / "Disconnecting from server..." progress lines on stdout around the JSON payload, so `| jq` failed. This violates the docs/cli-output-formatting.md contract that machine formats must be the only stdout content.

## Root cause

The pollution happens only on the standalone code path (daemon not running, or socket ping fails and client mode falls back at `cmd/mcpproxy/tools_cmd.go:554-563`). `runToolsListStandalone` wrote the banner (`tools_cmd.go:630-633`), "Connecting..." (`:665`) and the deferred "Disconnecting..." (`:672`, printed *after* the JSON) with plain `fmt.Printf` to stdout, unlike the daemon-mode paths which already used stderr (`tools_cmd.go:298`, `:566`). A sweep found the same class of stdout pollution in:

- `call tool-read|write|destructive`: intent banner (`call_cmd.go:379-388`), "Calling ..." progress (`:425`, `:505`)
- `security scan` sync mode: "Scanning ..." + one progress line per 750ms tick + completion/failure/cancel lines (`security_cmd.go:706-813`)
- `upstream add --if-not-exists` / `upstream remove --if-exists`: skip notices short-circuited before the json/yaml gates (`upstream_cmd.go`)
- `tools list --trace-transport` banner (`tools_cmd.go:245-247`)

## Fix

Human banner/progress text now goes to `os.Stderr` unconditionally (terminal UX unchanged; stdout stays parseable), matching the repo's existing daemon-mode convention. The upstream skip paths additionally emit a structured `{"name": ..., "skipped": true}` object on stdout in json/yaml mode (new helper `outputSkipNotice`), mirroring the adjacent success paths, so `-o json` always yields parseable stdout.

Note: scripts that previously grepped the skip notice or `security scan` progress from **stdout** now find it on **stderr** (exit codes unchanged) — this is the intended contract.

## Known follow-ups (out of scope, listed for tracking)

- Commands with no machine output at all under `-o json`: `tools enable/disable`, `token revoke/delete`, `upstream restart/enable/disable` + batch commands, `secrets set/delete/migrate`, `auth login`, `security scan`'s final sync report
- `call tool-*` registers a local `-o` flag defaulting to `pretty` that shadows the global format resolution, so `MCPPROXY_OUTPUT=json` is silently ignored for `call`
- config-file-mode `upstream add/remove` success output is not format-gated

## Tests

- `TestRunToolsListStandalone_MachineModeStdoutClean` (the QA finding: json mode, stdout clean, banner on stderr) and `TestRunToolsListStandalone_TableModeBannerOnStderr` (locks the unconditional-stderr convention) in `cmd/mcpproxy/tools_cmd_test.go` — written TDD-first, red before the fix
- `TestOutputSkipNotice` (json mode: structured object on stdout + notice on stderr; table mode: empty stdout) in `cmd/mcpproxy/upstream_cmd_test.go`
- Updated `TestAddHTTPServerConfigMode` / `TestRemoveServerConfigMode` skip subtests to the new stderr contract
- Commands run: `go test -race ./cmd/mcpproxy/` (all pass), `go build ./cmd/mcpproxy` + `go build -tags server ./cmd/mcpproxy`, `golangci-lint run --config .github/.golangci.yml ./cmd/mcpproxy/...` (0 issues)
- Manual repro with a scratch config + `@modelcontextprotocol/server-everything`, no daemon: `mcpproxy tools list --server=everything -o json 2>/dev/null | jq 'type, length'` → `"array"`, 13; same via `MCPPROXY_OUTPUT=json` and `--json`; `upstream add/remove --if-not-exists/--if-exists -o json 2>/dev/null | jq .` → `{"name": ..., "skipped": true}`