### PR TITLE
chore(specs): gardener checkbox sync

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -681,7 +681,7 @@ Legend: `shipped` ≥95% checked · `in-flight` 1–94% · `drafted` 0% · `—`
 | [006-oauth-extra-params](./specs/006-oauth-extra-params/) | `in-flight` | 43/65 (66%) |
 | [007-oauth-e2e-testing](./specs/007-oauth-e2e-testing/) | `in-flight` | 93/103 (90%) |
 | [008-oauth-token-refresh](./specs/008-oauth-token-refresh/) | `in-flight` | 57/64 (89%) |
-| [009-proactive-oauth-refresh](./specs/009-proactive-oauth-refresh/) | `in-flight` | 43/87 (49%) |
+| [009-proactive-oauth-refresh](./specs/009-proactive-oauth-refresh/) | `in-flight` | 47/87 (54%) |
 | [010-release-notes-generator](./specs/010-release-notes-generator/) | `in-flight` | 24/36 (67%) |
 | [011-resource-auto-detect](./specs/011-resource-auto-detect/) | `shipped` | 38/39 (97%) |
 | [012-docusaurus-docs-site](./specs/012-docusaurus-docs-site/) | `in-flight` | 74/89 (83%) |
@@ -714,14 +714,14 @@ Legend: `shipped` ≥95% checked · `in-flight` 1–94% · `drafted` 0% · `—`
 | [039-security-scanner-plugins](./specs/039-security-scanner-plugins/) | — | — |
 | [040-server-ux](./specs/040-server-ux/) | `in-flight` | 28/35 (80%) |
 | [041-quarantine-invariants](./specs/041-quarantine-invariants/) | — | — |
-| [042-telemetry-tier2](./specs/042-telemetry-tier2/) | `in-flight` | 60/91 (66%) |
+| [042-telemetry-tier2](./specs/042-telemetry-tier2/) | `in-flight` | 65/91 (71%) |
 | [043-linux-package-repos](./specs/043-linux-package-repos/) | `shipped` | 41/41 (100%) |
 | [044-diagnostics-taxonomy](./specs/044-diagnostics-taxonomy/) | `in-flight` | 59/106 (56%) |
-| [044-retention-telemetry-v3](./specs/044-retention-telemetry-v3/) | `in-flight` | 54/70 (77%) |
+| [044-retention-telemetry-v3](./specs/044-retention-telemetry-v3/) | `in-flight` | 55/70 (79%) |
 | [045-paperclip-cockpit](./specs/045-paperclip-cockpit/) | `in-flight` | 40/47 (85%) |
 | [046-local-first-onboarding](./specs/046-local-first-onboarding/) | — | — |
 | [046-local-launcher-for-http-sse](./specs/046-local-launcher-for-http-sse/) | — | — |
-| [047-cpu-hotpath-fix](./specs/047-cpu-hotpath-fix/) | `in-flight` | 25/46 (54%) |
+| [047-cpu-hotpath-fix](./specs/047-cpu-hotpath-fix/) | `in-flight` | 26/46 (57%) |
 | [048-tray-refetch-elimination](./specs/048-tray-refetch-elimination/) | `in-flight` | 18/31 (58%) |
 | [049-agent-discoverable-disabled-tools](./specs/049-agent-discoverable-disabled-tools/) | `shipped` | 18/18 (100%) |
 | [050-global-tools-page](./specs/050-global-tools-page/) | `in-flight` | 24/26 (92%) |
@@ -750,6 +750,6 @@ Legend: `shipped` ≥95% checked · `in-flight` 1–94% · `drafted` 0% · `—`
 | [080-telemetry-v7-churn](./specs/080-telemetry-v7-churn/) | — | — |
 | [081-release-qa-gate](./specs/081-release-qa-gate/) | — | — |
 | [082-work-sessions](./specs/082-work-sessions/) | — | — |
-| [083-discovery-profiler](./specs/083-discovery-profiler/) | `drafted` | 0/41 (0%) |
+| [083-discovery-profiler](./specs/083-discovery-profiler/) | `in-flight` | 4/41 (10%) |
 | [084-toon-output](./specs/084-toon-output/) | `in-flight` | 40/43 (93%) |
 | [085-compact-router](./specs/085-compact-router/) | `shipped` | 44/46 (96%) |

--- a/specs/009-proactive-oauth-refresh/tasks.md
+++ b/specs/009-proactive-oauth-refresh/tasks.md
@@ -152,8 +152,8 @@
 ### Implementation for User Story 4
 
 - [ ] T054 [US4] Add oauthExpired computed property to ServerCard.vue in frontend/src/components/ServerCard.vue
