### PR TITLE
fix(oauth): abort with oauth_client_id_required instead of empty-client_id authorize URL

### DIFF
--- a/internal/upstream/core/connection_oauth.go
+++ b/internal/upstream/core/connection_oauth.go
@@ -1080,9 +1080,11 @@ func (c *Client) handleOAuthAuthorization(ctx context.Context, authErr error, oa
 		}
 	}
 
-	// Continue with OAuth flow regardless of DCR result
-	// Public client OAuth (RFC 8252) with PKCE doesn't require client_id
-	// If server doesn't support this, it will reject the authorization request
+	// Continue with the OAuth flow when a client_id is available (static,
+	// persisted, or obtained via DCR). OAuth public clients (RFC 8252 + PKCE)
+	// still require a client_id — PKCE replaces the client secret, not the
+	// id — so the empty-client_id guard below aborts before opening a
+	// guaranteed-broken authorization URL (issue #975).
 
 	c.logger.Info("🌟 Starting OAuth authentication flow",
 		zap.String("server", c.config.Name),
@@ -1159,36 +1161,12 @@ func (c *Client) handleOAuthAuthorization(ctx context.Context, authErr error, oa
 		}
 	}
 
-	// Check if we're attempting public client OAuth with empty client_id
-	// Some servers (like Figma) advertise DCR but return 403, then reject empty client_id
-	parsedAuthURL, parseErr := url.Parse(authURL)
-	if parseErr == nil {
-		clientIDParam := parsedAuthURL.Query().Get("client_id")
-		if clientIDParam == "" && oauthMode == "public client (PKCE)" {
-			c.logger.Error("❌ OAuth server requires client_id but DCR failed",
-				zap.String("server", c.config.Name),
-				zap.String("url", c.config.URL),
-				zap.String("help", "Configure oauth.client_id in server config or contact the OAuth provider"))
-			// Return structured error for Spec 020
-			return &contracts.OAuthFlowError{
-				Success:    false,
-				ErrorType:  contracts.OAuthErrorClientIDRequired,
-				ErrorCode:  contracts.OAuthCodeNoClientID,
-				ServerName: c.config.Name,
-				Message:    fmt.Sprintf("Server '%s' requires client_id but Dynamic Client Registration returned 403", c.config.Name),
-				Details: &contracts.OAuthErrorDetails{
-					ServerURL: c.config.URL,
-					DCRStatus: &contracts.DCRStatus{
-						Attempted:  true,
-						Success:    false,
-						StatusCode: 403,
-						Error:      "Forbidden",
-					},
-				},
-				Suggestion: "Register an OAuth app with the provider and configure oauth.client_id in server config.",
-				DebugHint:  fmt.Sprintf("For logs: mcpproxy upstream logs %s", c.config.Name),
-			}
-		}
+	// Never proceed with an authorization URL that lacks a client_id — the
+	// provider will reject it (e.g. Figma after a DCR 403, GitHub which has no
+	// DCR endpoint at all; issue #975). Checked on the final URL so a
+	// client_id supplied via oauth.extra_params still passes.
+	if flowErr := c.emptyClientIDFlowError(authURL, ""); flowErr != nil {
+		return flowErr
 	}
 
 	// Always log the computed authorization URL so users can copy/paste if auto-launch fails.
@@ -2017,7 +1995,50 @@ func (c *Client) getAuthorizationURLQuick(ctx context.Context, oauthConfig *clie
 		}
 	}
 
+	// Issue #975: never hand back an authorization URL without a client_id —
+	// the provider is guaranteed to reject it (GitHub 404s on client_id=).
+	if flowErr := c.emptyClientIDFlowError(authURL, correlationID); flowErr != nil {
+		return "", nil, "", "", flowErr
+	}
+
 	return authURL, oauthHandler, codeVerifier, state, nil
+}
+
+// emptyClientIDFlowError returns a structured oauth_client_id_required error
+// when the final authorization URL carries no client_id. OAuth public clients
+// (RFC 8252 + PKCE) still require a client_id — PKCE replaces the client
+// secret, not the id — so a provider is guaranteed to reject such a URL
+// (GitHub responds 404; issue #975). Returns nil when the URL has a client_id
+// or cannot be parsed.
+func (c *Client) emptyClientIDFlowError(authURL, correlationID string) *contracts.OAuthFlowError {
+	parsed, err := url.Parse(authURL)
+	if err != nil {
+		return nil
+	}
+	if parsed.Query().Get("client_id") != "" {
+		return nil
+	}
+	c.logger.Error("❌ OAuth provider requires a client_id but none is available (DCR unsupported or failed)",
+		zap.String("server", c.config.Name),
+		zap.String("url", c.config.URL),
+		zap.String("help", "Register an OAuth app with the provider and set oauth.client_id in the server config"))
+	return &contracts.OAuthFlowError{
+		Success:       false,
+		ErrorType:     contracts.OAuthErrorClientIDRequired,
+		ErrorCode:     contracts.OAuthCodeNoClientID,
+		ServerName:    c.config.Name,
+		CorrelationID: correlationID,
+		Message:       fmt.Sprintf("Server '%s' requires a client_id: the OAuth provider does not support Dynamic Client Registration (or registration failed) and no oauth.client_id is configured", c.config.Name),
+		Details: &contracts.OAuthErrorDetails{
+			ServerURL: c.config.URL,
+			DCRStatus: &contracts.DCRStatus{
+				Attempted: true,
+				Success:   false,
+			},
+		},
+		Suggestion: "Register an OAuth app with the provider and set oauth.client_id in the server config.",
+		DebugHint:  fmt.Sprintf("For logs: mcpproxy upstream logs %s", c.config.Name),
+	}
 }
 
 // waitForOAuthCallbackAsync waits for OAuth callback and handles token exchange in background.

