### PR TITLE
docs(spec): spec 089 remote-access-tunnel (feature-flagged MVP) + roadmap epic

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,6 +42,7 @@ graph LR
   analytics_dashboard["Analytics dashboard as default page"]
   scanner_simplification["Scanner simplification (deterministic d…"]
   tpa_db["tpa-db: versioned TPA signature databas…"]
+  remote_access_tunnel["Remote access tunnel (feature-flagged M…"]
   telemetry_identity["Telemetry identity & data quality (mach…"]
   telemetry_v7_churn["Telemetry v7: honest funnel + churn ins…"]
 
@@ -50,6 +51,9 @@ graph LR
   ux_audit --> analytics_dashboard
   scanner_v2 --> scanner_simplification
   scanner_simplification --> tpa_db
+  tpa_db --> remote_access_tunnel
+  ux_audit --> remote_access_tunnel
+  analytics_dashboard --> remote_access_tunnel
   telemetry_identity --> telemetry_v7_churn
 
   classDef done fill:#1f7a1f,stroke:#0d3d0d,color:#ffffff;
@@ -57,7 +61,7 @@ graph LR
   classDef todo fill:#6e7781,stroke:#3d4248,color:#ffffff;
   class sandbox_isolation,scanner_v2,scanner_simplification done;
   class analytics_dashboard,telemetry_identity,telemetry_v7_churn in_progress;