-- [ ] T055 [US4] Update Login button v-if condition to include oauthExpired in frontend/src/components/ServerCard.vue
-- [ ] T056 [US4] Ensure Login button styling is consistent in frontend/src/components/ServerCard.vue
+- [x] T055 [US4] Update Login button v-if condition to include oauthExpired in frontend/src/components/ServerCard.vue
+- [x] T056 [US4] Ensure Login button styling is consistent in frontend/src/components/ServerCard.vue
 
 **Checkpoint**: Login button should now appear for connected servers with expired tokens
 
@@ -174,9 +174,9 @@
 ### Implementation for User Story 5
 
 - [ ] T060 [US5] Add isAuthenticated computed property to ServerCard.vue in frontend/src/components/ServerCard.vue
-- [ ] T061 [US5] Add Logout button with v-if="isAuthenticated" in frontend/src/components/ServerCard.vue
+- [x] T061 [US5] Add Logout button with v-if="isAuthenticated" in frontend/src/components/ServerCard.vue
 - [ ] T062 [US5] Implement handleLogout method with confirmation dialog in frontend/src/components/ServerCard.vue
-- [ ] T063 [US5] Connect handleLogout to serversStore.triggerOAuthLogout in frontend/src/components/ServerCard.vue
+- [x] T063 [US5] Connect handleLogout to serversStore.triggerOAuthLogout in frontend/src/components/ServerCard.vue
 
 **Checkpoint**: Logout button should work with confirmation dialog
 

--- a/specs/042-telemetry-tier2/tasks.md
+++ b/specs/042-telemetry-tier2/tasks.md
@@ -26,10 +26,10 @@ Single Go module project. All Go source under `internal/` and `cmd/`. New tests 
 
 **Purpose**: Verify baseline and identify exact integration points before touching any code.
 
-- [ ] T001 Read `internal/telemetry/telemetry.go` end-to-end and confirm the v1 `Service`, `HeartbeatPayload`, `Start()`, `send()`, and config fields match what `data-model.md` and `research.md` describe. Note any drift.
-- [ ] T002 Read `internal/httpapi/middleware.go` and `internal/httpapi/server.go` to identify the existing middleware chain and confirm the Chi router is `chi.Router`. Note the file/line where new middleware should be wired.
-- [ ] T003 Read `internal/server/mcp.go` to find the entry point of every built-in MCP tool handler (`handleRetrieveTools`, the call_tool variants, `upstream_servers`, `quarantine_security`, `code_execution`). List file:line for each.
-- [ ] T004 Read `internal/cliclient/client.go` (or wherever the CLI HTTP client is defined) to find the HTTP request construction site. Locate where to inject the `X-MCPProxy-Client` header.
+- [x] T001 Read `internal/telemetry/telemetry.go` end-to-end and confirm the v1 `Service`, `HeartbeatPayload`, `Start()`, `send()`, and config fields match what `data-model.md` and `research.md` describe. Note any drift.
+- [x] T002 Read `internal/httpapi/middleware.go` and `internal/httpapi/server.go` to identify the existing middleware chain and confirm the Chi router is `chi.Router`. Note the file/line where new middleware should be wired.
+- [x] T003 Read `internal/server/mcp.go` to find the entry point of every built-in MCP tool handler (`handleRetrieveTools`, the call_tool variants, `upstream_servers`, `quarantine_security`, `code_execution`). List file:line for each.
+- [x] T004 Read `internal/cliclient/client.go` (or wherever the CLI HTTP client is defined) to find the HTTP request construction site. Locate where to inject the `X-MCPProxy-Client` header.
 - [ ] T005 Locate the macOS tray's Swift HTTP request builder under `native/macos/MCPProxy/` (grep for `URLRequest` and `URLSession.shared`). Record the file path.
 - [ ] T006 Locate the web UI fetch wrapper under `frontend/src/api/` (grep for `fetch(` and existing `X-API-Key` injection). Record the file path.
 - [ ] T007 Confirm baseline: run `go test ./internal/telemetry/... -race` and `go build ./cmd/mcpproxy` from the worktree root. Both must pass before any code change.
@@ -298,7 +298,7 @@ Single Go module project. All Go source under `internal/` and `cmd/`. New tests 
 - [ ] T088 Run `go build ./cmd/mcpproxy` (personal edition) and `go build -tags server ./cmd/mcpproxy` (server edition). Both must compile clean.
 - [ ] T089 Run `./scripts/test-api-e2e.sh` and confirm no regressions.
 - [ ] T090 Manually verify the quickstart in `quickstart.md` end-to-end on the worktree binary: build, run `mcpproxy telemetry show-payload`, assert output contains `schema_version: 2` and all required fields.
