### PR TITLE
fix(storage): collect keys before deleting in ClearOAuthState

### DIFF
--- a/internal/storage/manager.go
+++ b/internal/storage/manager.go
@@ -1771,9 +1771,23 @@ func (m *Manager) ClearOAuthState(serverName string) error {
 			return fmt.Errorf("oauth token bucket not found")
 		}
 
+		// Collect the whole prefix range before deleting any of it. bbolt cursors
+		// are invalidated by mutations made during iteration ("Changing data while
+		// traversing with a cursor may cause it to be invalidated and return
+		// unexpected keys and/or values" — bbolt cursor.go): once any write in this
+		// transaction has materialised the leaf into a node, deleting through the
+		// cursor shifts the remaining entries under its index and Next() skips one.
+		// A key skipped here leaves an access token, a refresh token and the DCR
+		// client secret on disk after the user logged out, still reachable by
+		// PersistentTokenStore and RefreshManager.
 		prefix := []byte(serverName + "_")
+		var keys [][]byte
 		cursor := bucket.Cursor()
 		for k, _ := cursor.Seek(prefix); k != nil && bytes.HasPrefix(k, prefix); k, _ = cursor.Next() {
+			keys = append(keys, append([]byte(nil), k...))
+		}
+
+		for _, k := range keys {
 			if err := bucket.Delete(k); err != nil {
 				return err
 			}

--- a/internal/storage/manager_oauth_test.go
+++ b/internal/storage/manager_oauth_test.go
@@ -1,7 +1,9 @@
 package storage_test
 
 import (
+	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/oauth"
@@ -40,6 +42,84 @@ func TestManager_ClearOAuthState_RemovesHashedToken(t *testing.T) {
 
 	_, err = mgr.GetBoltDB().GetOAuthToken(serverKey)
 	require.Error(t, err)
+}
+
+// TestManager_ClearOAuthState_RemovesEveryPrefixedToken verifies that logout leaves
+// nothing behind when a server has accumulated many token records.
+//
+// A server accumulates one record per (name, URL) pair, because tokens are keyed by
+// oauth.GenerateServerKey(name, url). ClearOAuthState walks that prefix range with a
+// bbolt cursor; bbolt documents that mutating a bucket during iteration may invalidate
+// the cursor and skip keys (cursor.go). A skipped key here is not a cosmetic leak: the
+// records are plaintext JSON holding AccessToken, RefreshToken and the DCR ClientSecret,
+// and a survivor is still reachable by PersistentTokenStore/RefreshManager — the user
+// pressed "Logout" and stayed logged in.
+//
+// The record set is deliberately large enough to span many bbolt pages, and neighbouring
+// server names that sort either side of the target prefix must survive untouched.
+func TestManager_ClearOAuthState_RemovesEveryPrefixedToken(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "storage-clear-oauth-many-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	mgr, err := storage.NewManager(tmpDir, zap.NewNop().Sugar())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mgr.Close() })
+
+	const target = "demo"
+	const nTokens = 300
+
+	save := func(key, filler string) {
+		require.NoError(t, mgr.GetBoltDB().SaveOAuthToken(&storage.OAuthTokenRecord{
+			ServerName:   key,
+			AccessToken:  "access-" + filler,
+			RefreshToken: "refresh-" + filler,
+			ClientSecret: "secret-" + filler,
+		}))
+	}
+
+	// Legacy exact-name record. Key ordering in the bucket is:
+	//   dem_* < demo < demo-other_* < demoX_* < demo_* < demq_*
+	// so the legacy record and the neighbours sit immediately before the target
+	// range and share its first leaf page.
+	save(target, "")
+
+	// Neighbours that must NOT be touched: they sort around the "demo_" range but
+	// do not carry that prefix. Kept small so they share a page with the range.
+	neighbours := []string{}
+	for i := 0; i < 3; i++ {
+		for _, other := range []string{"dem", "demo-other", "demoX", "demq"} {
+			key := oauth.GenerateServerKey(other, fmt.Sprintf("https://example.com/%04d", i))
+			neighbours = append(neighbours, key)
+			save(key, "")
+		}
+	}
+
+	// Many hashed serverKey records for the same server: a server accumulates one
+	// per URL it has been pointed at. Sized so the range spans many leaf pages.
+	filler := strings.Repeat("t", 300)
+	targetKeys := make([]string, 0, nTokens)
+	for i := 0; i < nTokens; i++ {
+		key := oauth.GenerateServerKey(target, fmt.Sprintf("https://example.com/%04d", i))
+		targetKeys = append(targetKeys, key)
+		save(key, filler)
+	}
+
+	require.NoError(t, mgr.ClearOAuthState(target))
+
+	// Every record for the target server must be gone.
+	_, err = mgr.GetBoltDB().GetOAuthToken(target)
+	require.Error(t, err, "legacy exact-name token survived logout")
+	for _, key := range targetKeys {
+		_, err := mgr.GetBoltDB().GetOAuthToken(key)
+		require.Errorf(t, err, "token %q survived logout (access + refresh token and DCR secret still on disk)", key)
+	}
+
+	// Neighbouring servers must be untouched.
+	for _, key := range neighbours {
+		_, err := mgr.GetBoltDB().GetOAuthToken(key)
+		require.NoErrorf(t, err, "unrelated server token %q was destroyed by logout", key)
+	}
 }
 
 // TestBoltDB_UpdateOAuthClientCredentials_WithCallbackPort verifies that UpdateOAuthClientCredentials


### PR DESCRIPTION
## What this is

Hardening, not a live incident — and the report says so plainly.

`ClearOAuthState` deletes keys **inside a live bbolt cursor loop**, which bbolt documents as unsafe (`cursor.go:19`). A skipped key there means an OAuth token survives what the user experienced as a logout.

## Reproduction: negative, stated honestly

Nine probes, up to **120,000 keys** across depth-3 trees — delete-all, alternating, prefix-selective, 50 size combinations, variable-length keys — produced **zero skips**. The reason is in bbolt's source: a cursor created before any write in a transaction holds *page* refs, and `bucket.Delete` mutates a materialised *node*, never the page, so the walk iterates a stable pre-transaction snapshot.

## But the hazard is one line from arming

Two adversarial probes reproduced skips immediately: a `Put` before the cursor in the same transaction stranded 100 of 200 keys; a `Delete` before the cursor stranded 5 of 5000. **That second shape is exactly what you get by folding this function's legacy exact-name delete into its transaction** — an otherwise desirable atomicity improvement.

## Why fix it anyway

The keys hold **plaintext** `AccessToken`, `RefreshToken` and DCR `ClientSecret`. A survivor is not disk residue — it stays reachable by `PersistentTokenStore.GetToken` and `RefreshManager`, so the next connect silently re-authenticates with the old grant and the refresh scheduler keeps renewing it. The user pressed Logout and stayed logged in, with no UI signal. On server *removal* it is worse: the config entry is gone, so there is no affordance to log out again.

Collect-then-delete changes **nothing observable**: same key range, same order, same `cleared` count, same error and rollback semantics, same transaction boundary. It was also the odd one out — every other bulk delete in the package already collects first.

## On TDD, explicitly

A red-first test was not achievable: the current code is correct, so any test asserting correct behaviour passes before the change. Rather than fake a red, mutation-first was used — new test green on unmodified code, **red** on unfixed code under the realistic refactor (`token "demo_…" survived logout`), green with the fix under the same mutation, green after reverting it. The pre-existing two-key test stayed green throughout the red step; it never guarded this.

## Audit

25 cursor sites in `internal/storage`; only two mutate during iteration. The other — `enforceSessionRetention`, called from `CreateSession` *after* a `Put` in the same transaction — is the genuinely armed shape, so it was tested directly rather than reasoned about: survivors came back contiguous, so no skip. It is safe by pure geometry (the `Put` materialises the last leaf; retention deletes from the first), which would evaporate if the key scheme changed. Left unchanged and noted.

## Gates

`go build ./...` and `-tags server` OK · `go test ./internal/storage/... ./internal/oauth/...` pass · `golangci-lint` (v2, strict) **0 issues**.

## Follow-up not taken here

Logout is still non-atomic across two transactions; folding them is now *safe* (it is the mutation verified above) but changes observable behaviour, so it was kept out of a hardening change.