### PR TITLE
fix(connect): recognize OpenCode's opencode.jsonc global config

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -222,8 +222,10 @@ OpenCode can be connected through MCPProxy's Connect Clients flow.
 
 - Client ID: `opencode`
 - Config section: `mcp`
-- macOS/Linux global config path: `~/.config/opencode/opencode.json`
-- Windows global config path: `%LOCALAPPDATA%\opencode\opencode.json`
+- macOS/Linux global config: `~/.config/opencode/opencode.jsonc` or `opencode.json`
+- Windows global config: `%LOCALAPPDATA%\opencode\opencode.jsonc` or `opencode.json`
+- MCPProxy targets whichever file exists, preferring `opencode.jsonc` (recent OpenCode versions bootstrap it, and it shadows `opencode.json` for the same keys).
+- A `.jsonc` file that contains comments is not rewritten (comments would be lost) — MCPProxy asks you to edit the `mcp` section manually in that case.
 - OpenCode config must already exist; MCPProxy does not create it for you.
 - On connect, MCPProxy writes or updates only the OpenCode `mcp` subtree and preserves unrelated root config.
 - MCPProxy treats endpoint-equivalent existing entries as already connected, even if they use a non-canonical server name.

--- a/internal/connect/access.go
+++ b/internal/connect/access.go
@@ -127,7 +127,7 @@ func (s *Service) DetectAppDataDenial() (denied bool, remediation string) {
 		if !c.Supported {
 			continue
 		}
-		cfgPath := ConfigPath(c.ID, s.homeDir)
+		cfgPath := s.configPath(c.ID)
 		if cfgPath == "" {
 			continue
 		}

--- a/internal/connect/clients.go
+++ b/internal/connect/clients.go
@@ -166,18 +166,50 @@ func ConfigPath(clientID, homeDir string) string {
 		return filepath.Join(homeDir, ".gemini", "settings.json")
 
 	case "opencode":
-		if runtime.GOOS == "windows" {
-			localAppData := os.Getenv("LOCALAPPDATA")
-			if localAppData == "" {
-				localAppData = filepath.Join(homeDir, "AppData", "Local")
-			}
-			return filepath.Join(localAppData, "opencode", "opencode.json")
-		}
-		return filepath.Join(homeDir, ".config", "opencode", "opencode.json")
+		return filepath.Join(opencodeConfigDir(homeDir), "opencode.json")
 
 	default:
 		return ""
 	}
+}
+
+// opencodeConfigDir returns OpenCode's global config directory.
+func opencodeConfigDir(homeDir string) string {
+	if runtime.GOOS == "windows" {
+		localAppData := os.Getenv("LOCALAPPDATA")
+		if localAppData == "" {
+			localAppData = filepath.Join(homeDir, "AppData", "Local")
+		}
+		return filepath.Join(localAppData, "opencode")
+	}
+	return filepath.Join(homeDir, ".config", "opencode")
+}
+
+// opencodeConfigCandidates lists the global config files OpenCode itself loads,
+// highest precedence first: opencode.jsonc shadows opencode.json for the same
+// keys, and recent OpenCode versions bootstrap the .jsonc variant (#922).
+func opencodeConfigCandidates(homeDir string) []string {
+	dir := opencodeConfigDir(homeDir)
+	return []string{
+		filepath.Join(dir, "opencode.jsonc"),
+		filepath.Join(dir, "opencode.json"),
+	}
+}
+
+// configPath resolves the config file a client operation should target. For
+// OpenCode it prefers the candidate that actually exists — writing next to an
+// existing .jsonc would be silently shadowed by it — falling back to the static
+// ConfigPath default (opencode.json) for the create-new case. Stat-only: no
+// config content is read (Spec 075 FR-001).
+func (s *Service) configPath(clientID string) string {
+	if clientID == "opencode" {
+		for _, p := range opencodeConfigCandidates(s.homeDir) {
+			if _, err := os.Stat(p); err == nil {
+				return p
+			}
+		}
+	}
+	return ConfigPath(clientID, s.homeDir)
 }
 
 // buildServerEntry returns the JSON/TOML-serializable map inserted into the

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -426,6 +426,24 @@ func (s *Service) Disconnect(clientID, serverName string) (*ConnectResult, error
 	} else {
 		res, err = s.disconnectJSON(client, cfgPath, serverName)
 	}
