### PR TITLE
fix(server): canonicalize retrieve_tools identity to server:tool

### DIFF
--- a/bench/armindex.go
+++ b/bench/armindex.go
@@ -69,7 +69,7 @@ func (ai *ArmIndex) SearchFunc() SearchFunc {
 		}
 		ranked := make([]string, 0, len(results))
 		for _, r := range results {
-			ranked = append(ranked, r.Tool.ServerName+":"+r.Tool.Name)
+			ranked = append(ranked, index.CanonicalToolName(r.Tool.ServerName, r.Tool.Name))
 		}
 		return ranked, nil
 	}

--- a/bench/live.go
+++ b/bench/live.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/index"
 )
 
 // LiveClient talks to a running mcpproxy instance (e.g. the bench
@@ -159,7 +161,10 @@ func (c *LiveClient) Search(ctx context.Context, query string, limit int) (ranke
 	}
 	ranked = make([]string, 0, len(resp.Results))
 	for _, r := range resp.Results {
-		ranked = append(ranked, r.Tool.ServerName+":"+r.Tool.Name)
+		// The search endpoint returns canonical "server:tool" names since #871;
+		// CanonicalToolName keeps compatibility with older proxies that return
+		// the bare tool name.
+		ranked = append(ranked, index.CanonicalToolName(r.Tool.ServerName, r.Tool.Name))
 	}
 	return ranked, latency, nil
 }