-- [ ] T091 Update `cmd/mcpproxy/edition.go` or wherever the version constant lives if needed (no change expected, but verify version string is plumbed into the headers in T032/T033/T034).
+- [x] T091 Update `cmd/mcpproxy/edition.go` or wherever the version constant lives if needed (no change expected, but verify version string is plumbed into the headers in T032/T033/T034).
 
 **Final Checkpoint**: All tests pass, both editions build, e2e smoke is green, docs updated.
 

--- a/specs/044-retention-telemetry-v3/tasks.md
+++ b/specs/044-retention-telemetry-v3/tasks.md
@@ -32,7 +32,7 @@ description: "Task list for feature 044-retention-telemetry-v3"
 
 **Purpose**: Minor scaffolding. The existing `internal/telemetry` package already has v3 schema version and the build system is mature — no structural setup needed.
 
-- [ ] T001 Confirm `SchemaVersion = 3` constant in `internal/telemetry/telemetry.go` remains 3 (spec 044 extends v3, does not re-bump); add a short comment noting spec 044 additions above the constant.
+- [x] T001 Confirm `SchemaVersion = 3` constant in `internal/telemetry/telemetry.go` remains 3 (spec 044 extends v3, does not re-bump); add a short comment noting spec 044 additions above the constant.
 - [x] T002 Add a new BBolt bucket-name constant `ActivationBucketName = "activation"` in `internal/telemetry/activation.go` (file created in Phase 2).
 - [ ] T003 [P] Extend `docs/features/telemetry.md` skeleton with placeholder sections "Environment Classification", "Activation Tracking", and "Launch Source" (content filled in polish phase).
 

--- a/specs/047-cpu-hotpath-fix/tasks.md
+++ b/specs/047-cpu-hotpath-fix/tasks.md
@@ -22,7 +22,7 @@ US1 alone delivers the core CPU win even before US2-5 ship. US2+US4+US5 together
 
 ## Phase 1 — Setup
 
-- [ ] T001 Confirm working tree clean except for the in-progress pprof endpoint at `internal/server/server.go` (already on branch); preserve those changes for the PR.
+- [x] T001 Confirm working tree clean except for the in-progress pprof endpoint at `internal/server/server.go` (already on branch); preserve those changes for the PR.
 
 ## Phase 2 — Foundational
 

--- a/specs/083-discovery-profiler/tasks.md
+++ b/specs/083-discovery-profiler/tasks.md
@@ -17,7 +17,7 @@
 - [ ] T006 Implement Arm interface + registry in bench/arms/arm.go per contracts/arm-interface.md: `Name()`, `IndexAltering()`, `EncodeTool`, `EncodeListing`, `EncodeIndexMetadata`, `ErrArmUnavailable`, `LowerBound` self-report; registry rejects duplicate names
 - [ ] T007 Implement `baseline_json` arm in bench/arms/baseline.go (canonical full-definition renderer: name + description + canonical-JSON schema) making T005 pass; export the renderer for naive-menu/break-even reuse
 - [ ] T008 [P] Define ReportV2 Go types in bench/reportv2.go mirroring contracts/report-v2.schema.json (flat RetrievalScore DTO + mapping from existing `RetrievalMetrics`; provenance map; arms/corpora/response_cost/break_even/session_estimates/lap/subset sections) with a schema-validation test in bench/reportv2_test.go validating a sample report against the contract file
-- [ ] T009 [P] Create corpus_v2 generator script scripts/gen-corpus-v2.sh (boot snapshot proxy per quickstart, export GET /api/v1/tools with full input schemas, canonicalize ordering, write specs/083-discovery-profiler/datasets/corpus_v2.tools.json) and run it once; commit the generated corpus with tool count recorded in datasets/README.md
+- [x] T009 [P] Create corpus_v2 generator script scripts/gen-corpus-v2.sh (boot snapshot proxy per quickstart, export GET /api/v1/tools with full input schemas, canonicalize ordering, write specs/083-discovery-profiler/datasets/corpus_v2.tools.json) and run it once; commit the generated corpus with tool count recorded in datasets/README.md
 - [ ] T010 Extend bench/tokens.go to load corpus_v2 (schema-bearing) alongside corpus_v1, with validation test in bench/tokens_test.go (every corpus_v2 tool has non-empty schema; count matches datasets/README.md)
 
 ## Phase 3: User Story 1 — Measure live retrieve_tools response cost (P1) 🎯 MVP
@@ -56,7 +56,7 @@
 **Goal**: ToolRet retrieval-quality end-to-end; LiveMCPTool token/scale.
 **Independent test**: fetch → load → subset → score ToolRet; load committed LiveMCPTool snapshot → arm tokens.
 