+	// OpenCode candidate drift (#922): if the entry was written to opencode.json
+	// and OpenCode later bootstrapped opencode.jsonc, the resolver now targets
+	// the .jsonc — but the entry still lives in the .json. When the resolved
+	// file has no entry, retry the other existing candidate before giving up.
+	if err == nil && res != nil && !res.Success && res.Action == "not_found" && clientID == "opencode" {
+		for _, alt := range opencodeConfigCandidates(s.homeDir) {
+			if alt == cfgPath {
+				continue
+			}
+			if _, statErr := os.Stat(alt); statErr != nil {
+				continue
+			}
+			altRes, altErr := s.disconnectJSON(client, alt, serverName)
+			if altErr == nil && altRes != nil && altRes.Success {
+				return altRes, nil
+			}
+		}
+	}
 	return res, s.asAccessError(client, cfgPath, err)
 }
 
@@ -977,7 +995,10 @@ func unmarshalLenientJSON(raw []byte, out interface{}) error {
 	// JSONC tolerance (#922): OpenCode bootstraps opencode.jsonc, which may
 	// carry // and /* */ comments plus trailing commas. Strip comments first —
 	// comment removal can expose new trailing commas — then clean commas.
-	cleaned := stripJSONComments(raw)
+	cleaned, cerr := stripJSONComments(raw)
+	if cerr != nil {
+		return cerr
+	}
 	cleaned = trailingCommaPattern.ReplaceAll(cleaned, []byte(`$1`))
 	return json.Unmarshal(cleaned, out)
 }