--- a/internal/upstream/core/connection_oauth.go
+++ b/internal/upstream/core/connection_oauth.go
@@ -1010,6 +1010,7 @@ func (c *Client) handleOAuthAuthorization(ctx context.Context, authErr error, oa
 
 	// Determine OAuth mode and attempt registration if needed
 	var oauthMode string
+	var dcrErr error
 	if hasStaticCredentials {
 		// Skip DCR when static credentials are provided in config
 		oauthMode = "static credentials"
@@ -1040,7 +1041,9 @@ func (c *Client) handleOAuthAuthorization(ctx context.Context, authErr error, oa
 		}()
 
 		if regErr != nil {
-			// DCR failed - proceed with public client OAuth (PKCE without client_id)
+			// DCR failed - proceed and let the empty-client_id guard below
+			// surface a structured error if no client_id materializes
+			dcrErr = regErr
 			oauthMode = "public client (PKCE)"
 			c.logger.Warn("⚠️ Dynamic Client Registration not supported - using public client OAuth with PKCE",
 				zap.String("server", c.config.Name),
@@ -1165,7 +1168,7 @@ func (c *Client) handleOAuthAuthorization(ctx context.Context, authErr error, oa
 	// provider will reject it (e.g. Figma after a DCR 403, GitHub which has no
 	// DCR endpoint at all; issue #975). Checked on the final URL so a
 	// client_id supplied via oauth.extra_params still passes.
-	if flowErr := c.emptyClientIDFlowError(authURL, ""); flowErr != nil {
+	if flowErr := c.emptyClientIDFlowError(authURL, "", dcrErr); flowErr != nil {
 		return flowErr
 	}
 
@@ -1371,6 +1374,7 @@ func (c *Client) handleOAuthAuthorizationWithResult(ctx context.Context, authErr
 	hasStaticCredentials := c.config.OAuth != nil && c.config.OAuth.ClientID != ""
 	hasPersistedCredentials := oauthConfig.ClientID != ""
 
+	var dcrErr error
 	if !hasStaticCredentials && !hasPersistedCredentials {
 		c.logger.Info("📋 Attempting Dynamic Client Registration (optional)",
 			zap.String("server", c.config.Name))
@@ -1390,31 +1394,12 @@ func (c *Client) handleOAuthAuthorizationWithResult(ctx context.Context, authErr
 		}()
 
 		if regErr != nil {
+			// DCR failed - the empty-client_id guard below surfaces a
+			// structured error if no client_id materializes (issue #975)
+			dcrErr = regErr
 			c.logger.Info("ℹ️ DCR not available, continuing with public client OAuth",
 				zap.String("server", c.config.Name),
 				zap.Error(regErr))
-
-			if strings.Contains(regErr.Error(), "403") {
-				return result, &contracts.OAuthFlowError{
-					Success:       false,
-					ErrorType:     contracts.OAuthErrorClientIDRequired,
-					ErrorCode:     contracts.OAuthCodeNoClientID,
-					ServerName:    c.config.Name,
-					CorrelationID: result.CorrelationID,
-					Message:       fmt.Sprintf("Server '%s' requires client_id but Dynamic Client Registration returned 403", c.config.Name),
-					Details: &contracts.OAuthErrorDetails{
-						ServerURL: c.config.URL,
-						DCRStatus: &contracts.DCRStatus{
-							Attempted:  true,
-							Success:    false,
-							StatusCode: 403,
-							Error:      "Forbidden",
-						},
-					},
-					Suggestion: "Register an OAuth app with the provider and configure oauth.client_id in server config.",
-					DebugHint:  fmt.Sprintf("For logs: mcpproxy upstream logs %s", c.config.Name),
-				}
-			}
 		} else {
 			clientID := oauthHandler.GetClientID()
 			clientSecret := oauthHandler.GetClientSecret()
@@ -1495,6 +1480,12 @@ func (c *Client) handleOAuthAuthorizationWithResult(ctx context.Context, authErr
 				zap.String("server", c.config.Name),
 				zap.Error(err))
 		}
+	}
+
+	// Never store or open an authorization URL that lacks a client_id — the
+	// provider is guaranteed to reject it (issue #975).
+	if flowErr := c.emptyClientIDFlowError(authURL, result.CorrelationID, dcrErr); flowErr != nil {
+		return result, flowErr
 	}
 
 	// Store the auth URL in the result
@@ -1892,6 +1883,7 @@ func (c *Client) getAuthorizationURLQuick(ctx context.Context, oauthConfig *clie
 	hasStaticCredentials := c.config.OAuth != nil && c.config.OAuth.ClientID != ""
 	hasPersistedCredentials := oauthConfig.ClientID != ""
 
+	var dcrErr error
 	if !hasStaticCredentials && !hasPersistedCredentials {
 		c.logger.Info("📋 Attempting Dynamic Client Registration (DCR)",
 			zap.String("server", c.config.Name),
@@ -1908,26 +1900,13 @@ func (c *Client) getAuthorizationURLQuick(ctx context.Context, oauthConfig *clie
 		}()
 
 		if regErr != nil {
+			// DCR failed - the empty-client_id guard below surfaces a
+			// structured error if no client_id materializes (issue #975)
+			dcrErr = regErr
 			c.logger.Warn("⚠️ DCR failed",
 				zap.String("server", c.config.Name),
 				zap.String("correlation_id", correlationID),
 				zap.Error(regErr))
-
-			if strings.Contains(regErr.Error(), "403") {
-				c.logger.Error("❌ DCR returned 403 - client_id required",
-					zap.String("server", c.config.Name),
-					zap.String("correlation_id", correlationID),
-					zap.String("suggestion", "Register an OAuth app with the provider"))
-				return "", nil, "", "", &contracts.OAuthFlowError{
-					Success:       false,
-					ErrorType:     contracts.OAuthErrorClientIDRequired,
-					ErrorCode:     contracts.OAuthCodeNoClientID,
-					ServerName:    c.config.Name,
-					CorrelationID: correlationID,
-					Message:       fmt.Sprintf("Server '%s' requires client_id but DCR returned 403", c.config.Name),
-					Suggestion:    "Register an OAuth app with the provider and configure oauth.client_id in server config.",
-				}
-			}
 		} else {
 			c.logger.Info("✅ DCR succeeded",
 				zap.String("server", c.config.Name),
@@ -1997,7 +1976,7 @@ func (c *Client) getAuthorizationURLQuick(ctx context.Context, oauthConfig *clie
 
 	// Issue #975: never hand back an authorization URL without a client_id —
 	// the provider is guaranteed to reject it (GitHub 404s on client_id=).
-	if flowErr := c.emptyClientIDFlowError(authURL, correlationID); flowErr != nil {
+	if flowErr := c.emptyClientIDFlowError(authURL, correlationID, dcrErr); flowErr != nil {
 		return "", nil, "", "", flowErr
 	}
 
@@ -2009,8 +1988,11 @@ func (c *Client) getAuthorizationURLQuick(ctx context.Context, oauthConfig *clie
 // (RFC 8252 + PKCE) still require a client_id — PKCE replaces the client
 // secret, not the id — so a provider is guaranteed to reject such a URL
 // (GitHub responds 404; issue #975). Returns nil when the URL has a client_id
-// or cannot be parsed.
-func (c *Client) emptyClientIDFlowError(authURL, correlationID string) *contracts.OAuthFlowError {
+// or cannot be parsed. dcrErr, when non-nil, is the DCR failure that left the
+// client without an id; its real outcome is preserved in the error details so
+// a 403 rejection (Figma) stays distinguishable from a provider with no
+// registration endpoint at all (GitHub).
+func (c *Client) emptyClientIDFlowError(authURL, correlationID string, dcrErr error) *contracts.OAuthFlowError {
 	parsed, err := url.Parse(authURL)
 	if err != nil {
 		return nil
@@ -2021,7 +2003,22 @@ func (c *Client) emptyClientIDFlowError(authURL, correlationID string) *contract
 	c.logger.Error("❌ OAuth provider requires a client_id but none is available (DCR unsupported or failed)",
 		zap.String("server", c.config.Name),
 		zap.String("url", c.config.URL),
+		zap.NamedError("dcr_error", dcrErr),
 		zap.String("help", "Register an OAuth app with the provider and set oauth.client_id in the server config"))
+	details := &contracts.OAuthErrorDetails{
+		ServerURL: c.config.URL,
+	}
+	if dcrErr != nil {
+		dcrStatus := &contracts.DCRStatus{
+			Attempted: true,
+			Success:   false,
+			Error:     dcrErr.Error(),
+		}
+		if strings.Contains(dcrErr.Error(), "403") {
+			dcrStatus.StatusCode = 403
+		}
+		details.DCRStatus = dcrStatus
+	}
 	return &contracts.OAuthFlowError{
 		Success:       false,
 		ErrorType:     contracts.OAuthErrorClientIDRequired,
@@ -2029,15 +2026,9 @@ func (c *Client) emptyClientIDFlowError(authURL, correlationID string) *contract
 		ServerName:    c.config.Name,
 		CorrelationID: correlationID,
 		Message:       fmt.Sprintf("Server '%s' requires a client_id: the OAuth provider does not support Dynamic Client Registration (or registration failed) and no oauth.client_id is configured", c.config.Name),
-		Details: &contracts.OAuthErrorDetails{
-			ServerURL: c.config.URL,
-			DCRStatus: &contracts.DCRStatus{
-				Attempted: true,
-				Success:   false,
-			},
-		},
-		Suggestion: "Register an OAuth app with the provider and set oauth.client_id in the server config.",
-		DebugHint:  fmt.Sprintf("For logs: mcpproxy upstream logs %s", c.config.Name),
+		Details:       details,
+		Suggestion:    "Register an OAuth app with the provider and set oauth.client_id in the server config.",
+		DebugHint:     fmt.Sprintf("For logs: mcpproxy upstream logs %s", c.config.Name),
 	}
 }
 

--- a/internal/upstream/core/connection_oauth.go
+++ b/internal/upstream/core/connection_oauth.go
@@ -1168,7 +1168,7 @@ func (c *Client) handleOAuthAuthorization(ctx context.Context, authErr error, oa
 	// provider will reject it (e.g. Figma after a DCR 403, GitHub which has no
 	// DCR endpoint at all; issue #975). Checked on the final URL so a
 	// client_id supplied via oauth.extra_params still passes.
-	if flowErr := c.emptyClientIDFlowError(authURL, "", dcrErr); flowErr != nil {
+	if flowErr := c.emptyClientIDFlowError(authURL, "", dcrErr, oauthHandler); flowErr != nil {
 		return flowErr
 	}
 
@@ -1484,7 +1484,7 @@ func (c *Client) handleOAuthAuthorizationWithResult(ctx context.Context, authErr
 
 	// Never store or open an authorization URL that lacks a client_id — the
 	// provider is guaranteed to reject it (issue #975).
-	if flowErr := c.emptyClientIDFlowError(authURL, result.CorrelationID, dcrErr); flowErr != nil {
+	if flowErr := c.emptyClientIDFlowError(authURL, result.CorrelationID, dcrErr, oauthHandler); flowErr != nil {
 		return result, flowErr
 	}
 
@@ -1976,11 +1976,17 @@ func (c *Client) getAuthorizationURLQuick(ctx context.Context, oauthConfig *clie
 
 	// Issue #975: never hand back an authorization URL without a client_id —
 	// the provider is guaranteed to reject it (GitHub 404s on client_id=).
-	if flowErr := c.emptyClientIDFlowError(authURL, correlationID, dcrErr); flowErr != nil {
+	if flowErr := c.emptyClientIDFlowError(authURL, correlationID, dcrErr, oauthHandler); flowErr != nil {
 		return "", nil, "", "", flowErr
 	}
 
 	return authURL, oauthHandler, codeVerifier, state, nil
+}
+
+// clientIDProvider is the slice of mcp-go's OAuthHandler the empty-client_id
+// guard needs; an interface so tests can stub it.
+type clientIDProvider interface {
+	GetClientID() string
 }
 
 // emptyClientIDFlowError returns a structured oauth_client_id_required error
@@ -1992,12 +1998,21 @@ func (c *Client) getAuthorizationURLQuick(ctx context.Context, oauthConfig *clie
 // client without an id; its real outcome is preserved in the error details so
 // a 403 rejection (Figma) stays distinguishable from a provider with no
 // registration endpoint at all (GitHub).
-func (c *Client) emptyClientIDFlowError(authURL, correlationID string, dcrErr error) *contracts.OAuthFlowError {
+func (c *Client) emptyClientIDFlowError(authURL, correlationID string, dcrErr error, handler clientIDProvider) *contracts.OAuthFlowError {
 	parsed, err := url.Parse(authURL)
 	if err != nil {
 		return nil
 	}
 	if parsed.Query().Get("client_id") != "" {
+		// A client_id present in the URL but absent from the OAuth handler can
+		// only have come from oauth.extra_params. The authorize step will
+		// succeed, but the handler still sends its own (empty) client_id at
+		// token exchange, so only lenient providers accept this. Keep the
+		// escape hatch, but make the failure mode diagnosable.
+		if handler != nil && handler.GetClientID() == "" {
+			c.logger.Warn("⚠️ client_id injected via oauth.extra_params is not used at token exchange — if the callback fails, set oauth.client_id instead",
+				zap.String("server", c.config.Name))
+		}
 		return nil
 	}
 	c.logger.Error("❌ OAuth provider requires a client_id but none is available (DCR unsupported or failed)",
@@ -2014,7 +2029,12 @@ func (c *Client) emptyClientIDFlowError(authURL, correlationID string, dcrErr er
 			Success:   false,
 			Error:     dcrErr.Error(),
 		}
-		if strings.Contains(dcrErr.Error(), "403") {
+		// Best-effort: mcp-go returns untyped registration errors (a 403 whose
+		// body is valid OAuth JSON surfaces as e.g. "OAuth error:
+		// unauthorized_client" with no status), so the code is only set when
+		// the text makes it unambiguous; the verbatim error above is the
+		// authoritative detail.
+		if strings.Contains(dcrErr.Error(), "403") || strings.Contains(dcrErr.Error(), "Forbidden") {
 			dcrStatus.StatusCode = 403
 		}
 		details.DCRStatus = dcrStatus

--- a/internal/upstream/core/connection_oauth.go
+++ b/internal/upstream/core/connection_oauth.go
@@ -1168,7 +1168,7 @@ func (c *Client) handleOAuthAuthorization(ctx context.Context, authErr error, oa
 	// provider will reject it (e.g. Figma after a DCR 403, GitHub which has no
 	// DCR endpoint at all; issue #975). Checked on the final URL so a
 	// client_id supplied via oauth.extra_params still passes.
-	if flowErr := c.emptyClientIDFlowError(authURL, "", dcrErr, oauthHandler); flowErr != nil {
+	if flowErr := c.emptyClientIDFlowError(authURL, "", dcrErr); flowErr != nil {
 		return flowErr
 	}
 
@@ -1484,7 +1484,7 @@ func (c *Client) handleOAuthAuthorizationWithResult(ctx context.Context, authErr
 
 	// Never store or open an authorization URL that lacks a client_id — the
 	// provider is guaranteed to reject it (issue #975).
-	if flowErr := c.emptyClientIDFlowError(authURL, result.CorrelationID, dcrErr, oauthHandler); flowErr != nil {
+	if flowErr := c.emptyClientIDFlowError(authURL, result.CorrelationID, dcrErr); flowErr != nil {
 		return result, flowErr
 	}
 
@@ -1976,17 +1976,11 @@ func (c *Client) getAuthorizationURLQuick(ctx context.Context, oauthConfig *clie
 
 	// Issue #975: never hand back an authorization URL without a client_id —
 	// the provider is guaranteed to reject it (GitHub 404s on client_id=).
-	if flowErr := c.emptyClientIDFlowError(authURL, correlationID, dcrErr, oauthHandler); flowErr != nil {
+	if flowErr := c.emptyClientIDFlowError(authURL, correlationID, dcrErr); flowErr != nil {
 		return "", nil, "", "", flowErr
 	}
 
 	return authURL, oauthHandler, codeVerifier, state, nil
-}
-
-// clientIDProvider is the slice of mcp-go's OAuthHandler the empty-client_id
-// guard needs; an interface so tests can stub it.
-type clientIDProvider interface {
-	GetClientID() string
 }
 
 // emptyClientIDFlowError returns a structured oauth_client_id_required error
@@ -1998,21 +1992,17 @@ type clientIDProvider interface {
 // client without an id; its real outcome is preserved in the error details so
 // a 403 rejection (Figma) stays distinguishable from a provider with no
 // registration endpoint at all (GitHub).
-func (c *Client) emptyClientIDFlowError(authURL, correlationID string, dcrErr error, handler clientIDProvider) *contracts.OAuthFlowError {
+func (c *Client) emptyClientIDFlowError(authURL, correlationID string, dcrErr error) *contracts.OAuthFlowError {
 	parsed, err := url.Parse(authURL)
 	if err != nil {
 		return nil
 	}
 	if parsed.Query().Get("client_id") != "" {
-		// A client_id present in the URL but absent from the OAuth handler can
-		// only have come from oauth.extra_params. The authorize step will
-		// succeed, but the handler still sends its own (empty) client_id at
-		// token exchange, so only lenient providers accept this. Keep the
-		// escape hatch, but make the failure mode diagnosable.
-		if handler != nil && handler.GetClientID() == "" {
-			c.logger.Warn("⚠️ client_id injected via oauth.extra_params is not used at token exchange — if the callback fails, set oauth.client_id instead",
-				zap.String("server", c.config.Name))
-		}
+		// A client_id present in the URL but absent from the OAuth handler
+		// came from oauth.extra_params. That configuration is fully
+		// functional: OAuthTransportWrapper (internal/oauth/config.go) injects
+		// every extra param — client_id included — into token requests as
+		// well, so the exchange after callback carries it too.
 		return nil
 	}
 	c.logger.Error("❌ OAuth provider requires a client_id but none is available (DCR unsupported or failed)",

--- a/internal/upstream/core/oauth_clientid_guard_test.go
+++ b/internal/upstream/core/oauth_clientid_guard_test.go
@@ -30,7 +30,7 @@ func TestEmptyClientIDFlowError_EmptyClientID(t *testing.T) {
 	c := newClientIDGuardTestClient(t)
 
 	authURL := "https://github.com/login/oauth/authorize?client_id=&code_challenge=abc&code_challenge_method=S256&redirect_uri=http%3A%2F%2F127.0.0.1%3A62876%2Foauth%2Fcallback"
-	flowErr := c.emptyClientIDFlowError(authURL, "corr-123", errors.New("server does not support dynamic client registration"), nil)
+	flowErr := c.emptyClientIDFlowError(authURL, "corr-123", errors.New("server does not support dynamic client registration"))
 
 	require.NotNil(t, flowErr, "empty client_id in authorization URL must be rejected")
 	assert.Equal(t, contracts.OAuthErrorClientIDRequired, flowErr.ErrorType)
@@ -45,7 +45,7 @@ func TestEmptyClientIDFlowError_MissingClientIDParam(t *testing.T) {
 	c := newClientIDGuardTestClient(t)
 
 	authURL := "https://github.com/login/oauth/authorize?code_challenge=abc&code_challenge_method=S256"
-	flowErr := c.emptyClientIDFlowError(authURL, "", nil, nil)
+	flowErr := c.emptyClientIDFlowError(authURL, "", nil)
 
 	require.NotNil(t, flowErr, "authorization URL without client_id param must be rejected")
 	assert.Equal(t, contracts.OAuthErrorClientIDRequired, flowErr.ErrorType)
@@ -55,7 +55,7 @@ func TestEmptyClientIDFlowError_PresentClientID(t *testing.T) {
 	c := newClientIDGuardTestClient(t)
 
 	authURL := "https://github.com/login/oauth/authorize?client_id=Iv1.abc123&code_challenge=abc"
-	flowErr := c.emptyClientIDFlowError(authURL, "corr-123", nil, nil)
+	flowErr := c.emptyClientIDFlowError(authURL, "corr-123", nil)
 
 	assert.Nil(t, flowErr, "a URL carrying a client_id must pass the guard")
 }
@@ -66,7 +66,7 @@ func TestEmptyClientIDFlowError_ClientIDViaExtraParams(t *testing.T) {
 	// A client_id injected through oauth.extra_params must also satisfy the
 	// guard — the check is on the final URL, not on the handler state.
 	authURL := "https://example.com/authorize?client_id=from-extra-params&resource=https%3A%2F%2Fexample.com"
-	flowErr := c.emptyClientIDFlowError(authURL, "", nil, nil)
+	flowErr := c.emptyClientIDFlowError(authURL, "", nil)
 
 	assert.Nil(t, flowErr)
 }
@@ -75,7 +75,7 @@ func TestEmptyClientIDFlowError_UnparseableURL(t *testing.T) {
 	c := newClientIDGuardTestClient(t)
 
 	// An unparseable URL is not this guard's concern — never block on it.
-	flowErr := c.emptyClientIDFlowError("://not-a-url", "", nil, nil)
+	flowErr := c.emptyClientIDFlowError("://not-a-url", "", nil)
 
 	assert.Nil(t, flowErr)
 }
@@ -88,7 +88,7 @@ func TestEmptyClientIDFlowError_DCR403Details(t *testing.T) {
 	c := newClientIDGuardTestClient(t)
 
 	authURL := "https://example.com/authorize?client_id="
-	flowErr := c.emptyClientIDFlowError(authURL, "", errors.New("registration failed: HTTP 403 Forbidden"), nil)
+	flowErr := c.emptyClientIDFlowError(authURL, "", errors.New("registration failed: HTTP 403 Forbidden"))
 
 	require.NotNil(t, flowErr)
 	require.NotNil(t, flowErr.Details)
@@ -103,7 +103,7 @@ func TestEmptyClientIDFlowError_DCRUnsupportedDetails(t *testing.T) {
 	c := newClientIDGuardTestClient(t)
 
 	authURL := "https://github.com/login/oauth/authorize?client_id="
-	flowErr := c.emptyClientIDFlowError(authURL, "", errors.New("server does not support dynamic client registration"), nil)
+	flowErr := c.emptyClientIDFlowError(authURL, "", errors.New("server does not support dynamic client registration"))
 
 	require.NotNil(t, flowErr)
 	require.NotNil(t, flowErr.Details)
@@ -118,27 +118,11 @@ func TestEmptyClientIDFlowError_NoDCRAttempt(t *testing.T) {
 	c := newClientIDGuardTestClient(t)
 
 	// nil dcrErr (DCR not attempted or succeeded): no DCRStatus fabricated.
-	flowErr := c.emptyClientIDFlowError("https://example.com/authorize?client_id=", "", nil, nil)
+	flowErr := c.emptyClientIDFlowError("https://example.com/authorize?client_id=", "", nil)
 
 	require.NotNil(t, flowErr)
 	require.NotNil(t, flowErr.Details)
 	assert.Nil(t, flowErr.Details.DCRStatus)
-}
-
-type stubClientIDProvider struct{ id string }
-
-func (s stubClientIDProvider) GetClientID() string { return s.id }
-
-// Codex r2 finding 1: a client_id present only via oauth.extra_params passes
-// the guard (escape hatch for lenient providers) but must not be treated as a
-// fully-configured client — the helper only warns; behavior is pass-through.
-func TestEmptyClientIDFlowError_ExtraParamsClientIDStillPasses(t *testing.T) {
-	c := newClientIDGuardTestClient(t)
-
-	authURL := "https://example.com/authorize?client_id=from-extra-params"
-	flowErr := c.emptyClientIDFlowError(authURL, "", nil, stubClientIDProvider{id: ""})
-
-	assert.Nil(t, flowErr)
 }
 
 // Codex r2 finding 2: "Forbidden" without a literal "403" still maps to
@@ -146,7 +130,7 @@ func TestEmptyClientIDFlowError_ExtraParamsClientIDStillPasses(t *testing.T) {
 func TestEmptyClientIDFlowError_ForbiddenMapsTo403(t *testing.T) {
 	c := newClientIDGuardTestClient(t)
 
-	flowErr := c.emptyClientIDFlowError("https://example.com/authorize?client_id=", "", errors.New("registration request failed: Forbidden"), nil)
+	flowErr := c.emptyClientIDFlowError("https://example.com/authorize?client_id=", "", errors.New("registration request failed: Forbidden"))
 
 	require.NotNil(t, flowErr)
 	require.NotNil(t, flowErr.Details.DCRStatus)

--- a/internal/upstream/core/oauth_clientid_guard_test.go
+++ b/internal/upstream/core/oauth_clientid_guard_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,7 +30,7 @@ func TestEmptyClientIDFlowError_EmptyClientID(t *testing.T) {
 	c := newClientIDGuardTestClient(t)
 
 	authURL := "https://github.com/login/oauth/authorize?client_id=&code_challenge=abc&code_challenge_method=S256&redirect_uri=http%3A%2F%2F127.0.0.1%3A62876%2Foauth%2Fcallback"
-	flowErr := c.emptyClientIDFlowError(authURL, "corr-123")
+	flowErr := c.emptyClientIDFlowError(authURL, "corr-123", errors.New("server does not support dynamic client registration"))
 
 	require.NotNil(t, flowErr, "empty client_id in authorization URL must be rejected")
 	assert.Equal(t, contracts.OAuthErrorClientIDRequired, flowErr.ErrorType)
@@ -44,7 +45,7 @@ func TestEmptyClientIDFlowError_MissingClientIDParam(t *testing.T) {
 	c := newClientIDGuardTestClient(t)
 
 	authURL := "https://github.com/login/oauth/authorize?code_challenge=abc&code_challenge_method=S256"
-	flowErr := c.emptyClientIDFlowError(authURL, "")
+	flowErr := c.emptyClientIDFlowError(authURL, "", nil)
 
 	require.NotNil(t, flowErr, "authorization URL without client_id param must be rejected")
 	assert.Equal(t, contracts.OAuthErrorClientIDRequired, flowErr.ErrorType)
@@ -54,7 +55,7 @@ func TestEmptyClientIDFlowError_PresentClientID(t *testing.T) {
 	c := newClientIDGuardTestClient(t)
 
 	authURL := "https://github.com/login/oauth/authorize?client_id=Iv1.abc123&code_challenge=abc"
-	flowErr := c.emptyClientIDFlowError(authURL, "corr-123")
+	flowErr := c.emptyClientIDFlowError(authURL, "corr-123", nil)
 
 	assert.Nil(t, flowErr, "a URL carrying a client_id must pass the guard")
 }
@@ -65,7 +66,7 @@ func TestEmptyClientIDFlowError_ClientIDViaExtraParams(t *testing.T) {
 	// A client_id injected through oauth.extra_params must also satisfy the
 	// guard — the check is on the final URL, not on the handler state.
 	authURL := "https://example.com/authorize?client_id=from-extra-params&resource=https%3A%2F%2Fexample.com"
-	flowErr := c.emptyClientIDFlowError(authURL, "")
+	flowErr := c.emptyClientIDFlowError(authURL, "", nil)
 
 	assert.Nil(t, flowErr)
 }
@@ -74,7 +75,52 @@ func TestEmptyClientIDFlowError_UnparseableURL(t *testing.T) {
 	c := newClientIDGuardTestClient(t)
 
 	// An unparseable URL is not this guard's concern — never block on it.
-	flowErr := c.emptyClientIDFlowError("://not-a-url", "")
+	flowErr := c.emptyClientIDFlowError("://not-a-url", "", nil)
 
 	assert.Nil(t, flowErr)
+}
+
+// The structured error must preserve the real DCR outcome: a 403 rejection
+// (e.g. Figma) keeps its status code, a provider without a registration
+// endpoint (e.g. GitHub) keeps the "not supported" message — they are
+// distinguishable in the error details.
+func TestEmptyClientIDFlowError_DCR403Details(t *testing.T) {
+	c := newClientIDGuardTestClient(t)
+
+	authURL := "https://example.com/authorize?client_id="
+	flowErr := c.emptyClientIDFlowError(authURL, "", errors.New("registration failed: HTTP 403 Forbidden"))
+
+	require.NotNil(t, flowErr)
+	require.NotNil(t, flowErr.Details)
+	require.NotNil(t, flowErr.Details.DCRStatus)
+	assert.True(t, flowErr.Details.DCRStatus.Attempted)
+	assert.False(t, flowErr.Details.DCRStatus.Success)
+	assert.Equal(t, 403, flowErr.Details.DCRStatus.StatusCode)
+	assert.Contains(t, flowErr.Details.DCRStatus.Error, "403")
+}
+
+func TestEmptyClientIDFlowError_DCRUnsupportedDetails(t *testing.T) {
+	c := newClientIDGuardTestClient(t)
+
+	authURL := "https://github.com/login/oauth/authorize?client_id="
+	flowErr := c.emptyClientIDFlowError(authURL, "", errors.New("server does not support dynamic client registration"))
+
+	require.NotNil(t, flowErr)
+	require.NotNil(t, flowErr.Details)
+	require.NotNil(t, flowErr.Details.DCRStatus)
+	assert.True(t, flowErr.Details.DCRStatus.Attempted)
+	assert.False(t, flowErr.Details.DCRStatus.Success)
+	assert.Zero(t, flowErr.Details.DCRStatus.StatusCode)
+	assert.Contains(t, flowErr.Details.DCRStatus.Error, "does not support dynamic client registration")
+}
+
+func TestEmptyClientIDFlowError_NoDCRAttempt(t *testing.T) {
+	c := newClientIDGuardTestClient(t)
+
+	// nil dcrErr (DCR not attempted or succeeded): no DCRStatus fabricated.
+	flowErr := c.emptyClientIDFlowError("https://example.com/authorize?client_id=", "", nil)
+
+	require.NotNil(t, flowErr)
+	require.NotNil(t, flowErr.Details)
+	assert.Nil(t, flowErr.Details.DCRStatus)
 }

--- a/internal/upstream/core/oauth_clientid_guard_test.go
+++ b/internal/upstream/core/oauth_clientid_guard_test.go
@@ -1,0 +1,80 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/contracts"
+)
+
+func newClientIDGuardTestClient(t *testing.T) *Client {
+	t.Helper()
+	return &Client{
+		config: &config.ServerConfig{
+			Name: "github",
+			URL:  "https://api.githubcopilot.com/mcp/",
+		},
+		logger: zap.NewNop(),
+	}
+}
+
+// Issue #975: providers without Dynamic Client Registration (e.g. GitHub) must
+// produce a structured oauth_client_id_required error instead of an
+// authorization URL with an empty client_id, which the provider 404s.
+func TestEmptyClientIDFlowError_EmptyClientID(t *testing.T) {
+	c := newClientIDGuardTestClient(t)
+
+	authURL := "https://github.com/login/oauth/authorize?client_id=&code_challenge=abc&code_challenge_method=S256&redirect_uri=http%3A%2F%2F127.0.0.1%3A62876%2Foauth%2Fcallback"
+	flowErr := c.emptyClientIDFlowError(authURL, "corr-123")
+
+	require.NotNil(t, flowErr, "empty client_id in authorization URL must be rejected")
+	assert.Equal(t, contracts.OAuthErrorClientIDRequired, flowErr.ErrorType)
+	assert.Equal(t, contracts.OAuthCodeNoClientID, flowErr.ErrorCode)
+	assert.Equal(t, "github", flowErr.ServerName)
+	assert.Equal(t, "corr-123", flowErr.CorrelationID)
+	assert.Contains(t, flowErr.Suggestion, "oauth.client_id")
+	assert.False(t, flowErr.Success)
+}
+
+func TestEmptyClientIDFlowError_MissingClientIDParam(t *testing.T) {
+	c := newClientIDGuardTestClient(t)
+
+	authURL := "https://github.com/login/oauth/authorize?code_challenge=abc&code_challenge_method=S256"
+	flowErr := c.emptyClientIDFlowError(authURL, "")
+
+	require.NotNil(t, flowErr, "authorization URL without client_id param must be rejected")
+	assert.Equal(t, contracts.OAuthErrorClientIDRequired, flowErr.ErrorType)
+}
+
+func TestEmptyClientIDFlowError_PresentClientID(t *testing.T) {
+	c := newClientIDGuardTestClient(t)
+
+	authURL := "https://github.com/login/oauth/authorize?client_id=Iv1.abc123&code_challenge=abc"
+	flowErr := c.emptyClientIDFlowError(authURL, "corr-123")
+
+	assert.Nil(t, flowErr, "a URL carrying a client_id must pass the guard")
+}
+
+func TestEmptyClientIDFlowError_ClientIDViaExtraParams(t *testing.T) {
+	c := newClientIDGuardTestClient(t)
+
+	// A client_id injected through oauth.extra_params must also satisfy the
+	// guard — the check is on the final URL, not on the handler state.
+	authURL := "https://example.com/authorize?client_id=from-extra-params&resource=https%3A%2F%2Fexample.com"
+	flowErr := c.emptyClientIDFlowError(authURL, "")
+
+	assert.Nil(t, flowErr)
+}
+
+func TestEmptyClientIDFlowError_UnparseableURL(t *testing.T) {
+	c := newClientIDGuardTestClient(t)
+
+	// An unparseable URL is not this guard's concern — never block on it.
+	flowErr := c.emptyClientIDFlowError("://not-a-url", "")
+
+	assert.Nil(t, flowErr)
+}

--- a/internal/upstream/core/oauth_clientid_guard_test.go
+++ b/internal/upstream/core/oauth_clientid_guard_test.go
@@ -30,7 +30,7 @@ func TestEmptyClientIDFlowError_EmptyClientID(t *testing.T) {
 	c := newClientIDGuardTestClient(t)
 
 	authURL := "https://github.com/login/oauth/authorize?client_id=&code_challenge=abc&code_challenge_method=S256&redirect_uri=http%3A%2F%2F127.0.0.1%3A62876%2Foauth%2Fcallback"
-	flowErr := c.emptyClientIDFlowError(authURL, "corr-123", errors.New("server does not support dynamic client registration"))
+	flowErr := c.emptyClientIDFlowError(authURL, "corr-123", errors.New("server does not support dynamic client registration"), nil)
 
 	require.NotNil(t, flowErr, "empty client_id in authorization URL must be rejected")
 	assert.Equal(t, contracts.OAuthErrorClientIDRequired, flowErr.ErrorType)
@@ -45,7 +45,7 @@ func TestEmptyClientIDFlowError_MissingClientIDParam(t *testing.T) {
 	c := newClientIDGuardTestClient(t)
 
 	authURL := "https://github.com/login/oauth/authorize?code_challenge=abc&code_challenge_method=S256"
-	flowErr := c.emptyClientIDFlowError(authURL, "", nil)
+	flowErr := c.emptyClientIDFlowError(authURL, "", nil, nil)
 
 	require.NotNil(t, flowErr, "authorization URL without client_id param must be rejected")
 	assert.Equal(t, contracts.OAuthErrorClientIDRequired, flowErr.ErrorType)
@@ -55,7 +55,7 @@ func TestEmptyClientIDFlowError_PresentClientID(t *testing.T) {
 	c := newClientIDGuardTestClient(t)
 
 	authURL := "https://github.com/login/oauth/authorize?client_id=Iv1.abc123&code_challenge=abc"
-	flowErr := c.emptyClientIDFlowError(authURL, "corr-123", nil)
+	flowErr := c.emptyClientIDFlowError(authURL, "corr-123", nil, nil)
 
 	assert.Nil(t, flowErr, "a URL carrying a client_id must pass the guard")
 }
@@ -66,7 +66,7 @@ func TestEmptyClientIDFlowError_ClientIDViaExtraParams(t *testing.T) {
 	// A client_id injected through oauth.extra_params must also satisfy the
 	// guard — the check is on the final URL, not on the handler state.
 	authURL := "https://example.com/authorize?client_id=from-extra-params&resource=https%3A%2F%2Fexample.com"
-	flowErr := c.emptyClientIDFlowError(authURL, "", nil)
+	flowErr := c.emptyClientIDFlowError(authURL, "", nil, nil)
 
 	assert.Nil(t, flowErr)
 }
@@ -75,7 +75,7 @@ func TestEmptyClientIDFlowError_UnparseableURL(t *testing.T) {
 	c := newClientIDGuardTestClient(t)
 
 	// An unparseable URL is not this guard's concern — never block on it.
-	flowErr := c.emptyClientIDFlowError("://not-a-url", "", nil)
+	flowErr := c.emptyClientIDFlowError("://not-a-url", "", nil, nil)
 
 	assert.Nil(t, flowErr)
 }
@@ -88,7 +88,7 @@ func TestEmptyClientIDFlowError_DCR403Details(t *testing.T) {
 	c := newClientIDGuardTestClient(t)
 
 	authURL := "https://example.com/authorize?client_id="
-	flowErr := c.emptyClientIDFlowError(authURL, "", errors.New("registration failed: HTTP 403 Forbidden"))
+	flowErr := c.emptyClientIDFlowError(authURL, "", errors.New("registration failed: HTTP 403 Forbidden"), nil)
 
 	require.NotNil(t, flowErr)
 	require.NotNil(t, flowErr.Details)
@@ -103,7 +103,7 @@ func TestEmptyClientIDFlowError_DCRUnsupportedDetails(t *testing.T) {
 	c := newClientIDGuardTestClient(t)
 
 	authURL := "https://github.com/login/oauth/authorize?client_id="
-	flowErr := c.emptyClientIDFlowError(authURL, "", errors.New("server does not support dynamic client registration"))
+	flowErr := c.emptyClientIDFlowError(authURL, "", errors.New("server does not support dynamic client registration"), nil)
 
 	require.NotNil(t, flowErr)
 	require.NotNil(t, flowErr.Details)
@@ -118,9 +118,37 @@ func TestEmptyClientIDFlowError_NoDCRAttempt(t *testing.T) {
 	c := newClientIDGuardTestClient(t)
 
 	// nil dcrErr (DCR not attempted or succeeded): no DCRStatus fabricated.
-	flowErr := c.emptyClientIDFlowError("https://example.com/authorize?client_id=", "", nil)
+	flowErr := c.emptyClientIDFlowError("https://example.com/authorize?client_id=", "", nil, nil)
 
 	require.NotNil(t, flowErr)
 	require.NotNil(t, flowErr.Details)
 	assert.Nil(t, flowErr.Details.DCRStatus)
+}
+
+type stubClientIDProvider struct{ id string }
+
+func (s stubClientIDProvider) GetClientID() string { return s.id }
+
+// Codex r2 finding 1: a client_id present only via oauth.extra_params passes
+// the guard (escape hatch for lenient providers) but must not be treated as a
+// fully-configured client — the helper only warns; behavior is pass-through.
+func TestEmptyClientIDFlowError_ExtraParamsClientIDStillPasses(t *testing.T) {
+	c := newClientIDGuardTestClient(t)
+
+	authURL := "https://example.com/authorize?client_id=from-extra-params"
+	flowErr := c.emptyClientIDFlowError(authURL, "", nil, stubClientIDProvider{id: ""})
+
+	assert.Nil(t, flowErr)
+}
+
+// Codex r2 finding 2: "Forbidden" without a literal "403" still maps to
+// status_code 403 (best-effort; mcp-go errors are untyped).
+func TestEmptyClientIDFlowError_ForbiddenMapsTo403(t *testing.T) {
+	c := newClientIDGuardTestClient(t)
+
+	flowErr := c.emptyClientIDFlowError("https://example.com/authorize?client_id=", "", errors.New("registration request failed: Forbidden"), nil)
+
+	require.NotNil(t, flowErr)
+	require.NotNil(t, flowErr.Details.DCRStatus)
+	assert.Equal(t, 403, flowErr.Details.DCRStatus.StatusCode)
 }


### PR DESCRIPTION
Fixes #975.

## Root cause

GitHub's authorization server (`https://github.com/login/oauth`) advertises no `registration_endpoint` in its RFC 8414 metadata, so Dynamic Client Registration is impossible. mcpproxy attempted DCR, got `server does not support dynamic client registration` from mcp-go, logged a warning, and fell through to "public client OAuth with PKCE, no client_id" — a premise that is incorrect (OAuth public clients still require a `client_id`; PKCE replaces the client *secret*, not the id). The result was `https://github.com/login/oauth/authorize?client_id=&…`, which GitHub 404s.

Two paths were affected:
- `getAuthorizationURLQuick` (REST `POST /api/v1/servers/{name}/login` + `mcpproxy auth login` daemon mode) had **no** empty-client_id guard at all — the CLI printed "OAuth authentication flow initiated successfully" and exited 0 on a guaranteed-broken URL.
- `handleOAuthAuthorization` (connection-triggered) had a guard, but only keyed on DCR errors containing "403" (the Figma case) and misreported every failure as "DCR returned 403".

## Fix

New `Client.emptyClientIDFlowError` guard, wired into **both** paths: parses the *final* authorization URL (after `oauth.extra_params` injection, so a client_id supplied that way still passes) and returns a structured `oauth_client_id_required` / `OAUTH_NO_CLIENT_ID` error with an actionable suggestion instead of ever surfacing a broken URL.

## Verification (isolated instance against real api.githubcopilot.com)

- Before (main @ 2b90a105f, reproduced live): REST login → HTTP 200 `success:true` with `auth_url=…client_id=&…`; CLI → exit 0 "flow initiated successfully".
- After: REST login → `success:false, error_type=oauth_client_id_required` with suggestion to set `oauth.client_id`; CLI → exit 1 with the full structured error block; **zero** authorize URLs in logs.
- Regression guard: with `"oauth": {"client_id": "…"}` configured, the login flow still returns a working authorize URL carrying that client_id.
- `go test -race ./internal/upstream/... ./internal/oauth/...` green; both editions build; `golangci-lint` (CI v2 config) 0 issues; 5 new unit tests for the guard.