-- [ ] T026 [P] [US3] Create scripts/fetch-toolret.sh: `uv run --with huggingface_hub,pyarrow` download of mangopy/ToolRet-Tools + mangopy/ToolRet-Queries at pinned `--revision` (default recorded in script), parquet→JSON into bench/results/cache/toolret/<revision>/ with actionable errors (FR-013, research D5)
+- [x] T026 [P] [US3] Create scripts/fetch-toolret.sh: `uv run --with huggingface_hub,pyarrow` download of mangopy/ToolRet-Tools + mangopy/ToolRet-Queries at pinned `--revision` (default recorded in script), parquet→JSON into bench/results/cache/toolret/<revision>/ with actionable errors (FR-013, research D5)
 - [ ] T027 [US3] Write failing loader tests in bench/corpusio/toolret_test.go on a small committed synthetic fixture matching ToolRet's field shape (NOT real ToolRet data): per-record validation errors, stable-ID sort, seeded subset determinism (same revision+seed+size ⇒ same subset), missing-ID failure
 - [ ] T028 [US3] Implement bench/corpusio/toolret.go making T027 pass, mapping tools→Corpus and queries→GoldenSet with corpus/version stamping (FR-011/012/014)
 - [ ] T029 [P] [US3] Create LiveMCPTool committed snapshot under specs/083-discovery-profiler/datasets/livemcptool_snapshot/ with ATTRIBUTION.md (Apache 2.0, ICIP/LiveMCPBench, arXiv:2508.01780) via a documented one-time download; implement + test loader bench/corpusio/livemcptool.go (Corpus for token/scale; relevance-label derivation from task annotations as stretch — if labels not derivable, record explicit absence per FR-011)
@@ -89,8 +89,8 @@
 
 ## Phase 9: Polish & CI
 
-- [ ] T039 Extend .github/workflows/bench.yml: setup-node + `npm ci --prefix bench/tscg`, run `make bench-discovery`, live run with response-cost measurement, `uvx --from lap-score==0.8.0 lap lint --json` step (pinned; failure → skip with reason), upload lap.json + report.json + dashboard.html artifacts; job stays `continue-on-error: true` (FR-022); add optional `workflow_dispatch` ToolRet-subset job (< 30 min, SC-007)
-- [ ] T040 [P] Update bench/README.md: new modes/flags, arm descriptions, dataset provenance + license notes (ToolRet unstated-license rationale), tokenizer caveat, quickstart parity with specs/083-discovery-profiler/quickstart.md
+- [x] T039 Extend .github/workflows/bench.yml: setup-node + `npm ci --prefix bench/tscg`, run `make bench-discovery`, live run with response-cost measurement, `uvx --from lap-score==0.8.0 lap lint --json` step (pinned; failure → skip with reason), upload lap.json + report.json + dashboard.html artifacts; job stays `continue-on-error: true` (FR-022); add optional `workflow_dispatch` ToolRet-subset job (< 30 min, SC-007)
+- [x] T040 [P] Update bench/README.md: new modes/flags, arm descriptions, dataset provenance + license notes (ToolRet unstated-license rationale), tokenizer caveat, quickstart parity with specs/083-discovery-profiler/quickstart.md
 - [ ] T041 Run full verification: `go test ./bench/... -race`, `/opt/homebrew/bin/golangci-lint run --config .github/.golangci.yml ./bench/...`, `./scripts/test-api-e2e.sh`, `make bench-discovery` wall-clock < 15 min budget check (SC-007/SC-008)
 
 ## Dependencies


### PR DESCRIPTION
Spec-gardener run: 2026-07-20. Applied 15 checkbox ticks, proposing 1 un-tick candidate (NOT applied), across 34 specs with tick/un-tick candidates surfaced by `scripts/check-spec-evidence.py`.

## Applied ticks

