### PR TITLE
fix(serve): exit with code 2 on startup port conflict instead of lingering

### DIFF
--- a/cmd/mcpproxy/exit_codes_test.go
+++ b/cmd/mcpproxy/exit_codes_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/server"
+)
+
+// TestClassifyError_WrappedPortInUse pins the runServer → classifyError →
+// exit-code-2 contract: a *server.PortInUseError wrapped with %w must still
+// classify as a port conflict so the tray's state machine sees exit code 2.
+func TestClassifyError_WrappedPortInUse(t *testing.T) {
+	err := fmt.Errorf("server failed: %w", &server.PortInUseError{Address: "127.0.0.1:8080"})
+	if got := classifyError(err); got != ExitCodePortConflict {
+		t.Fatalf("classifyError(%v) = %d, want %d (ExitCodePortConflict)", err, got, ExitCodePortConflict)
+	}
+}
+
+func TestClassifyError_Nil(t *testing.T) {
+	if got := classifyError(nil); got != ExitCodeSuccess {
+		t.Fatalf("classifyError(nil) = %d, want %d (ExitCodeSuccess)", got, ExitCodeSuccess)
+	}
+}

--- a/cmd/mcpproxy/main.go
+++ b/cmd/mcpproxy/main.go
@@ -680,18 +680,32 @@ func runServer(cmd *cobra.Command, _ []string) error {
 	// Spec 042: clean start.
 	recordStartupOutcome(cfg, actualConfigPath, "success")
 
-	// Wait for context to be cancelled
-	<-ctx.Done()
-	logger.Info("Shutting down server")
-	// Spec 024: Set shutdown info for activity logging
-	srv.SetShutdownInfo("signal", receivedSignal.Load().(string))
-	// Use Shutdown() instead of StopServer() to ensure proper container cleanup
-	// Shutdown() calls runtime.Close() which triggers ShutdownAll() for Docker cleanup
-	if err := srv.Shutdown(); err != nil {
-		logger.Error("Error shutting down server", zap.Error(err))
+	// Wait for context cancellation (signal) or a fatal serve failure
+	select {
+	case <-ctx.Done():
+		logger.Info("Shutting down server")
+		// Spec 024: Set shutdown info for activity logging
+		srv.SetShutdownInfo("signal", receivedSignal.Load().(string))
+		// Use Shutdown() instead of StopServer() to ensure proper container cleanup
+		// Shutdown() calls runtime.Close() which triggers ShutdownAll() for Docker cleanup
+		if err := srv.Shutdown(); err != nil {
+			logger.Error("Error shutting down server", zap.Error(err))
+		}
+		return nil
+	case err := <-srv.ServeErr():
+		// The async StartServer goroutine hit a fatal error (e.g. the listen
+		// port is already in use). Exit instead of lingering with no
+		// listeners so the tray sees the documented exit code (2 for port
+		// conflicts) and can react via its state machine.
+		logger.Error("Server failed, shutting down", zap.Error(err))
+		// Spec 042: overwrite the optimistic "success" outcome recorded above.
+		recordStartupOutcome(cfg, actualConfigPath, classifyStartupError(err))
+		srv.SetShutdownInfo("error", "")
+		if shutdownErr := srv.Shutdown(); shutdownErr != nil {
+			logger.Error("Error shutting down server", zap.Error(shutdownErr))
+		}
+		return fmt.Errorf("server failed: %w", err)
 	}
-
-	return nil
 }
 
 func loadConfig(cmd *cobra.Command) (*config.Config, error) {

--- a/internal/server/listener.go
+++ b/internal/server/listener.go
@@ -77,6 +77,9 @@ func (m *ListenerManager) CreateTCPListener() (*Listener, error) {
 
 	ln, err := net.Listen("tcp", m.config.TCPAddress)
 	if err != nil {
+		if isAddrInUseError(err) {
+			return nil, &PortInUseError{Address: m.config.TCPAddress, Err: err}
+		}
 		return nil, fmt.Errorf("failed to create TCP listener: %w", err)
 	}
 

--- a/internal/server/listener_test.go
+++ b/internal/server/listener_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -34,6 +35,30 @@ func TestListenerManager_CreateTCPListener(t *testing.T) {
 	assert.Equal(t, ConnectionSourceTCP, listener.Source)
 	assert.NotEmpty(t, listener.Address)
 	assert.Contains(t, listener.Address, "127.0.0.1")
+}
+
+func TestCreateTCPListener_AddrInUse_ReturnsPortInUseError(t *testing.T) {
+	logger := zap.NewNop()
+	tmpDir := t.TempDir()
+
+	// Occupy a port so the manager's bind attempt fails.
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer occupied.Close()
+
+	manager := NewListenerManager(&ListenerConfig{
+		DataDir:    tmpDir,
+		TCPAddress: occupied.Addr().String(),
+		Logger:     logger,
+	})
+
+	listener, err := manager.CreateTCPListener()
+	require.Error(t, err)
+	require.Nil(t, listener)
+
+	var portErr *PortInUseError
+	require.True(t, errors.As(err, &portErr), "expected *PortInUseError, got %T: %v", err, err)
+	assert.Equal(t, occupied.Addr().String(), portErr.Address)
 }
 
 func TestListenerManager_CreateTrayListener_Unix(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -73,6 +73,12 @@ type Server struct {
 	statusCh chan interface{}
 	eventsCh chan runtime.Event
 
+	// serveErrCh delivers a fatal serve failure (startup bind error or
+	// serve-loop death) out of the async StartServer goroutine so the
+	// process can exit instead of lingering unreachable. Buffered (cap 1)
+	// so the goroutine never blocks; graceful shutdown never fires it.
+	serveErrCh chan error
+
 	// Spec 024: Track server start time for lifecycle events
 	startTime time.Time
 
@@ -168,6 +174,7 @@ func NewServerWithConfigPath(cfg *config.Config, configPath string, logger *zap.
 		runtime:       rt,
 		statusCh:      make(chan interface{}, 10),
 		eventsCh:      rt.SubscribeEvents(),
+		serveErrCh:    make(chan error, 1),
 		observability: obsManager,
 	}
 
@@ -1485,8 +1492,10 @@ func (s *Server) StartServer(ctx context.Context) error {
 			s.runtime.SetRunning(false)
 
 			// Only send "Stopped" status if there was no error
-			// If there was an error, the error status should remain
-			if serverError == nil || serverError == context.Canceled {
+			// If there was an error, the error status should remain.
+			// errors.Is: graceful cancellation may arrive wrapped
+			// (e.g. "MCP Streamable HTTP server error: context canceled").
+			if serverError == nil || errors.Is(serverError, context.Canceled) {
 				s.updateStatus(runtime.PhaseStopped, "Server has stopped")
 			}
 		}()
@@ -1500,13 +1509,28 @@ func (s *Server) StartServer(ctx context.Context) error {
 		s.updateStatus(runtime.PhaseStarting, "Server is starting...")
 
 		serverError = s.Start(s.serverCtx)
-		if serverError != nil && serverError != context.Canceled {
+		if serverError != nil && !errors.Is(serverError, context.Canceled) {
 			s.logger.Error("Server error during background start", zap.Error(serverError))
 			s.updateStatus(runtime.PhaseError, fmt.Sprintf("Server error: %v", serverError))
+			// Deliver the fatal error to ServeErr() so the process can
+			// exit (e.g. exit code 2 on port conflict) instead of
+			// lingering with no listeners. Non-blocking: buffered cap 1
+			// tolerates restarts when nobody is draining the channel.
+			select {
+			case s.serveErrCh <- serverError:
+			default:
+			}
 		}
 	}()
 
 	return nil
+}
+
+// ServeErr delivers a fatal serve failure: a startup bind error (e.g.
+// *PortInUseError) or a serve-loop death after start. Graceful shutdown
+// (context cancellation, http.ErrServerClosed) never fires it.
+func (s *Server) ServeErr() <-chan error {
+	return s.serveErrCh
 }
 
 // StopServer stops the server if it's running

--- a/internal/server/server_serveerr_test.go
+++ b/internal/server/server_serveerr_test.go
@@ -1,0 +1,106 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+)
+
+// newServeErrTestServer builds a minimal server instance the same way the e2e
+// harness does (temp data dir with 0700 perms, explicit listen address).
+func newServeErrTestServer(t *testing.T, listen string) *Server {
+	t.Helper()
+
+	// Disable OAuth to avoid network calls during upstream connection attempts.
+	t.Setenv("MCPPROXY_DISABLE_OAUTH", "true")
+
+	dataDir := filepath.Join(t.TempDir(), "data")
+	require.NoError(t, os.MkdirAll(dataDir, 0700))
+
+	logger := zap.NewNop()
+	quarantineDisabled := false
+	cfg := &config.Config{
+		DataDir:           dataDir,
+		Listen:            listen,
+		APIKey:            "test-api-key-serveerr",
+		ToolResponseLimit: 10000,
+		QuarantineEnabled: &quarantineDisabled,
+	}
+
+	srv, err := NewServer(cfg, logger)
+	require.NoError(t, err)
+	return srv
+}
+
+// TestStartServer_PortConflict_SignalsServeErr verifies that a startup bind
+// failure inside the async StartServer goroutine is delivered on ServeErr()
+// as a *PortInUseError, so the process can exit with code 2 instead of
+// lingering as an unreachable zombie (v0.51.0-rc.1 QA finding SERVE-PORT).
+func TestStartServer_PortConflict_SignalsServeErr(t *testing.T) {
+	// Occupy a port so the server's bind attempt fails.
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer occupied.Close()
+
+	srv := newServeErrTestServer(t, occupied.Addr().String())
+	defer func() { _ = srv.Shutdown() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// StartServer stays async-nil: the bind failure happens in the goroutine.
+	require.NoError(t, srv.StartServer(ctx))
+
+	select {
+	case serveErr := <-srv.ServeErr():
+		require.Error(t, serveErr)
+		var portErr *PortInUseError
+		require.True(t, errors.As(serveErr, &portErr),
+			"expected *PortInUseError, got %T: %v", serveErr, serveErr)
+	case <-time.After(10 * time.Second):
+		t.Fatal("no serve error delivered on ServeErr() within 10s")
+	}
+}
+
+// TestStartServer_GracefulCancel_NoServeErr pins the graceful shutdown path:
+// context cancellation must NOT fire ServeErr().
+func TestStartServer_GracefulCancel_NoServeErr(t *testing.T) {
+	// Find a free port (listen/close pattern used by the e2e harness).
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+
+	srv := newServeErrTestServer(t, addr)
+	defer func() { _ = srv.Shutdown() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, srv.StartServer(ctx))
+
+	// Wait for the server to come up.
+	require.Eventually(t, srv.IsRunning, 15*time.Second, 50*time.Millisecond,
+		"server did not reach running state")
+
+	cancel()
+
+	// ServeErr must stay silent on graceful cancellation.
+	select {
+	case serveErr := <-srv.ServeErr():
+		t.Fatalf("unexpected serve error on graceful cancel: %v", serveErr)
+	case <-time.After(2 * time.Second):
+		// Silence is the expected outcome.
+	}
+
+	require.NoError(t, srv.Shutdown())
+}


### PR DESCRIPTION
## Problem

Found by v0.51.0-rc.1 QA (2026-07-15). Running `mcpproxy serve` while the listen port is already occupied did not fail: the process lingered indefinitely as an unreachable zombie with zero listeners (no TCP, no tray socket), and never exited with the documented port-conflict exit code 2. The tray's dedicated port-conflict state (`StateCoreErrorPortConflict`, driven by exit code 2) never triggered because the core never exited.

## Root cause

The bind failure is swallowed by the async fire-and-forget goroutine in `StartServer`:

- `internal/server/server.go:1502-1505` — `serverError = s.Start(...)` failures were only logged and mapped to `PhaseError`; nothing carried the error back to the process exit path.
- `cmd/mcpproxy/main.go:684` — `runServer` blocked on a bare `<-ctx.Done()`, so only a signal could unblock it.
- `internal/server/listener.go:78-81` — the bind failure surfaced as a plain wrapped error; the typed `*PortInUseError` (checked by `errors.As` in both `Start` and `classifyError` → exit 2) was never constructed anywhere in the repo.

## Fix

1. `internal/server/listener.go` — construct `*PortInUseError` when `net.Listen` fails with addr-in-use (via the existing platform-tagged `isAddrInUseError`), activating the dormant `errors.As` consumers.
2. `internal/server/server.go` — new buffered `ServeErr() <-chan error`; the `StartServer` goroutine delivers fatal serve errors non-blockingly. Context-cancel filtering now uses `errors.Is` because graceful cancellation arrives wrapped (`"MCP Streamable HTTP server error: context canceled"`) — the TDD regression test caught that the investigation's assumption of an unwrapped `context.Canceled` didn't hold.
3. `cmd/mcpproxy/main.go` — `runServer` selects on `ctx.Done()` / `srv.ServeErr()`; on serve failure it re-records the Spec 042 startup outcome (equality-guarded), runs the idempotent `Shutdown()`, and returns the wrapped error so `classifyError` maps it to exit code 2.

Deliberate behavior change: a post-start fatal `Serve()` error now also terminates the process (exit 1 via `classifyError`) instead of lingering in `PhaseError` — the single mux listener feeds every transport (TCP + tray socket), so the core is unreachable without it, and the tray handles non-zero exits via its state machine. Note the addr-in-use error text changes from `"MCP Streamable HTTP server error: failed to create TCP listener: ..."` to `"port <addr> is already in use"`.

## Tests

Added (TDD — written first, confirmed failing for the expected reason, then fixed):
- `internal/server/listener_test.go`: `TestCreateTCPListener_AddrInUse_ReturnsPortInUseError`
- `internal/server/server_serveerr_test.go`: `TestStartServer_PortConflict_SignalsServeErr`, `TestStartServer_GracefulCancel_NoServeErr` (pins that graceful cancellation never fires `ServeErr`)
- `cmd/mcpproxy/exit_codes_test.go`: `TestClassifyError_WrappedPortInUse`, `TestClassifyError_Nil` (pins the `%w`-wrap → exit-2 contract)

Commands run:
- `go build ./cmd/mcpproxy` and `go build -tags server ./cmd/mcpproxy` — both OK
- `go test -race ./internal/server/` — ok (533s), `go test -race ./cmd/mcpproxy/` — ok
- `/opt/homebrew/bin/golangci-lint run --config .github/.golangci.yml ./internal/server/... ./cmd/mcpproxy/...` — 0 issues
- Manual QA repro: `serve` against an occupied port → exits with code 2 and `Error: server failed: port 127.0.0.1:<port> is already in use`, no lingering process; SIGINT on a healthy instance → clean exit 0.