@@ -985,7 +1006,9 @@ func unmarshalLenientJSON(raw []byte, out interface{}) error {
 // stripJSONComments removes // line and /* */ block comments from JSONC input,
 // string-aware so slashes inside JSON strings survive. Comment bytes are
 // replaced with spaces (newlines kept) to preserve offsets for error messages.
-func stripJSONComments(raw []byte) []byte {
+// An unterminated /* block is an error — silently blanking to EOF would make
+// truncated/malformed files parse as valid.
+func stripJSONComments(raw []byte) ([]byte, error) {
 	out := make([]byte, len(raw))
 	copy(out, raw)
 	inString := false
@@ -1013,10 +1036,12 @@ func stripJSONComments(raw []byte) []byte {
 		case c == '/' && i+1 < len(out) && out[i+1] == '*':
 			out[i], out[i+1] = ' ', ' '
 			i += 2
+			closed := false
 			for i < len(out) {
 				if out[i] == '*' && i+1 < len(out) && out[i+1] == '/' {
 					out[i], out[i+1] = ' ', ' '
 					i++
+					closed = true
 					break
 				}
 				if out[i] != '\n' {
@@ -1024,15 +1049,20 @@ func stripJSONComments(raw []byte) []byte {
 				}
 				i++
 			}
+			if !closed {
+				return nil, fmt.Errorf("unterminated /* block comment")
+			}
 		}
 	}
-	return out
+	return out, nil
 }
 
 // jsonHasComments reports whether stripping comments would change the content —
 // i.e. the file actually uses JSONC comments (not just slashes inside strings).
+// An unterminated block comment counts as commented (the write guard refuses).
 func jsonHasComments(raw []byte) bool {
-	return !bytes.Equal(stripJSONComments(raw), raw)
+	stripped, err := stripJSONComments(raw)
+	return err != nil || !bytes.Equal(stripped, raw)
 }
 
 // findEntryTOMLBytes parses TOML config bytes and looks for an entry that points

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -439,7 +439,13 @@ func (s *Service) Disconnect(clientID, serverName string) (*ConnectResult, error
 				continue
 			}
 			altRes, altErr := s.disconnectJSON(client, alt, serverName)
-			if altErr == nil && altRes != nil && altRes.Success {
+			if altErr != nil {
+				// An unreadable/malformed/comment-guarded alternate is a real
+				// failure — surfacing "not_found" would wrongly claim the entry
+				// is absent when we could not actually check the file.
+				return altRes, s.asAccessError(client, alt, altErr)
+			}
+			if altRes != nil && altRes.Success {
 				return altRes, nil
 			}
 		}

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -267,7 +268,7 @@ func (s *Service) GetAllStatus() []ClientStatus {
 	statuses := make([]ClientStatus, 0, len(clients))
 
 	for _, c := range clients {
-		cfgPath := ConfigPath(c.ID, s.homeDir)
+		cfgPath := s.configPath(c.ID)
 		status := ClientStatus{
 			ID:          c.ID,
 			Name:        c.Name,
@@ -301,7 +302,7 @@ func (s *Service) GetStatus(clientID string) (ClientStatus, error) {
 		return ClientStatus{}, fmt.Errorf("unknown client: %s", clientID)
 	}
 
-	cfgPath := ConfigPath(c.ID, s.homeDir)
+	cfgPath := s.configPath(c.ID)
 	status := ClientStatus{
 		ID:          c.ID,
 		Name:        c.Name,
@@ -372,13 +373,17 @@ func (s *Service) Connect(clientID, serverName string, force bool) (*ConnectResu
 		serverName = defaultServerName
 	}
 
-	cfgPath := ConfigPath(clientID, s.homeDir)
+	cfgPath := s.configPath(clientID)
 	if cfgPath == "" {
 		return nil, fmt.Errorf("cannot determine config path for %s", clientID)
 	}
 	if client.ID == "opencode" {
+		// configPath already prefers whichever candidate exists; reaching a
+		// nonexistent path here means NO OpenCode global config was found.
 		if _, err := os.Stat(cfgPath); os.IsNotExist(err) {
-			return nil, fmt.Errorf("OpenCode config file %s does not exist", cfgPath)
+			return nil, fmt.Errorf(
+				"no OpenCode config found (looked for opencode.jsonc and opencode.json in %s) — is OpenCode installed?",
+				filepath.Dir(cfgPath))
 		}
 	}
 
@@ -409,7 +414,7 @@ func (s *Service) Disconnect(clientID, serverName string) (*ConnectResult, error
 		serverName = defaultServerName
 	}
 
-	cfgPath := ConfigPath(clientID, s.homeDir)
+	cfgPath := s.configPath(clientID)
 	if cfgPath == "" {
 		return nil, fmt.Errorf("cannot determine config path for %s", clientID)
 	}
@@ -427,7 +432,30 @@ func (s *Service) Disconnect(clientID, serverName string) (*ConnectResult, error
 // ---------- JSON helpers ----------
 
 // connectJSON adds or updates the mcpproxy entry in a JSON config file.
+// guardJsoncComments refuses to rewrite a .jsonc file that actually uses
+// comments: mcpproxy re-serializes plain JSON, which would silently strip them
+// (#922). Comment-free .jsonc (OpenCode's bootstrap stub) rewrites safely.
+// Absent or unreadable files pass — the normal read/write path handles those.
+func (s *Service) guardJsoncComments(cfgPath string) error {
+	if !strings.HasSuffix(cfgPath, ".jsonc") {
+		return nil
+	}
+	raw, err := s.read(cfgPath)
+	if err != nil {
+		return nil
+	}
+	if jsonHasComments(raw) {
+		return fmt.Errorf(
+			"%s contains comments, which mcpproxy would strip on rewrite — edit the \"mcp\" section manually or remove the comments and retry",
+			cfgPath)
+	}
+	return nil
+}
+
 func (s *Service) connectJSON(client *ClientDef, cfgPath, serverName string, force bool) (*ConnectResult, error) {
+	if err := s.guardJsoncComments(cfgPath); err != nil {
+		return nil, err
+	}
 	// Read existing config or start fresh
 	data, perm, err := s.readOrCreateJSON(cfgPath)
 	if err != nil {
@@ -513,6 +541,9 @@ func (s *Service) connectJSON(client *ClientDef, cfgPath, serverName string, for
 
 // disconnectJSON removes the mcpproxy entry from a JSON config file.
 func (s *Service) disconnectJSON(client *ClientDef, cfgPath, serverName string) (*ConnectResult, error) {
+	if err := s.guardJsoncComments(cfgPath); err != nil {
+		return nil, err
+	}
 	raw, err := s.read(cfgPath)
 	if os.IsNotExist(err) {
 		return &ConnectResult{
@@ -943,8 +974,65 @@ func unmarshalLenientJSON(raw []byte, out interface{}) error {
 	if err := json.Unmarshal(raw, out); err == nil {
 		return nil
 	}
-	cleaned := trailingCommaPattern.ReplaceAll(raw, []byte(`$1`))
+	// JSONC tolerance (#922): OpenCode bootstraps opencode.jsonc, which may
+	// carry // and /* */ comments plus trailing commas. Strip comments first —
+	// comment removal can expose new trailing commas — then clean commas.
+	cleaned := stripJSONComments(raw)
+	cleaned = trailingCommaPattern.ReplaceAll(cleaned, []byte(`$1`))
 	return json.Unmarshal(cleaned, out)
+}
+
+// stripJSONComments removes // line and /* */ block comments from JSONC input,
+// string-aware so slashes inside JSON strings survive. Comment bytes are
+// replaced with spaces (newlines kept) to preserve offsets for error messages.
+func stripJSONComments(raw []byte) []byte {
+	out := make([]byte, len(raw))
+	copy(out, raw)
+	inString := false
+	escaped := false
+	for i := 0; i < len(out); i++ {
+		c := out[i]
+		if inString {
+			if escaped {
+				escaped = false
+			} else if c == '\\' {
+				escaped = true
+			} else if c == '"' {
+				inString = false
+			}
+			continue
+		}
+		switch {
+		case c == '"':
+			inString = true
+		case c == '/' && i+1 < len(out) && out[i+1] == '/':
+			for i < len(out) && out[i] != '\n' {
+				out[i] = ' '
+				i++
+			}
+		case c == '/' && i+1 < len(out) && out[i+1] == '*':
+			out[i], out[i+1] = ' ', ' '
+			i += 2
+			for i < len(out) {
+				if out[i] == '*' && i+1 < len(out) && out[i+1] == '/' {
+					out[i], out[i+1] = ' ', ' '
+					i++
+					break
+				}
+				if out[i] != '\n' {
+					out[i] = ' '
+				}
+				i++
+			}
+		}
+	}
+	return out
+}
+
+// jsonHasComments reports whether stripping comments would change the content —
+// i.e. the file actually uses JSONC comments (not just slashes inside strings).
+func jsonHasComments(raw []byte) bool {
+	return !bytes.Equal(stripJSONComments(raw), raw)
 }
 
 // findEntryTOMLBytes parses TOML config bytes and looks for an entry that points

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -116,7 +116,7 @@ func TestConnect_OpenCode_RequiresExistingConfigFile(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected missing-config error for OpenCode")
 	}
-	if !strings.Contains(strings.ToLower(err.Error()), "does not exist") {
+	if !strings.Contains(strings.ToLower(err.Error()), "no opencode config found") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/connect/opencode_jsonc_test.go
+++ b/internal/connect/opencode_jsonc_test.go
@@ -268,6 +268,24 @@ func TestDisconnectOpencodeFindsEntryInOtherCandidate(t *testing.T) {
 	}
 }
 
+func TestDisconnectOpencodeAlternateCandidateErrorPropagates(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Setenv("LOCALAPPDATA", "")
+	}
+	home := t.TempDir()
+	// Resolved target: comment-free .jsonc without the entry. Alternate: a
+	// commented .json... comments only guard .jsonc, so use malformed JSON to
+	// force a real error on the alternate path instead.
+	writeOpencodeFile(t, home, "opencode.jsonc", jsoncStub)
+	writeOpencodeFile(t, home, "opencode.json", `{"mcp": not-valid-json`)
+	s := NewServiceWithHome("127.0.0.1:8080", "key", home)
+
+	_, err := s.Disconnect("opencode", "mcpproxy")
+	if err == nil {
+		t.Fatal("an unreadable/malformed alternate candidate must surface an error, not a silent not_found")
+	}
+}
+
 func TestUndoOpencodeBackupTargetsItsOwnFileAfterDrift(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Setenv("LOCALAPPDATA", "")

--- a/internal/connect/opencode_jsonc_test.go
+++ b/internal/connect/opencode_jsonc_test.go
@@ -194,6 +194,111 @@ func TestConnectOpencodeCommentedJsoncRefusedSafely(t *testing.T) {
 	}
 }
 
+func TestUnmarshalLenientJSONEdgeCases(t *testing.T) {
+	t.Run("unterminated block comment is an error, not silently valid", func(t *testing.T) {
+		var data map[string]interface{}
+		if err := unmarshalLenientJSON([]byte(`{"mcp":{}} /* unterminated`), &data); err == nil {
+			t.Fatal("unterminated /* must not parse as valid JSONC")
+		}
+	})
+	t.Run("escaped quote inside string does not end string state", func(t *testing.T) {
+		var data map[string]interface{}
+		raw := []byte(`{"k": "quote \" then // not a comment", "n": 1}`)
+		if err := unmarshalLenientJSON(raw, &data); err != nil {
+			t.Fatalf("escaped-quote input failed: %v", err)
+		}
+		if data["k"] != `quote " then // not a comment` {
+			t.Fatalf("string mangled: %q", data["k"])
+		}
+	})
+	t.Run("line comment at EOF without newline", func(t *testing.T) {
+		var data map[string]interface{}
+		if err := unmarshalLenientJSON([]byte("{\"n\": 1} // trailing"), &data); err != nil {
+			t.Fatalf("EOF line comment failed: %v", err)
+		}
+	})
+}
+
+func TestDisconnectOpencodeCommentedJsoncRefusedWithoutBackup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Setenv("LOCALAPPDATA", "")
+	}
+	home := t.TempDir()
+	content := "{\n  // comments\n  \"mcp\": {\"mcpproxy\": {\"type\": \"remote\", \"url\": \"http://127.0.0.1:8080/mcp\"}}\n}\n"
+	writeOpencodeFile(t, home, "opencode.jsonc", content)
+	s := NewServiceWithHome("127.0.0.1:8080", "key", home)
+
+	_, err := s.Disconnect("opencode", "mcpproxy")
+	if err == nil {
+		t.Fatal("Disconnect must refuse a commented .jsonc")
+	}
+	entries, _ := os.ReadDir(opencodeDir(home))
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".bak.") {
+			t.Fatalf("refusal must not leave a backup behind, found %s", e.Name())
+		}
+	}
+}
+
+func TestDisconnectOpencodeFindsEntryInOtherCandidate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Setenv("LOCALAPPDATA", "")
+	}
+	home := t.TempDir()
+	// Entry written into opencode.json first; opencode.jsonc bootstrapped later
+	// (resolver now prefers it). Disconnect must still find and remove the entry.
+	writeOpencodeFile(t, home, "opencode.json",
+		`{"mcp":{"mcpproxy":{"type":"remote","url":"http://127.0.0.1:8080/mcp","enabled":true}}}`)
+	writeOpencodeFile(t, home, "opencode.jsonc", jsoncStub)
+	s := NewServiceWithHome("127.0.0.1:8080", "key", home)
+
+	res, err := s.Disconnect("opencode", "mcpproxy")
+	if err != nil || !res.Success {
+		t.Fatalf("Disconnect across candidates: err=%v res=%+v", err, res)
+	}
+	raw, _ := os.ReadFile(filepath.Join(opencodeDir(home), "opencode.json"))
+	var data map[string]interface{}
+	if err := json.Unmarshal(raw, &data); err != nil {
+		t.Fatal(err)
+	}
+	if mcp, _ := data["mcp"].(map[string]interface{}); mcp != nil {
+		if _, still := mcp["mcpproxy"]; still {
+			t.Fatal("entry still present in opencode.json after cross-candidate disconnect")
+		}
+	}
+}
+
+func TestUndoOpencodeBackupTargetsItsOwnFileAfterDrift(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Setenv("LOCALAPPDATA", "")
+	}
+	home := t.TempDir()
+	writeOpencodeFile(t, home, "opencode.json", `{"theme":"dark"}`)
+	s := NewServiceWithHome("127.0.0.1:8080", "key", home)
+
+	res, err := s.Connect("opencode", "mcpproxy", false)
+	if err != nil || !res.Success || res.BackupPath == "" {
+		t.Fatalf("connect: err=%v res=%+v", err, res)
+	}
+	backupName := filepath.Base(res.BackupPath)
+
+	// OpenCode upgrade bootstraps a .jsonc — resolver drift.
+	writeOpencodeFile(t, home, "opencode.jsonc", jsoncStub)
+
+	ures, err := s.Undo("opencode", "mcpproxy", backupName)
+	if err != nil || !ures.Success {
+		t.Fatalf("undo after drift must accept the opencode.json backup: err=%v res=%+v", err, ures)
+	}
+	raw, _ := os.ReadFile(filepath.Join(opencodeDir(home), "opencode.json"))
+	if string(raw) != `{"theme":"dark"}` {
+		t.Fatalf("opencode.json not restored to pre-connect content: %s", raw)
+	}
+	jsoncRaw, _ := os.ReadFile(filepath.Join(opencodeDir(home), "opencode.jsonc"))
+	if string(jsoncRaw) != jsoncStub {
+		t.Fatal("undo must not touch the unrelated opencode.jsonc")
+	}
+}
+
 func TestConnectOpencodeNoConfigMentionsBothCandidates(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Setenv("LOCALAPPDATA", "")

--- a/internal/connect/opencode_jsonc_test.go
+++ b/internal/connect/opencode_jsonc_test.go
@@ -1,0 +1,210 @@
+package connect
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Issue #922: recent OpenCode versions bootstrap ~/.config/opencode/opencode.jsonc
+// (not opencode.json). mcpproxy must detect, read, and write the file OpenCode
+// actually loads — preferring .jsonc, which shadows .json for the same keys.
+
+func opencodeDir(home string) string {
+	if runtime.GOOS == "windows" {
+		localAppData := os.Getenv("LOCALAPPDATA")
+		if localAppData == "" {
+			localAppData = filepath.Join(home, "AppData", "Local")
+		}
+		return filepath.Join(localAppData, "opencode")
+	}
+	return filepath.Join(home, ".config", "opencode")
+}
+
+func writeOpencodeFile(t *testing.T, home, name, content string) string {
+	t.Helper()
+	dir := opencodeDir(home)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+const jsoncStub = "{\n  \"$schema\": \"https://opencode.ai/config.json\"\n}\n"
+
+func TestOpencodeConfigPathResolution(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Setenv("LOCALAPPDATA", "")
+	}
+	cases := []struct {
+		name  string
+		files []string
+		want  string
+	}{
+		{"no files -> default .json for create-new", nil, "opencode.json"},
+		{"jsonc only -> jsonc", []string{"opencode.jsonc"}, "opencode.jsonc"},
+		{"json only -> json", []string{"opencode.json"}, "opencode.json"},
+		{"both -> jsonc (it shadows .json)", []string{"opencode.json", "opencode.jsonc"}, "opencode.jsonc"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			for _, f := range tc.files {
+				writeOpencodeFile(t, home, f, jsoncStub)
+			}
+			s := NewServiceWithHome("127.0.0.1:8080", "key", home)
+			got := s.configPath("opencode")
+			if filepath.Base(got) != tc.want {
+				t.Fatalf("configPath = %s, want basename %s", got, tc.want)
+			}
+			if filepath.Dir(got) != opencodeDir(home) {
+				t.Fatalf("configPath dir = %s, want %s", filepath.Dir(got), opencodeDir(home))
+			}
+		})
+	}
+}
+
+func TestConfigPathResolverLeavesOtherClientsAlone(t *testing.T) {
+	home := t.TempDir()
+	s := NewServiceWithHome("127.0.0.1:8080", "key", home)
+	if got, want := s.configPath("gemini"), ConfigPath("gemini", home); got != want {
+		t.Fatalf("gemini configPath = %s, want %s", got, want)
+	}
+}
+
+func TestUnmarshalLenientJSONComments(t *testing.T) {
+	raw := []byte(`{
+  // line comment
+  "$schema": "https://opencode.ai/config.json", /* block comment */
+  "note": "a // string with slashes and /* not a comment */",
+  "mcp": {
+    "x": { "url": "http://example/mcp", },
+  }
+}`)
+	var data map[string]interface{}
+	if err := unmarshalLenientJSON(raw, &data); err != nil {
+		t.Fatalf("unmarshalLenientJSON: %v", err)
+	}
+	if data["note"] != "a // string with slashes and /* not a comment */" {
+		t.Fatalf("string content mangled: %q", data["note"])
+	}
+	if _, ok := data["mcp"].(map[string]interface{})["x"]; !ok {
+		t.Fatal("nested key lost")
+	}
+}
+
+func TestConnectOpencodeJsoncOnly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Setenv("LOCALAPPDATA", "")
+	}
+	home := t.TempDir()
+	jsoncPath := writeOpencodeFile(t, home, "opencode.jsonc", jsoncStub)
+	s := NewServiceWithHome("127.0.0.1:8080", "key", home)
+
+	res, err := s.Connect("opencode", "mcpproxy", false)
+	if err != nil {
+		t.Fatalf("Connect on a .jsonc-only install must succeed: %v", err)
+	}
+	if !res.Success {
+		t.Fatalf("Connect not successful: %+v", res)
+	}
+	if res.ConfigPath != jsoncPath {
+		t.Fatalf("wrote to %s, want the existing %s", res.ConfigPath, jsoncPath)
+	}
+	// The entry must land INSIDE the .jsonc; no stray opencode.json created.
+	if _, err := os.Stat(filepath.Join(opencodeDir(home), "opencode.json")); !os.IsNotExist(err) {
+		t.Fatal("a stray opencode.json was created next to opencode.jsonc")
+	}
+	raw, _ := os.ReadFile(jsoncPath)
+	var data map[string]interface{}
+	if err := json.Unmarshal(raw, &data); err != nil {
+		t.Fatalf("rewritten .jsonc is not valid JSON: %v", err)
+	}
+	mcp, _ := data["mcp"].(map[string]interface{})
+	if _, ok := mcp["mcpproxy"]; !ok {
+		t.Fatalf("mcp.mcpproxy entry missing in %s: %s", jsoncPath, raw)
+	}
+	if data["$schema"] != "https://opencode.ai/config.json" {
+		t.Fatal("$schema stub key lost on rewrite")
+	}
+
+	// Detection: status must report the client as installed + connected.
+	st, err := s.GetStatus("opencode")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.Exists || !st.Connected {
+		t.Fatalf("GetStatus after connect: Exists=%v Connected=%v, want true/true", st.Exists, st.Connected)
+	}
+
+	// Disconnect must also target the .jsonc.
+	dres, err := s.Disconnect("opencode", "mcpproxy")
+	if err != nil || !dres.Success {
+		t.Fatalf("Disconnect: %v %+v", err, dres)
+	}
+}
+
+func TestGetAllStatusSeesJsoncOnlyInstall(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Setenv("LOCALAPPDATA", "")
+	}
+	home := t.TempDir()
+	writeOpencodeFile(t, home, "opencode.jsonc", jsoncStub)
+	s := NewServiceWithHome("127.0.0.1:8080", "key", home)
+	for _, st := range s.GetAllStatus() {
+		if st.ID == "opencode" {
+			if !st.Exists {
+				t.Fatal("GetAllStatus: opencode .jsonc-only install reported as not installed")
+			}
+			if filepath.Base(st.ConfigPath) != "opencode.jsonc" {
+				t.Fatalf("GetAllStatus ConfigPath = %s, want the existing opencode.jsonc", st.ConfigPath)
+			}
+			return
+		}
+	}
+	t.Fatal("opencode not in GetAllStatus")
+}
+
+func TestConnectOpencodeCommentedJsoncRefusedSafely(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Setenv("LOCALAPPDATA", "")
+	}
+	home := t.TempDir()
+	content := "{\n  // keep my comments\n  \"$schema\": \"https://opencode.ai/config.json\"\n}\n"
+	p := writeOpencodeFile(t, home, "opencode.jsonc", content)
+	s := NewServiceWithHome("127.0.0.1:8080", "key", home)
+
+	_, err := s.Connect("opencode", "mcpproxy", false)
+	if err == nil {
+		t.Fatal("Connect must refuse to rewrite a commented .jsonc (comments would be lost)")
+	}
+	if !strings.Contains(err.Error(), "comment") {
+		t.Fatalf("error should explain the comment refusal, got: %v", err)
+	}
+	after, _ := os.ReadFile(p)
+	if string(after) != content {
+		t.Fatal("commented .jsonc was modified despite the refusal")
+	}
+}
+
+func TestConnectOpencodeNoConfigMentionsBothCandidates(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Setenv("LOCALAPPDATA", "")
+	}
+	home := t.TempDir()
+	s := NewServiceWithHome("127.0.0.1:8080", "key", home)
+	_, err := s.Connect("opencode", "mcpproxy", false)
+	if err == nil {
+		t.Fatal("Connect with no OpenCode install must still refuse")
+	}
+	if !strings.Contains(err.Error(), "opencode.jsonc") || !strings.Contains(err.Error(), "opencode.json") {
+		t.Fatalf("refusal should name both probed files, got: %v", err)
+	}
+}