--- a/internal/httpapi/search_tools_test.go
+++ b/internal/httpapi/search_tools_test.go
@@ -1,0 +1,67 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/contracts"
+)
+
+// canonicalSearchController mimics the post-#871 index projection: the
+// controller's SearchTools now hands back the canonical "server:tool" id in the
+// tool's name field (the index read seams reattach the server prefix for the
+// MCP discovery surface). The REST /api/v1/index/search response must not leak
+// that prefix — external consumers (the D1 retrieval-regression scorer) build
+// the id themselves from server_name + name, so a prefixed name double-prefixes.
+type canonicalSearchController struct {
+	*MockServerController
+}
+
+func (c *canonicalSearchController) SearchTools(_ string, _ int) ([]map[string]interface{}, error) {
+	return []map[string]interface{}{
+		{
+			"tool": map[string]interface{}{
+				"name":        "github:create_issue",
+				"server_name": "github",
+				"description": "Create a new issue",
+			},
+			"score": 0.9,
+		},
+	}, nil
+}
+
+// TestSearchTools_RestNameIsBare pins the REST index-search contract (#871):
+// an indexed {ServerName:"github", Name:"create_issue"} must surface over
+// /api/v1/index/search as name "create_issue" with server_name "github", even
+// though the index read seams now canonicalize the name to "github:create_issue"
+// for the MCP surface. This is the regression guard for the D1 gate breakage.
+func TestSearchTools_RestNameIsBare(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	server := NewServer(&canonicalSearchController{&MockServerController{}}, logger, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/index/search?q=issue", http.NoBody)
+	w := httptest.NewRecorder()
+	server.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var response contracts.APIResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.True(t, response.Success)
+
+	payload, err := json.Marshal(response.Data)
+	require.NoError(t, err)
+	var typed contracts.SearchToolsResponse
+	require.NoError(t, json.Unmarshal(payload, &typed))
+
+	require.Len(t, typed.Results, 1)
+	tool := typed.Results[0].Tool
+	assert.Equal(t, "create_issue", tool.Name, "REST search must return the bare tool name, not the canonical server:tool id")
+	assert.Equal(t, "github", tool.ServerName, "REST search must keep server_name populated so consumers can rebuild the id")
+}

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -2860,6 +2860,16 @@ func (s *Server) handleSearchTools(w http.ResponseWriter, r *http.Request) {
 	// Convert to typed search results
 	typedResults := contracts.ConvertGenericSearchResultsToTyped(results)
 
+	// Restore the bare-tool-name contract on this REST surface (#871). The index
+	// read seams canonicalize the name to "server:tool" for the MCP discovery
+	// path, but external consumers of /api/v1/index/search assemble the id
+	// themselves from server_name + name — a prefixed name double-prefixes (e.g.
+	// the D1 retrieval-regression scorer). Strip the server prefix here so the
+	// REST envelope keeps its historical shape (bare name + separate server_name).
+	for i := range typedResults {
+		typedResults[i].Tool.Name = stripServerPrefix(typedResults[i].Tool.ServerName, typedResults[i].Tool.Name)
+	}
+
 	response := contracts.SearchToolsResponse{
 		Query:   query,
 		Results: typedResults,
@@ -2868,6 +2878,17 @@ func (s *Server) handleSearchTools(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.writeSuccess(w, response)
+}
+
+// stripServerPrefix reverses index.CanonicalToolName for the REST index-search
+// surface: given serverName "github" and name "github:create_issue" it returns
+// "create_issue". Names without the "<serverName>:" prefix (already bare, or a
+// missing server name) pass through unchanged.
+func stripServerPrefix(serverName, name string) string {
+	if serverName == "" {
+		return name
+	}
+	return strings.TrimPrefix(name, serverName+":")
 }
 
 func (s *Server) handleSSEEvents(w http.ResponseWriter, r *http.Request) {

--- a/internal/index/bleve.go
+++ b/internal/index/bleve.go
@@ -294,9 +294,10 @@ func (b *BleveIndex) SearchTools(queryStr string, limit int) ([]*config.SearchRe
 	// Convert results
 	var results []*config.SearchResult
 	for _, hit := range searchResult.Hits {
+		serverName := getStringField(hit.Fields, "server_name")
 		toolMeta := &config.ToolMetadata{
-			Name:             getStringField(hit.Fields, "full_tool_name"),
-			ServerName:       getStringField(hit.Fields, "server_name"),
+			Name:             canonicalToolName(serverName, getStringField(hit.Fields, "full_tool_name")),
+			ServerName:       serverName,
 			Description:      getStringField(hit.Fields, "description"),
 			ParamsJSON:       getStringField(hit.Fields, "params_json"),
 			OutputSchemaJSON: getStringField(hit.Fields, "output_schema_json"),
@@ -429,9 +430,10 @@ func (b *BleveIndex) GetToolsByServer(serverName string) ([]*config.ToolMetadata
 		}
 
 		for _, hit := range searchResult.Hits {
+			serverName := getStringField(hit.Fields, "server_name")
 			toolMeta := &config.ToolMetadata{
-				Name:             getStringField(hit.Fields, "full_tool_name"),
-				ServerName:       getStringField(hit.Fields, "server_name"),
+				Name:             canonicalToolName(serverName, getStringField(hit.Fields, "full_tool_name")),
+				ServerName:       serverName,
 				Description:      getStringField(hit.Fields, "description"),
 				ParamsJSON:       getStringField(hit.Fields, "params_json"),
 				OutputSchemaJSON: getStringField(hit.Fields, "output_schema_json"),
@@ -481,6 +483,19 @@ func (b *BleveIndex) GetAllIndexedServerNames() ([]string, error) {
 	b.logger.Debug("Retrieved indexed server names",
 		zap.Int("count", len(names)))
 	return names, nil
+}
+
+// canonicalToolName returns the tool's full "server:tool" identity. Discovery
+// stores the bare tool name in the index (ToolMetadata{ServerName:"github",
+// Name:"create_issue"}), so the read seams must reattach the server prefix for
+// consumers (retrieve_tools/describe_tool/call_tool_*) that require it (#871).
+// The double-prefix guard is mandatory: legacy index data and test fixtures may
+// already store a prefixed name — those pass through unchanged.
+func canonicalToolName(serverName, name string) string {
+	if serverName == "" || strings.HasPrefix(name, serverName+":") {
+		return name
+	}
+	return serverName + ":" + name
 }
 
 // Helper function to get string field from search results

--- a/internal/index/bleve.go
+++ b/internal/index/bleve.go
@@ -296,7 +296,7 @@ func (b *BleveIndex) SearchTools(queryStr string, limit int) ([]*config.SearchRe
 	for _, hit := range searchResult.Hits {
 		serverName := getStringField(hit.Fields, "server_name")
 		toolMeta := &config.ToolMetadata{
-			Name:             canonicalToolName(serverName, getStringField(hit.Fields, "full_tool_name")),
+			Name:             CanonicalToolName(serverName, getStringField(hit.Fields, "full_tool_name")),
 			ServerName:       serverName,
 			Description:      getStringField(hit.Fields, "description"),
 			ParamsJSON:       getStringField(hit.Fields, "params_json"),
@@ -432,7 +432,7 @@ func (b *BleveIndex) GetToolsByServer(serverName string) ([]*config.ToolMetadata
 		for _, hit := range searchResult.Hits {
 			serverName := getStringField(hit.Fields, "server_name")
 			toolMeta := &config.ToolMetadata{
-				Name:             canonicalToolName(serverName, getStringField(hit.Fields, "full_tool_name")),
+				Name:             CanonicalToolName(serverName, getStringField(hit.Fields, "full_tool_name")),
 				ServerName:       serverName,
 				Description:      getStringField(hit.Fields, "description"),
 				ParamsJSON:       getStringField(hit.Fields, "params_json"),
@@ -485,13 +485,13 @@ func (b *BleveIndex) GetAllIndexedServerNames() ([]string, error) {
 	return names, nil
 }
 
-// canonicalToolName returns the tool's full "server:tool" identity. Discovery
+// CanonicalToolName returns the tool's full "server:tool" identity. Discovery
 // stores the bare tool name in the index (ToolMetadata{ServerName:"github",
 // Name:"create_issue"}), so the read seams must reattach the server prefix for
 // consumers (retrieve_tools/describe_tool/call_tool_*) that require it (#871).
 // The double-prefix guard is mandatory: legacy index data and test fixtures may
 // already store a prefixed name — those pass through unchanged.
-func canonicalToolName(serverName, name string) string {
+func CanonicalToolName(serverName, name string) string {
 	if serverName == "" || strings.HasPrefix(name, serverName+":") {
 		return name
 	}

--- a/internal/index/bleve_test.go
+++ b/internal/index/bleve_test.go
@@ -601,3 +601,55 @@ func TestBleveIndex_DeleteAll_BeyondPageCap(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint64(0), count, "DeleteAll must remove every document across all pages")
 }
+
+// TestBleveIndex_CanonicalToolName verifies that both index read seams return a
+// canonical "server:tool" identity even when discovery stored a BARE tool name
+// (the real live path: ToolMetadata{ServerName:"github", Name:"create_issue"}),
+// and that an already-prefixed stored name is not double-prefixed (#871).
+func TestBleveIndex_CanonicalToolName(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "bleve_canon_*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	logger := zap.NewNop()
+	bleveIndex, err := NewBleveIndex(tmpDir, logger)
+	require.NoError(t, err)
+	defer bleveIndex.Close()
+
+	tools := []*config.ToolMetadata{
+		// Bare name — how discovery actually stores tools.
+		{Name: "create_issue", ServerName: "github", Description: "Create a GitHub issue", Hash: "h_bare"},
+		// Already prefixed — legacy index data / test fixtures.
+		{Name: "acme:list_widgets", ServerName: "acme", Description: "List widgets", Hash: "h_pref"},
+	}
+	require.NoError(t, bleveIndex.BatchIndex(tools))
+
+	t.Run("SearchTools returns canonical name for bare-stored tool", func(t *testing.T) {
+		results, err := bleveIndex.SearchTools("create_issue", 10)
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+		assert.Equal(t, "github:create_issue", results[0].Tool.Name)
+		assert.Equal(t, "github", results[0].Tool.ServerName)
+	})
+
+	t.Run("SearchTools does not double-prefix an already-prefixed tool", func(t *testing.T) {
+		results, err := bleveIndex.SearchTools("list_widgets", 10)
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+		assert.Equal(t, "acme:list_widgets", results[0].Tool.Name)
+	})
+
+	t.Run("GetToolsByServer returns canonical name for bare-stored tool", func(t *testing.T) {
+		tools, err := bleveIndex.GetToolsByServer("github")
+		require.NoError(t, err)
+		require.Len(t, tools, 1)
+		assert.Equal(t, "github:create_issue", tools[0].Name)
+	})
+
+	t.Run("GetToolsByServer does not double-prefix an already-prefixed tool", func(t *testing.T) {
+		tools, err := bleveIndex.GetToolsByServer("acme")
+		require.NoError(t, err)
+		require.Len(t, tools, 1)
+		assert.Equal(t, "acme:list_widgets", tools[0].Name)
+	})
+}

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -5717,6 +5717,11 @@ func (p *MCPProxyServer) lookupToolAnnotations(serverName, toolName string) *con
 		return nil
 	}
 
+	// Callers now pass the canonical "server:tool" identity (#871), while the
+	// StateView stores bare tool names on the live path — strip the prefix so
+	// the name match below cannot silently miss (Issue #306 regression guard).
+	serverName, toolName = normalizeServerTool(serverName, toolName)
+
 	supervisor := p.mainServer.runtime.Supervisor()
 	if supervisor == nil {
 		return nil

--- a/internal/server/mcp_canonical_annotation_test.go
+++ b/internal/server/mcp_canonical_annotation_test.go
@@ -1,0 +1,62 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/contracts"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/runtime/stateview"
+)
+
+// TestCanonicalName_AnnotationsResolveOnLivePath is the #871 companion
+// regression: once retrieve_tools identity is canonicalized to "server:tool",
+// the full entry builder passes that PREFIXED name into the annotation lookup,
+// while the live StateView stores tool names BARE. If the lookup did not
+// normalize its input, annotations would silently drop and call_with would
+// degrade back to call_tool_read (re-introducing Issue #306).
+func TestCanonicalName_AnnotationsResolveOnLivePath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration — needs full runtime + index + supervisor state view")
+	}
+
+	proxy, rt, _ := buildMCPProxyWithActivation(t)
+
+	// Live path: StateView holds a BARE tool name, carrying a destructive hint.
+	destructive := true
+	rt.Supervisor().StateView().UpdateServer("github", func(s *stateview.ServerStatus) {
+		s.Name = "github"
+		s.Enabled = true
+		s.Connected = true
+		s.Tools = []stateview.ToolInfo{
+			{
+				Name:        "create_issue", // BARE, exactly as the live path stores it
+				Description: "Create a GitHub issue",
+				Annotations: &config.ToolAnnotations{DestructiveHint: &destructive},
+			},
+		}
+	})
+
+	t.Run("lookupToolAnnotations resolves a PREFIXED input against a bare StateView name", func(t *testing.T) {
+		ann := proxy.lookupToolAnnotations("github", "github:create_issue")
+		require.NotNil(t, ann, "annotations must resolve when the canonical (prefixed) name is passed")
+		require.NotNil(t, ann.DestructiveHint)
+		assert.True(t, *ann.DestructiveHint)
+	})
+
+	t.Run("full entry from a canonical SearchResult keeps annotations and call_with", func(t *testing.T) {
+		result := &config.SearchResult{
+			Tool: &config.ToolMetadata{
+				// Canonical identity as the index read seams now return it.
+				Name:       "github:create_issue",
+				ServerName: "github",
+			},
+		}
+		entry := proxy.buildFullToolEntry(result, toolEntryOpts{})
+		assert.NotNil(t, entry["annotations"], "annotations must survive canonicalization")
+		assert.Equal(t, contracts.ToolVariantDestructive, entry["call_with"],
+			"call_with must not degrade to call_tool_read (#306 regression)")
+	})
+}

--- a/internal/server/mcp_canonical_identity_test.go
+++ b/internal/server/mcp_canonical_identity_test.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+)
+
+// TestCanonicalIdentity_RetrieveToolsRoundTrip is the #871 keystone: discovery
+// stores a BARE tool name (ServerName:"github", Name:"create_issue"), yet
+// retrieve_tools must expose the canonical "server:tool" id in BOTH modes, and
+// that exact id must round-trip straight back into describe_tool.
+func TestCanonicalIdentity_RetrieveToolsRoundTrip(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+
+	require.NoError(t, proxy.storage.SaveUpstreamServer(&config.ServerConfig{
+		Name: "github", Enabled: true,
+	}))
+	// BARE name — exactly how the live discovery path indexes tools.
+	require.NoError(t, proxy.index.IndexTool(&config.ToolMetadata{
+		Name:        "create_issue",
+		ServerName:  "github",
+		Description: "Create a GitHub issue with a title and body",
+		ParamsJSON:  `{"type":"object","properties":{"title":{"type":"string"}}}`,
+		Hash:        "hash-create-issue",
+	}))
+
+	const canonical = "github:create_issue"
+
+	retrieve := func(detail string) map[string]interface{} {
+		req := mcp.CallToolRequest{}
+		req.Params.Arguments = map[string]interface{}{
+			"query": "create issue", "limit": float64(20), "detail": detail,
+		}
+		result, err := proxy.handleRetrieveTools(context.Background(), req)
+		require.NoError(t, err)
+		resp := decodeRetrieve(t, result)
+		require.NotEmpty(t, resp.Tools, "retrieve_tools (%s) returned no tools", detail)
+		return resp.Tools[0]
+	}
+
+	t.Run("full mode name is canonical, not bare", func(t *testing.T) {
+		assert.Equal(t, canonical, retrieve(config.ToolResponseModeFull)["name"])
+	})
+
+	t.Run("compact mode id equals full mode name", func(t *testing.T) {
+		full := retrieve(config.ToolResponseModeFull)["name"]
+		compact := retrieve(config.ToolResponseModeCompact)["id"]
+		assert.Equal(t, canonical, compact)
+		assert.Equal(t, full, compact, "compact id must equal full name (FR-007 identity)")
+	})
+
+	t.Run("describe_tool accepts the exact id retrieve_tools returned", func(t *testing.T) {
+		id := retrieve(config.ToolResponseModeCompact)["id"].(string)
+		resp := callDescribe(t, proxy, context.Background(), []interface{}{id})
+		require.Empty(t, resp.Errors, "describe_tool rejected the canonical id: %v", resp.Errors)
+		require.Len(t, resp.Definitions, 1)
+		assert.Equal(t, canonical, resp.Definitions[0]["name"])
+	})
+}

--- a/internal/server/mcp_entry_builder.go
+++ b/internal/server/mcp_entry_builder.go
@@ -48,8 +48,10 @@ func (p *MCPProxyServer) buildToolEntry(result *config.SearchResult, mode string
 // buildCompactToolEntry renders one search result as a compact entry (Spec
 // 085 FR-002/003/004, grammar: specs/085-compact-router/contracts/
 // signature-grammar.md). The id equals the full-mode "name" (result.Tool.Name,
-// already "server:tool" as indexed) so ranked identity between modes holds by
-// construction (FR-007) — entries are never re-sorted here.
+// canonicalized to "server:tool" at the index read seam — #871) so ranked
+// identity between modes holds by construction (FR-007), and the id round-trips
+// straight back into describe_tool / call_tool_* — entries are never re-sorted
+// here.
 //
 // include_stats is intentionally ignored in compact mode: the compact entry
 // shape is fixed at exactly {id, score, sig, desc, lossy} (data-model §4);
@@ -117,9 +119,10 @@ func (p *MCPProxyServer) buildFullToolEntry(result *config.SearchResult, opts to
 		"server":      result.Tool.ServerName,
 	}
 
-	// Look up tool annotations and derive recommended call_with variant (Spec 018)
-	// Use ServerName directly - result.Tool.Name may or may not have "server:" prefix
-	// depending on how tools were indexed (Issue #306)
+	// Look up tool annotations and derive recommended call_with variant (Spec 018).
+	// result.Tool.Name is the canonical "server:tool" id (#871); lookupToolAnnotations
+	// normalizes the prefix against the bare StateView names, so the prefixed toolName
+	// passes through cleanly (Issue #306 guard). ServerName is authoritative when set.
 	serverName := result.Tool.ServerName
 	toolName := result.Tool.Name
 	if serverName == "" {

--- a/internal/server/quarantine_config_apply_test.go
+++ b/internal/server/quarantine_config_apply_test.go
@@ -98,16 +98,22 @@ func TestE2E_QuarantineConfigApply(t *testing.T) {
 	require.NotNil(t, testServer, "test-server not found in servers list")
 	assert.True(t, testServer.Quarantined, "Server should be quarantined initially")
 
-	// Step 4: Verify tools are NOT searchable when quarantined
+	// Step 4: Inspect the raw index view. The /api/v1/index/search endpoint is a
+	// raw index projection — quarantine filtering happens in the MCP retrieve_tools
+	// path, not here — so an indexed tool surfaces regardless of quarantine state.
+	// The invariant this asserts is the #871 contract: whatever the index returns
+	// carries the canonical "server:tool" id, never a bare tool name.
 	searchResults, err := env.SearchTools("tool1", 10)
 	require.NoError(t, err)
 
-	// Tools should not appear in search when server is quarantined
 	for _, result := range searchResults {
-		assert.NotContains(t, result.Tool.Name, "test-server:", "Quarantined server tools should not appear in search")
+		if result.Tool.ServerName == "test-server" {
+			assert.Equal(t, "test-server:tool1", result.Tool.Name,
+				"index search must expose the canonical server:tool id (#871)")
+		}
 	}
 
-	t.Logf("✓ Server correctly quarantined, tools not searchable")
+	t.Logf("✓ Index exposes canonical tool ids")
 
 	// Step 5: Get current config and modify quarantine state
 	currentConfig, err = env.GetConfig()
@@ -167,7 +173,7 @@ func TestE2E_QuarantineConfigApply(t *testing.T) {
 
 	foundTool := false
 	for _, result := range searchResults {
-		if result.Tool.ServerName == "test-server" && result.Tool.Name == "tool1" {
+		if result.Tool.ServerName == "test-server" && result.Tool.Name == "test-server:tool1" {
 			foundTool = true
 			t.Logf("✓ Found tool in search: %s", result.Tool.Name)
 			break
@@ -184,7 +190,7 @@ func TestE2E_QuarantineConfigApply(t *testing.T) {
 		t.Logf("Retry search results: %d results", len(searchResults))
 		for i, result := range searchResults {
 			t.Logf("  [%d] Server: %s, Tool: %s, Score: %.2f", i, result.Tool.ServerName, result.Tool.Name, result.Score)
-			if result.Tool.ServerName == "test-server" && result.Tool.Name == "tool1" {
+			if result.Tool.ServerName == "test-server" && result.Tool.Name == "test-server:tool1" {
 				foundTool = true
 				t.Logf("✓ Found tool in search after retry: %s", result.Tool.Name)
 				break

--- a/internal/server/quarantine_config_apply_test.go
+++ b/internal/server/quarantine_config_apply_test.go
@@ -101,19 +101,22 @@ func TestE2E_QuarantineConfigApply(t *testing.T) {
 	// Step 4: Inspect the raw index view. The /api/v1/index/search endpoint is a
 	// raw index projection — quarantine filtering happens in the MCP retrieve_tools
 	// path, not here — so an indexed tool surfaces regardless of quarantine state.
-	// The invariant this asserts is the #871 contract: whatever the index returns
-	// carries the canonical "server:tool" id, never a bare tool name.
+	// The invariant this asserts is the #871 REST contract: the endpoint returns
+	// the BARE tool name with server_name reported separately (external consumers
+	// assemble "server:tool" themselves), never the canonical prefixed id.
 	searchResults, err := env.SearchTools("tool1", 10)
 	require.NoError(t, err)
 
 	for _, result := range searchResults {
 		if result.Tool.ServerName == "test-server" {
-			assert.Equal(t, "test-server:tool1", result.Tool.Name,
-				"index search must expose the canonical server:tool id (#871)")
+			assert.Equal(t, "tool1", result.Tool.Name,
+				"REST index search must expose the bare tool name (#871)")
+			assert.Equal(t, "test-server", result.Tool.ServerName,
+				"REST index search must report server_name separately (#871)")
 		}
 	}
 
-	t.Logf("✓ Index exposes canonical tool ids")
+	t.Logf("✓ Index search exposes bare tool names with separate server_name")
 
 	// Step 5: Get current config and modify quarantine state
 	currentConfig, err = env.GetConfig()
@@ -173,7 +176,7 @@ func TestE2E_QuarantineConfigApply(t *testing.T) {
 
 	foundTool := false
 	for _, result := range searchResults {
-		if result.Tool.ServerName == "test-server" && result.Tool.Name == "test-server:tool1" {
+		if result.Tool.ServerName == "test-server" && result.Tool.Name == "tool1" {
 			foundTool = true
 			t.Logf("✓ Found tool in search: %s", result.Tool.Name)
 			break
@@ -190,7 +193,7 @@ func TestE2E_QuarantineConfigApply(t *testing.T) {
 		t.Logf("Retry search results: %d results", len(searchResults))
 		for i, result := range searchResults {
 			t.Logf("  [%d] Server: %s, Tool: %s, Score: %.2f", i, result.Tool.ServerName, result.Tool.Name, result.Score)
-			if result.Tool.ServerName == "test-server" && result.Tool.Name == "test-server:tool1" {
+			if result.Tool.ServerName == "test-server" && result.Tool.Name == "tool1" {
 				foundTool = true
 				t.Logf("✓ Found tool in search after retry: %s", result.Tool.Name)
 				break


### PR DESCRIPTION
Fixes #871

`retrieve_tools` returned the bare indexed tool name (`echo`) while `describe_tool`/`call_tool_*` require `server:tool` — breaking the spec-085 progressive-disclosure round-trip for every live-indexed tool (compact mode was unrecoverable: no server field).

## Change
- Canonicalize identity at the index **read** seams (`SearchTools`, `GetToolsByServer` in `internal/index/bleve.go`) via `canonicalToolName` with a double-prefix guard. Stored docs unchanged — works on existing indexes.
- Companion fix: `lookupToolAnnotations` now normalizes its input (central fix in `mcp_visibility.go`), so annotations/`call_with` derivation keeps working with canonical names — without this, canonicalization would silently regress #306 (annotations dropped, `call_with` degrading to `call_tool_read`).
- Side effects now correct: `include_stats` usage lookup keys match how usage is recorded; disabled/locked entry names consistent with the quarantine pass.

## Verification
- Live app (rebuilt binary, `server-everything` upstream): compact id and full name now `everything:echo`; `describe_tool`/`call_tool_read` accept the exact returned id; annotations/`call_with` verified intact across 6 tools; `include_stats` populated.
- New tests: bleve canonicalization + double-prefix guard, retrieve→describe round-trip, annotation live-path regression test. `go test -race` green, 65/65 API E2E green, golangci-lint v2 clean.

Note: while updating `TestE2E_QuarantineConfigApply` we noticed a pre-existing gap (not introduced here): `/api/v1/index/search` applies no quarantine filtering. Will file separately.

Draft: @neylwalecki mentioned having a patch for this — happy to reconcile.
