### PR TITLE
fix(upstream): stop leaking a health-check goroutine on every reconnect

### DIFF
--- a/internal/upstream/managed/client.go
+++ b/internal/upstream/managed/client.go
@@ -787,8 +787,19 @@ func (mc *Client) onStateChange(oldState, newState types.ConnectionState, info *
 	}
 }
 
-// startBackgroundMonitoring starts monitoring the connection health
+// startBackgroundMonitoring starts monitoring the connection health.
+//
+// Idempotent: tryReconnect() re-enters Connect() after tearing down only the
+// core client, so this is reached again on every reconnect while the existing
+// monitor is still running (stopBackgroundMonitoring is only called from the
+// managed client's Disconnect()). Without this guard each reconnect leaked
+// another backgroundHealthCheck goroutine, multiplying the ListTools liveness
+// probes sent to the upstream server for the rest of the process's life.
 func (mc *Client) startBackgroundMonitoring() {
+	if mc.monitoringStarted {
+		return
+	}
+
 	// Mark that monitoring has been started
 	mc.monitoringStarted = true
 	mc.monitoringWG.Add(1)

--- a/internal/upstream/managed/monitoring_leak_test.go
+++ b/internal/upstream/managed/monitoring_leak_test.go
@@ -1,0 +1,70 @@
+package managed
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+)
+
+func newTestClientForMonitoring(t *testing.T) *Client {
+	t.Helper()
+	mc := &Client{
+		logger:         zap.NewNop(),
+		stopMonitoring: make(chan struct{}),
+	}
+	mc.SetConfig(&config.ServerConfig{Name: "monitor-server"})
+	return mc
+}
+
+// settledGoroutines polls runtime.NumGoroutine until it stops changing, so the
+// assertions below compare stable counts rather than racing the scheduler.
+func settledGoroutines() int {
+	prev := -1
+	for i := 0; i < 100; i++ {
+		runtime.Gosched()
+		time.Sleep(2 * time.Millisecond)
+		n := runtime.NumGoroutine()
+		if n == prev {
+			return n
+		}
+		prev = n
+	}
+	return runtime.NumGoroutine()
+}
+
+// TestStartBackgroundMonitoring_IsIdempotent pins the fix for a goroutine leak
+// that made an upstream server's health check fire N times per interval.
+//
+// startBackgroundMonitoring is reached from Connect(), and tryReconnect()
+// re-enters Connect() after tearing down only the *core* client — it never
+// calls the managed Client's Disconnect(), which is the sole caller of
+// stopBackgroundMonitoring(). So every reconnect used to add another
+// backgroundHealthCheck goroutine that lived until the process exited.
+//
+// Each of those goroutines probes liveness with ListTools(), so a server whose
+// tool catalog is large turns the leak into sustained traffic: an installation
+// observed here had ~16 concurrent tickers for a single configured upstream,
+// pushing ~80 kB per probe and accumulating 72 GB of audit rows downstream.
+func TestStartBackgroundMonitoring_IsIdempotent(t *testing.T) {
+	mc := newTestClientForMonitoring(t)
+
+	base := settledGoroutines()
+
+	// Simulates Connect() → reconnect → reconnect on one managed client.
+	mc.startBackgroundMonitoring()
+	mc.startBackgroundMonitoring()
+	mc.startBackgroundMonitoring()
+
+	assert.Equal(t, 1, settledGoroutines()-base,
+		"repeated startBackgroundMonitoring must run exactly one health-check goroutine")
+
+	mc.stopBackgroundMonitoring()
+
+	assert.Equal(t, base, settledGoroutines(),
+		"stopBackgroundMonitoring must leave no health-check goroutine behind")
+}


### PR DESCRIPTION
# Pull Request

## Description

`startBackgroundMonitoring()` spawns a `backgroundHealthCheck` goroutine unconditionally, so a managed client can end up with many concurrent health-check tickers.

The path that leaks:

1. `startBackgroundMonitoring()` is reached from `Connect()` (`client.go:321`).
2. `tryReconnect()` tears down only the **core** client — `mc.coreClient.Disconnect()` — then calls `mc.Connect(ctx)` again.
3. `stopBackgroundMonitoring()` is only ever called from the **managed** client's `Disconnect()` (`client.go:353`), which that path never reaches.

So every reconnect adds another 30-second ticker and none of the earlier ones ever stop. They accumulate for the life of the process and reset only on restart.

Because each ticker probes liveness via `ListTools()`, the cost scales with the upstream's tool-catalog size. On the install where I found this, one `streamable-http` server with a large catalog was being probed by **~16 concurrent tickers — 32.5 calls/min against a configured 2/min**, at roughly 80 kB per response. Downstream, the MCP audit log on the server being probed had grown to **72 GB across 911k `tools/list` rows**, and its daily row count climbed steadily between restarts (10k/day → 65k/day over ten days, then back to near-zero after a restart) — the signature of the accumulation rather than a fixed-rate load.

### The fix

Make the start idempotent:

```go
func (mc *Client) startBackgroundMonitoring() {
	if mc.monitoringStarted {
		return
	}
	...
```

No extra locking is needed: both call sites already hold `mc.mu` (`Connect()` takes it at `client.go:317`, `Disconnect()` defers it), and `stopBackgroundMonitoring()` already resets `monitoringStarted` and recreates the stop channel, so a later reconnect still gets a fresh monitor.

I want to flag the alternative I rejected, in case it looks more natural to you: having `tryReconnect()` call the managed `Disconnect()` instead of `mc.coreClient.Disconnect()`. That deadlocks on `mc.mu`, and it would discard the retry/backoff state that the adjacent `ResetForReconnect()` call deliberately preserves.

### Effect after deploying this

Measured on the affected install, same server, before and after the rebuild:

```
before:  65 calls / 2 min   (~16 tickers)
after:    4 calls / 2 min   (1 ticker, matching the 30s interval)
```

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests that prove my fix is effective or my feature works
- [x] All existing tests pass

`internal/upstream/managed/monitoring_leak_test.go` calls `startBackgroundMonitoring()` three times and asserts the goroutine delta. It fails on `main` (`expected: 1, actual: 3`) and passes with the guard, then asserts `stopBackgroundMonitoring()` returns the count to baseline.

What I ran locally:

- `go test -race ./internal/upstream/...` — pass (this is the changed package and its neighbours)
- `go test ./internal/...` — every package that completed passes (46 of them). `internal/server`, `internal/tray` and `internal/tui` did not finish inside my sandbox's time limit, so I'm relying on CI for those; nothing in this change touches them.
- `go build ./...`, `go vet ./internal/upstream/managed/`, `gofmt -l` — all clean

I did not run `scripts/run-all-tests.sh` end-to-end (the E2E portion needs a built binary driving live servers, which my environment couldn't host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsbwvZM4fxioyop4PM7z4d