| Spec / Task | File:Line | Decisive code |
|---|---|---|
| 009-proactive-oauth-refresh T055 | frontend/src/components/ServerCard.vue:163 + internal/health/calculator.go:211-217 | v-if="healthAction === 'login'"; CalculateHealth sets Action:ActionLogin when OAuthStatus=="expired" |
| 009-proactive-oauth-refresh T056 | frontend/src/components/ServerCard.vue:156,166,176 | Login button uses class="btn btn-sm btn-primary", identical to sibling Enable/Restart buttons |
| 009-proactive-oauth-refresh T061 | frontend/src/components/ServerCard.vue:208-215 | v-if="canLogout" gates on server.authenticated===true (canLogout, line 575-576) plus sensible UX refinements |
| 009-proactive-oauth-refresh T063 | frontend/src/components/ServerCard.vue:708 | await serversStore.triggerOAuthLogout(props.server.name) |
| 042-telemetry-tier2 T001 | internal/telemetry/telemetry.go:76,290,569,677 | Service/HeartbeatPayload/Start() confirmed at cited lines, send() is actually named sendHeartbeat() (the noted drift) |
| 042-telemetry-tier2 T002 | internal/httpapi/middleware.go:29, internal/httpapi/server.go:605-606 | SurfaceClassifierMiddleware wired into chi router chain |
| 042-telemetry-tier2 T003 | internal/server/mcp.go:1254,1701,815,854,914 | handleRetrieveTools/call_tool variants/code_execution/upstream_servers/quarantine_security handler entry points confirmed at cited locations |
| 042-telemetry-tier2 T004 | internal/cliclient/client.go:55,64 | X-MCPProxy-Client header injection site located, matches later T091/T032 usage |
| 042-telemetry-tier2 T091 | cmd/mcpproxy/main.go:524 (cliclient.SetClientVersion), frontend/src/services/api.ts:182 ('webui/web' constant with documented rationale) | version string genuinely plumbed into CLI/tray/webui headers |
| 044-retention-telemetry-v3 T001 | internal/telemetry/telemetry.go:129 | "// Spec 044 additions. schema_version stays at 3 (set by spec 042); these" |
| 047-cpu-hotpath-fix T001 | internal/server/server.go:2094-2124 | mux.Handle("/debug/pprof/", pprofGated) |
| 083-discovery-profiler T009 | scripts/gen-corpus-v2.sh; specs/083-discovery-profiler/datasets/corpus_v2.tools.json; datasets/README.md:20 | "Tool count: 45 (all 7 servers connected; no reduced-corpus caveat)." |
| 083-discovery-profiler T026 | scripts/fetch-toolret.sh | pinned-revision uv download of mangopy/ToolRet-Tools + mangopy/ToolRet-Queries, parquet→JSON conversion |
| 083-discovery-profiler T039 | .github/workflows/bench.yml:68,74,152 | npm ci --prefix bench/tscg; make bench-discovery; uvx --from lap-score==0.8.0 lap lint |
| 083-discovery-profiler T040 | bench/README.md:142-260 | dashboard shows provenance badge + tokenizer caveat |

All 15 were independently re-verified by the gardener session (reading the cited files directly) in addition to the sub-agent that originally proposed each.

## Proposed un-ticks (NOT applied)

| Spec / Task | Why the artifact is absent |
|---|---|
| 044-diagnostics-taxonomy T080 | --server flag exists (doctor_cmd.go:79) but no test anywhere exercises it or asserts its formatted output |

All other 85 UNRESOLVED/REMOVED/RELOCATED findings from the checker were investigated and found to be **RELOCATED-NOT-ABSENT** — the cited evidence path was stale (file renamed/consolidated/moved), but the actual behavior exists elsewhere in the current codebase (e.g. `internal/contracts/config.go` → consolidated into `internal/contracts/types.go`; `cmd/mcpproxy/teams_register.go` → renamed to `serveredition_register.go` as part of a deliberate Teams→Server-Edition rename). These are correctly left ticked and are not proposed as un-ticks.

## Dropped by verification

130 `possibly_built` candidates (unchecked tasks where every cited file happens to exist) were investigated and dropped — the file existed but the specific promised behavior was absent, differently implemented without meeting the task's bar, an unwired component, a stub, or an untested claim. Grouped by spec:

<details><summary><code>001-code-execution</code> — 12 dropped</summary>

- **T020**: no test exercises two mock upstream servers
- **T032**: mockToolCaller.errors map never populated by any test
- **T033**: no test has JS call failing tool then continue to second tool
- **T034**: no integration test with failing upstream tool
- **T051**: tests only pass flat input, no nested objects/arrays
- **T052**: no test asserts complex/nested result serialization
- **T071**: zero matches for EnableCodeExecution/code_execution in mcp_test.go
- **T072**: no rejection-when-disabled integration test
- **T073**: no true-includes-tool integration test
- **T074**: no config-defaults-apply-when-omitted test
- **T079**: no test asserts uniqueness/format of execution_id
- **T080**: no test asserts logs contain execution_id/truncated_code/tools_called/duration_ms

</details>

<details><summary><code>001-oas-endpoint-documentation</code> — 6 dropped</summary>

- **T013**: handleGetSecretRefs has no swag @Summary/@Router comment block
- **T014**: handleGetConfigSecrets same absence
- **T015**: handleMigrateSecrets same absence
- **T025**: code_exec.go has zero swag annotations
- **T026**: handleSSEEvents has no swag annotation block
- **T027**: same handler, same absence

