### PR TITLE
ci: align codeql-action steps on one SHA (fixes red CodeQL on main)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,14 @@ updates:
       interval: weekly
     commit-message:
       prefix: "chore(ci)"
+    groups:
+      # codeql-action's init/autobuild/analyze subpaths are separate
+      # dependencies to dependabot but must stay on the same version —
+      # skew makes analyze reject init's config file (broke CI: #895
+      # bumped only init to 4.37.3 while analyze stayed on 4.37.0).
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
   - package-ecosystem: npm
     directory: "/frontend"
     schedule:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,11 +46,17 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
+      # NOTE: init/autobuild/analyze MUST be pinned to the SAME codeql-action
+      # SHA. Version skew breaks hard at runtime: init writes a config file
+      # that older analyze/autobuild binaries refuse to load ("Loaded a
+      # configuration file for version 'X', but running version 'Y'").
+      # Dependabot bumps them together via the codeql-action group in
+      # .github/dependabot.yml.
       - name: Autobuild
         if: matrix.build-mode == 'autobuild'
-        uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a  # v4.37.1
+        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.37.3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.37.3
         with:
           category: /language:${{ matrix.language }}


### PR DESCRIPTION
Every CodeQL run on `main` and on PRs has failed in ~20s since #895: dependabot treats `github/codeql-action/{init,autobuild,analyze}` as three separate dependencies and bumped only `init` to v4.37.3, leaving `autobuild` on v4.37.1 and `analyze` on v4.37.0. The newer init writes a config file the older binaries refuse to load:

```
Loaded a configuration file for version '4.37.3', but running version '4.37.0'
```

## Fix

- Pin all three steps to the same v4.37.3 SHA (`e4fba868…`, verified against the upstream tag).
- Add a `codeql-action` dependabot group so the subpaths are always bumped together in one PR — prevents recurrence.

After this merges, re-running the CodeQL checks on open PRs (e.g. #899) should turn them green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)