### PR TITLE
fix(storage): repair the retention test build after GetRecentSessions gained a status filter

### DIFF
--- a/internal/storage/sessions_retention_test.go
+++ b/internal/storage/sessions_retention_test.go
@@ -213,7 +213,7 @@ func TestEnforceSessionRetention_KeepsLiveSessionWhenClosedOnesCouldGo(t *testin
 		"a connected client's record must not be evicted while closed records remain")
 	assert.Equal(t, "active", got.Status)
 
-	sessions, total, err := m.GetRecentSessions(sessionRetentionLimit)
+	sessions, total, err := m.GetRecentSessions(sessionRetentionLimit, "")
 	require.NoError(t, err)
 	assert.LessOrEqual(t, total, sessionRetentionLimit, "the hard cap must still hold")
 	assert.True(t, containsSessionID(sessions, "live-session"),
@@ -249,7 +249,7 @@ func TestEnforceSessionRetention_KeepsIdleLiveSessionOverFresherClosedOnes(t *te
 		"however recently those closed sessions were active")
 	assert.Equal(t, "active", got.Status)
 
-	sessions, total, err := m.GetRecentSessions(sessionRetentionLimit)
+	sessions, total, err := m.GetRecentSessions(sessionRetentionLimit, "")
 	require.NoError(t, err)
 	assert.Equal(t, sessionRetentionLimit, total)
 	assert.True(t, containsSessionID(sessions, "idle-live-session"),
@@ -275,7 +275,7 @@ func TestEnforceSessionRetention_CapHoldsWhenEverySessionIsActive(t *testing.T) 
 		require.NoError(t, m.CreateSession(s))
 	}
 
-	sessions, total, err := m.GetRecentSessions(sessionRetentionLimit + 100)
+	sessions, total, err := m.GetRecentSessions(sessionRetentionLimit+100, "")
 	require.NoError(t, err)
 	assert.Equal(t, sessionRetentionLimit, total,
 		"an all-active bucket must still be capped — otherwise abandoned sessions grow without bound")
@@ -297,7 +297,7 @@ func TestEnforceSessionRetention_EvictsOldestClosedFirst(t *testing.T) {
 		require.NoError(t, m.CreateSession(s))
 	}
 
-	sessions, total, err := m.GetRecentSessions(sessionRetentionLimit + 50)
+	sessions, total, err := m.GetRecentSessions(sessionRetentionLimit+50, "")
 	require.NoError(t, err)
 	assert.Equal(t, sessionRetentionLimit, total)
 


### PR DESCRIPTION
**main is currently red** — `internal/storage` fails to build, which failed the `v0.53.0-rc.1` prerelease build at the qa-gate step.

## Cause

A semantic merge conflict between two PRs that were each green on their own:

- #928 added `internal/storage/sessions_retention_test.go`, calling `GetRecentSessions(limit)`
- #930 added a `status string` parameter to `GetRecentSessions` for the tray glance's client filtering

Neither PR was required to be up to date with main before merging (`strict=false` on branch protection), so the combination was never built until it landed.

```
internal/storage/sessions_retention_test.go:216:46: not enough arguments in call to m.GetRecentSessions
	have (number)
	want (int, string)
```
(and the same at :252, :278, :300)

## Fix

Pass `""` at the four call sites. That is the documented no-filter value — the retention tests want to count every surviving record, so unfiltered is the semantically correct argument rather than just the one that compiles.

## Verification

`go build ./...`, `go vet ./internal/storage/`, and `go test -race ./internal/storage/` all pass locally.

Once this lands I will re-cut the release candidate.