### PR TITLE
chore(deps): ignore TypeScript 7.x for frontend until vue-tsc/typescript-eslint support it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,12 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+      # Revisit when vue-tsc + typescript-eslint support TypeScript 7.
+      # TS 7 cannot even `npm ci`: typescript-eslint peer-caps at <6.1.0 and
+      # vue-tsc fails on TS 7's package exports (see PR #869).
+      - dependency-name: "typescript"
+        versions: ["7.x"]
     groups:
       frontend-dependencies:
         patterns:


### PR DESCRIPTION
## Summary
Stop Dependabot from proposing TypeScript 7.x for `/frontend` until the toolchain supports it.

PR #869 showed `typescript@7` cannot even `npm ci`:
- `typescript-eslint` peer-caps at `<6.1.0`
- `vue-tsc` fails on TS 7's package exports

We reverted to `^6` and merged the rest. This adds an `ignore` entry so TS 7 majors are held back automatically; revisit when `vue-tsc` + `typescript-eslint` support TS 7.

Config-only change (`.github/dependabot.yml`); YAML validated.

Refs #869
