### PR TITLE
fix(cli): fall back to TCP daemon detection when unix socket is unavailable

### DIFF
--- a/cmd/mcpproxy/activity_cmd.go
+++ b/cmd/mcpproxy/activity_cmd.go
@@ -976,40 +976,12 @@ func runActivityWatch(cmd *cobra.Command, _ []string) error {
 		return outputActivityError(err, "CONFIG_ERROR")
 	}
 
-	// Try socket first, then HTTP (same as getActivityClient)
-	endpoint := socket.GetDefaultSocketPath(cfg.DataDir)
-	if cfg.Listen != "" {
-		// Check if socket exists (use IsSocketAvailable which handles unix:// prefix)
-		if !socket.IsSocketAvailable(endpoint) {
-			// Handle listen addresses like ":8080" (no host)
-			listen := cfg.Listen
-			if strings.HasPrefix(listen, ":") {
-				listen = "127.0.0.1" + listen
-			}
-			endpoint = "http://" + listen
-		}
-	}
-
-	// Create HTTP client with socket support
-	transport := &http.Transport{}
-	dialer, baseURL, dialErr := socket.CreateDialer(endpoint)
-	if dialErr != nil {
-		logger.Sugar().Warnw("Failed to create socket dialer, using TCP",
-			"endpoint", endpoint,
-			"error", dialErr)
-		baseURL = endpoint
-	}
-	if dialer != nil {
-		transport.DialContext = dialer
-		logger.Sugar().Debugw("Using socket/pipe connection for SSE", "endpoint", endpoint)
-	} else {
-		baseURL = endpoint
-	}
-
-	// Build SSE URL
-	sseURL := baseURL + "/events"
-	if cfg.APIKey != "" {
-		sseURL += "?apikey=" + cfg.APIKey
+	// Resolve the SSE target via the shared daemon detection: socket first,
+	// then probed TCP fallback with the env>config API key (QA finding
+	// CLI-SOCKET — same semantics as getActivityClient).
+	sseURL, apiKey, transport, ok := activityWatchTarget(cfg, logger.Sugar())
+	if !ok {
+		return outputActivityError(fmt.Errorf("mcpproxy daemon is not reachable. Start with: mcpproxy serve"), "CONNECTION_ERROR")
 	}
 
 	// Setup context with signal handling
@@ -1033,16 +1005,53 @@ func runActivityWatch(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Watch with reconnection
-	return watchWithReconnect(ctx, sseURL, outputFormat, logger.Sugar(), httpClient)
+	return watchWithReconnect(ctx, sseURL, apiKey, outputFormat, logger.Sugar(), httpClient)
+}
+
+// activityWatchTarget resolves the SSE URL, API key, and HTTP transport for
+// `activity watch` using the shared daemon detection (daemonEndpoint):
+// socket first (no API key needed), then probed TCP fallback with the
+// env>config API key. ok=false when no daemon is reachable.
+func activityWatchTarget(cfg *config.Config, logger *zap.SugaredLogger) (sseURL, apiKey string, transport *http.Transport, ok bool) {
+	endpoint, apiKey, ok := daemonEndpoint(cfg)
+	if !ok {
+		return "", "", nil, false
+	}
+	transport, baseURL := activityTransport(endpoint, logger)
+	return baseURL + "/events", apiKey, transport, true
+}
+
+// activityTransport builds an HTTP transport + base URL for a daemonEndpoint
+// result: unix://|npipe:// endpoints get a socket dialer, http(s) endpoints
+// are used as-is.
+func activityTransport(endpoint string, logger *zap.SugaredLogger) (*http.Transport, string) {
+	transport := &http.Transport{}
+	dialer, baseURL, err := socket.CreateDialer(endpoint)
+	if err != nil {
+		if logger != nil {
+			logger.Warnw("Failed to create socket dialer, using endpoint directly",
+				"endpoint", endpoint,
+				"error", err)
+		}
+		return transport, endpoint
+	}
+	if dialer == nil {
+		return transport, endpoint
+	}
+	transport.DialContext = dialer
+	if logger != nil {
+		logger.Debugw("Using socket/pipe connection", "endpoint", endpoint)
+	}
+	return transport, baseURL
 }
 
 // watchWithReconnect watches the SSE stream with automatic reconnection
-func watchWithReconnect(ctx context.Context, sseURL string, outputFormat string, logger *zap.SugaredLogger, httpClient *http.Client) error {
+func watchWithReconnect(ctx context.Context, sseURL, apiKey string, outputFormat string, logger *zap.SugaredLogger, httpClient *http.Client) error {
 	backoff := 1 * time.Second
 	maxBackoff := 30 * time.Second
 
 	for {
-		err := watchActivityStream(ctx, sseURL, outputFormat, logger, httpClient)
+		err := watchActivityStream(ctx, sseURL, apiKey, outputFormat, logger, httpClient)
 
 		select {
 		case <-ctx.Done():
@@ -1062,12 +1071,17 @@ func watchWithReconnect(ctx context.Context, sseURL string, outputFormat string,
 }
 
 // watchActivityStream connects to SSE and streams events
-func watchActivityStream(ctx context.Context, sseURL string, outputFormat string, _ *zap.SugaredLogger, httpClient *http.Client) error {
+func watchActivityStream(ctx context.Context, sseURL, apiKey string, outputFormat string, _ *zap.SugaredLogger, httpClient *http.Client) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sseURL, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Set("Accept", "text/event-stream")
+	if apiKey != "" {
+		// TCP fallback: /events sits behind apiKeyAuthMiddleware. Header, not
+		// ?apikey= query param, so the key never lands in URLs/logs.
+		req.Header.Set("X-API-Key", apiKey)
+	}
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
@@ -1562,12 +1576,13 @@ func runActivityExport(cmd *cobra.Command, _ []string) error {
 		return outputActivityError(err, "CONFIG_ERROR")
 	}
 
-	// Build export URL
-	listen := cfg.Listen
-	if strings.HasPrefix(listen, ":") {
-		listen = "127.0.0.1" + listen
+	// Resolve the daemon via the shared detection: socket first, then probed
+	// TCP fallback with the env>config API key (QA finding CLI-SOCKET).
+	endpoint, apiKey, ok := daemonEndpoint(cfg)
+	if !ok {
+		return outputActivityError(fmt.Errorf("mcpproxy daemon is not reachable. Start with: mcpproxy serve"), "CONNECTION_ERROR")
 	}
-	baseURL := "http://" + listen
+	transport, baseURL := activityTransport(endpoint, logger.Sugar())
 	exportURL := baseURL + "/api/v1/activity/export"
 
 	q := url.Values{}
@@ -1608,12 +1623,12 @@ func runActivityExport(cmd *cobra.Command, _ []string) error {
 		return outputActivityError(err, "REQUEST_ERROR")
 	}
 
-	// Add API key header
-	if cfg.APIKey != "" {
-		req.Header.Set("X-API-Key", cfg.APIKey)
+	// Add API key header (empty over socket — OS-level auth)
+	if apiKey != "" {
+		req.Header.Set("X-API-Key", apiKey)
 	}
 
-	client := &http.Client{}
+	client := &http.Client{Transport: transport}
 	resp, err := client.Do(req)
 	if err != nil {
 		return outputActivityError(err, "CONNECTION_ERROR")

--- a/cmd/mcpproxy/activity_cmd.go
+++ b/cmd/mcpproxy/activity_cmd.go
@@ -792,21 +792,12 @@ func getActivityClient(logger *zap.SugaredLogger) (*cliclient.Client, error) {
 		return nil, fmt.Errorf("failed to load config: %w", err)
 	}
 
-	// Try socket first, then HTTP
-	endpoint := socket.GetDefaultSocketPath(cfg.DataDir)
-	if cfg.Listen != "" {
-		// Check if socket exists (use IsSocketAvailable which handles unix:// prefix)
-		if !socket.IsSocketAvailable(endpoint) {
-			// Handle listen addresses like ":8080" (no host)
-			listen := cfg.Listen
-			if strings.HasPrefix(listen, ":") {
-				listen = "127.0.0.1" + listen
-			}
-			endpoint = "http://" + listen
-		}
+	// Try socket first, then TCP fallback (cfg.Listen + API key)
+	client, ok := newDaemonClient(cfg, logger)
+	if !ok {
+		return nil, fmt.Errorf("mcpproxy daemon is not reachable. Start with: mcpproxy serve")
 	}
-
-	return cliclient.NewClientWithAPIKey(endpoint, cfg.APIKey, logger), nil
+	return client, nil
 }
 
 // runActivityList implements the activity list command

--- a/cmd/mcpproxy/activity_daemon_test.go
+++ b/cmd/mcpproxy/activity_daemon_test.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+)
+
+// resetActivityExportFlags snapshots and restores the package-level flag
+// variables used by runActivityExport so tests stay hermetic.
+func resetActivityExportFlags(t *testing.T) {
+	t.Helper()
+	savedConfigFile := configFile
+	savedFormat := activityExportFormat
+	savedOutput := activityExportOutput
+	savedType := activityType
+	savedServer := activityServer
+	savedTool := activityTool
+	savedStatus := activityStatus
+	savedSession := activitySessionID
+	savedStart := activityStartTime
+	savedEnd := activityEndTime
+	savedBodies := activityIncludeBodies
+	t.Cleanup(func() {
+		configFile = savedConfigFile
+		activityExportFormat = savedFormat
+		activityExportOutput = savedOutput
+		activityType = savedType
+		activityServer = savedServer
+		activityTool = savedTool
+		activityStatus = savedStatus
+		activitySessionID = savedSession
+		activityStartTime = savedStart
+		activityEndTime = savedEnd
+		activityIncludeBodies = savedBodies
+	})
+	activityType = ""
+	activityServer = ""
+	activityTool = ""
+	activityStatus = ""
+	activitySessionID = ""
+	activityStartTime = ""
+	activityEndTime = ""
+	activityIncludeBodies = false
+}
+
+// TestActivityExportUsesSharedDaemonDetection guards QA finding CLI-SOCKET for
+// `activity export`: when the unix socket is unavailable the command must go
+// through the shared daemon detection (daemonEndpoint), which honors the
+// MCPPROXY_API_KEY env override, instead of the old hand-rolled
+// cfg.Listen+cfg.APIKey fallback that sent a stale file key.
+func TestActivityExportUsesSharedDaemonDetection(t *testing.T) {
+	clearDaemonEnv(t)
+	t.Setenv("MCPPROXY_API_KEY", "env-key")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/status", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-API-Key") != "env-key" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte(`{"success":true,"data":{"running":true}}`))
+	})
+	mux.HandleFunc("/api/v1/activity/export", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-API-Key") != "env-key" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte(`[]`))
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	dataDir := t.TempDir() // no socket file here → TCP fallback
+	cfgJSON, err := json.Marshal(map[string]string{
+		"listen":   strings.TrimPrefix(ts.URL, "http://"),
+		"api_key":  "stale-file-key", // daemon was started with MCPPROXY_API_KEY instead
+		"data_dir": dataDir,
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal config: %v", err)
+	}
+	cfgPath := filepath.Join(t.TempDir(), "mcp_config.json")
+	if err := os.WriteFile(cfgPath, cfgJSON, 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	resetActivityExportFlags(t)
+	configFile = cfgPath
+	activityExportFormat = "json"
+	activityExportOutput = filepath.Join(t.TempDir(), "export.json")
+
+	if err := runActivityExport(&cobra.Command{Use: "export"}, nil); err != nil {
+		t.Fatalf("activity export should reach the daemon over TCP with the env API key, got: %v", err)
+	}
+
+	data, err := os.ReadFile(activityExportOutput)
+	if err != nil {
+		t.Fatalf("failed to read export output: %v", err)
+	}
+	if string(data) != `[]` {
+		t.Fatalf("unexpected export payload: %q", string(data))
+	}
+}
+
+// TestActivityWatchTargetTCPFallback guards QA finding CLI-SOCKET for
+// `activity watch`: the SSE target must come from the shared daemon
+// detection (socket first, then probed TCP fallback with env>config key).
+func TestActivityWatchTargetTCPFallback(t *testing.T) {
+	clearDaemonEnv(t)
+	t.Setenv("MCPPROXY_API_KEY", "env-key")
+
+	ts := newStatusServer(t, "env-key")
+	defer ts.Close()
+
+	cfg := &config.Config{
+		DataDir: t.TempDir(), // no socket file here
+		Listen:  strings.TrimPrefix(ts.URL, "http://"),
+		APIKey:  "stale-file-key",
+	}
+
+	sseURL, apiKey, _, ok := activityWatchTarget(cfg, nil)
+	if !ok {
+		t.Fatal("expected watch target to resolve via TCP fallback when the socket is missing")
+	}
+	if sseURL != ts.URL+"/events" {
+		t.Fatalf("expected SSE URL %s/events, got %s", ts.URL, sseURL)
+	}
+	if apiKey != "env-key" {
+		t.Fatalf("expected env API key to win over the config file key, got %q", apiKey)
+	}
+	if strings.Contains(sseURL, "apikey=") {
+		t.Fatalf("API key must be sent via X-API-Key header, not query param: %s", sseURL)
+	}
+}
+
+// TestWatchActivityStreamSendsAPIKeyHeader verifies the SSE request carries
+// X-API-Key so the TCP fallback authenticates against /events.
+func TestWatchActivityStreamSendsAPIKeyHeader(t *testing.T) {
+	gotKey := make(chan string, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey <- r.Header.Get("X-API-Key")
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: activity.completed\ndata: {}\n\n"))
+	}))
+	defer ts.Close()
+
+	err := watchActivityStream(context.Background(), ts.URL+"/events", "secret", "table", nil, ts.Client())
+	if err != nil {
+		t.Fatalf("watchActivityStream failed: %v", err)
+	}
+	select {
+	case key := <-gotKey:
+		if key != "secret" {
+			t.Fatalf("expected X-API-Key 'secret', got %q", key)
+		}
+	default:
+		t.Fatal("SSE handler was never called")
+	}
+}

--- a/cmd/mcpproxy/auth_cmd.go
+++ b/cmd/mcpproxy/auth_cmd.go
@@ -13,7 +13,6 @@ import (
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/contracts"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/logs"
-	"github.com/smart-mcp-proxy/mcpproxy-go/internal/socket"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/upstream/cli"
 
 	"github.com/spf13/cobra"
@@ -182,13 +181,13 @@ func runAuthLogin(cmd *cobra.Command, _ []string) error {
 
 	// Handle --all flag: authenticate all servers
 	if authAll {
-		return runAuthLoginAll(ctx, cfg.DataDir)
+		return runAuthLoginAll(ctx, cfg)
 	}
 
 	// Handle single server authentication
-	// Check if daemon is running and use client mode
-	if shouldUseAuthDaemon(cfg.DataDir) {
-		return runAuthLoginClientMode(ctx, cfg.DataDir, authServerName)
+	// Check if daemon is running (socket first, then TCP fallback) and use client mode
+	if client, ok := newDaemonClient(cfg, nil); ok {
+		return runAuthLoginClientMode(ctx, client, authServerName)
 	}
 
 	// No daemon detected, use standalone mode
@@ -196,20 +195,18 @@ func runAuthLogin(cmd *cobra.Command, _ []string) error {
 }
 
 // runAuthLoginAll authenticates all servers that require OAuth authentication.
-func runAuthLoginAll(ctx context.Context, dataDir string) error {
-	// Auth login --all REQUIRES daemon
-	if !shouldUseAuthDaemon(dataDir) {
-		return fmt.Errorf("auth login --all requires running daemon. Start with: mcpproxy serve")
-	}
-
-	socketPath := socket.DetectSocketPath(dataDir)
+func runAuthLoginAll(ctx context.Context, cfg *config.Config) error {
 	logger, err := logs.SetupCommandLogger(false, authLogLevel, false, "")
 	if err != nil {
 		return fmt.Errorf("failed to create logger: %w", err)
 	}
 	defer func() { _ = logger.Sync() }()
 
-	client := cliclient.NewClient(socketPath, logger.Sugar())
+	// Auth login --all REQUIRES daemon
+	client, ok := newDaemonClient(cfg, logger.Sugar())
+	if !ok {
+		return fmt.Errorf("auth login --all requires running daemon. Start with: mcpproxy serve")
+	}
 
 	// Ping daemon to verify connectivity
 	pingCtx, pingCancel := context.WithTimeout(ctx, 2*time.Second)
@@ -322,24 +319,16 @@ func runAuthStatus(_ *cobra.Command, _ []string) error {
 	}
 
 	// Auth status REQUIRES daemon (to show real daemon state)
-	if !shouldUseAuthDaemon(cfg.DataDir) {
+	client, ok := newDaemonClient(cfg, nil)
+	if !ok {
 		return fmt.Errorf("auth status requires running daemon. Start with: mcpproxy serve")
 	}
 
-	return runAuthStatusClientMode(ctx, cfg.DataDir, authServerName, authAll)
+	return runAuthStatusClientMode(ctx, client, authServerName, authAll)
 }
 
-// runAuthStatusClientMode fetches auth status from daemon via socket.
-func runAuthStatusClientMode(ctx context.Context, dataDir, serverName string, allServers bool) error {
-	socketPath := socket.DetectSocketPath(dataDir)
-	logger, err := logs.SetupCommandLogger(false, authLogLevel, false, "")
-	if err != nil {
-		return fmt.Errorf("failed to create logger: %w", err)
-	}
-	defer func() { _ = logger.Sync() }()
-
-	client := cliclient.NewClient(socketPath, logger.Sugar())
-
+// runAuthStatusClientMode fetches auth status from the daemon.
+func runAuthStatusClientMode(ctx context.Context, client *cliclient.Client, serverName string, allServers bool) error {
 	// Fetch all servers to check OAuth status
 	servers, err := client.GetServers(ctx)
 	if err != nil {
@@ -631,15 +620,8 @@ func getAuthAvailableServerNames(cfg *config.Config) []string {
 	return names
 }
 
-// shouldUseAuthDaemon checks if daemon is running by detecting socket file.
-func shouldUseAuthDaemon(dataDir string) bool {
-	socketPath := socket.DetectSocketPath(dataDir)
-	return socket.IsSocketAvailable(socketPath)
-}
-
-// runAuthLoginClientMode triggers OAuth via daemon HTTP API over socket.
-func runAuthLoginClientMode(ctx context.Context, dataDir, serverName string) error {
-	socketPath := socket.DetectSocketPath(dataDir)
+// runAuthLoginClientMode triggers OAuth via the daemon HTTP API.
+func runAuthLoginClientMode(ctx context.Context, client *cliclient.Client, serverName string) error {
 	// Create simple logger for client (no file logging for command)
 	logger, err := logs.SetupCommandLogger(false, authLogLevel, false, "")
 	if err != nil {
@@ -647,20 +629,17 @@ func runAuthLoginClientMode(ctx context.Context, dataDir, serverName string) err
 	}
 	defer func() { _ = logger.Sync() }()
 
-	client := cliclient.NewClient(socketPath, logger.Sugar())
-
 	// Ping daemon to verify connectivity
 	pingCtx, pingCancel := context.WithTimeout(ctx, 2*time.Second)
 	defer pingCancel()
 	if err := client.Ping(pingCtx); err != nil {
 		logger.Warn("Failed to ping daemon, falling back to standalone mode",
-			zap.Error(err),
-			zap.String("socket_path", socketPath))
+			zap.Error(err))
 		// Fall back to standalone mode
 		return runAuthLoginStandalone(ctx, serverName)
 	}
 
-	fmt.Fprintf(os.Stderr, "ℹ️  Using daemon mode (via socket) - coordinating OAuth with running server\n\n")
+	fmt.Fprintf(os.Stderr, "ℹ️  Using daemon mode - coordinating OAuth with running server\n\n")
 
 	// Trigger OAuth via daemon
 	if err := client.TriggerOAuthLogin(ctx, serverName); err != nil {
@@ -859,18 +838,17 @@ func runAuthLogout(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
 
-	// Check if daemon is running and use client mode
-	if shouldUseAuthDaemon(cfg.DataDir) {
-		return runAuthLogoutClientMode(ctx, cfg.DataDir, authServerName)
+	// Check if daemon is running (socket first, then TCP fallback) and use client mode
+	if client, ok := newDaemonClient(cfg, nil); ok {
+		return runAuthLogoutClientMode(ctx, client, authServerName)
 	}
 
 	// No daemon detected, use standalone mode
 	return runAuthLogoutStandalone(ctx, authServerName, cfg)
 }
 
-// runAuthLogoutClientMode triggers OAuth logout via daemon HTTP API over socket.
-func runAuthLogoutClientMode(ctx context.Context, dataDir, serverName string) error {
-	socketPath := socket.DetectSocketPath(dataDir)
+// runAuthLogoutClientMode triggers OAuth logout via the daemon HTTP API.
+func runAuthLogoutClientMode(ctx context.Context, client *cliclient.Client, serverName string) error {
 	// Create simple logger for client (no file logging for command)
 	logger, err := logs.SetupCommandLogger(false, authLogLevel, false, "")
 	if err != nil {
@@ -878,15 +856,12 @@ func runAuthLogoutClientMode(ctx context.Context, dataDir, serverName string) er
 	}
 	defer func() { _ = logger.Sync() }()
 
-	client := cliclient.NewClient(socketPath, logger.Sugar())
-
 	// Ping daemon to verify connectivity
 	pingCtx, pingCancel := context.WithTimeout(ctx, 2*time.Second)
 	defer pingCancel()
 	if err := client.Ping(pingCtx); err != nil {
 		logger.Warn("Failed to ping daemon, falling back to standalone mode",
-			zap.Error(err),
-			zap.String("socket_path", socketPath))
+			zap.Error(err))
 
 		// Load config for standalone mode
 		cfg, loadErr := loadAuthConfig()
@@ -896,7 +871,7 @@ func runAuthLogoutClientMode(ctx context.Context, dataDir, serverName string) er
 		return runAuthLogoutStandalone(ctx, serverName, cfg)
 	}
 
-	fmt.Fprintf(os.Stderr, "ℹ️  Using daemon mode (via socket) - coordinating OAuth logout with running server\n\n")
+	fmt.Fprintf(os.Stderr, "ℹ️  Using daemon mode - coordinating OAuth logout with running server\n\n")
 
 	// Trigger OAuth logout via daemon
 	if err := client.TriggerOAuthLogout(ctx, serverName); err != nil {

--- a/cmd/mcpproxy/auth_cmd_test.go
+++ b/cmd/mcpproxy/auth_cmd_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/socket"
 
 	"github.com/spf13/cobra"
@@ -13,23 +14,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestShouldUseAuthDaemon(t *testing.T) {
-	// Test with non-existent directory
-	result := shouldUseAuthDaemon("/tmp/nonexistent-mcpproxy-test-dir-auth-88888")
-	assert.False(t, result, "shouldUseAuthDaemon should return false for non-existent directory")
+func TestAuthDaemonDetection_NoDaemon(t *testing.T) {
+	clearDaemonEnv(t)
 
-	// Test with existing directory but no socket
+	// Non-existent directory, no socket, no API key → no daemon
+	_, _, ok := daemonEndpoint(&config.Config{DataDir: "/tmp/nonexistent-mcpproxy-test-dir-auth-88888"})
+	assert.False(t, ok, "daemonEndpoint should report no daemon for non-existent directory")
+
+	// Existing directory but no socket
 	tmpDir := t.TempDir()
-	result = shouldUseAuthDaemon(tmpDir)
-	assert.False(t, result, "shouldUseAuthDaemon should return false when socket doesn't exist")
+	_, _, ok = daemonEndpoint(&config.Config{DataDir: tmpDir})
+	assert.False(t, ok, "daemonEndpoint should report no daemon when socket doesn't exist")
 }
 
 func TestAuthStatus_RequiresDaemon(t *testing.T) {
+	clearDaemonEnv(t)
 	tmpDir := t.TempDir()
 
 	// Test that auth status requires daemon
-	result := shouldUseAuthDaemon(tmpDir)
-	assert.False(t, result, "Should return false when daemon not running")
+	_, _, ok := daemonEndpoint(&config.Config{DataDir: tmpDir})
+	assert.False(t, ok, "Should report no daemon when daemon not running")
 }
 
 func TestDetectSocketPath_Auth(t *testing.T) {
@@ -147,10 +151,11 @@ func TestAuthLogin_SilenceUsageAfterValidation(t *testing.T) {
 }
 
 func TestRunAuthLoginAll_NoDaemon(t *testing.T) {
+	clearDaemonEnv(t)
 	ctx := context.Background()
 	tmpDir := t.TempDir()
 
-	err := runAuthLoginAll(ctx, tmpDir)
+	err := runAuthLoginAll(ctx, &config.Config{DataDir: tmpDir})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "requires running daemon")
 }

--- a/cmd/mcpproxy/call_cmd.go
+++ b/cmd/mcpproxy/call_cmd.go
@@ -16,7 +16,6 @@ import (
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/index"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/secret"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/server"
-	"github.com/smart-mcp-proxy/mcpproxy-go/internal/socket"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/truncate"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/upstream"
@@ -318,12 +317,6 @@ func createLogger(level string) (*zap.Logger, error) {
 	return config.Build()
 }
 
-// shouldUseCallDaemon checks if daemon is running by detecting socket file.
-func shouldUseCallDaemon(dataDir string) bool {
-	socketPath := socket.DetectSocketPath(dataDir)
-	return socket.IsSocketAvailable(socketPath)
-}
-
 // runCallToolRead handles the tool-read command (Spec 018)
 func runCallToolRead(_ *cobra.Command, _ []string) error {
 	return runCallToolVariant("call_tool_read", "read")
@@ -387,10 +380,10 @@ func runCallToolVariant(toolVariant, operationType string) error {
 	}
 	fmt.Printf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n")
 
-	// Detect daemon and use client mode if available
-	if shouldUseCallDaemon(globalConfig.DataDir) {
-		logger.Info("Detected running daemon, using client mode via socket")
-		return runCallToolVariantClientMode(globalConfig.DataDir, toolVariant, variantArgs, logger)
+	// Detect daemon (socket first, then TCP fallback) and use client mode if available
+	if client, ok := newDaemonClient(globalConfig, logger.Sugar()); ok {
+		logger.Info("Detected running daemon, using client mode")
+		return runCallToolVariantClientMode(client, toolVariant, variantArgs, logger)
 	}
 
 	// No daemon - use standalone mode
@@ -398,28 +391,21 @@ func runCallToolVariant(toolVariant, operationType string) error {
 	return runCallToolVariantStandalone(ctx, toolVariant, variantArgs, globalConfig)
 }
 
-// runCallToolVariantClientMode calls tool variant via daemon HTTP API over socket
-func runCallToolVariantClientMode(dataDir, toolVariant string, args map[string]interface{}, logger *zap.Logger) error {
-	// Detect socket endpoint
-	socketPath := socket.DetectSocketPath(dataDir)
-
-	// Create CLI client
-	client := cliclient.NewClient(socketPath, logger.Sugar())
-
+// runCallToolVariantClientMode calls tool variant via the daemon HTTP API
+func runCallToolVariantClientMode(client *cliclient.Client, toolVariant string, args map[string]interface{}, logger *zap.Logger) error {
 	// Ping daemon to verify connectivity
 	pingCtx, pingCancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer pingCancel()
 	if err := client.Ping(pingCtx); err != nil {
 		logger.Warn("Failed to ping daemon, falling back to standalone mode",
-			zap.Error(err),
-			zap.String("socket_path", socketPath))
+			zap.Error(err))
 		// Fall back to standalone mode
 		cfg, _ := loadCallConfig()
 		standaloneCtx := context.Background()
 		return runCallToolVariantStandalone(standaloneCtx, toolVariant, args, cfg)
 	}
 
-	fmt.Fprintf(os.Stderr, "ℹ️  Using daemon mode (via socket) - fast execution\n")
+	fmt.Fprintf(os.Stderr, "ℹ️  Using daemon mode - fast execution\n")
 
 	// Call tool via daemon
 	fmt.Printf("🔗 Calling %s via daemon socket...\n", toolVariant)

--- a/cmd/mcpproxy/code_cmd.go
+++ b/cmd/mcpproxy/code_cmd.go
@@ -15,7 +15,6 @@ import (
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/index"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/secret"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/server"
-	"github.com/smart-mcp-proxy/mcpproxy-go/internal/socket"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/truncate"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/upstream"
@@ -158,37 +157,24 @@ func runCodeExec(_ *cobra.Command, _ []string) error {
 		return exitError(2)
 	}
 
-	// Detect daemon and choose mode
-	if shouldUseDaemon(globalConfig.DataDir) {
-		logger.Info("Detected running daemon, using client mode via socket")
-		return runCodeExecClientMode(globalConfig.DataDir, code, inputData, logger)
+	// Detect daemon (socket first, then TCP fallback) and choose mode
+	if client, ok := newDaemonClient(globalConfig, logger.Sugar()); ok {
+		logger.Info("Detected running daemon, using client mode")
+		return runCodeExecClientMode(client, code, inputData, logger)
 	}
 
 	logger.Info("No daemon detected, using standalone mode")
 	return runCodeExecStandalone(globalConfig, code, inputData, logger)
 }
 
-// shouldUseDaemon checks if daemon is running by detecting socket file.
-func shouldUseDaemon(dataDir string) bool {
-	socketPath := socket.DetectSocketPath(dataDir)
-	return socket.IsSocketAvailable(socketPath)
-}
-
-// runCodeExecClientMode executes code via daemon HTTP API over socket.
-func runCodeExecClientMode(dataDir, code string, input map[string]interface{}, logger *zap.Logger) error {
-	// Detect socket endpoint
-	socketPath := socket.DetectSocketPath(dataDir)
-
-	// Create CLI client
-	client := cliclient.NewClient(socketPath, logger.Sugar())
-
+// runCodeExecClientMode executes code via the daemon HTTP API.
+func runCodeExecClientMode(client *cliclient.Client, code string, input map[string]interface{}, logger *zap.Logger) error {
 	// Ping daemon to verify connectivity
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	if err := client.Ping(ctx); err != nil {
 		logger.Warn("Failed to ping daemon, falling back to standalone mode",
 			zap.Error(err),
-			zap.String("socket_path", socketPath),
 			zap.Duration("ping_timeout", 2*time.Second),
 			zap.String("fallback_mode", "standalone"))
 		// Fall back to standalone mode
@@ -197,7 +183,7 @@ func runCodeExecClientMode(dataDir, code string, input map[string]interface{}, l
 	}
 
 	// ADD CLI mode indicator
-	fmt.Fprintf(os.Stderr, "ℹ️  Using daemon mode (via socket) - fast execution\n")
+	fmt.Fprintf(os.Stderr, "ℹ️  Using daemon mode - fast execution\n")
 
 	// Execute code via daemon
 	result, err := client.CodeExec(

--- a/cmd/mcpproxy/daemon_client.go
+++ b/cmd/mcpproxy/daemon_client.go
@@ -1,0 +1,118 @@
+package main
+
+// Shared daemon detection for CLI commands (v0.51.0-rc.1 QA finding CLI-SOCKET).
+//
+// Historically every CLI command detected a running daemon with a bare stat()
+// on the Unix-socket path. When the daemon could not bind its socket (macOS
+// 104-byte sun_path limit, enable_socket:false) it keeps serving over TCP,
+// but the stat-only check reported "daemon not running" and commands silently
+// fell back to standalone/config-only mode. daemonEndpoint adds a TCP
+// fallback: socket first (unchanged semantics), then the config's listen
+// address probed with the config's API key.
+
+import (
+	"context"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/cliclient"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/socket"
+
+	"go.uber.org/zap"
+)
+
+// daemonProbeTimeout caps the HTTP probe used to verify a TCP endpoint.
+// On localhost a dead port fails in <1ms (connection refused), so commands
+// stay fast when no daemon is running.
+const daemonProbeTimeout = 2 * time.Second
+
+// resolveAPIKey returns the API key the daemon would accept, mirroring
+// Config.EnsureAPIKey precedence (env > config file) WITHOUT ever generating
+// a new key — a fabricated key cannot match a running daemon's.
+func resolveAPIKey(cfg *config.Config) string {
+	if envAPIKey, exists := os.LookupEnv("MCPPROXY_API_KEY"); exists && envAPIKey != "" {
+		return envAPIKey
+	}
+	if cfg != nil {
+		return cfg.APIKey
+	}
+	return ""
+}
+
+// tcpFallbackEndpoint converts a config listen address into a dialable
+// http:// URL. Wildcard hosts ("", "0.0.0.0", "::") are normalized to
+// loopback; other hosts come from the user's own config and are kept
+// verbatim. ok=false when the address cannot be parsed.
+func tcpFallbackEndpoint(listen string) (endpoint string, ok bool) {
+	host, port, err := net.SplitHostPort(listen)
+	if err != nil || port == "" {
+		return "", false
+	}
+	switch host {
+	case "", "0.0.0.0", "::":
+		host = "127.0.0.1"
+	}
+	return "http://" + net.JoinHostPort(host, port), true
+}
+
+// probeDaemon verifies a daemon is answering at endpoint by hitting
+// GET /api/v1/status with the given API key.
+func probeDaemon(endpoint, apiKey string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), daemonProbeTimeout)
+	defer cancel()
+	client := cliclient.NewClientWithAPIKey(endpoint, apiKey, nil)
+	return client.Ping(ctx) == nil
+}
+
+// daemonEndpoint resolves how to reach a running daemon.
+// Order:
+//  1. explicit http(s) MCPPROXY_TRAY_ENDPOINT (probed with the API key);
+//  2. unix socket / named pipe — stat-only, preserves existing semantics;
+//     socket connections bypass API-key auth so apiKey is "";
+//  3. TCP fallback: cfg.Listen + API key (MCPPROXY_API_KEY env overrides
+//     cfg.APIKey), verified by a short GET /api/v1/status probe. No key ⇒
+//     no TCP attempt (the REST API always requires a key over TCP).
+//
+// ok=false means no daemon is reachable and the caller should use its
+// standalone/config-only path (or error out for daemon-only commands).
+func daemonEndpoint(cfg *config.Config) (endpoint, apiKey string, ok bool) {
+	if env := os.Getenv("MCPPROXY_TRAY_ENDPOINT"); strings.HasPrefix(env, "http://") || strings.HasPrefix(env, "https://") {
+		key := resolveAPIKey(cfg)
+		if probeDaemon(env, key) {
+			return env, key, true
+		}
+		return "", "", false
+	}
+
+	var dataDir string
+	if cfg != nil {
+		dataDir = cfg.DataDir
+	}
+	socketPath := socket.DetectSocketPath(dataDir)
+	if socket.IsSocketAvailable(socketPath) {
+		return socketPath, "", true
+	}
+
+	key := resolveAPIKey(cfg)
+	if key == "" || cfg == nil {
+		return "", "", false
+	}
+	tcpEndpoint, valid := tcpFallbackEndpoint(cfg.Listen)
+	if !valid || !probeDaemon(tcpEndpoint, key) {
+		return "", "", false
+	}
+	return tcpEndpoint, key, true
+}
+
+// newDaemonClient returns a client connected to the running daemon, or
+// ok=false when no daemon is reachable (caller falls back to standalone mode).
+func newDaemonClient(cfg *config.Config, logger *zap.SugaredLogger) (client *cliclient.Client, ok bool) {
+	endpoint, apiKey, ok := daemonEndpoint(cfg)
+	if !ok {
+		return nil, false
+	}
+	return cliclient.NewClientWithAPIKey(endpoint, apiKey, logger), true
+}

--- a/cmd/mcpproxy/daemon_client_test.go
+++ b/cmd/mcpproxy/daemon_client_test.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+)
+
+// clearDaemonEnv neutralizes environment variables that influence
+// daemonEndpoint so tests are hermetic. Empty values are treated as unset.
+func clearDaemonEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("MCPPROXY_TRAY_ENDPOINT", "")
+	t.Setenv("MCPPROXY_API_KEY", "")
+}
+
+// newStatusServer returns an httptest server that serves GET /api/v1/status
+// only when the request carries the expected X-API-Key.
+func newStatusServer(t *testing.T, key string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-API-Key") != key {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":{"running":true}}`))
+	}))
+}
+
+func TestDaemonEndpoint_TCPFallbackWhenSocketMissing(t *testing.T) {
+	clearDaemonEnv(t)
+
+	ts := newStatusServer(t, "secret")
+	defer ts.Close()
+
+	listen := strings.TrimPrefix(ts.URL, "http://")
+	cfg := &config.Config{
+		DataDir: t.TempDir(), // no socket file here
+		Listen:  listen,
+		APIKey:  "secret",
+	}
+
+	endpoint, apiKey, ok := daemonEndpoint(cfg)
+	if !ok {
+		t.Fatal("expected TCP fallback to find the daemon when socket is missing")
+	}
+	if endpoint != "http://"+listen {
+		t.Fatalf("expected endpoint http://%s, got %s", listen, endpoint)
+	}
+	if apiKey != "secret" {
+		t.Fatalf("expected apiKey 'secret', got %q", apiKey)
+	}
+}
+
+func TestDaemonEndpoint_SocketPreferred(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix socket test not applicable on Windows")
+	}
+	clearDaemonEnv(t)
+
+	// If the socket path exists, no HTTP probe may happen.
+	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("no HTTP probe expected when socket is available")
+	}))
+	defer ts.Close()
+
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "mcpproxy.sock")
+	if err := os.WriteFile(sockPath, nil, 0o600); err != nil {
+		t.Fatalf("failed to create fake socket file: %v", err)
+	}
+
+	cfg := &config.Config{
+		DataDir: dir,
+		Listen:  strings.TrimPrefix(ts.URL, "http://"),
+		APIKey:  "secret",
+	}
+
+	endpoint, apiKey, ok := daemonEndpoint(cfg)
+	if !ok {
+		t.Fatal("expected socket endpoint to be detected")
+	}
+	if endpoint != "unix://"+sockPath {
+		t.Fatalf("expected unix://%s, got %s", sockPath, endpoint)
+	}
+	if apiKey != "" {
+		t.Fatalf("socket connections bypass API-key auth; expected empty key, got %q", apiKey)
+	}
+}
+
+func TestDaemonEndpoint_NoAPIKeyNoProbe(t *testing.T) {
+	clearDaemonEnv(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("no HTTP probe expected without an API key")
+	}))
+	defer ts.Close()
+
+	cfg := &config.Config{
+		DataDir: t.TempDir(),
+		Listen:  strings.TrimPrefix(ts.URL, "http://"),
+		APIKey:  "",
+	}
+
+	if _, _, ok := daemonEndpoint(cfg); ok {
+		t.Fatal("expected ok=false when no API key is available (REST over TCP always requires a key)")
+	}
+}
+
+func TestDaemonEndpoint_WrongKeyOrDaemonDown(t *testing.T) {
+	clearDaemonEnv(t)
+
+	// Wrong key: server only accepts "right-key".
+	ts := newStatusServer(t, "right-key")
+	cfg := &config.Config{
+		DataDir: t.TempDir(),
+		Listen:  strings.TrimPrefix(ts.URL, "http://"),
+		APIKey:  "wrong-key",
+	}
+	if _, _, ok := daemonEndpoint(cfg); ok {
+		t.Fatal("expected ok=false when the API key is rejected by the daemon")
+	}
+
+	// Daemon down: closed port.
+	addr := ts.Listener.Addr().String()
+	ts.Close()
+	cfg.Listen = addr
+	cfg.APIKey = "right-key"
+	if _, _, ok := daemonEndpoint(cfg); ok {
+		t.Fatal("expected ok=false when nothing listens on the port")
+	}
+}
+
+func TestDaemonEndpoint_EnvTrayEndpointHTTP(t *testing.T) {
+	clearDaemonEnv(t)
+
+	ts := newStatusServer(t, "secret")
+	defer ts.Close()
+
+	t.Setenv("MCPPROXY_TRAY_ENDPOINT", ts.URL)
+
+	cfg := &config.Config{
+		DataDir: t.TempDir(),
+		Listen:  "127.0.0.1:1", // must not be used
+		APIKey:  "secret",
+	}
+
+	endpoint, apiKey, ok := daemonEndpoint(cfg)
+	if !ok {
+		t.Fatal("expected explicit http MCPPROXY_TRAY_ENDPOINT to be used")
+	}
+	if endpoint != ts.URL {
+		t.Fatalf("expected endpoint %s, got %s", ts.URL, endpoint)
+	}
+	if apiKey != "secret" {
+		t.Fatalf("expected apiKey 'secret', got %q", apiKey)
+	}
+}
+
+func TestTCPFallbackEndpoint(t *testing.T) {
+	cases := []struct {
+		listen string
+		want   string
+		ok     bool
+	}{
+		{":8080", "http://127.0.0.1:8080", true},
+		{"0.0.0.0:8080", "http://127.0.0.1:8080", true},
+		{"[::]:8080", "http://127.0.0.1:8080", true},
+		{"192.168.1.5:8080", "http://192.168.1.5:8080", true},
+		{"127.0.0.1:18091", "http://127.0.0.1:18091", true},
+		{"garbage", "", false},
+		{"", "", false},
+	}
+
+	for _, tc := range cases {
+		got, ok := tcpFallbackEndpoint(tc.listen)
+		if ok != tc.ok {
+			t.Errorf("tcpFallbackEndpoint(%q) ok = %v, want %v", tc.listen, ok, tc.ok)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("tcpFallbackEndpoint(%q) = %q, want %q", tc.listen, got, tc.want)
+		}
+	}
+}

--- a/cmd/mcpproxy/doctor_cmd.go
+++ b/cmd/mcpproxy/doctor_cmd.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/cliclient"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
-	"github.com/smart-mcp-proxy/mcpproxy-go/internal/socket"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/updatecheck"
 )
 
@@ -98,18 +97,14 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	// Check if daemon is running
-	if !shouldUseDoctorDaemon(globalConfig.DataDir) {
+	// Check if daemon is running (socket first, then TCP fallback)
+	client, ok := newDaemonClient(globalConfig, logger.Sugar())
+	if !ok {
 		return fmt.Errorf("doctor requires running daemon. Start with: mcpproxy serve")
 	}
 
 	logger.Info("Fetching diagnostics from daemon")
-	return runDoctorClientMode(ctx, globalConfig.DataDir, logger)
-}
-
-func shouldUseDoctorDaemon(dataDir string) bool {
-	socketPath := socket.DetectSocketPath(dataDir)
-	return socket.IsSocketAvailable(socketPath)
+	return runDoctorClientMode(ctx, client, logger)
 }
 
 // quarantineServerStats holds quarantine stats for a single server.
@@ -119,10 +114,7 @@ type quarantineServerStats struct {
 	ChangedCount int
 }
 
-func runDoctorClientMode(ctx context.Context, dataDir string, logger *zap.Logger) error {
-	socketPath := socket.DetectSocketPath(dataDir)
-	client := cliclient.NewClient(socketPath, logger.Sugar())
-
+func runDoctorClientMode(ctx context.Context, client *cliclient.Client, logger *zap.Logger) error {
 	// Call GET /api/v1/info with refresh=true to get fresh update info
 	info, err := client.GetInfoWithRefresh(ctx, true)
 	if err != nil {

--- a/cmd/mcpproxy/doctor_cmd_test.go
+++ b/cmd/mcpproxy/doctor_cmd_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/socket"
 )
 
@@ -403,18 +404,18 @@ func TestOutputDiagnostics_EmptyFormat(t *testing.T) {
 	}
 }
 
-func TestShouldUseDoctorDaemon(t *testing.T) {
+func TestDoctorDaemonDetection_NoDaemon(t *testing.T) {
+	clearDaemonEnv(t)
+
 	// Test with non-existent directory
-	result := shouldUseDoctorDaemon("/tmp/nonexistent-mcpproxy-test-dir-67890")
-	if result {
-		t.Error("shouldUseDoctorDaemon should return false for non-existent directory")
+	if _, ok := newDaemonClient(&config.Config{DataDir: "/tmp/nonexistent-mcpproxy-test-dir-67890"}, nil); ok {
+		t.Error("newDaemonClient should report no daemon for non-existent directory")
 	}
 
 	// Test with existing directory but no socket
 	tmpDir := t.TempDir()
-	result = shouldUseDoctorDaemon(tmpDir)
-	if result {
-		t.Error("shouldUseDoctorDaemon should return false when socket doesn't exist")
+	if _, ok := newDaemonClient(&config.Config{DataDir: tmpDir}, nil); ok {
+		t.Error("newDaemonClient should report no daemon when socket doesn't exist")
 	}
 }
 

--- a/cmd/mcpproxy/doctor_fix_cmd.go
+++ b/cmd/mcpproxy/doctor_fix_cmd.go
@@ -14,8 +14,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/cliclient"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/diagnostics"
-	"github.com/smart-mcp-proxy/mcpproxy-go/internal/socket"
 )
 
 var (
@@ -80,25 +80,26 @@ func runDoctorFix(_ *cobra.Command, args []string) error {
 		mode = diagnostics.ModeExecute
 	}
 
-	// Resolve the data directory used to locate the daemon socket. Order of
-	// precedence: --data-dir (root persistent flag) > config-file data_dir >
-	// platform default (~/.mcpproxy).
-	resolvedDataDir := dataDir
-	if resolvedDataDir == "" {
-		if globalConfig, err := loadDoctorConfig(); err == nil && globalConfig.DataDir != "" {
-			resolvedDataDir = globalConfig.DataDir
-		}
+	// Resolve the config used to locate the daemon (socket path, listen
+	// address, API key). --data-dir (root persistent flag) overrides the
+	// config-file data_dir; DetectSocketPath falls back to the platform
+	// default (~/.mcpproxy) when both are empty.
+	globalConfig, cfgErr := loadDoctorConfig()
+	if cfgErr != nil || globalConfig == nil {
+		globalConfig = &config.Config{}
+	}
+	if dataDir != "" {
+		globalConfig.DataDir = dataDir
 	}
 
 	logger, err := createDoctorLogger(doctorFixLogLevel)
 	if err != nil {
 		return err
 	}
-	if !shouldUseDoctorDaemon(resolvedDataDir) {
+	client, ok := newDaemonClient(globalConfig, logger.Sugar())
+	if !ok {
 		return fmt.Errorf("doctor fix requires a running daemon. Start with: mcpproxy serve")
 	}
-	socketPath := socket.DetectSocketPath(resolvedDataDir)
-	client := cliclient.NewClient(socketPath, logger.Sugar())
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/cmd/mcpproxy/registry_cmd.go
+++ b/cmd/mcpproxy/registry_cmd.go
@@ -16,7 +16,6 @@ import (
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/experiments"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/registries"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/reqcontext"
-	"github.com/smart-mcp-proxy/mcpproxy-go/internal/socket"
 )
 
 // Registry command flags (spec 070).
@@ -97,7 +96,8 @@ from it.`,
 
 			// remove MUST go through the daemon: the registry list lives on the
 			// runtime config snapshot and is updated copy-on-write via UpdateConfig.
-			if !shouldUseUpstreamDaemon(cfg.DataDir) {
+			client, ok := newDaemonClient(cfg, nil)
+			if !ok {
 				return outputError(clioutput.NewStructuredError(clioutput.ErrCodeConnectionFailed,
 					"removing a registry source requires a running mcpproxy daemon").
 					WithGuidance("Start the daemon, then retry").
@@ -106,8 +106,6 @@ from it.`,
 
 			ctx, cancel := registryContext()
 			defer cancel()
-
-			client := cliclient.NewClient(socket.DetectSocketPath(cfg.DataDir), nil)
 			reg, err := client.RemoveRegistrySource(ctx, registryID)
 			if err != nil {
 				return registryRemoveErrorOutput(err)
@@ -183,7 +181,8 @@ with quarantine enabled (the default) they land quarantined for review:
 
 			// add-source MUST go through the daemon: the registry list lives on the
 			// runtime config snapshot and is updated copy-on-write via UpdateConfig.
-			if !shouldUseUpstreamDaemon(cfg.DataDir) {
+			client, ok := newDaemonClient(cfg, nil)
+			if !ok {
 				return outputError(clioutput.NewStructuredError(clioutput.ErrCodeConnectionFailed,
 					"adding a registry source requires a running mcpproxy daemon").
 					WithGuidance("Start the daemon, then retry").
@@ -192,8 +191,6 @@ with quarantine enabled (the default) they land quarantined for review:
 
 			ctx, cancel := registryContext()
 			defer cancel()
-
-			client := cliclient.NewClient(socket.DetectSocketPath(cfg.DataDir), nil)
 			reg, err := client.AddRegistrySource(ctx, sourceURL, registryAddSourceProto, registryAddSourceID, registryAddSourceName)
 			if err != nil {
 				return registryAddErrorOutput(err)
@@ -245,7 +242,8 @@ also given.
 
 			// edit MUST go through the daemon: the registry list lives on the
 			// runtime config snapshot and is updated copy-on-write via UpdateConfig.
-			if !shouldUseUpstreamDaemon(cfg.DataDir) {
+			client, ok := newDaemonClient(cfg, nil)
+			if !ok {
 				return outputError(clioutput.NewStructuredError(clioutput.ErrCodeConnectionFailed,
 					"editing a registry source requires a running mcpproxy daemon").
 					WithGuidance("Start the daemon, then retry").
@@ -254,8 +252,6 @@ also given.
 
 			ctx, cancel := registryContext()
 			defer cancel()
-
-			client := cliclient.NewClient(socket.DetectSocketPath(cfg.DataDir), nil)
 			reg, err := client.EditRegistrySource(ctx, registryID, registryEditName, registryEditURL, registryEditServersURL)
 			if err != nil {
 				return registryEditErrorOutput(err)
@@ -324,8 +320,7 @@ func newRegistryListCmd() *cobra.Command {
 			}
 
 			// Daemon-first.
-			if shouldUseUpstreamDaemon(cfg.DataDir) {
-				client := cliclient.NewClient(socket.DetectSocketPath(cfg.DataDir), nil)
+			if client, ok := newDaemonClient(cfg, nil); ok {
 				if regs, derr := client.ListRegistries(ctx); derr == nil {
 					return renderRegistries(formatter, regs)
 				}
@@ -381,8 +376,7 @@ The printed ID column is what you pass to 'registry add'.`,
 			}
 
 			// Daemon-first.
-			if shouldUseUpstreamDaemon(cfg.DataDir) {
-				client := cliclient.NewClient(socket.DetectSocketPath(cfg.DataDir), nil)
+			if client, ok := newDaemonClient(cfg, nil); ok {
 				if servers, derr := client.SearchRegistry(ctx, registryID, registrySearchTag, query, registryLimit); derr == nil {
 					return renderRegistryServers(formatter, servers)
 				}
@@ -450,7 +444,8 @@ inputs, supply them with --env KEY=VALUE.`,
 			}
 
 			// add MUST go through the daemon (keystone op is server-side).
-			if !shouldUseUpstreamDaemon(cfg.DataDir) {
+			client, ok := newDaemonClient(cfg, nil)
+			if !ok {
 				return outputError(clioutput.NewStructuredError(clioutput.ErrCodeConnectionFailed,
 					"adding from a registry requires a running mcpproxy daemon").
 					WithGuidance("Start the daemon, then retry").
@@ -459,8 +454,6 @@ inputs, supply them with --env KEY=VALUE.`,
 
 			ctx, cancel := registryContext()
 			defer cancel()
-
-			client := cliclient.NewClient(socket.DetectSocketPath(cfg.DataDir), nil)
 			enabled := registryAddEnabled
 			result, err := client.AddFromRegistry(ctx, registryID, serverID, registryAddName, env, &enabled)
 			if err != nil {

--- a/cmd/mcpproxy/security_cmd.go
+++ b/cmd/mcpproxy/security_cmd.go
@@ -17,7 +17,6 @@ import (
 	clioutput "github.com/smart-mcp-proxy/mcpproxy-go/internal/cli/output"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/cliclient"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
-	"github.com/smart-mcp-proxy/mcpproxy-go/internal/socket"
 )
 
 var (
@@ -95,19 +94,15 @@ func newSecurityCLIClient() (*cliclient.Client, *config.Config, error) {
 	if dataDir != "" {
 		cfg.DataDir = dataDir
 	}
-	cfg.EnsureAPIKey()
-
-	socketPath := socket.DetectSocketPath(cfg.DataDir)
 
 	logger, _ := zap.NewProduction()
 	defer func() { _ = logger.Sync() }()
 
-	var client *cliclient.Client
-	if socket.IsSocketAvailable(socketPath) {
-		client = cliclient.NewClient(socketPath, logger.Sugar())
-	} else {
-		endpoint := fmt.Sprintf("http://%s", cfg.Listen)
-		client = cliclient.NewClientWithAPIKey(endpoint, cfg.APIKey, logger.Sugar())
+	// Socket first, then TCP fallback. Never generate an API key here —
+	// a fabricated key cannot match the running daemon's.
+	client, ok := newDaemonClient(cfg, logger.Sugar())
+	if !ok {
+		return nil, nil, fmt.Errorf("mcpproxy daemon is not reachable. Start with: mcpproxy serve")
 	}
 
 	return client, cfg, nil

--- a/cmd/mcpproxy/status_cmd.go
+++ b/cmd/mcpproxy/status_cmd.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 
 	clioutput "github.com/smart-mcp-proxy/mcpproxy-go/internal/cli/output"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/cliclient"
@@ -160,18 +159,15 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 func collectStatus(cfg *config.Config, configPath string) (*StatusInfo, error) {
 	socketPath := socket.DetectSocketPath(cfg.DataDir)
 
-	if socket.IsSocketAvailable(socketPath) {
-		return collectStatusFromDaemon(cfg, socketPath, configPath)
+	// Daemon detection: socket first, then TCP fallback (cfg.Listen + API key).
+	if client, ok := newDaemonClient(cfg, nil); ok {
+		return collectStatusFromDaemon(cfg, client, socketPath, configPath)
 	}
 
 	return collectStatusFromConfig(cfg, socketPath, configPath), nil
 }
 
-func collectStatusFromDaemon(cfg *config.Config, socketPath, configPath string) (*StatusInfo, error) {
-	logger, _ := zap.NewProduction()
-	defer logger.Sync()
-
-	client := cliclient.NewClient(socketPath, logger.Sugar())
+func collectStatusFromDaemon(cfg *config.Config, client *cliclient.Client, socketPath, configPath string) (*StatusInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 

--- a/cmd/mcpproxy/telemetry_cmd.go
+++ b/cmd/mcpproxy/telemetry_cmd.go
@@ -14,9 +14,7 @@ import (
 	"go.uber.org/zap"
 
 	clioutput "github.com/smart-mcp-proxy/mcpproxy-go/internal/cli/output"
-	"github.com/smart-mcp-proxy/mcpproxy-go/internal/cliclient"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
-	"github.com/smart-mcp-proxy/mcpproxy-go/internal/socket"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/telemetry"
 )
 
@@ -83,15 +81,14 @@ func runTelemetryShowPayload(_ *cobra.Command, _ []string) error {
 
 	// Require running daemon so runtime stats are populated. Offline mode
 	// would emit zero-valued runtime fields and mislead users.
-	socketPath := socket.DetectSocketPath(cfg.DataDir)
-	if !socket.IsSocketAvailable(socketPath) {
+	client, ok := newDaemonClient(cfg, nil)
+	if !ok {
 		return fmt.Errorf("telemetry show-payload requires running daemon. Start with: mcpproxy serve")
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	client := cliclient.NewClient(socketPath, nil)
 	payload, err := client.GetTelemetryPayload(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get telemetry payload from daemon: %w", err)

--- a/cmd/mcpproxy/token_cmd.go
+++ b/cmd/mcpproxy/token_cmd.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/cliclient"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
-	"github.com/smart-mcp-proxy/mcpproxy-go/internal/socket"
 )
 
 var (
@@ -129,19 +128,15 @@ func newTokenCLIClient() (*cliclient.Client, *config.Config, error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to load config: %w", err)
 	}
-	cfg.EnsureAPIKey()
-
-	socketPath := socket.DetectSocketPath(cfg.DataDir)
 
 	logger, _ := zap.NewProduction()
 	defer func() { _ = logger.Sync() }()
 
-	var client *cliclient.Client
-	if socket.IsSocketAvailable(socketPath) {
-		client = cliclient.NewClient(socketPath, logger.Sugar())
-	} else {
-		endpoint := fmt.Sprintf("http://%s", cfg.Listen)
-		client = cliclient.NewClientWithAPIKey(endpoint, cfg.APIKey, logger.Sugar())
+	// Socket first, then TCP fallback. Never generate an API key here —
+	// a fabricated key cannot match the running daemon's.
+	client, ok := newDaemonClient(cfg, logger.Sugar())
+	if !ok {
+		return nil, nil, fmt.Errorf("mcpproxy daemon is not reachable. Start with: mcpproxy serve")
 	}
 
 	return client, cfg, nil

--- a/cmd/mcpproxy/tools_cmd.go
+++ b/cmd/mcpproxy/tools_cmd.go
@@ -13,7 +13,6 @@ import (
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/logs"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/secret"
-	"github.com/smart-mcp-proxy/mcpproxy-go/internal/socket"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/transport"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/upstream/managed"
@@ -262,14 +261,14 @@ func runToolsList(_ *cobra.Command, _ []string) error {
 
 	// If no --server given → global list (requires daemon)
 	if serverName == "" {
-		return runToolsListGlobal(ctx, globalConfig.DataDir, logger)
+		return runToolsListGlobal(ctx, globalConfig, logger)
 	}
 
 	// --server given → server-scoped path (daemon or standalone)
-	if shouldUseToolsDaemon(globalConfig.DataDir) {
-		logger.Info("Detected running daemon, using client mode via socket",
+	if client, ok := newDaemonClient(globalConfig, logger.Sugar()); ok {
+		logger.Info("Detected running daemon, using client mode",
 			zap.String("server", serverName))
-		return runToolsListClientMode(ctx, globalConfig.DataDir, serverName, logger)
+		return runToolsListClientMode(ctx, client, serverName, logger)
 	}
 
 	// No daemon detected, use standalone mode
@@ -279,14 +278,12 @@ func runToolsList(_ *cobra.Command, _ []string) error {
 }
 
 // runToolsListGlobal fetches all tools from the global endpoint via the daemon.
-func runToolsListGlobal(ctx context.Context, dataDir string, logger *zap.Logger) error {
-	if !shouldUseToolsDaemon(dataDir) {
+func runToolsListGlobal(ctx context.Context, globalConfig *config.Config, logger *zap.Logger) error {
+	client, ok := newDaemonClient(globalConfig, logger.Sugar())
+	if !ok {
 		return fmt.Errorf("global tool list requires the daemon to be running.\n" +
 			"Start mcpproxy (mcpproxy serve) and try again, or use --server=<name> for a single-server debug listing")
 	}
-
-	socketPath := socket.DetectSocketPath(dataDir)
-	client := cliclient.NewClient(socketPath, logger.Sugar())
 
 	pingCtx, pingCancel := context.WithTimeout(ctx, 2*time.Second)
 	defer pingCancel()
@@ -295,7 +292,7 @@ func runToolsListGlobal(ctx context.Context, dataDir string, logger *zap.Logger)
 			"Start mcpproxy (mcpproxy serve) and try again", err)
 	}
 
-	fmt.Fprintf(os.Stderr, "Using daemon mode (via socket)\n\n")
+	fmt.Fprintf(os.Stderr, "Using daemon mode\n\n")
 
 	tools, err := client.GetGlobalTools(ctx)
 	if err != nil {
@@ -391,13 +388,11 @@ func runToolsSetEnabled(args []string, enabled bool) error {
 	}
 	defer func() { _ = logger.Sync() }()
 
-	if !shouldUseToolsDaemon(globalConfig.DataDir) {
+	client, ok := newDaemonClient(globalConfig, logger.Sugar())
+	if !ok {
 		return fmt.Errorf("enable/disable requires the daemon to be running.\n" +
 			"Start mcpproxy (mcpproxy serve) and try again")
 	}
-
-	socketPath := socket.DetectSocketPath(globalConfig.DataDir)
-	client := cliclient.NewClient(socketPath, logger.Sugar())
 
 	pingCtx, pingCancel := context.WithTimeout(ctx, 2*time.Second)
 	defer pingCancel()
@@ -537,24 +532,14 @@ func outputToolsFromMetadata(tools []*config.ToolMetadata, serverName string) er
 	return nil
 }
 
-// shouldUseToolsDaemon checks if daemon is running by detecting socket file.
-func shouldUseToolsDaemon(dataDir string) bool {
-	socketPath := socket.DetectSocketPath(dataDir)
-	return socket.IsSocketAvailable(socketPath)
-}
-
-// runToolsListClientMode executes tools list via daemon HTTP API over socket.
-func runToolsListClientMode(ctx context.Context, dataDir, serverName string, logger *zap.Logger) error {
-	socketPath := socket.DetectSocketPath(dataDir)
-	client := cliclient.NewClient(socketPath, logger.Sugar())
-
+// runToolsListClientMode executes tools list via the daemon HTTP API.
+func runToolsListClientMode(ctx context.Context, client *cliclient.Client, serverName string, logger *zap.Logger) error {
 	// Ping daemon to verify connectivity
 	pingCtx, pingCancel := context.WithTimeout(ctx, 2*time.Second)
 	defer pingCancel()
 	if err := client.Ping(pingCtx); err != nil {
 		logger.Warn("Failed to ping daemon, falling back to standalone mode",
-			zap.Error(err),
-			zap.String("socket_path", socketPath))
+			zap.Error(err))
 		// Fall back to standalone mode
 		cfg, err := loadToolsConfig()
 		if err != nil {
@@ -563,7 +548,7 @@ func runToolsListClientMode(ctx context.Context, dataDir, serverName string, log
 		return runToolsListStandalone(ctx, serverName, cfg, logger)
 	}
 
-	fmt.Fprintf(os.Stderr, "Using daemon mode (via socket) - fast execution\n\n")
+	fmt.Fprintf(os.Stderr, "Using daemon mode - fast execution\n\n")
 
 	// Fetch tools from daemon
 	tools, err := client.GetServerTools(ctx, serverName)

--- a/cmd/mcpproxy/tools_cmd_test.go
+++ b/cmd/mcpproxy/tools_cmd_test.go
@@ -8,21 +8,24 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/socket"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestShouldUseToolsDaemon(t *testing.T) {
+func TestToolsDaemonDetection_NoDaemon(t *testing.T) {
+	clearDaemonEnv(t)
+
 	// Test with non-existent directory
-	result := shouldUseToolsDaemon("/tmp/nonexistent-mcpproxy-test-dir-tools-99999")
-	assert.False(t, result, "shouldUseToolsDaemon should return false for non-existent directory")
+	_, ok := newDaemonClient(&config.Config{DataDir: "/tmp/nonexistent-mcpproxy-test-dir-tools-99999"}, nil)
+	assert.False(t, ok, "newDaemonClient should report no daemon for non-existent directory")
 
 	// Test with existing directory but no socket
 	tmpDir := t.TempDir()
-	result = shouldUseToolsDaemon(tmpDir)
-	assert.False(t, result, "shouldUseToolsDaemon should return false when socket doesn't exist")
+	_, ok = newDaemonClient(&config.Config{DataDir: tmpDir}, nil)
+	assert.False(t, ok, "newDaemonClient should report no daemon when socket doesn't exist")
 }
 
 func TestDetectSocketPath_Tools(t *testing.T) {

--- a/cmd/mcpproxy/tui_cmd.go
+++ b/cmd/mcpproxy/tui_cmd.go
@@ -40,16 +40,15 @@ func GetTUICommand() *cobra.Command {
 				cfg = config.DefaultConfig()
 			}
 
-			// Detect socket or fall back to TCP
-			socketPath := socket.DetectSocketPath(cfg.DataDir)
-			var endpoint string
-			if socket.IsSocketAvailable(socketPath) {
-				endpoint = socketPath
-			} else {
-				endpoint = fmt.Sprintf("http://%s", cfg.Listen)
+			// Detect socket or fall back to TCP (probed with the API key)
+			client, ok := newDaemonClient(cfg, logger.Sugar())
+			if !ok {
+				// No reachable daemon: keep prior behavior of starting the
+				// TUI pointed at the socket path so it can surface
+				// connection errors (and recover once the daemon starts).
+				client = cliclient.NewClientWithAPIKey(
+					socket.DetectSocketPath(cfg.DataDir), resolveAPIKey(cfg), logger.Sugar())
 			}
-
-			client := cliclient.NewClientWithAPIKey(endpoint, cfg.APIKey, logger.Sugar())
 
 			ctx, cancel := context.WithCancel(cmd.Context())
 			defer cancel()

--- a/cmd/mcpproxy/upstream_cmd.go
+++ b/cmd/mcpproxy/upstream_cmd.go
@@ -24,7 +24,6 @@ import (
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/health"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/logs"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/reqcontext"
-	"github.com/smart-mcp-proxy/mcpproxy-go/internal/socket"
 )
 
 var (
@@ -392,10 +391,10 @@ func runUpstreamList(_ *cobra.Command, _ []string) error {
 		return outputError(err, output.ErrCodeOperationFailed)
 	}
 
-	// Check if daemon is running
-	if shouldUseUpstreamDaemon(globalConfig.DataDir) {
-		logger.Info("Detected running daemon, using client mode via socket")
-		return runUpstreamListClientMode(ctx, globalConfig.DataDir, logger)
+	// Check if daemon is running (socket first, then TCP fallback)
+	if client, ok := newDaemonClient(globalConfig, logger.Sugar()); ok {
+		logger.Info("Detected running daemon, using client mode")
+		return runUpstreamListClientMode(ctx, client, logger)
 	}
 
 	// No daemon - load from config file
@@ -403,15 +402,7 @@ func runUpstreamList(_ *cobra.Command, _ []string) error {
 	return runUpstreamListFromConfig(globalConfig)
 }
 
-func shouldUseUpstreamDaemon(dataDir string) bool {
-	socketPath := socket.DetectSocketPath(dataDir)
-	return socket.IsSocketAvailable(socketPath)
-}
-
-func runUpstreamListClientMode(ctx context.Context, dataDir string, logger *zap.Logger) error {
-	socketPath := socket.DetectSocketPath(dataDir)
-	client := cliclient.NewClient(socketPath, logger.Sugar())
-
+func runUpstreamListClientMode(ctx context.Context, client *cliclient.Client, _ *zap.Logger) error {
 	// Call GET /api/v1/servers
 	servers, err := client.GetServers(ctx)
 	if err != nil {
@@ -706,9 +697,12 @@ func runUpstreamLogs(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Detect daemon (socket first, then TCP fallback)
+	client, daemonOK := newDaemonClient(globalConfig, logger.Sugar())
+
 	// Follow mode requires daemon
 	if upstreamLogsFollow {
-		if !shouldUseUpstreamDaemon(globalConfig.DataDir) {
+		if !daemonOK {
 			return fmt.Errorf("--follow requires running daemon")
 		}
 		logger.Info("Following logs from daemon")
@@ -731,13 +725,13 @@ func runUpstreamLogs(cmd *cobra.Command, args []string) error {
 			}
 		}()
 
-		return runUpstreamLogsFollowMode(bgCtx, globalConfig.DataDir, serverName, logger)
+		return runUpstreamLogsFollowMode(bgCtx, client, serverName, logger)
 	}
 
 	// Check if daemon is running
-	if shouldUseUpstreamDaemon(globalConfig.DataDir) {
-		logger.Info("Detected running daemon, using client mode via socket")
-		return runUpstreamLogsClientMode(ctx, globalConfig.DataDir, serverName, logger)
+	if daemonOK {
+		logger.Info("Detected running daemon, using client mode")
+		return runUpstreamLogsClientMode(ctx, client, serverName)
 	}
 
 	// No daemon - read from log file
@@ -745,10 +739,7 @@ func runUpstreamLogs(cmd *cobra.Command, args []string) error {
 	return runUpstreamLogsFromFile(globalConfig, serverName)
 }
 
-func runUpstreamLogsClientMode(ctx context.Context, dataDir, serverName string, logger *zap.Logger) error {
-	socketPath := socket.DetectSocketPath(dataDir)
-	client := cliclient.NewClient(socketPath, logger.Sugar())
-
+func runUpstreamLogsClientMode(ctx context.Context, client *cliclient.Client, serverName string) error {
 	// Call GET /api/v1/servers/{name}/logs?tail=N
 	logs, err := client.GetServerLogs(ctx, serverName, upstreamLogsTail)
 	if err != nil {
@@ -800,10 +791,7 @@ func runUpstreamLogsFromFile(globalConfig *config.Config, serverName string) err
 	return nil
 }
 
-func runUpstreamLogsFollowMode(ctx context.Context, dataDir, serverName string, logger *zap.Logger) error {
-	socketPath := socket.DetectSocketPath(dataDir)
-	client := cliclient.NewClient(socketPath, logger.Sugar())
-
+func runUpstreamLogsFollowMode(ctx context.Context, client *cliclient.Client, serverName string, logger *zap.Logger) error {
 	fmt.Printf("Following logs for server '%s' (Ctrl+C to stop)...\n", serverName)
 
 	ticker := time.NewTicker(1 * time.Second)
@@ -948,12 +936,10 @@ func runUpstreamAction(serverName, action string) error {
 	}
 
 	// Require daemon for actions
-	if !shouldUseUpstreamDaemon(globalConfig.DataDir) {
+	client, ok := newDaemonClient(globalConfig, logger.Sugar())
+	if !ok {
 		return fmt.Errorf("server actions require running daemon. Start with: mcpproxy serve")
 	}
-
-	socketPath := socket.DetectSocketPath(globalConfig.DataDir)
-	client := cliclient.NewClient(socketPath, logger.Sugar())
 
 	fmt.Printf("Performing action '%s' on server '%s'...\n", action, serverName)
 
@@ -994,12 +980,10 @@ func runUpstreamToolAction(serverName, toolName string, enabled bool) error {
 		return err
 	}
 
-	if !shouldUseUpstreamDaemon(globalConfig.DataDir) {
+	client, ok := newDaemonClient(globalConfig, logger.Sugar())
+	if !ok {
 		return fmt.Errorf("tool actions require running daemon. Start with: mcpproxy serve")
 	}
-
-	socketPath := socket.DetectSocketPath(globalConfig.DataDir)
-	client := cliclient.NewClient(socketPath, logger.Sugar())
 
 	// "enable" / "disable" are ASCII verbs, so an inline ASCII-only
 	// title-case is fine here and avoids the deprecated strings.Title.
@@ -1038,12 +1022,10 @@ func runUpstreamToolBulkAction(serverName string, enabled bool) error {
 		return err
 	}
 
-	if !shouldUseUpstreamDaemon(globalConfig.DataDir) {
+	client, ok := newDaemonClient(globalConfig, logger.Sugar())
+	if !ok {
 		return fmt.Errorf("tool actions require running daemon. Start with: mcpproxy serve")
 	}
-
-	socketPath := socket.DetectSocketPath(globalConfig.DataDir)
-	client := cliclient.NewClient(socketPath, logger.Sugar())
 
 	fmt.Printf("Running tools %s on server '%s'...\n", verb, serverName)
 	changed, err := client.SetAllToolsEnabled(ctx, serverName, enabled)
@@ -1085,12 +1067,10 @@ func runUpstreamBulkAction(action string, force bool) error {
 	}
 
 	// Require daemon
-	if !shouldUseUpstreamDaemon(globalConfig.DataDir) {
+	client, ok := newDaemonClient(globalConfig, logger.Sugar())
+	if !ok {
 		return fmt.Errorf("server actions require running daemon. Start with: mcpproxy serve")
 	}
-
-	socketPath := socket.DetectSocketPath(globalConfig.DataDir)
-	client := cliclient.NewClient(socketPath, logger.Sugar())
 
 	// Get server count for confirmation
 	servers, err := client.GetServers(ctx)
@@ -1273,18 +1253,15 @@ func runUpstreamAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	// Check if daemon is running
-	if shouldUseUpstreamDaemon(globalConfig.DataDir) {
-		return runUpstreamAddDaemonMode(ctx, globalConfig.DataDir, req)
+	if client, ok := newDaemonClient(globalConfig, nil); ok {
+		return runUpstreamAddDaemonMode(ctx, client, req)
 	}
 
 	// Direct config file mode
 	return runUpstreamAddConfigMode(req, globalConfig)
 }
 
-func runUpstreamAddDaemonMode(ctx context.Context, dataDir string, req *cliclient.AddServerRequest) error {
-	socketPath := socket.DetectSocketPath(dataDir)
-	client := cliclient.NewClient(socketPath, nil)
-
+func runUpstreamAddDaemonMode(ctx context.Context, client *cliclient.Client, req *cliclient.AddServerRequest) error {
 	result, err := client.AddServer(ctx, req)
 	if err != nil {
 		// Check if it's "already exists" error and --if-not-exists is set
@@ -1392,18 +1369,15 @@ func runUpstreamRemove(cmd *cobra.Command, args []string) error {
 	}
 
 	// Check if daemon is running
-	if shouldUseUpstreamDaemon(globalConfig.DataDir) {
-		return runUpstreamRemoveDaemonMode(ctx, globalConfig.DataDir, serverName)
+	if client, ok := newDaemonClient(globalConfig, nil); ok {
+		return runUpstreamRemoveDaemonMode(ctx, client, serverName)
 	}
 
 	// Direct config file mode
 	return runUpstreamRemoveConfigMode(serverName, globalConfig)
 }
 
-func runUpstreamRemoveDaemonMode(ctx context.Context, dataDir, serverName string) error {
-	socketPath := socket.DetectSocketPath(dataDir)
-	client := cliclient.NewClient(socketPath, nil)
-
+func runUpstreamRemoveDaemonMode(ctx context.Context, client *cliclient.Client, serverName string) error {
 	err := client.RemoveServer(ctx, serverName)
 	if err != nil {
 		// Check if it's "not found" error and --if-exists is set
@@ -1530,8 +1504,8 @@ func runUpstreamAddJSON(cmd *cobra.Command, args []string) error {
 	}
 
 	// Check if daemon is running
-	if shouldUseUpstreamDaemon(globalConfig.DataDir) {
-		return runUpstreamAddDaemonMode(ctx, globalConfig.DataDir, req)
+	if client, ok := newDaemonClient(globalConfig, nil); ok {
+		return runUpstreamAddDaemonMode(ctx, client, req)
 	}
 
 	// Direct config file mode
@@ -1815,8 +1789,8 @@ func applyImportedServers(imported []*configimport.ImportedServer, globalConfig 
 	defer cancel()
 
 	// Check if daemon is running
-	if shouldUseUpstreamDaemon(globalConfig.DataDir) {
-		return applyImportedServersDaemonMode(ctx, globalConfig.DataDir, imported)
+	if client, ok := newDaemonClient(globalConfig, nil); ok {
+		return applyImportedServersDaemonMode(ctx, client, imported)
 	}
 
 	// Direct config file mode
@@ -1824,10 +1798,7 @@ func applyImportedServers(imported []*configimport.ImportedServer, globalConfig 
 }
 
 // applyImportedServersDaemonMode adds servers via the daemon
-func applyImportedServersDaemonMode(ctx context.Context, dataDir string, imported []*configimport.ImportedServer) error {
-	socketPath := socket.DetectSocketPath(dataDir)
-	client := cliclient.NewClient(socketPath, nil)
-
+func applyImportedServersDaemonMode(ctx context.Context, client *cliclient.Client, imported []*configimport.ImportedServer) error {
 	for _, s := range imported {
 		req := &cliclient.AddServerRequest{
 			Name:       s.Server.Name,
@@ -1868,17 +1839,15 @@ func runUpstreamInspect(_ *cobra.Command, args []string) error {
 			WithRecoveryCommand("mcpproxy doctor"), output.ErrCodeConfigNotFound)
 	}
 
-	if !shouldUseUpstreamDaemon(globalConfig.DataDir) {
-		return fmt.Errorf("mcpproxy daemon is not running. Start it with: mcpproxy serve")
-	}
-
 	logger, err := createUpstreamLogger("warn")
 	if err != nil {
 		return outputError(err, output.ErrCodeOperationFailed)
 	}
 
-	socketPath := socket.DetectSocketPath(globalConfig.DataDir)
-	client := cliclient.NewClient(socketPath, logger.Sugar())
+	client, ok := newDaemonClient(globalConfig, logger.Sugar())
+	if !ok {
+		return fmt.Errorf("mcpproxy daemon is not running. Start it with: mcpproxy serve")
+	}
 
 	// If a specific tool is requested, show the diff
 	if upstreamInspectTool != "" {
@@ -2002,17 +1971,15 @@ func runUpstreamApprove(_ *cobra.Command, args []string) error {
 			WithRecoveryCommand("mcpproxy doctor"), output.ErrCodeConfigNotFound)
 	}
 
-	if !shouldUseUpstreamDaemon(globalConfig.DataDir) {
-		return fmt.Errorf("mcpproxy daemon is not running. Start it with: mcpproxy serve")
-	}
-
 	logger, err := createUpstreamLogger("warn")
 	if err != nil {
 		return outputError(err, output.ErrCodeOperationFailed)
 	}
 
-	socketPath := socket.DetectSocketPath(globalConfig.DataDir)
-	client := cliclient.NewClient(socketPath, logger.Sugar())
+	client, ok := newDaemonClient(globalConfig, logger.Sugar())
+	if !ok {
+		return fmt.Errorf("mcpproxy daemon is not running. Start it with: mcpproxy serve")
+	}
 
 	approveAll := len(toolNames) == 0
 	count, err := client.ApproveTools(ctx, serverName, toolNames, approveAll)
@@ -2162,15 +2129,14 @@ func runUpstreamPatch(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
-	if !shouldUseUpstreamDaemon(globalConfig.DataDir) {
-		return fmt.Errorf("mcpproxy daemon is not running — start it with `mcpproxy serve` first; the `patch` subcommand requires a live backend so configuration changes are applied with full deep-merge semantics and propagated to running upstream connections immediately. Editing the config file by hand only works while the daemon is offline")
-	}
 	logger, err := createUpstreamLogger("warn")
 	if err != nil {
 		return fmt.Errorf("failed to create logger: %w", err)
 	}
-	socketPath := socket.DetectSocketPath(globalConfig.DataDir)
-	client := cliclient.NewClient(socketPath, logger.Sugar())
+	client, ok := newDaemonClient(globalConfig, logger.Sugar())
+	if !ok {
+		return fmt.Errorf("mcpproxy daemon is not running — start it with `mcpproxy serve` first; the `patch` subcommand requires a live backend so configuration changes are applied with full deep-merge semantics and propagated to running upstream connections immediately. Editing the config file by hand only works while the daemon is offline")
+	}
 
 	if err := client.PatchServer(ctx, serverName, bodyBytes); err != nil {
 		return err

--- a/cmd/mcpproxy/upstream_cmd_test.go
+++ b/cmd/mcpproxy/upstream_cmd_test.go
@@ -227,18 +227,18 @@ func TestOutputServers_EmptyList(t *testing.T) {
 	}
 }
 
-func TestShouldUseUpstreamDaemon(t *testing.T) {
+func TestUpstreamDaemonDetection_NoDaemon(t *testing.T) {
+	clearDaemonEnv(t)
+
 	// Test with non-existent directory
-	result := shouldUseUpstreamDaemon("/tmp/nonexistent-mcpproxy-test-dir-12345")
-	if result {
-		t.Error("shouldUseUpstreamDaemon should return false for non-existent directory")
+	if _, ok := newDaemonClient(&config.Config{DataDir: "/tmp/nonexistent-mcpproxy-test-dir-12345"}, nil); ok {
+		t.Error("newDaemonClient should report no daemon for non-existent directory")
 	}
 
 	// Test with existing directory but no socket
 	tmpDir := t.TempDir()
-	result = shouldUseUpstreamDaemon(tmpDir)
-	if result {
-		t.Error("shouldUseUpstreamDaemon should return false when socket doesn't exist")
+	if _, ok := newDaemonClient(&config.Config{DataDir: tmpDir}, nil); ok {
+		t.Error("newDaemonClient should report no daemon when socket doesn't exist")
 	}
 }
 
@@ -377,10 +377,10 @@ func TestCreateUpstreamLogger(t *testing.T) {
 func TestOutputServers_BooleanFields(t *testing.T) {
 	// Test that unified health status is displayed correctly based on server state
 	tests := []struct {
-		name           string
-		healthLevel    string
-		adminState     string
-		expectedEmoji  string
+		name          string
+		healthLevel   string
+		adminState    string
+		expectedEmoji string
 	}{
 		{"healthy enabled", "healthy", "enabled", "✅"},
 		{"disabled", "healthy", "disabled", "⏸️"},

--- a/internal/cliclient/client.go
+++ b/internal/cliclient/client.go
@@ -41,18 +41,31 @@ func SetClientVersion(v string) {
 // surfaceHeaderTransport wraps another http.RoundTripper to inject the
 // X-MCPProxy-Client header on every outbound request. The header value is
 // "cli/<version>". Spec 042 User Story 1.
+//
+// It also injects X-API-Key when the client was constructed with an API key.
+// Doing this at the transport level guarantees every request authenticates
+// over TCP, including methods that skip prepareRequest (e.g. Ping) — the REST
+// API always requires a key on TCP; only socket connections bypass it.
 type surfaceHeaderTransport struct {
-	base http.RoundTripper
+	base   http.RoundTripper
+	apiKey string
 }
 
 func (t *surfaceHeaderTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if req.Header.Get("X-MCPProxy-Client") == "" {
+	needClientHeader := req.Header.Get("X-MCPProxy-Client") == ""
+	needAPIKey := t.apiKey != "" && req.Header.Get("X-API-Key") == ""
+	if needClientHeader || needAPIKey {
 		// Clone the header map so we don't mutate caller-owned state.
 		newHeaders := req.Header.Clone()
 		if newHeaders == nil {
 			newHeaders = http.Header{}
 		}
-		newHeaders.Set("X-MCPProxy-Client", "cli/"+clientVersion)
+		if needClientHeader {
+			newHeaders.Set("X-MCPProxy-Client", "cli/"+clientVersion)
+		}
+		if needAPIKey {
+			newHeaders.Set("X-API-Key", t.apiKey)
+		}
 		reqCopy := req.Clone(req.Context())
 		reqCopy.Header = newHeaders
 		req = reqCopy
@@ -140,8 +153,9 @@ func NewClientWithAPIKey(endpoint, apiKey string, logger *zap.SugaredLogger) *Cl
 		httpClient: &http.Client{
 			Timeout: 5 * time.Minute, // Generous timeout for long operations
 			// Spec 042: wrap transport so every request carries the
-			// X-MCPProxy-Client: cli/<version> header.
-			Transport: &surfaceHeaderTransport{base: transport},
+			// X-MCPProxy-Client: cli/<version> header, plus X-API-Key
+			// when the client was constructed with one.
+			Transport: &surfaceHeaderTransport{base: transport, apiKey: apiKey},
 		},
 		logger: logger,
 	}

--- a/internal/cliclient/client_auth_test.go
+++ b/internal/cliclient/client_auth_test.go
@@ -1,0 +1,73 @@
+package cliclient
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// newKeyGatedServer returns an httptest server that responds 401 unless the
+// request carries X-API-Key: <key>. On success it returns the given body.
+func newKeyGatedServer(t *testing.T, key, body string, sawClientHeader *bool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if sawClientHeader != nil && r.Header.Get("X-MCPProxy-Client") != "" {
+			*sawClientHeader = true
+		}
+		if r.Header.Get("X-API-Key") != key {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"success":false,"error":"unauthorized"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+// TestPingSendsAPIKeyOverTCP verifies that a client constructed with an API
+// key authenticates Ping against a TCP endpoint. /api/v1/status sits behind
+// apiKeyAuthMiddleware, so without this the CLI's TCP fallback can never
+// detect a running daemon (v0.51.0-rc.1 QA finding CLI-SOCKET).
+func TestPingSendsAPIKeyOverTCP(t *testing.T) {
+	ts := newKeyGatedServer(t, "secret", `{"success":true,"data":{}}`, nil)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	withKey := NewClientWithAPIKey(ts.URL, "secret", nil)
+	if err := withKey.Ping(ctx); err != nil {
+		t.Fatalf("Ping with API key should succeed, got: %v", err)
+	}
+
+	withoutKey := NewClient(ts.URL, nil)
+	if err := withoutKey.Ping(ctx); err == nil {
+		t.Fatal("Ping without API key should fail against a key-gated endpoint")
+	}
+}
+
+// TestTransportInjectsAPIKeyOnAllRequests verifies the API key is injected at
+// the transport level, covering methods that do not call prepareRequest
+// (e.g. GetServers). Also guards the Spec 042 X-MCPProxy-Client header.
+func TestTransportInjectsAPIKeyOnAllRequests(t *testing.T) {
+	sawClientHeader := false
+	ts := newKeyGatedServer(t, "secret", `{"success":true,"data":{"servers":[]}}`, &sawClientHeader)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client := NewClientWithAPIKey(ts.URL, "secret", nil)
+	servers, err := client.GetServers(ctx)
+	if err != nil {
+		t.Fatalf("GetServers with API key should succeed, got: %v", err)
+	}
+	if len(servers) != 0 {
+		t.Fatalf("expected empty server list, got %d entries", len(servers))
+	}
+	if !sawClientHeader {
+		t.Fatal("X-MCPProxy-Client header must still be sent (Spec 042 regression)")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1825,9 +1825,14 @@ func (s *Server) startCustomHTTPServer(ctx context.Context, streamableServer *se
 	if cfg.EnableSocket {
 		trayListener, err = listenerManager.CreateTrayListener()
 		if err != nil {
-			s.logger.Warn("Failed to create tray listener, tray will use TCP fallback",
-				zap.Error(err))
-			// Continue without tray listener - tray will fall back to TCP
+			socketPath := cfg.TrayEndpoint
+			if socketPath == "" {
+				socketPath = filepath.Join(cfg.DataDir, "mcpproxy.sock")
+			}
+			s.logger.Warn("Failed to create tray/CLI socket listener; tray and CLI will fall back to TCP (API key required)",
+				zap.Error(err),
+				zap.String("socket_path", socketPath))
+			// Continue without tray listener - tray and CLI fall back to TCP
 		}
 	} else {
 		s.logger.Info("Socket communication disabled by configuration, clients will use TCP")


### PR DESCRIPTION
## Problem

When the daemon cannot bind its unix socket — macOS 104-byte `sun_path` limit on long `--data-dir` paths, or `enable_socket: false` — it keeps serving over TCP, but every CLI command detects the daemon with a bare `stat()` on the socket path. The CLI then reports `"status": "Daemon not running"` and silently falls back to standalone/config-only mode next to a live daemon (which also contends for the BBolt lock). Found by v0.51.0-rc.1 QA (2026-07-15), finding CLI-SOCKET.

## Root cause

- `internal/socket/detect.go:74-89` — `IsSocketAvailable` returns true only for `unix://`/`npipe://` endpoints; there is no TCP fallback, and each command carries its own copy of the stat-only check (`cmd/mcpproxy/upstream_cmd.go:406-409`, `tools_cmd.go:541-544`, `call_cmd.go:321-325`, `code_cmd.go:171-174`, `auth_cmd.go:634-638`, `doctor_cmd.go:110-113`, plus ~20 socket-only `cliclient.NewClient(socket.DetectSocketPath(...))` sites).
- Latent blocker: `internal/cliclient/client.go:366-385` — `Ping` (and ~10 other methods) never sent `X-API-Key`, while `/api/v1/status` sits behind `apiKeyAuthMiddleware` (`internal/httpapi/server.go:599-609`), so a TCP probe with a valid key still got 401.

## Fix

- **internal/cliclient**: inject `X-API-Key` at the transport level (`surfaceHeaderTransport`), so every request authenticates over TCP, including methods that skip `prepareRequest`. Socket clients pass an empty key — nothing changes for them.
- **cmd/mcpproxy/daemon_client.go** (new): shared `daemonEndpoint`/`newDaemonClient` — order: explicit http(s) `MCPPROXY_TRAY_ENDPOINT` (probed), then socket (stat-only, unchanged semantics), then TCP fallback using `cfg.Listen` + API key (`MCPPROXY_API_KEY` env > config), verified by a 2s `GET /api/v1/status` probe. Wildcard hosts (``, `0.0.0.0`, `::`) normalize to `127.0.0.1`; no key ⇒ no TCP attempt; keys are never generated client-side. On localhost a dead port fails in <1ms, so no-daemon commands stay fast.
- **All CLI commands** (upstream, tools, call, code, auth, doctor, doctor fix, registry, telemetry, status, activity, token, security, tui) now use the shared helper; deleted the per-command `shouldUse*Daemon` helpers and unified the four inconsistent hand-rolled TCP fallbacks (fixes the undialable `http://:8080` endpoint bug and the `EnsureAPIKey` fabricated-key bug in token/security).
- **internal/server**: reworded the tray-listener failure WARN ("tray and CLI will fall back to TCP (API key required)") and added the socket path, so the sun_path-overflow case is diagnosable.

## Tests

- `internal/cliclient/client_auth_test.go` (new): `TestPingSendsAPIKeyOverTCP`, `TestTransportInjectsAPIKeyOnAllRequests` (also guards the Spec 042 `X-MCPProxy-Client` header) — written first, failed with 401 before the fix.
- `cmd/mcpproxy/daemon_client_test.go` (new): TCP fallback when socket missing, socket-preferred (no HTTP probe), no-key ⇒ no probe, wrong key / daemon down ⇒ standalone, explicit `MCPPROXY_TRAY_ENDPOINT`, listen-address normalization table.
- Updated the daemon-detection tests that exercised the deleted helpers.
- E2E repro: daemon with `enable_socket: false` on `127.0.0.1:18091` — `upstream list`/`status`/`doctor`/`tools list` now use daemon mode over TCP (previously "Daemon not running"); with the daemon stopped, standalone mode still works with no added latency (~30ms).
- Commands: `go test -race ./cmd/mcpproxy/... ./internal/cliclient/... ./internal/tui/... ./internal/server/...` (all ok), `go build` both editions, `golangci-lint run --config .github/.golangci.yml` on touched packages: 0 issues.