### PR TITLE
fix(eval): pin the D1 dataset's upstream servers, all seven

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -199,6 +199,25 @@ jobs:
             exit 1
           fi
 
+          # The count above only gates readiness; the corpus contract is the exact
+          # ID set. A same-count rename/substitution (or a 46th tool) must fail
+          # here, not silently skew recall against a frozen golden set.
+          curl -fsS -H "X-API-Key: $key" "$base/api/v1/tools" > "$RUNNER_TEMP/live-tools.json"
+          if ! python3 - "$DS/corpus_v1.tools.json" "$RUNNER_TEMP/live-tools.json" <<'PYEOF'
+          import json, sys
+          corpus = {t["tool_id"] for t in json.load(open(sys.argv[1]))["tools"]}
+          live_raw = (json.load(open(sys.argv[2])).get("data") or {}).get("tools", [])
+          live = {f"{t['server_name']}:{t['name']}" for t in live_raw}
+          missing, extra = sorted(corpus - live), sorted(live - corpus)
+          if missing or extra:
+              print(f"::error::live catalog does not match corpus_v1 exactly: missing={missing} extra={extra}")
+              sys.exit(1)
+          print(f"Catalog matches corpus_v1 exactly ({len(corpus)} canonical ids).")
+          PYEOF
+          then
+            exit 1
+          fi
+
           ( cd "$GITHUB_WORKSPACE/mcp-eval" && PYTHONPATH=src uv run python -m mcp_eval.cli retrieval \
             --corpus "$DS/corpus_v1.tools.json" \
             --golden "$DS/retrieval_golden_v1.json" \

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -175,11 +175,11 @@ jobs:
           # Wait for the FULL tool catalog before scoring: the retrieval index is
           # built from the connected servers' tools, and scoring a partially
           # indexed instance tanks recall (a ≥1-result check fires far too early).
-          # The 7 reference servers expose ~45 tools; require near-full + a short
+          # The 7 reference servers expose exactly 45 tools (pinned); require the full catalog + a short
           # settle for the index build. /api/v1/tools wraps as
           # {"success":true,"data":{"tools":[...]}}.
           ready=0
-          expected=44
+          expected=45
           for i in $(seq 1 60); do
             if ! kill -0 "$server_pid" 2>/dev/null; then
               echo "::error::mcpproxy process exited during startup"

--- a/specs/065-evaluation-foundation/datasets/README.md
+++ b/specs/065-evaluation-foundation/datasets/README.md
@@ -51,6 +51,40 @@ PYTHONPATH=src uv run python -m mcp_eval.cli retrieval \
   --base-url http://127.0.0.1:8092 --api-key eval-corpus-snapshot
 ```
 
+### Upstream version pinning (why the config is fully pinned)
+
+Every server in `snapshot-servers.config.json` pins an **exact** upstream version,
+and each `uvx` server additionally pins the MCP Python SDK via
+`--with mcp==<version>`. This is load-bearing, not cosmetic: the corpus, golden
+set and baseline are frozen, so a floating upstream silently redefines the
+universe the gate scores against, and the gate flakes whenever anyone publishes.
+
+That is exactly how it broke on 2026-07-28: the `mcp` SDK cut **2.0.0**, which
+renamed `McpError` → `MCPError` and removed the low-level `Server.list_tools` /
+`Server.list_resources` decorators. All four `uvx` servers (`fetch`, `git`,
+`time`, `sqlite`) declare only a lower bound (`mcp>=1.x`), so they resolved 2.0.0
+and crashed on import. Only the three `npx` servers connected — 24 tools instead
+of 45 — and D1 failed the catalog-readiness check.
+
+Current pins reproduce the frozen 45-tool corpus exactly (verified tool-for-tool):
+
+| Server | Pin |
+|--------|-----|
+| filesystem | `@modelcontextprotocol/server-filesystem@2026.7.10` |
+| memory | `@modelcontextprotocol/server-memory@2026.7.4` |
+| sequential-thinking | `@modelcontextprotocol/server-sequential-thinking@2026.7.4` |
+| git | `mcp-server-git==2026.7.10` + `mcp==1.29.0` |
+| fetch | `mcp-server-fetch==2026.7.10` + `mcp==1.29.0` |
+| time | `mcp-server-time==2026.7.10` + `mcp==1.29.0` |
+| sqlite | `mcp-server-sqlite==2025.4.25` + `mcp==1.29.0` |
+
+**When bumping a pin**, treat it as a corpus change: re-run the snapshot, diff the
+tool set, and if it moved, cut `corpus_v2` rather than editing `corpus_v1`.
+
+> Note: `mcpproxy serve --config <this file>` **rewrites the file in place**
+> (normalised key order + defaults). Copy it to a scratch path before booting a
+> core against it locally, or `git checkout` it afterwards.
+
 The golden set was seeded by intent and **hand-curated** for graded relevance and
 cross-server hard-negatives (e.g. `filesystem:search_files` vs `memory:search_nodes`;
 `sqlite:read_query` vs `filesystem:read_text_file`; `fetch:fetch` vs

--- a/specs/065-evaluation-foundation/datasets/README.md
+++ b/specs/065-evaluation-foundation/datasets/README.md
@@ -66,17 +66,36 @@ renamed `McpError` → `MCPError` and removed the low-level `Server.list_tools` 
 and crashed on import. Only the three `npx` servers connected — 24 tools instead
 of 45 — and D1 failed the catalog-readiness check.
 
-Current pins reproduce the frozen 45-tool corpus exactly (verified tool-for-tool):
+The pins are the **freeze-era versions** — the releases that were current when the
+corpus was frozen (2026-05-31) — not "latest at pin time". Pinning a later version
+reproduces a *different* universe: e.g. `server-filesystem@2026.7.10` drops
+`read_file` (44-tool catalog) and `server-sequential-thinking@2026.7.4` renames
+`sequentialthinking` → `sequential_thinking`, so two golden queries can never
+score and the gate passes only on threshold slack.
+
+Current pins reproduce the frozen 45-tool corpus exactly (verified tool-for-tool
+against a live `GET /api/v1/tools` snapshot):
 
 | Server | Pin |
 |--------|-----|
-| filesystem | `@modelcontextprotocol/server-filesystem@2026.7.10` |
-| memory | `@modelcontextprotocol/server-memory@2026.7.4` |
-| sequential-thinking | `@modelcontextprotocol/server-sequential-thinking@2026.7.4` |
-| git | `mcp-server-git==2026.7.10` + `mcp==1.29.0` |
-| fetch | `mcp-server-fetch==2026.7.10` + `mcp==1.29.0` |
-| time | `mcp-server-time==2026.7.10` + `mcp==1.29.0` |
-| sqlite | `mcp-server-sqlite==2025.4.25` + `mcp==1.29.0` |
+| filesystem | `@modelcontextprotocol/server-filesystem@2026.1.14` |
+| memory | `@modelcontextprotocol/server-memory@2026.1.26` |
+| sequential-thinking | `@modelcontextprotocol/server-sequential-thinking@2025.12.18` |
+| git | `mcp-server-git==2026.1.14` + `mcp==1.27.2` |
+| fetch | `mcp-server-fetch==2025.4.7` + `mcp==1.27.2` |
+| time | `mcp-server-time==2026.1.26` + `mcp==1.27.2` |
+| sqlite | `mcp-server-sqlite==2025.4.25` + `mcp==1.27.2` |
+
+**What the pins do and do not freeze.** Published package versions are immutable,
+and a server's tool list is defined by the server package's own code — so the
+corpus itself cannot drift under these pins. What still floats are *transitive*
+dependencies resolved at install time (notably the npm servers' `@modelcontextprotocol/sdk`
+semver ranges; there is no lockfile in an `npx`/`uvx` invocation). A breaking
+transitive publish therefore cannot silently alter the corpus, but it can crash a
+server at startup — which fails **loudly** via the catalog-readiness check
+(`expected=45` in `eval.yml`), the same way the SDK 2.0.0 incident did. Full
+hermeticity would need a lockfile-based install or prebuilt images; not worth it
+until this actually bites.
 
 **When bumping a pin**, treat it as a corpus change: re-run the snapshot, diff the
 tool set, and if it moved, cut `corpus_v2` rather than editing `corpus_v1`.

--- a/specs/065-evaluation-foundation/datasets/README.md
+++ b/specs/065-evaluation-foundation/datasets/README.md
@@ -92,8 +92,10 @@ corpus itself cannot drift under these pins. What still floats are *transitive*
 dependencies resolved at install time (notably the npm servers' `@modelcontextprotocol/sdk`
 semver ranges; there is no lockfile in an `npx`/`uvx` invocation). A breaking
 transitive publish therefore cannot silently alter the corpus, but it can crash a
-server at startup — which fails **loudly** via the catalog-readiness check
-(`expected=45` in `eval.yml`), the same way the SDK 2.0.0 incident did. Full
+server at startup — and either way the gate fails **loudly**: `eval.yml` waits for
+the full 45-tool catalog and then requires the live canonical ID set to match
+`corpus_v1.tools.json` exactly before scoring, so a crash, a rename, a dropped
+tool, or an extra tool all fail the job rather than silently skewing recall. Full
 hermeticity would need a lockfile-based install or prebuilt images; not worth it
 until this actually bites.
 

--- a/specs/065-evaluation-foundation/datasets/snapshot-servers.config.json
+++ b/specs/065-evaluation-foundation/datasets/snapshot-servers.config.json
@@ -10,7 +10,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@modelcontextprotocol/server-filesystem",
+        "@modelcontextprotocol/server-filesystem@2026.7.10",
         "/tmp"
       ],
       "oauth": null,
@@ -25,7 +25,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@modelcontextprotocol/server-memory"
+        "@modelcontextprotocol/server-memory@2026.7.4"
       ],
       "oauth": null,
       "enabled": true,
@@ -39,7 +39,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@modelcontextprotocol/server-sequential-thinking"
+        "@modelcontextprotocol/server-sequential-thinking@2026.7.4"
       ],
       "oauth": null,
       "enabled": true,
@@ -52,7 +52,9 @@
       "protocol": "stdio",
       "command": "uvx",
       "args": [
-        "mcp-server-git"
+        "--with",
+        "mcp==1.29.0",
+        "mcp-server-git==2026.7.10"
       ],
       "oauth": null,
       "enabled": true,
@@ -65,7 +67,9 @@
       "protocol": "stdio",
       "command": "uvx",
       "args": [
-        "mcp-server-fetch"
+        "--with",
+        "mcp==1.29.0",
+        "mcp-server-fetch==2026.7.10"
       ],
       "oauth": null,
       "enabled": true,
@@ -78,7 +82,9 @@
       "protocol": "stdio",
       "command": "uvx",
       "args": [
-        "mcp-server-time"
+        "--with",
+        "mcp==1.29.0",
+        "mcp-server-time==2026.7.10"
       ],
       "oauth": null,
       "enabled": true,
@@ -91,7 +97,9 @@
       "protocol": "stdio",
       "command": "uvx",
       "args": [
-        "mcp-server-sqlite",
+        "--with",
+        "mcp==1.29.0",
+        "mcp-server-sqlite==2025.4.25",
         "--db-path",
         "/tmp/mcpproxy-corpus-snapshot/snapshot.db"
       ],

--- a/specs/065-evaluation-foundation/datasets/snapshot-servers.config.json
+++ b/specs/065-evaluation-foundation/datasets/snapshot-servers.config.json
@@ -10,7 +10,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@modelcontextprotocol/server-filesystem@2026.7.10",
+        "@modelcontextprotocol/server-filesystem@2026.1.14",
         "/tmp"
       ],
       "oauth": null,
@@ -25,7 +25,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@modelcontextprotocol/server-memory@2026.7.4"
+        "@modelcontextprotocol/server-memory@2026.1.26"
       ],
       "oauth": null,
       "enabled": true,
@@ -39,7 +39,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@modelcontextprotocol/server-sequential-thinking@2026.7.4"
+        "@modelcontextprotocol/server-sequential-thinking@2025.12.18"
       ],
       "oauth": null,
       "enabled": true,
@@ -53,8 +53,8 @@
       "command": "uvx",
       "args": [
         "--with",
-        "mcp==1.29.0",
-        "mcp-server-git==2026.7.10"
+        "mcp==1.27.2",
+        "mcp-server-git==2026.1.14"
       ],
       "oauth": null,
       "enabled": true,
@@ -68,8 +68,8 @@
       "command": "uvx",
       "args": [
         "--with",
-        "mcp==1.29.0",
-        "mcp-server-fetch==2026.7.10"
+        "mcp==1.27.2",
+        "mcp-server-fetch==2025.4.7"
       ],
       "oauth": null,
       "enabled": true,
@@ -83,8 +83,8 @@
       "command": "uvx",
       "args": [
         "--with",
-        "mcp==1.29.0",
-        "mcp-server-time==2026.7.10"
+        "mcp==1.27.2",
+        "mcp-server-time==2026.1.26"
       ],
       "oauth": null,
       "enabled": true,
@@ -98,7 +98,7 @@
       "command": "uvx",
       "args": [
         "--with",
-        "mcp==1.29.0",
+        "mcp==1.27.2",
         "mcp-server-sqlite==2025.4.25",
         "--db-path",
         "/tmp/mcpproxy-corpus-snapshot/snapshot.db"


### PR DESCRIPTION
## The break

The **Retrieval regression gate (D1)** fails on every PR that triggers it. The cause is outside this repo: the `mcp` Python SDK cut **2.0.0 on 2026-07-28**, which renamed `McpError` → `MCPError` and removed the low-level `Server.list_tools`/`list_resources` decorators.

Every uvx server in `specs/065-evaluation-foundation/datasets/snapshot-servers.config.json` declares only a **lower** bound (`fetch mcp>=1.1.3`, `git mcp>=1.0.0`, `time mcp>=1.23.0`, `sqlite mcp[cli]>=1.6.0`), so all four resolve 2.0.0 and all four are dead:

- `fetch`, `time` → `ImportError: cannot import name 'McpError' … Did you mean: 'MCPError'?`
- `git`, `sqlite` → `AttributeError: 'Server' object has no attribute 'list_tools'`

The failing log's **24 tools** confirms the mechanism exactly: the dataset has **seven** servers, not four. The three npx servers are healthy and expose 14 + 9 + 1 = 24; the four uvx servers expose 21 and are all down. 24 of 45 means the readiness loop (expects ≥ 44) times out and the job exits 1.

## The fix

Every server pinned exactly, and the uvx ones additionally carry `--with mcp==1.29.0`.

**Pinning the server packages alone would not have worked** — `mcp-server-fetch==2026.7.10` still resolves `mcp>=1.1.3` → 2.0.0. The break is transitive, so the constraint has to name the SDK. Both pins verified together, live.

**Exact `mcp==1.29.0` rather than `mcp<2`**, deliberately: `mcp<2` fixes today and still floats within 1.x, which is the same latent flake one release later. 1.29.0 is the newest 1.x and is what `mcp<2` resolves to today, so nothing is downgraded.

**All seven pinned, not just the broken four.** `npx -y <pkg>` with no `@version` resolves latest on every run against a frozen corpus — identical exposure, just not yet triggered. Two of the non-fetch uvx servers were *already* failing with a different-looking error, so a fetch-only pin would have left the gate red.

An unpinned dependency in a **regression gate** is a flake by construction: the baseline moves whenever an upstream publishes.

## Verification

Reproduced the CI step verbatim (`retrieval-d1`, `.github/workflows/eval.yml:114-219`) against the frozen corpus, golden set and baseline:

```
catalog has 45 tool(s)
Recall@1/3/5/10: 0.418 0.560 0.681 0.791
Gate (recall_at_5): PASS (value=0.681 threshold=0.631)
GATE EXIT: 0
```

Run twice, same result. The pinned versions reproduce the frozen 45-tool `corpus_v1` **tool for tool** — names diffed, not just counts: filesystem 14, git 12, memory 9, sqlite 6, time 2, fetch 1, sequential-thinking 1.

Caveat on what that proves: verified on macOS/arm64 with CPython 3.14; CI is ubuntu-latest at Python 3.11.13. The packages are pure-Python and the schemas platform-independent, so parity is expected — but the first CI run is the real check.

Residual not claimed as closed: transitive deps (httpx, pydantic, click) still float. A truly hermetic gate needs a lockfile, which a uvx-from-config invocation cannot express.

## Two traps documented in the datasets README

1. **`mcpproxy serve --config <file>` rewrites the file in place** — alphabetised keys, all defaults materialised. A first local run turned a 7-line change into 140 insertions / 151 deletions on a *tracked dataset file*. The README previously told you to point `serve --config` straight at it.
2. The same config backs the **D4 bench** job (`.github/workflows/bench.yml:104`) and `bench/docker-compose.yml`, so this one file fixes both gates.

Also added an *Upstream version pinning* section recording the incident, the pin table, and the rule that **bumping a pin is a corpus change** — re-snapshot, diff, cut `corpus_v2`; never edit `corpus_v1` (CN-002/FR-012).

## Scope

Two files: the dataset config and the datasets README. No Go code, no `go.mod` change.