</details>

<details><summary><code>001-update-version-display</code> — 6 dropped</summary>

- **T012**: tray_test.go has no test referencing version menu item
- **T019**: no test verifies immediate pre-ticker check fires on startup
- **T020**: no test exercises periodic 4-hour ticker firing
- **T024**: e2e script never asserts .data.update exists
- **T028**: no test toggling/asserting visibility of updateMenuItem
- **T029**: no test verifies removal of Check for Updates menu item

</details>

<details><summary><code>003-tool-annotations-webui</code> — 3 dropped</summary>

- **T046**: SessionsTable.vue does not exist and no integration into Dashboard.vue
- **T050**: frontend/src/services/api.ts:607 getToolCalls has no sessionId parameter
- **T058**: server.go has no SSE emission of sessions.created/updated/closed events

</details>

<details><summary><code>004-management-health-refactor</code> — 9 dropped</summary>

- **T022**: no restart-related test in cmd/mcpproxy/upstream_cmd_test.go
- **T039**: doctor_cmd_test.go has no E2E test running mcpproxy doctor against live daemon
- **T069**: no --all/bulk-restart E2E CLI test exists
- **T083**: client.go has no logHTTPRequest method or HTTP-request-logging code
- **T085**: monitoring.go intentionally does NOT stream container logs (comment confirms opposite of task)
- **T086**: no redactToken/sanitizeAuthHeader functions exist anywhere in repo
- **T087**: sanitizer_test.go tests pre-existing functions only, not T086's (nonexistent) deliverables
- **T091**: cli-management-commands.md table is Command|Daemon|Standalone, not a REST endpoint mapping
- **T092**: plan.md has only a checklist sentence claiming a diagram, no actual diagram

</details>

<details><summary><code>006-oauth-extra-params</code> — 8 dropped</summary>

- **T039**: cmd/mcpproxy/auth_cmd.go:500-523 displays extra params raw with no masking applied; maskExtraParams/maskOAuthSecret unexported, never called from auth_cmd.go
- **T040**: scopes and PKCE shown at auth_cmd.go:485-497 but redirect URI never displayed anywhere in the file
- **T042**: token expiration shown (auth_cmd.go:549-558) but "last refresh" display does not exist anywhere in codebase
- **T043**: runAuthLoginClientMode (auth_cmd.go:624-668) has no configuration preview printed before OAuth call
- **T044**: no pre-browser-open summary of provider/scopes/PKCE/extra_params; only generic "Using daemon mode" message
- **T045**: no authorization URL is ever printed by the CLI in auth_cmd.go
- **T046**: post-success output (auth_cmd.go:663-665) is generic "flow initiated" message, not a verification summary
- **T054**: doctor_cmd.go has no example config/JSON snippets; only plain-text resolution string in diagnostics.go:104-106

</details>

<details><summary><code>007-oauth-e2e-testing</code> — 5 dropped</summary>

- **T080**: neither runAuthLoginClientMode nor runAuthLoginStandalone prints authorization-URL preview before opening browser
- **T082**: same as T039 - no secret masking applied to any auth status field in auth_cmd.go
- **T084**: internal/upstream/core/connection.go has zero occurrences of grant_type/provider_url/scope logging fields
- **T086**: diagnostics.go has no discovery-endpoint reachability check
- **T088**: auth_cmd_test.go exists but tests never exercise displayAuthStatusPretty or assert on printed auth-status text

</details>

<details><summary><code>008-oauth-token-refresh</code> — 6 dropped</summary>

- **T020**: config.go CreateOAuthConfig/CreateOAuthConfigWithExtraParams take no correlation_id-bearing context param
- **T021**: handleCallback (config.go:1105) has no correlation_id in its logging
- **T022**: internal/oauth/discovery.go has zero references to correlation/CorrelationLogger
- **T023**: internal/oauth/persistent_token_store.go has zero references to correlation
- **T026**: handleOAuthAuthorization/handleOAuthAuthorizationWithResult contain no correlation_id logging
- **T027**: internal/upstream/managed/client.go has zero references to correlation

</details>

<details><summary><code>009-proactive-oauth-refresh</code> — 19 dropped</summary>