-  class ux_audit,action_log_transparency,tpa_db todo;
+  class ux_audit,action_log_transparency,tpa_db,remote_access_tunnel todo;
 ```
 
 **Independent epics** (15) — no cross-epic prerequisites; each stands alone:
@@ -321,6 +325,37 @@ graph LR
 | Signature DB format + loader (versioned, signed, bundled default) | ⚪ Todo | — |
 | Seed corpus: catalog known public TPA campaigns/patterns into the DB | ⚪ Todo | — |
 | Out-of-band refresh (offline-friendly: manual file drop + optional fetch), eval-gated | ⚪ Todo | — |
+
+</details>
+
+<details>
+<summary>⚪ Remote access tunnel (feature-flagged MVP, spec 089) — Todo · P2</summary>
+
+> One-button Web UI exposure of /mcp via external tunnel binary (cloudflared quick tunnel first) so Claude custom connectors (all tiers incl. Free, syncs to iOS/Android) can reach local MCP servers (e.g. Obsidian) — behind a feature flag, off by default, mandatory OAuth 2.1+PKCE+DCR gate, per-server exposure allowlist, remote-origin activity logging. Research: docs/research/remote-access-tunnel-research-2026-07-29.html (25/25 claims verified; niche unoccupied — Docker MCP Gateway lacks it). Sequenced after tpa-db (+ shipped scanner work 086-088), macOS tray redesign (ux-audit) and analytics-dashboard per owner decision 2026-07-29. No hosted relay/payments in MVP.
+
+Spec: [089-remote-access-tunnel](./specs/089-remote-access-tunnel/)
+
+```mermaid
+graph LR
+  tunnel_oauth_gate["OAuth 2.1 authorization-server gate for tunne…"]
+  tunnel_orchestration["cloudflared quick-tunnel orchestration (detec…"]
+  tunnel_exposure_allowlist["Per-server exposure allowlist (default none;…"]
+  tunnel_webui_tray["Web UI open/close button + URL/QR/instruction…"]
+
+  tunnel_oauth_gate --> tunnel_exposure_allowlist
+  tunnel_orchestration --> tunnel_webui_tray
+  tunnel_exposure_allowlist --> tunnel_webui_tray
+
+  classDef todo fill:#6e7781,stroke:#3d4248,color:#ffffff;
+  class tunnel_oauth_gate,tunnel_orchestration,tunnel_exposure_allowlist,tunnel_webui_tray todo;
+```
+
+| Task | Status | Refs |
+| --- | --- | --- |
+| OAuth 2.1 authorization-server gate for tunnel-origin traffic (PKCE, DCR, Anthropic callback allowlist, token lifecycle/revocation) | ⚪ Todo | — |
+| cloudflared quick-tunnel orchestration (detect/launch/supervise/parse URL) + feature flag + never-auto-start | ⚪ Todo | — |
+| Per-server exposure allowlist (default none; quarantined non-exposable; hot-reload) | ⚪ Todo | — |
+| Web UI open/close button + URL/QR/instructions + warning banner; tray active-state indicator; remote-origin activity marker | ⚪ Todo | — |
 
 </details>
 
@@ -636,6 +671,7 @@ graph LR
 | Web UI + macOS app UX audit | Todo | P0 | — |  |  |
 | Action log / transparency — info at a glance | Todo | P1 | — |  |  |
 | tpa-db: versioned TPA signature database for the offline scanner | Todo | P1 | — |  |  |
+| Remote access tunnel (feature-flagged MVP, spec 089) | Todo | P2 | — | [089-remote-access-tunnel](./specs/089-remote-access-tunnel/) |  |
 | Planning/docs truth automation | Todo | P2 | — |  |  |
 | Security gateway Tracks C/D (per-arg least-privilege + signature provenance) | Todo | P3 | — | [054-mcp-security-gateway](./specs/054-mcp-security-gateway/) |  |
 | Discovery-quality eval harness (Spec 065 second half) | Todo | P3 | — | [065-evaluation-foundation](./specs/065-evaluation-foundation/) |  |
@@ -754,3 +790,4 @@ Legend: `shipped` ≥95% checked · `in-flight` 1–94% · `drafted` 0% · `—`
 | [086-tpa-scanner-approval](./specs/086-tpa-scanner-approval/) | — | — |
 | [087-tpa-daily-refresh](./specs/087-tpa-daily-refresh/) | — | — |
 | [088-scanner-trust-ui](./specs/088-scanner-trust-ui/) | `shipped` | 29/29 (100%) |
+| [089-remote-access-tunnel](./specs/089-remote-access-tunnel/) | — | — |

--- a/docs/research/remote-access-tunnel-research-2026-07-29.html
+++ b/docs/research/remote-access-tunnel-research-2026-07-29.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Удалённый доступ к mcpproxy: исследование (2026-07-29)</title>
+<style>
+  :root {
+    --bg: #ffffff; --fg: #1a1d23; --muted: #6b7280; --card: #f7f8fa;
+    --border: #e2e5ea; --accent: #2563eb; --ok: #15803d; --ok-bg: #ecfdf3;
+    --warn: #b45309; --warn-bg: #fffbeb; --bad: #b91c1c; --bad-bg: #fef2f2;
+    --info-bg: #eff6ff; --code-bg: #eef1f5;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #101318; --fg: #e5e8ee; --muted: #9aa3b2; --card: #181c24;
+      --border: #2a3140; --accent: #60a5fa; --ok: #4ade80; --ok-bg: #10281a;
+      --warn: #fbbf24; --warn-bg: #2a2210; --bad: #f87171; --bad-bg: #2a1414;
+      --info-bg: #14202f; --code-bg: #1e242f;
+    }
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; font-family: -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+         background: var(--bg); color: var(--fg); line-height: 1.6; }
+  .wrap { max-width: 960px; margin: 0 auto; padding: 2rem 1.25rem 4rem; }
+  h1 { font-size: 1.7rem; line-height: 1.3; margin: .2rem 0 .4rem; }
+  h2 { font-size: 1.25rem; margin: 2.2rem 0 .8rem; padding-bottom: .3rem; border-bottom: 1px solid var(--border); }
+  h3 { font-size: 1.05rem; margin: 1.4rem 0 .5rem; }
+  p { margin: .6rem 0; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .meta { color: var(--muted); font-size: .88rem; }
+  .badge { display: inline-block; font-size: .72rem; font-weight: 600; padding: .1rem .5rem;
+           border-radius: 999px; vertical-align: middle; white-space: nowrap; }
+  .b-ok   { color: var(--ok); background: var(--ok-bg); }
+  .b-warn { color: var(--warn); background: var(--warn-bg); }
+  .b-bad  { color: var(--bad); background: var(--bad-bg); }
+  .b-info { color: var(--accent); background: var(--info-bg); }
+  .card { background: var(--card); border: 1px solid var(--border); border-radius: 10px;
+          padding: 1rem 1.2rem; margin: 1rem 0; }
+  .verdict { border-left: 4px solid var(--ok); }
+  .warncard { border-left: 4px solid var(--warn); }
+  table { border-collapse: collapse; width: 100%; margin: .8rem 0; font-size: .92rem; }
+  .tablewrap { overflow-x: auto; }
+  th, td { border: 1px solid var(--border); padding: .45rem .6rem; text-align: left; vertical-align: top; }
+  th { background: var(--card); }
+  code { background: var(--code-bg); padding: .1rem .35rem; border-radius: 4px; font-size: .87em;
+         font-family: "SF Mono", ui-monospace, Menlo, Consolas, monospace; }
+  ul, ol { padding-left: 1.4rem; }
+  li { margin: .3rem 0; }
+  details { margin: .5rem 0; }
+  summary { cursor: pointer; font-weight: 600; }
+  .kpi-row { display: flex; flex-wrap: wrap; gap: .7rem; margin: 1rem 0; }
+  .kpi { flex: 1 1 130px; background: var(--card); border: 1px solid var(--border); border-radius: 10px;
+         padding: .7rem .9rem; text-align: center; }
+  .kpi .num { font-size: 1.5rem; font-weight: 700; }
+  .kpi .lbl { font-size: .78rem; color: var(--muted); }
+  .src { font-size: .82rem; color: var(--muted); margin-top: .4rem; }
+  blockquote { border-left: 3px solid var(--border); margin: .6rem 0; padding: .1rem 0 .1rem .9rem;
+               color: var(--muted); font-size: .92rem; }
+  .toc { font-size: .92rem; }
+  .toc a { display: inline-block; margin: .1rem 0; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<p class="meta">mcpproxy-go · deep-research · 29 июля 2026 · 104 агента · 22 источника · 109 извлечённых утверждений · 25 верифицировано (25 подтверждено, 0 опровергнуто)</p>
+<h1>Стоит ли встраивать в mcpproxy удалённый доступ к локальному инстансу?</h1>
+<p class="meta">«Кнопка в Web UI открывает защищённый туннель наружу» — чтобы Claude mobile (и другие клиенты) доставали до локальных MCP-серверов вроде Obsidian MCP.</p>
+
+<div class="card verdict">
+<h3 style="margin-top:0">Вердикт: <span class="badge b-ok">ПРОБУЕМ</span> — но как security-gated MVP, а не «голый туннель»</h3>
+<ul>
+<li><b>Спрос реален и подтверждён:</b> Claude custom connectors работают на <b>всех</b> тарифах, включая Free, и синхронизируются на iOS/Android — но требуют публично доступный HTTPS-endpoint со Streamable HTTP и OAuth 2.1. Localhost-mcpproxy без туннеля недостижим для Claude в принципе (подключается облако Anthropic, не телефон).</li>
+<li><b>Ниша не занята:</b> ngrok официально документирует себя как «MCP gateway», OpenAI выпустила собственный first-party Secure MCP Tunnel — а ближайший конкурент Docker MCP Gateway такой функции не имеет при открытом запросе от пользователей (issue #503).</li>
+<li><b>Планка безопасности жёсткая:</b> в интернете уже тысячи неаутентифицированных MCP-серверов (Censys: 12,5 → 21+ тыс.). Фича обязана быть off-by-default, per-server, с <b>невыключаемым</b> OAuth 2.1 + DCR на уровне самого mcpproxy.</li>
+<li><b>Монетизация напрямую — нет:</b> при 100–300 DAU платящих будет единицы (~1–15 чел., $10–150/мес — оценка, см. §7); бесплатные Cloudflare Tunnel / Tailscale Funnel убивают ценность платного relay. Ценность фичи — <b>рост и дифференциация</b>, мостик к монетизации позже, если появится массовый спрос.</li>
+<li><b>Рекомендуемый MVP — архитектура (a):</b> UX-обёртка над внешним туннелем (cloudflared / Tailscale Funnel; опц. zrok SDK / tsnet как embed-вариант), спереди — собственный обязательный OAuth-гейт mcpproxy. Свой relay-бэкенд и юрлицо — не сейчас.</li>
+</ul>
+</div>
+
+<div class="kpi-row">
+  <div class="kpi"><div class="num">25/25</div><div class="lbl">утверждений подтверждено (3-голосная адверсариальная проверка)</div></div>
+  <div class="kpi"><div class="num">0</div><div class="lbl">опровергнуто</div></div>
+  <div class="kpi"><div class="num">5</div><div class="lbl">направлений поиска</div></div>
+  <div class="kpi"><div class="num">22</div><div class="lbl">источника (Anthropic, OpenAI, NSA, Censys, Trend Micro, CSA…)</div></div>
+</div>
+
+<div class="card toc">
+<b>Содержание:</b><br>
+<a href="#demand">1. Спрос: что могут мобильные AI-клиенты</a> ·
+<a href="#tech">2. Технические требования</a> ·
+<a href="#competitors">3. Прецеденты и конкуренты</a> ·
+<a href="#security">4. Безопасность: масштаб проблемы</a> ·
+<a href="#localfirst">5. Не противоречит ли local-first?</a> ·
+<a href="#assets">6. Что уже есть в mcpproxy</a> ·
+<a href="#arch">7. Архитектурные варианты и экономика</a> ·
+<a href="#mvp">8. Рекомендация: MVP по фазам</a> ·
+<a href="#open">9. Открытые вопросы и оговорки</a> ·
+<a href="#method">10. Методология и источники</a>
+</div>
+
+<h2 id="demand">1. Спрос: что реально могут мобильные AI-клиенты <span class="badge b-ok">верифицировано 3-0</span></h2>
+
+<h3>Claude — сильная и фактически единственная цель сегодня</h3>
+<ul>
+<li>Custom connectors через remote MCP доступны на <b>всех тарифах</b>: Free (лимит — 1 коннектор), Pro, Max, Team, Enterprise; и во всех клиентах: claude.ai web, Claude Desktop, Cowork, <b>iOS/Android</b>. Проверено дословно на живой странице поддержки 29.07.2026.</li>
+<li>Нюанс UX: добавить коннектор <b>с телефона нельзя</b> — настройка только на claude.ai web, затем коннектор синхронизируется на мобильные. На Team/Enterprise добавлять могут только Owners.</li>
+<li><b>Туннель — необходимость, а не удобство:</b> к MCP-серверу подключается <b>облако Anthropic</b> (не устройство пользователя), поэтому endpoint должен быть достижим из интернета с IP-диапазонов Anthropic. Localhost, LAN, корпоративный VPN и «обычный» Tailscale (без Funnel) — не работают. Локальные stdio-серверы из <code>claude_desktop_config.json</code> живут только в Claude Desktop и недоступны в web/mobile.</li>
+<li>Это ровно тот сценарий, который нужен Algis'у: <b>Obsidian MCP с телефона</b> — сейчас недостижим без туннеля, и встроенного решения у Anthropic нет (открытый feature request на Tailscale-only connectivity это подтверждает).</li>
+</ul>
+
+<h3>ChatGPT — слабая цель <span class="badge b-warn">medium confidence</span></h3>
+<ul>
+<li>Кастомные MCP apps/connectors: <b>«Are MCP apps available on mobile? No — web only»</b> (дословно из FAQ OpenAI, июль 2026). Доступ только на web, за developer mode / планами Business-Enterprise-Edu.</li>
+<li>Для локальных серверов OpenAI предлагает собственный <b>Secure MCP Tunnel</b> (май 2026) — но он требует Platform-org доступа, ориентирован на enterprise, не consumer one-click. Т.е. OpenAI сама подтверждает паттерн, но не закрывает consumer-нишу.</li>
+</ul>
+<p class="src">Источники: <a href="https://support.claude.com/en/articles/11175166-get-started-with-custom-connectors-using-remote-mcp">support.claude.com #11175166</a> · <a href="https://claude.com/docs/connectors/building">claude.com/docs/connectors/building</a> · <a href="https://help.openai.com/en/articles/12584461-developer-mode-apps-and-full-mcp-connectors-in-chatgpt-beta">help.openai.com #12584461</a> · <a href="https://developers.openai.com/api/docs/guides/secure-mcp-tunnels">OpenAI Secure MCP Tunnels</a></p>
+
+<h2 id="tech">2. Технические требования клиентского пути <span class="badge b-ok">верифицировано</span></h2>
+<div class="tablewrap"><table>
+<tr><th>Требование</th><th>Детали</th><th>Статус в mcpproxy</th></tr>
+<tr><td>Транспорт</td><td>Streamable HTTP (легаси HTTP+SSE депрекируется)</td><td><span class="badge b-ok">есть</span> — <code>/mcp</code> уже Streamable HTTP</td></tr>
+<tr><td>Публичная достижимость</td><td>HTTPS-endpoint, доступный с IP-диапазонов Anthropic</td><td><span class="badge b-bad">нет</span> — нужен туннель (предмет фичи)</td></tr>
+<tr><td>Авторизация</td><td>OAuth 2.1-сервер по MCP auth-спекам 2025-03-26 / 2025-06-18 / 2025-11-25, PKCE</td><td><span class="badge b-warn">частично</span> — есть OAuth-<i>клиент</i> (<code>internal/oauth</code>) и OAuth-логин в server edition (Spec 024); серверной роли для personal edition нет</td></tr>
+<tr><td>Dynamic Client Registration</td><td>DCR — zero-config default для Claude (ручные креды тоже поддерживаются)</td><td><span class="badge b-bad">нет</span> — надо реализовать</td></tr>
+<tr><td>Redirect URI allowlist</td><td><code>https://claude.ai/api/mcp/auth_callback</code> + <code>https://claude.com/…</code> (Anthropic предупреждает: домен может смениться) + loopback для Claude Code</td><td><span class="badge b-bad">нет</span></td></tr>
+<tr><td>Token lifecycle</td><td>Протокол не задаёт refresh/revocation/reuse-контроль — прокси должен сам управлять истечением/ротацией/отзывом (NSA)</td><td><span class="badge b-warn">частично</span> — есть agent tokens (HMAC-SHA256), JWT в server edition</td></tr>
+</table></div>
+
+<h2 id="competitors">3. Прецеденты и конкуренты</h2>
+<div class="tablewrap"><table>
+<tr><th>Игрок</th><th>Что делает</th><th>Вывод для mcpproxy</th></tr>
+<tr><td><b>ngrok</b> <span class="badge b-ok">3-0</span></td><td>Официальная документация «Using ngrok as your MCP gateway»: экспонирование локального MCP для OpenAI/Claude. Рекомендует лишь static bearer + IP-allowlist + rate limits.</td><td>Паттерн легитимизирован вендором №1. Их security-планка низкая — mcpproxy может её превзойти (полноценный OAuth 2.1 + DCR).</td></tr>
+<tr><td><b>OpenAI Secure MCP Tunnel</b> <span class="badge b-ok">3-0</span></td><td>First-party продукт (27.05.2026, open-source клиент): outbound-only HTTPS к OpenAI-hosted MCP endpoint. Требует Platform org.</td><td>Сильнейший сигнал валидности паттерна. Enterprise-ориентирован → consumer-desktop-ниша свободна.</td></tr>
+<tr><td><b>Docker MCP Gateway</b> <span class="badge b-warn">2-1</span></td><td>Чисто локальный прокси, туннеля/remote-exposure <b>нет</b>. Открытый feature request <a href="https://github.com/docker/mcp-gateway/issues/503">#503</a> «expose MCP servers remotely on public internet» — пользователи городят Cloudflare Tunnel + OAuth 2.1 руками.</td><td>Прямое свидетельство неудовлетворённого спроса; ближайший конкурент нишу не занял. (Proof-of-absence — перепроверить при реализации.)</td></tr>
+<tr><td>Smithery / Composio / Glama / LiteLLM</td><td colspan="2"><span class="badge b-warn">пробел покрытия</span> — по ним верифицированных данных не собрано (см. §9).</td></tr>
+</table></div>
+<p>Дополнительный контекст из fetch-фазы (не прошёл финальную верификацию): типовой «playbook» для деплоя кастомных агентов на Claude mobile рекомендует <b>облачный хостинг (~$15/мес Cloud Run)</b> и даже не упоминает туннели — то есть однокнопочный локальный туннель в mcpproxy закрыл бы дыру, которую сейчас затыкают платным облаком.</p>
+
+<h2 id="security">4. Безопасность: масштаб проблемы <span class="badge b-ok">верифицировано 3-0 (6 слитых утверждений)</span></h2>
+<div class="card warncard">
+<p style="margin-top:0"><b>Это главный риск фичи.</b> Незащищённая экспозиция MCP — массовый, измеряемый сканерами феномен:</p>
+<ul>
+<li><b>Censys:</b> 12 520 интернет-доступных MCP-сервисов / 8 758 IP / 56 стран (28.04.2026) → 21 000+ к 06.05.2026 (частично — расширение покрытия сканера). Возможности серверов перечислимы полностью неаутентифицированным клиентом; <b>~90 серверов</b> рекламировали <code>run_command</code>/<code>shell_exec</code>-класс инструментов = неаутентифицированный RCE.</li>
+<li><b>Trend Micro:</b> когорта выросла с 492 (июль 2025, все — без auth и шифрования) до 1 467; <code>execute_sql</code> на 70 хостах, Graphiti Agent Memory на 39, 3+ сервера <b>сливали медкарты пациентов</b>. (~74% когорты — cloud-hosted, но failure mode идентичен туннелированному локальному.)</li>
+<li><b>CSA / arXiv:</b> 7 973 каталогизированных открытых серверов, 40,55% — вовсе без аутентификации.</li>
+<li><b>Спека MCP:</b> «Authorization is OPTIONAL for MCP implementations» — на upstream-серверы полагаться нельзя.</li>
+<li><b>CVE-2025-6514</b> (из fetch-фазы, не в финальном сете): command injection в <code>mcp-remote</code>, 437 тыс.+ загрузок — даже мостики-посредники были дырявыми.</li>
+</ul>
+<p><b>Конвергенция рекомендаций (NSA CSI + Trend Micro):</b> OAuth-аутентификация клиентов + reverse-proxy/gateway-слой с authn/authz/логированием перед любым интернет-экспонированным MCP — <i>ровно роль mcpproxy</i>. NSA отдельно: MCP OAuth 2.1 bearer не задаёт lifecycle токенов → прокси обязан сам реализовать expiration/rotation/revocation. Практический мандат: <b>OAuth 2.1 + PKCE на воротах туннеля, невыключаемо, с proxy-managed token lifecycle</b>.</p>
+</div>
+<p class="src">Источники: <a href="https://censys.com/blog/mcp-servers-on-the-internet/">Censys</a> · <a href="https://www.trendmicro.com/vinfo/us/security/news/vulnerabilities-and-exploits/update-on-exposed-mcp-servers-the-threat-widens-to-the-cloud">Trend Micro</a> · <a href="https://media.defense.gov/2026/Jun/02/2003943289/-1/-1/0/CSI_MCP_SECURITY.PDF">NSA CSI (U/OO/6030316-26)</a> · <a href="https://labs.cloudsecurityalliance.org/agentic/agentic-mcp-security-best-practices-v1/">CSA</a> · arXiv:2605.22333 · <a href="https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization">MCP spec</a></p>
+
+<h2 id="localfirst">5. Не противоречит ли это local-first? <span class="badge b-ok">3-0</span></h2>
+<p><b>Нет — при правильной постановке.</b> NSA прямо рекомендует предпочитать локальные MCP-инстансы для приватных данных и пропускать внешние подключения через фильтрующие прокси/DLP. В продуктовых терминах фича — «<b>local-first с охраняемой дверью</b>», а не «cloud-first»:</p>
+<ul>
+<li>обработка и данные остаются локально; наружу — только явно выбранное;</li>
+<li>туннель строго <b>off-by-default</b>;</li>
+<li>экспонирование <b>per-server</b> (allowlist, least privilege): открыть наружу Obsidian MCP ≠ открыть весь прокси;</li>
+<li>на воротах — существующая машинерия mcpproxy: quarantine, sensitive-data detection, activity log, intent-варианты <code>call_tool_*</code>.</li>
+</ul>
+<p>Более того, это <i>усиливает</i> позиционирование: пользователь получает облачный UX без передачи данных в чьё-либо облако — данные проходят транзитом через туннель, но живут дома. (Оговорка воркфлоу: NSA-гайд написан для enterprise; перенос на продукт — интерпретация, не прямая валидация.)</p>
+
+<h2 id="assets">6. Что уже есть в mcpproxy (локальный аудит репозитория)</h2>
+<div class="tablewrap"><table>
+<tr><th>Актив</th><th>Где</th><th>Переиспользование для фичи</th></tr>
+<tr><td>OAuth-логин Google/GitHub/MS: PKCE, session cookie + JWT bearer для MCP</td><td>Server edition, Spec 024 (<code>internal/serveredition/auth/</code>)</td><td>Прямой прототип «пароль/OAuth как в SynapBus». Но код за build-тегом <code>server</code> — для personal edition нужен перенос/адаптация.</td></tr>
+<tr><td>OAuth 2.1-клиент + PKCE, координатор, refresh</td><td><code>internal/oauth/</code></td><td>Частично: нужна <i>серверная</i> роль (authorization server + DCR) — открытый вопрос объёма работ (§9).</td></tr>
+<tr><td>Agent tokens (<code>mcp_agt_</code>, HMAC-SHA256), API-ключи, <code>require_mcp_auth</code></td><td>Spec 028, core</td><td>Готовые скоупированные креды — быстрый фолбэк-механизм до полного OAuth.</td></tr>
+<tr><td>Quarantine + TPA-сканер, sensitive-data detection, activity log</td><td><code>internal/security/</code>, <code>internal/runtime/</code></td><td>Готовый «gateway-слой с authn/authz/логированием», который NSA/Trend Micro требуют перед экспонированием.</td></tr>
+<tr><td>Туннелей нет; официальная позиция — «BYO Tailscale/WireGuard/SSH»</td><td><code>docs/getting-started/installation.md:247</code></td><td>Фича закрывает разрыв между рекомендацией и однокнопочным UX.</td></tr>
+</table></div>
+
+<h2 id="arch">7. Архитектурные варианты и экономика</h2>
+<p><span class="badge b-warn">Внимание:</span> ни одно экономическое утверждение (цены туннелей, стоимость relay, конверсия free→paid) <b>не прошло верификацию воркфлоу</b> — до verify-фазы дошли только спрос/прецеденты/безопасность. Цифры ниже — из fetch-фазы (сырьё из блогов/прайс-страниц) и помечены как неверифицированные.</p>
+
+<h3>Цены туннелей <span class="badge b-warn">не верифицировано</span></h3>
+<div class="tablewrap"><table>
+<tr><th>Сервис</th><th>Free tier</th><th>Платно</th></tr>
+<tr><td>Cloudflare Tunnel</td><td>Бесплатно, без лимитов трафика для типового использования</td><td>—</td></tr>
+<tr><td>Tailscale (Funnel)</td><td>Personal: до 6 юзеров, 100 устройств — $0</td><td>$8–18 /юзер/мес</td></tr>
+<tr><td>ngrok</td><td>1 ГБ/мес, 3 endpoint'а, interstitial-страница</td><td>Hobbyist $8–10/мес (5 ГБ); PAYG от $20</td></tr>
+<tr><td>zrok (NetFoundry)</td><td>5 ГБ/<b>день</b>, 25 environments; open source, self-hostable, <b>Go SDK</b></td><td>hosted-тарифы NetFoundry</td></tr>
+<tr><td>Pinggy / Homeway / localtunnel</td><td>free (с ограничениями)</td><td>$2.5 / $2.49 / — в мес</td></tr>
+</table></div>
+<p><b>Вывод по ценам:</b> рынок туннелей переполнен (40+ open-source инструментов в awesome-tunneling), якорные цены — $0–2.5/мес. Продавать <i>сам туннель</i> за $5–10/мес против бесплатного Cloudflare — нежизнеспособно.</p>
+
+<h3>Сравнение архитектур</h3>
+<div class="tablewrap"><table>
+<tr><th></th><th>(a) BYO-туннель, UX-обёртка</th><th>(b) Собственный relay</th><th>(c) P2P / WebRTC</th></tr>
+<tr><td>Что это</td><td>mcpproxy оркестрирует cloudflared / Tailscale Funnel (или embed: zrok SDK, tsnet — оба Go-native, in-process, без root) + свой обязательный OAuth-гейт</td><td>Свой backend: relay-серверы, домены, abuse-handling, биллинг, юрлицо</td><td>Прямое соединение устройство↔устройство</td></tr>
+<tr><td>Стоимость для нас</td><td>~0 инфраструктуры; только код</td><td>Bandwidth + опс + юрлицо + приём платежей</td><td>Средняя (STUN/TURN)</td></tr>
+<tr><td>Стоимость для юзера</td><td>$0 (Cloudflare/Tailscale free)</td><td>Подписка $5–10</td><td>$0</td></tr>
+<tr><td>Совместимость с Claude</td><td><span class="badge b-ok">Да</span> — публичный HTTPS URL</td><td><span class="badge b-ok">Да</span></td><td><span class="badge b-bad">Нет</span> — соединение инициирует <b>облако Anthropic/OpenAI</b>, ему нужен публичный HTTPS endpoint; P2P до телефона не поможет для Claude app</td></tr>
+<tr><td>Вердикт</td><td><span class="badge b-ok">MVP</span></td><td><span class="badge b-warn">Только при доказанном спросе</span></td><td><span class="badge b-bad">Не для этого сценария</span></td></tr>
+</table></div>
+
+<h3>Прогноз для 100–300 DAU <span class="badge b-warn">оценка, не данные</span></h3>
+<ul>
+<li><b>Заинтересуются</b> (пользуются Claude web/mobile и хотят доступ к локальным серверам): по аналогии с активностью запросов у конкурентов и долей mobile-юзеров — порядка <b>15–30%</b> ≈ 15–90 человек попробуют.</li>
+<li><b>Заплатят $5–10/мес</b> за hosted relay при бесплатных альтернативах: типовая конверсия OSS free→paid 1–5% даёт <b>~1–15 платящих ≈ $10–150/мес</b> — не окупает ни backend, ни юрлицо.</li>
+<li><b>Но:</b> как <i>бесплатная</i> фича это сильный магнит роста («Obsidian с телефона через Claude за 2 клика» — готовый вирусный сценарий для блога/YouTube) и строительный блок будущей монетизации (mcpproxy Cloud / Teams), когда DAU вырастет на порядок. Мостик к монетизации — да; монетизация сейчас — нет.</li>
+</ul>
+
+<h2 id="mvp">8. Рекомендация: MVP по фазам</h2>
+<ol>
+<li><b>Фаза 0 — OAuth-ворота (пререквизит):</b> OAuth 2.1 authorization server в personal edition: DCR endpoint, PKCE, allowlist callback-доменов Claude (оба: claude.ai и claude.com), собственный lifecycle токенов (expiry/rotation/revocation). Максимум переиспользовать Spec 024 (server edition) и <code>internal/oauth</code>. Это ценность и без туннеля — любой сам-настроенный reverse proxy станет безопасным.</li>
+<li><b>Фаза 1 — BYO-туннель UX:</b> кнопка «Открыть удалённый доступ» в Web UI: детект/запуск <code>cloudflared</code> (quick tunnel — бесплатно, без аккаунта) или Tailscale Funnel; показ итогового URL + QR + пошаговая инструкция «добавьте коннектор на claude.ai web → появится на телефоне». Off-by-default, per-server allowlist экспонируемых серверов, баннер-предупреждение, всё в activity log.</li>
+<li><b>Фаза 2 — embed-вариант:</b> если внешний бинарь — трение, встроить zrok SDK (Go-first, self-hostable) или tsnet (нужно проверить Funnel-доступность через tsnet). Телеметрия использования фичи (opt-in) — она и ответит, есть ли спрос для фазы 3.</li>
+<li><b>Фаза 3 (условная) — hosted relay:</b> только при доказанном спросе (сотни активных туннелей): управляемые поддомены <code>*.mcpproxy.app</code>, биллинг, юрлицо. Не раньше.</li>
+</ol>
+<p>Перед стартом: спот-перепроверить proof-of-absence утверждения (Docker всё ещё без туннеля; у Claude web/mobile всё ещё нет локального пути) и актуальность callback-доменов — Anthropic явно предупреждает, что они могут смениться.</p>
+
+<h2 id="open">9. Открытые вопросы и оговорки воркфлоу</h2>
+<ul>
+<li><b>Экономика не верифицирована:</b> вопрос 4 исследования (цены, стоимость relay, конверсии, прецеденты Tailscale/Headscale/LocalCan) не покрыт подтверждёнными утверждениями — прогноз §7 опирается на неверифицированное сырьё и экспертную оценку.</li>
+<li><b>Пробел по MCP-экосистеме:</b> mcp-remote, Smithery, Composio, Glama, LiteLLM gateway — верифицированных данных нет; конкурентная картина подтверждена только для Docker MCP Gateway, ngrok и OpenAI.</li>
+<li><b>Объём работ по OAuth-серверу</b> (DCR + lifecycle) внутри mcpproxy не оценён — сколько из <code>internal/oauth</code> (клиентская роль) переиспользуемо, надо смотреть в коде.</li>
+<li><b>Волатильность вендорских политик:</b> все факты о клиентах (Free-tier коннекторы, mobile sync, web-only setup, отсутствие ChatGPT mobile, депрекация SSE) проверены на 29.07.2026 и могут измениться быстро. Если OpenAI выкатит consumer-туннель или Anthropic разрешит private-network connectivity — адресуемость фичи изменится.</li>
+<li><b>Нюансы измерений:</b> рост Censys частично от расширения сканера; когорта Trend Micro на ~74% cloud-hosted (аналогия, не идентичная популяция); «примерно половина» у CSA завышает измеренные 40,55%.</li>
+<li>Три вывода включают утверждения с голосованием 2-1 (пробел Docker, нюанс Cowork, DCR, ChatGPT mobile) — каждое сверено с первоисточником, но с оговорками.</li>
+</ul>
+
+<h2 id="method">10. Методология и источники</h2>
+<p class="meta">Deep-research workflow: декомпозиция на 5 направлений → 5 параллельных поисковых агентов → фетч 22 источников → извлечение 109 фальсифицируемых утверждений → адверсариальная верификация топ-25 (3 независимых «опровергателя» на утверждение, порог 2/3) → синтез. Итог: 25 подтверждено, 0 опровергнуто, 8 отброшено по бюджету. 104 агента, ~4,1 млн токенов, 13 мин.</p>
+<details><summary>Ключевые источники (22)</summary>
+<ul>
+<li><b>Первичные:</b> <a href="https://support.claude.com/en/articles/11175166-get-started-with-custom-connectors-using-remote-mcp">Claude Help: custom connectors</a>, <a href="https://claude.com/docs/connectors/building">Claude: building connectors</a>, <a href="https://help.openai.com/en/articles/12584461-developer-mode-apps-and-full-mcp-connectors-in-chatgpt-beta">OpenAI: MCP apps FAQ</a>, <a href="https://developers.openai.com/api/docs/guides/secure-mcp-tunnels">OpenAI Secure MCP Tunnels</a>, <a href="https://github.com/openai/tunnel-client">openai/tunnel-client</a>, <a href="https://ngrok.com/docs/using-ngrok-with/using-mcp">ngrok MCP gateway docs</a>, <a href="https://github.com/docker/mcp-gateway">docker/mcp-gateway</a> (+ <a href="https://github.com/docker/mcp-gateway/issues/503">issue #503</a>), <a href="https://censys.com/blog/mcp-servers-on-the-internet/">Censys</a>, <a href="https://www.trendmicro.com/vinfo/us/security/news/vulnerabilities-and-exploits/update-on-exposed-mcp-servers-the-threat-widens-to-the-cloud">Trend Micro</a>, NSA CSI «MCP Security» (media.defense.gov), <a href="https://labs.cloudsecurityalliance.org/agentic/agentic-mcp-security-best-practices-v1/">CSA best practices</a>, <a href="https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization">MCP spec: authorization</a>, <a href="https://tailscale.com/docs/features/tsnet">Tailscale tsnet</a></li>
+<li><b>Вторичные/блоги:</b> authzed.com (таймлайн MCP-инцидентов, CVE-2025-6514), practical-devsecops.com, nomadlab (Tailscale vs Cloudflare vs ngrok 2026), pinggy.io, instatunnel.my (zrok), thenewstack.io (туннель для локального MCP), <a href="https://github.com/anderspitman/awesome-tunneling">awesome-tunneling</a>, blog.openziti.io (zrok SDK), medium.com (MCP playbook для Claude mobile), GitHub issues anthropics/claude-ai-mcp</li>
+<li><b>Устаревшие URL:</b> claude.com/docs/connectors/faq → 404 (контент сверен на support.claude.com); NSA PDF блокируется Akamai для не-браузеров (сверено через зеркало media.defense.gov); Trend Micro отдаёт 403 на прямой fetch (сверено по индексированным выдержкам).</li>
+</ul>
+</details>
+
+<p class="meta" style="margin-top:2rem">Отчёт сгенерирован Claude Code (deep-research workflow, 104 агента) · 29 июля 2026 · файл: docs/research/remote-access-tunnel-research-2026-07-29.html</p>
+
+</div>
+</body>
+</html>

--- a/roadmap.yaml
+++ b/roadmap.yaml
@@ -313,6 +313,31 @@ epics:
         status: todo
         depends_on: [tpa-db-format]
 
+  - id: remote-access-tunnel
+    title: Remote access tunnel (feature-flagged MVP, spec 089)
+    status: todo
+    priority: P2
+    spec: specs/089-remote-access-tunnel
+    depends_on: [tpa-db, ux-audit, analytics-dashboard]
+    note: "One-button Web UI exposure of /mcp via external tunnel binary (cloudflared quick tunnel first) so Claude custom connectors (all tiers incl. Free, syncs to iOS/Android) can reach local MCP servers (e.g. Obsidian) — behind a feature flag, off by default, mandatory OAuth 2.1+PKCE+DCR gate, per-server exposure allowlist, remote-origin activity logging. Research: docs/research/remote-access-tunnel-research-2026-07-29.html (25/25 claims verified; niche unoccupied — Docker MCP Gateway lacks it). Sequenced after tpa-db (+ shipped scanner work 086-088), macOS tray redesign (ux-audit) and analytics-dashboard per owner decision 2026-07-29. No hosted relay/payments in MVP."
+    tasks:
+      - id: tunnel-oauth-gate
+        title: "OAuth 2.1 authorization-server gate for tunnel-origin traffic (PKCE, DCR, Anthropic callback allowlist, token lifecycle/revocation)"
+        status: todo
+        depends_on: []
+      - id: tunnel-orchestration
+        title: "cloudflared quick-tunnel orchestration (detect/launch/supervise/parse URL) + feature flag + never-auto-start"
+        status: todo
+        depends_on: []
+      - id: tunnel-exposure-allowlist
+        title: "Per-server exposure allowlist (default none; quarantined non-exposable; hot-reload)"
+        status: todo
+        depends_on: [tunnel-oauth-gate]
+      - id: tunnel-webui-tray
+        title: "Web UI open/close button + URL/QR/instructions + warning banner; tray active-state indicator; remote-origin activity marker"
+        status: todo
+        depends_on: [tunnel-orchestration, tunnel-exposure-allowlist]
+
   # ── TELEMETRY-DRIVEN REPLAN (2026-07-02) ──────────────────────────────────
   - id: upgrade-nudge
     title: Upgrade awareness & guided update

--- a/specs/089-remote-access-tunnel/checklists/requirements.md
+++ b/specs/089-remote-access-tunnel/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Remote Access Tunnel (MVP, feature-flagged)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-29
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Named technologies that DO appear (cloudflared/Cloudflare quick tunnel, Tailscale Funnel, OAuth 2.1/PKCE/DCR, Anthropic callback domains, Streamable HTTP) are **externally imposed interface constraints** — they define what the outside world (Claude clients, tunnel providers, MCP auth specs) requires, not internal implementation choices; per spec-kit convention such protocol/vendor constraints belong in the spec.
+- No [NEEDS CLARIFICATION] markers: the three candidate ambiguities (provider choice, ephemeral vs stable URLs, auth-code reuse) all have documented reasonable defaults in Assumptions, backed by the 2026-07-29 research report.
+- Roadmap placement (P2, after tpa-db / scanner / tray-redesign / analytics-dashboard) recorded in Assumptions per product owner decision 2026-07-29.
+- **Cross-model review (Codex)**: 3 rounds on 2026-07-29. R1: 4×P1 + 8×P2 + 2×P3 (OAuth bootstrap surface, ingress trust boundary, full-MCP-surface allowlist, redirect-URI validation, etc.) — all P1/P2 fixed except commit-conventions nit (template-mandated). R2: 2×P1 + 1×P2 (protected-resource metadata in pre-auth surface; token audience-binding vs URL churn; logging wording) — fixed. R3: **CLEAN**. Spec is ready for `/speckit.plan`.

--- a/specs/089-remote-access-tunnel/spec.md
+++ b/specs/089-remote-access-tunnel/spec.md
@@ -1,0 +1,174 @@
+# Feature Specification: Remote Access Tunnel (MVP, feature-flagged)
+
+**Feature Branch**: `089-remote-access-tunnel`
+**Created**: 2026-07-29
+**Status**: Draft
+**Input**: User description: "Remote Access Tunnel (MVP, feature-flagged): expose the local mcpproxy /mcp endpoint to the public internet through an external tunnel binary (cloudflared quick tunnel first; Tailscale Funnel as second provider) so cloud AI clients — primarily Claude custom connectors (claude.ai web + iOS/Android via web-side setup) — can reach local MCP servers like Obsidian MCP. One button in the Web UI opens/closes the tunnel; mandatory OAuth 2.1 gate; per-server exposure allowlist; feature flag, off by default."
+
+**Research basis**: [docs/research/remote-access-tunnel-research-2026-07-29.html](../../docs/research/remote-access-tunnel-research-2026-07-29.html) — deep-research run (25/25 claims adversarially verified). Key verified facts: Claude custom connectors are available on **all plan tiers including Free** and sync to iOS/Android, but Anthropic's **cloud** (not the user's device) originates the connection, so the MCP endpoint must be publicly reachable over HTTPS with Streamable HTTP; local stdio servers are unavailable in claude.ai web/mobile. NSA and Trend Micro guidance mandates gateway-layer authentication with proxy-managed token lifecycle for any internet-exposed MCP endpoint (thousands of unauthenticated MCP servers are already exposed and being scanned). Docker MCP Gateway — the closest competitor — has no such feature despite open user demand.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Expose my local MCP servers to Claude mobile in a few clicks (Priority: P1)
+
+A user runs mcpproxy on their desktop with local MCP servers configured (e.g., Obsidian MCP over their notes vault). They want to ask Claude on their phone questions that use those local tools. Today this is impossible: Claude's cloud cannot reach `127.0.0.1`. With this feature, the user enables the remote-access feature flag in config, opens the Web UI, picks which servers to expose, presses **"Open remote access"**, and gets a public HTTPS URL (plus QR code and step-by-step instructions for adding it as a custom connector on claude.ai web). After the one-time web-side setup, the connector appears in the Claude iOS/Android app and tools from the exposed local servers work from the phone.
+
+**Why this priority**: This is the entire point of the feature — the verified, unmet use case (Claude connectors work on every plan tier, but only against a public endpoint). Without this journey working end-to-end there is no feature.
+
+**Independent Test**: With the flag enabled, press the button in the Web UI, confirm a public URL is issued, add it as a custom connector on claude.ai, and successfully call an exposed server's tool from the Claude mobile app. Delivers the full "local files from my phone" value on its own.
+
+**Acceptance Scenarios**:
+
+1. **Given** the feature flag is enabled and at least one upstream server is marked as exposed, **When** the user presses "Open remote access" in the Web UI, **Then** within 30 seconds the UI shows a public HTTPS URL, a QR code, and connector-setup instructions, and the tunnel state is "active".
+2. **Given** an active tunnel, **When** a Claude client completes the authorization flow and calls `retrieve_tools`/`call_tool_*`, **Then** only tools from exposed servers are visible/callable and the calls succeed end-to-end.
+3. **Given** an active tunnel, **When** the user presses "Close remote access" (or shuts down mcpproxy), **Then** the tunnel process terminates, the public URL stops being served by the proxy (requests to it no longer reach mcpproxy), and the UI/tray state returns to "inactive".
+4. **Given** the feature flag is disabled (default), **When** the user opens the Web UI or queries the API, **Then** no remote-access UI, endpoints, or tunnel behavior are present — behavior is identical to today.
+
+---
+
+### User Story 2 - Remote endpoint is locked by mandatory authentication (Priority: P1)
+
+A security-conscious user (and the project itself) must be guaranteed that opening the tunnel never exposes an unauthenticated MCP endpoint to the internet. The tunneled endpoint requires every client to complete an OAuth 2.1 authorization flow (with PKCE and Dynamic Client Registration so Claude's zero-config connector setup works); unauthenticated requests through the tunnel are rejected. The user authorizes the connector by logging in with a local credential shown/configured in the Web UI. Tokens expire, can be rotated, and can be revoked from the Web UI ("disconnect this client").
+
+**Why this priority**: Non-negotiable safety requirement. Research documented thousands of unauthenticated MCP servers already exposed and scanned (including shell-exec tools and leaked personal records); NSA/Trend Micro guidance converges on a mandatory gateway-layer auth with proxy-managed token lifecycle. Shipping a bare tunnel would be a reputational disaster for a security-focused proxy.
+
+**Independent Test**: With an active tunnel, issue unauthenticated MCP requests to the public URL and confirm rejection; complete the OAuth flow and confirm access; revoke the client and confirm subsequent requests are rejected. Testable without any Claude client (any MCP-capable HTTP client suffices).
+
+**Acceptance Scenarios**:
+
+1. **Given** an active tunnel, **When** an MCP request arrives through the tunnel without valid authorization, **Then** it is rejected with a standards-compliant auth challenge and no MCP payload is served (no tool listing, no tool calls, no server metadata).
+2. **Given** a Claude connector performing zero-config setup, **When** it registers dynamically and completes the authorization flow (with the user approving via local login), **Then** it receives a token accepted only through the tunnel origin, scoped to exposed servers.
+3. **Given** an authorized remote client, **When** the user revokes its access in the Web UI, **Then** its tokens stop working within one minute without restarting mcpproxy — including for already-established sessions: the next message on any open session is refused.
+4. **Given** an issued token past its expiry, **When** it is used, **Then** the request is rejected and the client must re-authorize (or refresh, if a refresh path is granted).
+5. **Given** any configuration attempt to disable authentication on the tunneled endpoint, **Then** no such configuration exists — there is no supported way to run the tunnel without the auth gate (local `/mcp` behavior on localhost remains unchanged).
+
+---
+
+### User Story 3 - Least-privilege exposure: I choose exactly which servers go remote (Priority: P2)
+
+The user has 15 upstream servers configured but only wants Obsidian MCP and a read-only weather server reachable remotely. In the Web UI they toggle "exposed via remote access" per server (default: none exposed). Remote clients see only the exposed subset; local clients continue to see everything. Quarantined servers cannot be exposed.
+
+**Why this priority**: Core least-privilege control that makes the feature compatible with mcpproxy's local-first, security-first identity. P2 only because the tunnel (US1) and the lock (US2) must exist first; exposure control is what makes it safe to use daily.
+
+**Independent Test**: Expose one of two servers; through the tunnel confirm search/list/call only reaches the exposed one while the local endpoint still reaches both.
+
+**Acceptance Scenarios**:
+
+1. **Given** servers A (exposed) and B (not exposed), **When** a remote client searches or lists tools, **Then** only A's tools appear; **When** it attempts to call a B tool by name, **Then** the call is refused.
+2. **Given** a quarantined server, **When** the user tries to mark it exposed, **Then** the action is blocked with an explanation.
+3. **Given** no servers exposed, **When** the user tries to open the tunnel, **Then** opening is blocked with an explanation (no public surface is created when nothing can be served).
+4. **Given** a server is un-exposed (or becomes quarantined) while the tunnel is active, **Then** remote visibility of its capabilities ends without restart, including for already-established sessions — the next remote message touching it is refused.
+
+---
+
+### User Story 4 - Full visibility of remote activity (Priority: P2)
+
+Every authenticated MCP request that arrives through the tunnel is recorded in the activity log marked with a "remote" origin, and passes through the same quarantine and sensitive-data detection pipeline as local traffic; rejected/unauthenticated probes are counted in bounded aggregate form rather than logged per request. The Web UI and tray clearly show when the tunnel is active (persistent indicator/warning), so the user can always tell their proxy is reachable from the internet, review what remote clients did, and spot anomalies.
+
+**Why this priority**: Transparency is the project's stated pillar and the compensating control that security guidance requires for internet-exposed endpoints. P2 because it hardens and audits journeys delivered by US1/US2.
+
+**Independent Test**: Make remote and local calls; verify the activity log distinguishes remote origin, sensitive-data detection fires on remote responses, and Web UI + tray show the active-tunnel indicator while open and clear it when closed.
+
+**Acceptance Scenarios**:
+
+1. **Given** an active tunnel, **When** a remote client calls a tool, **Then** the activity log entry carries a remote-origin marker (distinguishable and filterable) alongside the usual request correlation data.
+2. **Given** a remote tool response containing detectable sensitive data, **When** it flows through the proxy, **Then** the sensitive-data detection behaves exactly as for local traffic (same detections, same logging).
+3. **Given** the tunnel is active, **Then** the Web UI shows a persistent warning banner and the tray shows a distinct "remote access active" state; both clear when the tunnel closes.
+4. **Given** mcpproxy restarts, **Then** the tunnel does NOT auto-restart; remote access requires a fresh explicit user action (the exposure allowlist and flag persist, the live tunnel does not).
+
+---
+
+### Edge Cases
+
+- **Tunnel binary missing**: cloudflared (or the chosen provider binary) is not installed → the UI detects this before attempting to start, explains what is missing, and links/offers guidance to install it; no partial "active" state.
+- **Tunnel process dies unexpectedly** (network loss, binary crash, provider outage): state transitions to "error/closed" within seconds, UI/tray indicators update, an activity/log entry records the termination; no silent zombie "active" display.
+- **Provider URL churn**: quick tunnels issue a new random URL each start → instructions must warn that closing/reopening changes the URL and the Claude connector must be updated; the UI surfaces the current URL as the single source of truth.
+- **Claude callback domain changes**: the authorization redirect allowlist covers both documented Anthropic callback domains, and the research notes Anthropic reserves the right to change them → allowlist must be maintainable via configuration without a release.
+- **Clock skew / long-lived sessions**: token expiry validation must tolerate reasonable clock skew while still enforcing expiry.
+- **Flag disabled while tunnel active**: config hot-reload turns the feature flag off → tunnel is torn down immediately, remote tokens stop being accepted.
+- **Concurrent open attempts**: pressing "Open" twice, or opening from two browser tabs → exactly one tunnel process; second request returns the existing state.
+- **Local API surface**: the tunnel must forward only the MCP endpoint plus the enumerated authorization surface (discovery metadata, DCR, authorize/consent, token) — the REST management API, Web UI, and events stream must NOT be reachable through the tunnel.
+- **Rate abuse**: a remote client hammering the endpoint (or an internet scanner probing the public URL) must not exhaust local resources — throttling applies to tunnel-origin traffic, and auth challenges are cheap (no upstream work before authorization).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001 (Feature flag)**: The entire capability MUST be gated behind a configuration feature flag, default **off**. With the flag off: no remote-access UI elements, no additional API surface, no tunnel processes, no OAuth-server endpoints — observable behavior identical to current releases.
+- **FR-002 (Explicit start, never auto-start)**: Remote access MUST start only on explicit user action and MUST NOT persist across proxy restarts. Stopping mcpproxy MUST terminate the tunnel.
+- **FR-003 (External tunnel orchestration)**: The system MUST establish public reachability by orchestrating an external tunnel provider binary; MVP acceptance is defined against Cloudflare quick tunnel only. Provider-specific behavior (availability detection, process launch/supervision/termination, public-URL discovery) MUST sit behind a single internal provider contract so a second provider (e.g. Tailscale Funnel) is an additive implementation of that contract; the contract itself is the testable artifact (MVP tests exercise it via the Cloudflare implementation).
+- **FR-004 (One-button UX)**: The Web UI MUST provide a single control to open/close remote access, displaying: current state (inactive / starting / active / error), the public URL, a QR code of the URL, and step-by-step instructions for adding the URL as a Claude custom connector (including the web-only setup + mobile sync caveat).
+- **FR-005 (Mandatory auth gate)**: Every MCP request arriving via the tunnel MUST require successful authorization before any MCP payload is served or any upstream work occurs. The gate implements an OAuth 2.1 authorization server with PKCE (S256 only) and Dynamic Client Registration compatible with the MCP authorization specifications supported by Claude clients (2025-03-26, 2025-06-18, 2025-11-25). Redirect-URI validation MUST use exact-match against registered URIs (no wildcard, suffix, or prefix matching), HTTPS-only (loopback excepted per OAuth 2.1), pre-seeded with both documented Anthropic callback URIs and maintainable via configuration. Authorization codes MUST be single-use and bound to the requesting client, redirect URI, and PKCE verifier. There MUST be no configuration that disables this gate while the tunnel is active.
+- **FR-006 (User-approved authorization ceremony)**: Completing an authorization grant MUST require explicit user approval on a consent page that identifies the requesting client and the currently exposed servers, protected by a proxy-managed credential. The credential MUST be generated (never a default), MUST meet a minimum entropy bar, MUST be rotatable from the Web UI, and the consent flow MUST have brute-force throttling and CSRF protection. The consent page MAY be served through the tunnel (that is how a cloud-initiated redirect reaches the user's browser), but approval is impossible without the credential. Silent/anonymous grants are prohibited.
+- **FR-007 (Token lifecycle & binding)**: The proxy MUST manage token lifecycle itself: bounded token lifetime, refresh path, per-client revocation from the Web UI effective within one minute, and persistence of user approvals across restarts. Two layers are distinct: (a) the **user approval/grant** (client registration + consent) persists across tunnel sessions and restarts; (b) **access tokens** are audience-bound to the canonical resource URI of the tunnel session that issued them (per the MCP authorization specs' resource-indicator requirement) and MUST NOT be accepted for a different resource URI — after the tunnel reopens under a new URL, clients MUST obtain new tokens for the new resource URI (re-authorization MAY proceed without a fresh consent ceremony because the approval persists, provided client identity is unchanged and the exposure set is re-evaluated at dispatch per FR-008). Closing the tunnel or disabling the feature flag MUST suspend acceptance of all remote credentials (they resume only when remote access is explicitly reopened); revocation is permanent.
+- **FR-008 (Per-server exposure allowlist — full MCP surface)**: Exposure MUST be opt-in per upstream server, default none. The allowlist governs the entire MCP capability surface — tools, resources, prompts, completions, subscriptions, and notifications — not only tool discovery/calls. Authorization MUST be evaluated against the current allowlist at the moment of each dispatch (effective access = granted client ∩ currently exposed servers), so expose/un-expose/quarantine transitions apply immediately, including to established sessions. Quarantined servers MUST be non-exposable. Changes take effect without restart.
+- **FR-009 (Scope of exposure)**: Tunnel-origin requests MAY reach only: (a) the MCP protocol endpoint (post-authorization, with pre-authorization requests answered by a 401 challenge carrying `resource_metadata` discovery information), and (b) the minimal authorization surface required to obtain access — OAuth protected-resource metadata (`.well-known/oauth-protected-resource`), authorization-server discovery metadata, DCR, authorization/consent, and token endpoints — plus nothing else. The 401-challenge and metadata-discovery bootstrap required by the supported MCP authorization specs MUST be covered by tests. REST management API, Web UI assets (other than the consent page of FR-006), and event streams MUST NOT be served to tunnel-origin requests. The pre-authorization surface MUST be explicitly enumerated in the design and covered by tests.
+- **FR-010 (Remote-origin activity, redacted & bounded)**: All tunnel-origin MCP activity MUST be recorded in the activity log with a distinct, filterable remote-origin marker, and MUST pass through existing quarantine and sensitive-data detection pipelines unchanged. Authorization material — authorization headers, codes, PKCE verifiers, tokens, cookies, credentials — MUST never be recorded. Rejected/unauthenticated probe traffic MUST be logged in bounded, aggregated form (count/rate, not per-request records) so scanners cannot exhaust storage.
+- **FR-011 (Status surfacing)**: Tunnel state MUST be visible in the Web UI (persistent warning banner while active) and in the tray (distinct state/indicator), driven by the same state source, updating within seconds of state changes.
+- **FR-012 (Failure honesty)**: The system MUST actively verify tunnel health (process liveness plus a periodic end-to-end reachability probe of the public URL) and MUST transition to a non-active state within one probe interval (≤30 seconds) of the tunnel process exiting or the public URL becoming unreachable, surfacing the reason and logging the event. No stale "active" indications.
+- **FR-013 (Abuse resistance, per endpoint)**: Tunnel-origin traffic MUST be rate-limited independently of local traffic, and unauthenticated probes MUST be rejected before any upstream server interaction occurs. The pre-authorization surface MUST have endpoint-specific protections: DCR registration quotas with automatic cleanup of never-approved registrations, per-endpoint rate limits on authorization/token requests, and request-size caps — each with defined limits verified by tests.
+- **FR-014 (Unspoofable ingress boundary)**: Tunnel-origin traffic MUST enter through a dedicated ingress (e.g., a separate listener used exclusively by the tunnel process) whose classification as "remote" cannot be forged or bypassed via request headers, host names, or paths. Remote traffic MUST never be able to reach the local endpoint's authentication semantics (API-key or socket bypass), and tests MUST prove that tunnel-origin requests cannot enter the local path.
+- **FR-015 (Documentation)**: User-facing documentation MUST cover: what the feature does and its risks, the security model (auth gate, allowlist, logging), provider prerequisites, the Claude connector setup walkthrough, and the URL-churn caveat of quick tunnels.
+
+### Key Entities
+
+- **Tunnel session**: The lifecycle of one remote-access activation — provider, public URL, state (inactive/starting/active/error/closed), start/stop timestamps, terminating reason.
+- **Remote client grant**: A dynamically registered client plus its user-approved authorization — client identity, token metadata (issue/expiry/rotation), revocation/suspension state. Effective access at any moment is this grant intersected with the *current* exposure allowlist (FR-008), never a snapshot.
+- **Exposure allowlist**: Per-upstream-server boolean "exposed via remote access", persisted in configuration; interacts with quarantine state (quarantined ⇒ non-exposable).
+- **Remote activity record**: Existing activity-log record extended with an origin marker (local vs remote) for filtering and audit.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user with the flag enabled can go from "no tunnel" to "working Claude custom connector on their phone" in under 10 minutes, with at most one external tool installation and no manual config-file editing.
+- **SC-002**: 100% of unauthenticated MCP requests through the tunnel are rejected without reaching any upstream server, in every shipped configuration (verified by automated tests — there is no reachable unauthenticated state).
+- **SC-003**: With the feature flag off, a full regression pass shows zero behavioral or API differences versus the prior release.
+- **SC-004**: Remote calls appear in the activity log with correct remote-origin marking in 100% of cases; sensitive-data detection parity between local and remote traffic is verified by tests.
+- **SC-005**: Tunnel state shown in Web UI and tray matches the real process state within 5 seconds across open/close/crash scenarios.
+- **SC-006**: Revoking a remote client renders its credentials unusable within 60 seconds without a proxy restart.
+- **SC-007**: Within 10 seconds of closing the tunnel (or stopping mcpproxy), requests to the public URL no longer reach the proxy (HTTP reachability, not DNS resolution, is the criterion).
+
+## Assumptions
+
+- **Provider choice**: Cloudflare quick tunnel is the first provider because it is free, requires no account for ephemeral URLs, and issues HTTPS URLs immediately; the research confirms free external tunnels undercut any hosted-relay approach for an MVP. Tailscale Funnel is the planned second provider, not required for MVP acceptance.
+- **Ephemeral URLs are acceptable for MVP**: quick-tunnel URLs change on every start; the UX mitigates via visible current-URL + instructions. Stable/named tunnels (user-owned Cloudflare account or domain) are a future enhancement, not MVP.
+- **Claude is the target client**: ChatGPT custom MCP apps are web-only and enterprise-gated today (verified 2026-07-29), so acceptance is defined against Claude connectors; nothing in the design may preclude other MCP-over-HTTP clients that implement the same auth specs.
+- **Auth reuse**: The personal edition currently has OAuth *client* code and the server edition has an OAuth login stack (Spec 024). The MVP brings a spec-compliant authorization-server role to the personal edition; how much is reused is a planning-phase decision, not a spec constraint.
+- **Local behavior unchanged**: localhost `/mcp` auth semantics (`require_mcp_auth`, socket bypass) are out of scope and unchanged; the mandatory gate applies to tunnel-origin traffic.
+- **Roadmap placement**: normal priority (P2), sequenced after TPA DB, security-scanner work, macOS tray redesign, and usage-graphs-as-dashboard (per product owner, 2026-07-29).
+
+## Out of Scope (MVP)
+
+- Own relay backend / hosted infrastructure, payments, legal entity — revisit only if opt-in telemetry shows sustained tunnel usage.
+- P2P/WebRTC transport (cannot serve Claude/ChatGPT: their clouds originate connections and require a public HTTPS endpoint).
+- Embedding tunnel libraries in-process (zrok SDK, tsnet) — future phase after MVP validates demand.
+- ChatGPT-specific support, stable custom domains, multi-user remote access (server edition already covers team scenarios).
+- Exposing the Web UI or REST API remotely.
+
+## Commit Message Conventions *(mandatory)*
+
+### Issue References
+- ✅ **Use**: `Related #[issue-number]` - Links the commit to the issue without auto-closing
+- ❌ **Do NOT use**: `Fixes #[issue-number]`, `Closes #[issue-number]`, `Resolves #[issue-number]` - These auto-close issues on merge
+
+**Rationale**: Issues should only be closed manually after verification and testing in production, not automatically on merge.
+
+### Co-Authorship
+- ❌ **Do NOT include**: `Co-Authored-By: Claude <noreply@anthropic.com>`
+- ❌ **Do NOT include**: "🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+
+**Rationale**: Commit authorship should reflect the human contributors, not the AI tools used.
+
+### Example Commit Message
+```
+feat(tunnel): [brief description of change]
+
+Related #[issue-number]
+
+## Changes
+- [Bulleted list of key changes]
+
+## Testing
+- [Test results summary]
+```