--- a/internal/connect/preview.go
+++ b/internal/connect/preview.go
@@ -54,7 +54,7 @@ func (s *Service) Preview(clientID, serverName string) (*ConnectPreview, error) 
 		serverName = defaultServerName
 	}
 
-	cfgPath := ConfigPath(clientID, s.homeDir)
+	cfgPath := s.configPath(clientID)
 	if cfgPath == "" {
 		return nil, fmt.Errorf("cannot determine config path for %s", clientID)
 	}

--- a/internal/connect/undo.go
+++ b/internal/connect/undo.go
@@ -68,8 +68,30 @@ func (s *Service) Undo(clientID, serverName, backupName string) (*ConnectResult,
 		if base != backupName {
 			return nil, fmt.Errorf("invalid backup name %q: must be a bare filename, not a path", backupName)
 		}
-		if !strings.HasPrefix(base, filepath.Base(cfgPath)+".bak.") {
+		// The allowlist of restorable basenames stays registry-derived. OpenCode
+		// has two candidate config files (#922): a backup made when connect
+		// targeted opencode.json must stay restorable to THAT file even if an
+		// opencode.jsonc has appeared since and the resolver now prefers it —
+		// so the restore target follows the backup's own basename.
+		allowed := []string{filepath.Base(cfgPath)}
+		if clientID == "opencode" {
+			allowed = nil
+			for _, p := range opencodeConfigCandidates(s.homeDir) {
+				allowed = append(allowed, filepath.Base(p))
+			}
+		}
+		matched := ""
+		for _, b := range allowed {
+			if strings.HasPrefix(base, b+".bak.") {
+				matched = b
+				break
+			}
+		}
+		if matched == "" {
 			return nil, fmt.Errorf("invalid backup name %q: not a backup of %s", backupName, filepath.Base(cfgPath))
+		}
+		if matched != filepath.Base(cfgPath) {
+			cfgPath = filepath.Join(filepath.Dir(cfgPath), matched)
 		}
 		backupPath = filepath.Join(filepath.Dir(cfgPath), base)
 	}

--- a/internal/connect/undo.go
+++ b/internal/connect/undo.go
@@ -49,7 +49,7 @@ func (s *Service) Undo(clientID, serverName, backupName string) (*ConnectResult,
 	if serverName == "" {
 		serverName = defaultServerName
 	}
-	cfgPath := ConfigPath(clientID, s.homeDir)
+	cfgPath := s.configPath(clientID)
 	if cfgPath == "" {
 		return nil, fmt.Errorf("cannot determine config path for %s", clientID)
 	}

--- a/internal/httpapi/connect_test.go
+++ b/internal/httpapi/connect_test.go
@@ -84,7 +84,7 @@ func TestHandleConnectClient_OpenCodeMissingConfigReturns400(t *testing.T) {
 	}
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
 	assert.False(t, resp.Success)
-	assert.Contains(t, resp.Error, "does not exist")
+	assert.Contains(t, resp.Error, "no OpenCode config found")
 }
 
 // TestHandleGetConnectStatus_IncludesAccessStateUnknown asserts the overall


### PR DESCRIPTION
Related #922

Fresh OpenCode installs (≥ ~1.18) bootstrap `~/.config/opencode/opencode.jsonc`, but mcpproxy only recognized `opencode.json` — so OpenCode showed as not installed and `mcpproxy connect opencode` refused.

## What
- **Path resolution**: a Service-level resolver targets whichever candidate exists, preferring `opencode.jsonc` (OpenCode loads it after `.json`, so it shadows the same keys — writing a new `.json` next to an existing `.jsonc` would be silently shadowed later). Static `ConfigPath` keeps the `.json` default for the create-new case. Wired through connect, disconnect, status (`GetStatus`/`GetAllStatus`), access classification, preview, undo, and doctor's denial probe.
- **JSONC parsing**: `unmarshalLenientJSON` strips `//` and `/* */` comments (string-aware) before the existing trailing-comma cleanup, so commented files still parse for detection/status.
- **Safe writes**: connect/disconnect refuse to rewrite a `.jsonc` that actually uses comments (mcpproxy re-serializes plain JSON, which would strip them) with a manual-edit hint. OpenCode's comment-free bootstrap stub rewrites safely — the primary broken case now just works.
- **Better refusal**: with no OpenCode config at all, the error names both probed files and the directory.
- docs/setup.md OpenCode section updated.

## Testing
- 8 new tests: candidate resolution (4 layouts), string-aware JSONC parsing, `.jsonc`-only connect→status→disconnect round-trip (asserts the entry lands **inside** the `.jsonc`, `$schema` preserved, no stray `opencode.json` created), commented-file refusal leaves the file byte-identical, `GetAllStatus` detection, both-candidate error message.
- `go test -race` on connect + httpapi green; golangci-lint v2 (CI config) 0 issues; `./scripts/test-api-e2e.sh` all passed.