- **T011**: contracts.ts SSEEventType has no oauth.token_refreshed/oauth.refresh_failed variants
- **T031**: no TestTriggerOAuthLogout_* test exists in service_test.go
- **T032**: no unit test for TriggerOAuthLogout+disable_management
- **T033**: no unit test for TriggerOAuthLogout with non-OAuth server
- **T034**: no unit test for TriggerOAuthLogout with non-existent server
- **T041**: authLogoutCmd has no --all flag (unlike authLoginCmd)
- **T054**: no oauthExpired computed property exists; specific named artifact never created (behavior achieved differently via backend health.action, judged too indirect to tick this specific subtask even though the sibling task T055 — which promises the *outcome* rather than the artifact — was ticked)
- **T060**: no isAuthenticated computed property exists; canLogout (line 566) bundles several unrelated conditions beyond simple auth status
- **T062**: triggerLogout() (line 705-723) calls store action directly with no window.confirm/modal - no confirmation dialog exists
- **T067**: no oauthError computed property exists anywhere in ServerCard.vue
- **T068**: no standalone Token Expired badge; overridden to generic Sign-in required text
- **T069**: no distinct Auth Error badge; collapses into generic Sign-in required chip
- **T070**: no such distinct badges exist to style
- **T071**: status_test.go has no relative-time-formatting test
- **T074**: status.go has no FormatRelativeTime function
- **T076**: no expiration-time display element added to server details
- **T077**: no 5-minute warning indicator element
- **T078**: no EXPIRED text formatting element
- **T082**: verify-oas-coverage.sh sed regex bug (\U without \E) breaks route extraction; script produces false failures, does not verify OAS coverage

</details>

<details><summary><code>010-release-notes-generator</code> — 1 dropped</summary>

- **T021**: docs has no releases/ directory structure section; actual mechanism is flat RELEASE_NOTES file, not documented as such

</details>

<details><summary><code>011-resource-auto-detect</code> — 1 dropped</summary>

- **T033**: doctor_cmd.go has zero occurrences of "resource"; no resource-parameter diagnostic added

</details>

<details><summary><code>014-cli-output-formatting</code> — 1 dropped</summary>

- **T035**: doctor_cmd.go still hand-rolls output; never calls internal/cli/output

</details>

<details><summary><code>016-activity-log-backend</code> — 1 dropped</summary>

- **T035**: no unit test for handleExportActivity json+csv exists

</details>

<details><summary><code>017-activity-cli-commands</code> — 9 dropped</summary>

- **T028**: no ULID-format validation exists in activity_cmd.go
- **T029**: no test exercises actual show table-formatting code path
- **T035**: no client-side invalid-ID-format handling, only not-found case
- **T037**: no GetActivitySummary() in internal/storage/activity.go; computed inline in httpapi
- **T041**: test only decodes mock JSON, never invokes CLI summary table-formatting output
- **T047**: no export file path validation tested, only --format value
- **T055**: docs/cli-management-commands.md has zero occurrences of "activity"
- **T059**: CI process action, not verifiable statically
- **T060**: CI process action, not verifiable statically

</details>

<details><summary><code>019-activity-webui</code> — 1 dropped</summary>

- **T046**: ActivityWidget.vue exists but never imported/rendered in Dashboard.vue (unwired)

</details>

<details><summary><code>021-request-id-logging</code> — 1 dropped</summary>

- **T030**: E2E test covers REST API directly, none invoke CLI activity list --request-id

</details>

<details><summary><code>026-pii-detection</code> — 3 dropped</summary>

- **T104**: no custom-pattern-detection test in e2e_test.go
- **T108**: no sensitive/pii/detection scenarios in test-api-e2e.sh
- **T109**: no SSE emission test for detection in e2e_test.go

</details>

<details><summary><code>028-agent-tokens</code> — 1 dropped</summary>

- **T023**: token_cmd_test.go only tests scaffolding, not list/revoke/regenerate behavior

</details>

<details><summary><code>029-mcpproxy-teams</code> — 1 dropped</summary>

- **T020**: server-edition Linux matrix entries commented out in release.yml

</details>

<details><summary><code>040-server-ux</code> — 4 dropped</summary>

- **T016**: no import preview step; ImportServerForm goes straight to single Import button, no checkboxes
- **T017**: only aggregate "N imported, M skipped" string, no per-server breakdown/failure reasons
- **T018**: no NSOpenPanel/Browse button anywhere in AddServerView.swift
- **T019**: no timeoutInterval/120 setting in APIClient.swift importFromPath

</details>

<details><summary><code>042-telemetry-tier2</code> — 12 dropped</summary>