### PR DESCRIPTION
## Summary

Spec-only PR: feature specification for **remote access tunnel** (spec 089) plus the backing research report and a roadmap epic.

- **What**: one-button Web UI exposure of the local `/mcp` endpoint via an external tunnel binary (cloudflared quick tunnel first) so Claude custom connectors (all plan tiers incl. Free, synced to iOS/Android) can reach local MCP servers such as Obsidian MCP.
- **Hard requirements**: entire feature behind a config feature flag (default off — zero behavior change when off); tunnel never auto-starts; mandatory OAuth 2.1 + PKCE + DCR gate with audience-bound tokens and an unspoofable tunnel ingress boundary; per-server exposure allowlist covering the full MCP capability surface; remote-origin activity logging with credential redaction.
- **Research**: `docs/research/remote-access-tunnel-research-2026-07-29.html` — deep-research run, 25/25 claims adversarially verified (Claude connector requirements, exposed-MCP incident data, NSA/Trend Micro guidance, competitor gap).
- **Roadmap**: epic `remote-access-tunnel`, priority P2 (normal), `depends_on: [tpa-db, ux-audit, analytics-dashboard]` per owner decision 2026-07-29; out of scope for MVP: hosted relay, payments, P2P.

## Review

Cross-model review (Codex): 3 rounds — 6 P1 + 9 P2 findings fixed (OAuth bootstrap surface, ingress trust boundary, full-MCP-surface allowlist, redirect-URI validation, token audience-binding vs URL churn, logging redaction) → round 3 **CLEAN**. Details in `specs/089-remote-access-tunnel/checklists/requirements.md`.

## Testing

- Spec/docs only; no code paths touched.
- `python3 scripts/gen-roadmap.py` regenerates `ROADMAP.md` cleanly (pre-commit hook verified).