- **T009**: no TestTelemetryConfigTier2Roundtrip or equivalent roundtrip test in config_test.go
- **T028**: no TestMCPRequestCountedAsSurfaceMCP test exists
- **T035**: no TestBuiltinToolCounterIncrementsPerCall test exists
- **T036**: no TestUpstreamToolCallIncrementsBucket test exists
- **T037**: no TestUpstreamToolNameNotInSnapshot privacy test exists
- **T054**: no TestOAuthRefreshFailureRecordsErrorCategory test exists
- **T056**: no TestToolQuarantineBlockedRecordsErrorCategory test exists
- **T057**: coordinator.go has zero RecordError/ErrCat references; ErrCatOAuthTokenExpired never called anywhere; required T054 test also absent
- **T073**: no TestDoctorCommandFeedsRegistry test exists
- **T076**: no TestShowPayloadPrintsValidJSON test exists
- **T077**: no TestShowPayloadMakesNoNetworkCall test exists
- **T083**: docs/features/telemetry.md missing DO_NOT_TRACK/CI env docs, first-run notice text, ID rotation policy

</details>

<details><summary><code>044-diagnostics-taxonomy</code> — 10 dropped</summary>

- **T004**: no go:generate directive in registry.go; no codegen tool exists anywhere in repo
- **T019**: no RecordFixAttempt on activity_service.go writing to activity log; same-named function is unrelated in-memory telemetry counter
- **T034**: test-diagnostics-e2e.sh only runs go test twice + docs-link checker, no broken-stdio-server E2E scenario
- **T045**: check-errors-docs-links.sh exists but never invoked from run-all-tests.sh (unwired)
- **T083**: script has no doctor fix dry-run invocation, no dry-run/rate-limit assertions
- **T090**: stdio_show_last_logs fixer is an explicit stub string, does not tail logs
- **T162**: telemetry_payload_test.go tests never reference diagnostics sub-object despite struct field existing
- **T201**: docs/architecture.md has no internal/diagnostics reference
- **T202**: rest-api.md doesn't document new server-scoped diagnostics/diagnostics-fix endpoints
- **T203**: docs/errors/README.md hand-maintained and stale (33 vs 37 codes), no generator tooling exists

</details>

<details><summary><code>044-retention-telemetry-v3</code> — 3 dropped</summary>

- **T003**: docs/features/telemetry.md has no Environment Classification/Activation Tracking/Launch Source sections
- **T063**: docs/features/telemetry.md never documents env_kind/env_markers/activation block/autostart_enabled/decision tree/token-bucketing
- **T069**: manual quickstart-verification task with no recorded deviations/results artifact

</details>

<details><summary><code>056-output-schema-validation</code> — 1 dropped</summary>

- **T019**: e2e/stubs/outputschema/main.go exists but never invoked anywhere - unwired

</details>

<details><summary><code>057-in-proxy-profiles</code> — 1 dropped</summary>

- **T022**: CLAUDE.md and README.md missing profile slug documentation (2 of 3 required doc updates missing)

</details>

<details><summary><code>073-activity-size-retention</code> — 1 dropped</summary>

- **T012**: docs/configuration.md has no mention of activity_max_size_mb or any Activity* field

</details>

<details><summary><code>076-deterministic-tool-scanner</code> — 1 dropped</summary>

- **T023**: gofmt -l reports unformatted files still within task's own scope

</details>

<details><summary><code>077-scanner-simplification</code> — 2 dropped</summary>

- **T040**: no recorded quickstart-scenario results, manual verification task
- **T041**: go test -race ./internal/runtime/... ./internal/config/... fails (2 pre-existing tests, unrelated read-only-directory assumptions that don't hold when run as root in the audit sandbox)

</details>

<details><summary><code>083-discovery-profiler</code> — 1 dropped</summary>

- **T041**: go test ./bench/... -race fails (tiktoken network fetch 403 in sandbox), can't confirm green gate

</details>

## Methodology note

Given the volume (147 `possibly_built` candidates + 88 UNRESOLVED/REMOVED/RELOCATED findings across 34 specs), verification was fanned out across 8 parallel research sub-agents (one per group of specs), each applying the tick test from this repo's spec-gardener instructions: state the promised behavior, cite file:line, confirm it's real (not a stub/comment/unwired component/skipped test), and default to not-ticking when uncertain. The gardener session then independently re-verified every candidate the sub-agents recommended ticking by reading the cited source directly before applying any checkbox change, and dropped two of a sub-agent's proposed ticks where the task named a specific artifact (a named computed property) that did not actually exist in the code even though the surrounding behavior worked via a different mechanism (009-proactive-oauth-refresh T054, T060 — dropped despite sibling tasks T055/T056/T061/T063 for the same feature area being ticked, since those name outcomes rather than specific artifacts).

`ROADMAP.md` was regenerated via `scripts/gen-roadmap.py` in a separate commit after the checkbox sync, per the pre-commit hook's staleness check.

---
_Note: the branch was rebased onto a newer `main` after this PR opened; the diff content is unchanged (same 15 checkbox ticks, same files) — verified against the current file list._