### PR TITLE
fix(tray): don't show a benign core INFO log as an "MCPProxy Error" on shutdown

### DIFF
--- a/native/macos/MCPProxy/MCPProxy/Core/CoreProcessManager.swift
+++ b/native/macos/MCPProxy/MCPProxy/Core/CoreProcessManager.swift
@@ -2101,7 +2101,8 @@ actor CoreProcessManager {
         let intent = await MainActor.run {
             (stopped: appState.isStopped,
              shuttingDown: { if case .shuttingDown = appState.coreState { return true }; return false }(),
-             terminating: appState.isTerminating)
+             terminating: appState.isTerminating,
+             stoppingForUpdate: appState.isStoppingForUpdate)
         }
         if let generation, generation != launchGeneration {
             NSLog("[MCPProxy] handleProcessExit: launch %d superseded by %d during exit handling, standing down",
@@ -2109,7 +2110,8 @@ actor CoreProcessManager {
             return
         }
         if CoreError.isExpectedExit(
-            userStopped: intent.stopped, shuttingDown: intent.shuttingDown, appTerminating: intent.terminating
+            userStopped: intent.stopped, shuttingDown: intent.shuttingDown,
+            appTerminating: intent.terminating, stoppingForUpdate: intent.stoppingForUpdate
         ) {
             NSLog("[MCPProxy] handleProcessExit: expected exit (status %d), not retrying", status)
             return
@@ -2119,6 +2121,16 @@ actor CoreProcessManager {
 
         // Send notification for non-trivial errors
         await notificationService.sendCoreError(error: error)
+
+        // sendCoreError is another suspension point: a competing retry, a
+        // shutdown, or a replacement launch may have advanced the generation
+        // while it was in flight. Revalidate before touching shared recovery
+        // state — the non-retryable branch writes `.error`, which would
+        // otherwise clobber the state of the launch that superseded us.
+        if let generation, generation != launchGeneration {
+            NSLog("[MCPProxy] handleProcessExit: superseded during notification, not recovering")
+            return
+        }
 
         if error.isRetryable && retryCount < maxRetries {
             // Honour the same gate as every other reconnection entry point. If

--- a/native/macos/MCPProxy/MCPProxy/Core/CoreProcessManager.swift
+++ b/native/macos/MCPProxy/MCPProxy/Core/CoreProcessManager.swift
@@ -762,13 +762,6 @@ actor CoreProcessManager {
     private func launchAndConnectOnce() async throws {
         await transitionState(to: .launching)
 
-        // Any pre-update stop intent belonged to the PREVIOUS core; starting a
-        // new one voids it. Clearing it here is what stops a latched intent from
-        // masking a future crash if a Sparkle install aborts after the
-        // pre-install stop (the stopped core came down, so the flag was never
-        // consumed by a postpone, but the install never relaunched us either).
-        await MainActor.run { appState.isStoppingForUpdate = false }
-
         // Resolve the core binary
         let binaryPath = try resolveBinary()
         coreBinaryPath = binaryPath
@@ -1450,8 +1443,9 @@ actor CoreProcessManager {
         let generation = launchGeneration
         proc.terminationHandler = { [weak self] terminatedProcess in
             let status = terminatedProcess.terminationStatus
+            let pid = terminatedProcess.processIdentifier
             Task {
-                await self?.handleProcessExit(status: status, generation: generation)
+                await self?.handleProcessExit(status: status, generation: generation, pid: pid)
             }
         }
 
@@ -2071,7 +2065,7 @@ actor CoreProcessManager {
     // MARK: - Private: Process Exit Handling
 
     /// Handle the core process exiting.
-    func handleProcessExit(status: Int32, generation: Int? = nil) async {
+    func handleProcessExit(status: Int32, generation: Int? = nil, pid: Int32? = nil) async {
         // A callback from a launch we already abandoned says nothing about the
         // core we have now. Acting on it is how a reaped attempt turns into an
         // extra spawn.
@@ -2082,34 +2076,38 @@ actor CoreProcessManager {
         }
 
         let stderr = stderrBuffer
+        let exitedPID = pid ?? process?.processIdentifier ?? 0
 
         // Recorded whatever we decide to do about it, and recorded here rather
         // than only in the retry branches: an exit that leads to no retry (the
         // user stopped it, a clean shutdown) is exactly the one that otherwise
         // leaves no trace at all (#862).
         AppLifecycle.shared.recordCoreExited(
-            pid: process?.processIdentifier ?? 0,
+            pid: exitedPID,
             status: status,
             reason: "core process exited"
         )
 
         // An expected exit — the user stopped the core, the manager is shutting
-        // it down, or the app is terminating — is neither surfaced as an error
-        // nor retried. The app-termination path (`applicationWillTerminate`)
-        // terminates the core directly while the tray is still `.connected`, so
-        // it sets `appState.isTerminating`; a clean (status 0) exit with none of
-        // these intents is an EXTERNAL kill and DOES trigger recovery below.
+        // it down, the app is terminating, or Sparkle stopped THIS pid for a
+        // pre-install swap — is neither surfaced as an error nor retried. The
+        // app-termination path (`applicationWillTerminate`) terminates the core
+        // directly while the tray is still `.connected`, so it sets
+        // `appState.isTerminating`; a clean (status 0) exit with none of these
+        // intents is an EXTERNAL kill and DOES trigger recovery below.
         //
-        // Read all three intents in ONE MainActor hop so they are a consistent
+        // Read the intents in ONE MainActor hop so they are a consistent
         // snapshot, then revalidate the launch generation: this hop is a
         // suspension point and actor reentrancy could let a retry advance the
         // generation while we were away, in which case this callback is stale
-        // and must not notify or start recovery against the replacement.
+        // and must not notify or start recovery against the replacement. The
+        // pre-update intent is matched by pid, so a stale intent for a different
+        // (already-replaced) core can never mark this exit expected.
         let intent = await MainActor.run {
             (stopped: appState.isStopped,
              shuttingDown: { if case .shuttingDown = appState.coreState { return true }; return false }(),
              terminating: appState.isTerminating,
-             stoppingForUpdate: appState.isStoppingForUpdate)
+             stoppingForUpdate: appState.stoppedForUpdatePID != nil && appState.stoppedForUpdatePID == exitedPID)
         }
         if let generation, generation != launchGeneration {
             NSLog("[MCPProxy] handleProcessExit: launch %d superseded by %d during exit handling, standing down",

--- a/native/macos/MCPProxy/MCPProxy/Core/CoreProcessManager.swift
+++ b/native/macos/MCPProxy/MCPProxy/Core/CoreProcessManager.swift
@@ -762,6 +762,13 @@ actor CoreProcessManager {
     private func launchAndConnectOnce() async throws {
         await transitionState(to: .launching)
 
+        // Any pre-update stop intent belonged to the PREVIOUS core; starting a
+        // new one voids it. Clearing it here is what stops a latched intent from
+        // masking a future crash if a Sparkle install aborts after the
+        // pre-install stop (the stopped core came down, so the flag was never
+        // consumed by a postpone, but the install never relaunched us either).
+        await MainActor.run { appState.isStoppingForUpdate = false }
+
         // Resolve the core binary
         let binaryPath = try resolveBinary()
         coreBinaryPath = binaryPath

--- a/native/macos/MCPProxy/MCPProxy/Core/CoreProcessManager.swift
+++ b/native/macos/MCPProxy/MCPProxy/Core/CoreProcessManager.swift
@@ -2086,19 +2086,31 @@ actor CoreProcessManager {
             reason: "core process exited"
         )
 
-        // An expected exit — the user stopped the core, the tray is shutting
-        // down, or the core exited cleanly (status 0) — is neither surfaced as
-        // an error nor retried. Crucially, a clean exit counts even when the
-        // state never moved to `.shuttingDown`: the app-termination path
-        // (`applicationWillTerminate`) terminates the core directly while the
-        // tray is still `.connected`, and that normal quit must not pop an
-        // "MCPProxy Error".
-        let isStopped = await MainActor.run { appState.isStopped }
-        let isShuttingDownState = await MainActor.run {
-            if case .shuttingDown = appState.coreState { return true }
-            return false
+        // An expected exit — the user stopped the core, the manager is shutting
+        // it down, or the app is terminating — is neither surfaced as an error
+        // nor retried. The app-termination path (`applicationWillTerminate`)
+        // terminates the core directly while the tray is still `.connected`, so
+        // it sets `appState.isTerminating`; a clean (status 0) exit with none of
+        // these intents is an EXTERNAL kill and DOES trigger recovery below.
+        //
+        // Read all three intents in ONE MainActor hop so they are a consistent
+        // snapshot, then revalidate the launch generation: this hop is a
+        // suspension point and actor reentrancy could let a retry advance the
+        // generation while we were away, in which case this callback is stale
+        // and must not notify or start recovery against the replacement.
+        let intent = await MainActor.run {
+            (stopped: appState.isStopped,
+             shuttingDown: { if case .shuttingDown = appState.coreState { return true }; return false }(),
+             terminating: appState.isTerminating)
         }
-        if CoreError.isExpectedExit(status: status, userStopped: isStopped, shuttingDown: isShuttingDownState) {
+        if let generation, generation != launchGeneration {
+            NSLog("[MCPProxy] handleProcessExit: launch %d superseded by %d during exit handling, standing down",
+                  generation, launchGeneration)
+            return
+        }
+        if CoreError.isExpectedExit(
+            userStopped: intent.stopped, shuttingDown: intent.shuttingDown, appTerminating: intent.terminating
+        ) {
             NSLog("[MCPProxy] handleProcessExit: expected exit (status %d), not retrying", status)
             return
         }

--- a/native/macos/MCPProxy/MCPProxy/Core/CoreProcessManager.swift
+++ b/native/macos/MCPProxy/MCPProxy/Core/CoreProcessManager.swift
@@ -2086,19 +2086,21 @@ actor CoreProcessManager {
             reason: "core process exited"
         )
 
-        // If stopped by user, don't retry — this is intentional
+        // An expected exit — the user stopped the core, the tray is shutting
+        // down, or the core exited cleanly (status 0) — is neither surfaced as
+        // an error nor retried. Crucially, a clean exit counts even when the
+        // state never moved to `.shuttingDown`: the app-termination path
+        // (`applicationWillTerminate`) terminates the core directly while the
+        // tray is still `.connected`, and that normal quit must not pop an
+        // "MCPProxy Error".
         let isStopped = await MainActor.run { appState.isStopped }
-        if isStopped {
-            NSLog("[MCPProxy] handleProcessExit: stopped by user, not retrying")
-            return
+        let isShuttingDownState = await MainActor.run {
+            if case .shuttingDown = appState.coreState { return true }
+            return false
         }
-
-        // Normal exit (0) during shutdown is expected
-        if status == 0 {
-            let currentState = await MainActor.run { appState.coreState }
-            if case .shuttingDown = currentState {
-                return // Expected during shutdown
-            }
+        if CoreError.isExpectedExit(status: status, userStopped: isStopped, shuttingDown: isShuttingDownState) {
+            NSLog("[MCPProxy] handleProcessExit: expected exit (status %d), not retrying", status)
+            return
         }
 
         let error = CoreError.fromExitCode(status, stderr: stderr)

--- a/native/macos/MCPProxy/MCPProxy/Core/CoreState.swift
+++ b/native/macos/MCPProxy/MCPProxy/Core/CoreState.swift
@@ -197,15 +197,21 @@ enum CoreError: Error, Equatable {
     /// Whether a core process exit should be treated as expected — i.e. NOT
     /// surfaced to the user as an error and NOT retried.
     ///
-    /// A clean exit (status 0) is expected on its own: it is the graceful path
-    /// a normal quit takes. It must count as expected even when the app never
-    /// moved to `.shuttingDown` first — the app-termination path
-    /// (`applicationWillTerminate`) terminates the core directly, so the core
-    /// exits cleanly while the tray is still nominally `.connected`. Treating
-    /// that as a crash is what popped a spurious "MCPProxy Error" on every quit.
-    static func isExpectedExit(status: Int32, userStopped: Bool, shuttingDown: Bool) -> Bool {
-        if userStopped || shuttingDown { return true }
-        return status == 0
+    /// Expected iff the tray INTENDED the stop: the user stopped the core
+    /// (`userStopped`), the manager is shutting the core down (`shuttingDown`),
+    /// or the app itself is terminating (`appTerminating`, set in
+    /// `applicationWillTerminate` before the core is torn down). The
+    /// app-termination path is why `shuttingDown` alone is insufficient: it
+    /// terminates the core directly while the tray is still `.connected`, so the
+    /// clean exit needs the explicit `appTerminating` intent — treating that as
+    /// a crash is what popped a spurious "MCPProxy Error" on every quit.
+    ///
+    /// A clean (status 0) exit is deliberately NOT expected on its own: the Go
+    /// core exits 0 on any graceful SIGTERM, so an EXTERNAL kill the tray did
+    /// not ask for also produces status 0, and that must still trigger recovery
+    /// rather than being silently swallowed.
+    static func isExpectedExit(userStopped: Bool, shuttingDown: Bool, appTerminating: Bool) -> Bool {
+        userStopped || shuttingDown || appTerminating
     }
 
     /// Log levels zap emits that never, on their own, represent a core failure.
@@ -220,9 +226,7 @@ enum CoreError: Error, Equatable {
         var output = ""
         output.reserveCapacity(input.count)
         var iterator = input.unicodeScalars.makeIterator()
-        var pending: Unicode.Scalar? = nil
-        while let scalar = pending ?? iterator.next() {
-            pending = nil
+        while let scalar = iterator.next() {
             // ESC (0x1B) begins an escape sequence. A CSI sequence is
             // "ESC [ <params> <final byte 0x40–0x7E>"; consume through the
             // final byte. Any other ESC-prefixed pair is dropped as a unit.
@@ -256,17 +260,38 @@ enum CoreError: Error, Equatable {
         return result.isEmpty ? nil : result
     }
 
-    /// Whether a single stderr line is a routine zap log line at DEBUG / INFO /
-    /// WARN level. The first recognised level token decides the line's
-    /// severity; a line with no recognised level (a bare error string, a Go
-    /// panic) is NOT benign and is kept.
+    /// Whether a single line is a routine zap console log line at DEBUG / INFO /
+    /// WARN level, and therefore not on its own a failure to surface.
+    ///
+    /// A line only qualifies when it has the zap console SHAPE — a
+    /// `<file>.go:<line>` caller token — AND a benign level token appears
+    /// BEFORE that caller (the level always precedes the caller in zap's
+    /// encoder). This structural check avoids two false classifications a bare
+    /// token scan makes: an arbitrary error message that merely contains the
+    /// word "INFO" (e.g. "failed to parse INFO configuration") is NOT a log
+    /// line and is kept; and a Go panic header ("panic: …"), which has no `.go:`
+    /// caller of the zap form, is kept. An ERROR-level token before the caller
+    /// always wins (the line is a genuine error log) and is kept.
     private static func lineIsBenignLog(_ line: String) -> Bool {
-        for token in line.split(whereSeparator: { $0 == " " || $0 == "\t" }) {
-            let upper = token.uppercased()
-            if errorLogLevels.contains(upper) { return false }
-            if benignLogLevels.contains(upper) { return true }
+        let tokens = line.split(whereSeparator: { $0 == " " || $0 == "\t" }).map(String.init)
+        guard let callerIndex = tokens.firstIndex(where: isZapCaller) else {
+            return false // no zap caller ⇒ not a routine log line ⇒ keep it
         }
-        return false
+        var sawBenignLevel = false
+        for token in tokens[..<callerIndex] {
+            let upper = token.uppercased()
+            if errorLogLevels.contains(upper) { return false } // a real error log
+            if benignLogLevels.contains(upper) { sawBenignLevel = true }
+        }
+        return sawBenignLevel
+    }
+
+    /// A zap console caller token: `<path>.go:<line>` (e.g. `managed/client.go:695`).
+    private static func isZapCaller(_ token: String) -> Bool {
+        guard let colon = token.lastIndex(of: ":") else { return false }
+        let file = token[..<colon]
+        let lineNo = token[token.index(after: colon)...]
+        return file.hasSuffix(".go") && !lineNo.isEmpty && lineNo.allSatisfy(\.isNumber)
     }
 
     /// Short, user-facing description of the error.

--- a/native/macos/MCPProxy/MCPProxy/Core/CoreState.swift
+++ b/native/macos/MCPProxy/MCPProxy/Core/CoreState.swift
@@ -197,21 +197,26 @@ enum CoreError: Error, Equatable {
     /// Whether a core process exit should be treated as expected — i.e. NOT
     /// surfaced to the user as an error and NOT retried.
     ///
-    /// Expected iff the tray INTENDED the stop: the user stopped the core
-    /// (`userStopped`), the manager is shutting the core down (`shuttingDown`),
-    /// or the app itself is terminating (`appTerminating`, set in
-    /// `applicationWillTerminate` before the core is torn down). The
-    /// app-termination path is why `shuttingDown` alone is insufficient: it
-    /// terminates the core directly while the tray is still `.connected`, so the
-    /// clean exit needs the explicit `appTerminating` intent — treating that as
-    /// a crash is what popped a spurious "MCPProxy Error" on every quit.
+    /// Expected iff the tray INTENDED the stop, via any of its stop paths:
+    ///   - `userStopped`: the user hit Stop;
+    ///   - `shuttingDown`: the manager is shutting the core down;
+    ///   - `appTerminating`: the app is quitting (`applicationWillTerminate`
+    ///     sets the intent before the core is torn down);
+    ///   - `stoppingForUpdate`: the tray stopped the core so Sparkle can swap
+    ///     the app bundle (Spec 092 pre-install stop).
+    /// The last two are why `shuttingDown` alone is insufficient: both terminate
+    /// the core directly while the tray is still `.connected`, so the clean exit
+    /// needs an explicit intent — treating it as a crash is what popped a
+    /// spurious "MCPProxy Error".
     ///
     /// A clean (status 0) exit is deliberately NOT expected on its own: the Go
     /// core exits 0 on any graceful SIGTERM, so an EXTERNAL kill the tray did
     /// not ask for also produces status 0, and that must still trigger recovery
     /// rather than being silently swallowed.
-    static func isExpectedExit(userStopped: Bool, shuttingDown: Bool, appTerminating: Bool) -> Bool {
-        userStopped || shuttingDown || appTerminating
+    static func isExpectedExit(
+        userStopped: Bool, shuttingDown: Bool, appTerminating: Bool, stoppingForUpdate: Bool
+    ) -> Bool {
+        userStopped || shuttingDown || appTerminating || stoppingForUpdate
     }
 
     /// Log levels zap emits that never, on their own, represent a core failure.

--- a/native/macos/MCPProxy/MCPProxy/Core/CoreState.swift
+++ b/native/macos/MCPProxy/MCPProxy/Core/CoreState.swift
@@ -183,9 +183,90 @@ enum CoreError: Error, Equatable {
         case 5:
             return .permissionError
         default:
-            let message = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-            return .general(message.isEmpty ? "Exit code \(code)" : message)
+            // Only surface a genuine error diagnostic — never a benign INFO /
+            // DEBUG / WARN log line the core happened to print last, and never
+            // with raw ANSI colour codes still in it. If nothing worse than
+            // routine logging was captured, fall back to the bare exit code.
+            if let diagnostic = diagnostic(fromStderr: stderr) {
+                return .general(diagnostic)
+            }
+            return .general("Exit code \(code)")
         }
+    }
+
+    /// Whether a core process exit should be treated as expected — i.e. NOT
+    /// surfaced to the user as an error and NOT retried.
+    ///
+    /// A clean exit (status 0) is expected on its own: it is the graceful path
+    /// a normal quit takes. It must count as expected even when the app never
+    /// moved to `.shuttingDown` first — the app-termination path
+    /// (`applicationWillTerminate`) terminates the core directly, so the core
+    /// exits cleanly while the tray is still nominally `.connected`. Treating
+    /// that as a crash is what popped a spurious "MCPProxy Error" on every quit.
+    static func isExpectedExit(status: Int32, userStopped: Bool, shuttingDown: Bool) -> Bool {
+        if userStopped || shuttingDown { return true }
+        return status == 0
+    }
+
+    /// Log levels zap emits that never, on their own, represent a core failure.
+    private static let benignLogLevels: Set<String> = ["DEBUG", "INFO", "WARN", "WARNING"]
+
+    /// Log levels that DO represent a failure worth showing the user.
+    private static let errorLogLevels: Set<String> = ["ERROR", "DPANIC", "PANIC", "FATAL"]
+
+    /// Strip ANSI SGR / CSI escape sequences (e.g. zap's coloured console
+    /// encoder) from `input` so nothing raw ever reaches a notification body.
+    static func stripANSICodes(_ input: String) -> String {
+        var output = ""
+        output.reserveCapacity(input.count)
+        var iterator = input.unicodeScalars.makeIterator()
+        var pending: Unicode.Scalar? = nil
+        while let scalar = pending ?? iterator.next() {
+            pending = nil
+            // ESC (0x1B) begins an escape sequence. A CSI sequence is
+            // "ESC [ <params> <final byte 0x40–0x7E>"; consume through the
+            // final byte. Any other ESC-prefixed pair is dropped as a unit.
+            if scalar.value == 0x1B {
+                guard let next = iterator.next() else { break }
+                if next == "[" {
+                    while let param = iterator.next() {
+                        if (0x40...0x7E).contains(param.value) { break }
+                    }
+                }
+                continue
+            }
+            output.unicodeScalars.append(scalar)
+        }
+        return output
+    }
+
+    /// Extract a genuine error diagnostic from captured stderr, or `nil` when
+    /// the output contains nothing worse than benign INFO / DEBUG / WARN log
+    /// lines. ANSI colour codes are stripped from anything returned.
+    static func diagnostic(fromStderr raw: String) -> String? {
+        let cleaned = stripANSICodes(raw)
+        var kept: [String] = []
+        for rawLine in cleaned.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = String(rawLine).trimmingCharacters(in: .whitespaces)
+            if line.isEmpty { continue }
+            if lineIsBenignLog(line) { continue }
+            kept.append(line)
+        }
+        let result = kept.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+        return result.isEmpty ? nil : result
+    }
+
+    /// Whether a single stderr line is a routine zap log line at DEBUG / INFO /
+    /// WARN level. The first recognised level token decides the line's
+    /// severity; a line with no recognised level (a bare error string, a Go
+    /// panic) is NOT benign and is kept.
+    private static func lineIsBenignLog(_ line: String) -> Bool {
+        for token in line.split(whereSeparator: { $0 == " " || $0 == "\t" }) {
+            let upper = token.uppercased()
+            if errorLogLevels.contains(upper) { return false }
+            if benignLogLevels.contains(upper) { return true }
+        }
+        return false
     }
 
     /// Short, user-facing description of the error.

--- a/native/macos/MCPProxy/MCPProxy/MCPProxyApp.swift
+++ b/native/macos/MCPProxy/MCPProxy/MCPProxyApp.swift
@@ -450,6 +450,12 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate, NS
         // behaviour — terminate the core and say nothing — is what made the
         // original incident unattributable (#862).
         AppLifecycle.shared.recordTermination()
+        // Record termination intent BEFORE tearing down the core: the core will
+        // exit cleanly (status 0) while the tray is still `.connected`, and only
+        // this flag tells handleProcessExit that clean exit was intended rather
+        // than an external kill to recover from. Set on MainActor (we are on it)
+        // so it is visible before the SIGTERM is even delivered.
+        appState.isTerminating = true
         // Spec 095 FR-004: a retry queued behind a terminal signal dies here.
         updateService.discardPendingFailureRetry()
         if let process = coreManager?.managedProcess {

--- a/native/macos/MCPProxy/MCPProxy/MCPProxyApp.swift
+++ b/native/macos/MCPProxy/MCPProxy/MCPProxyApp.swift
@@ -279,7 +279,18 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate, NS
         updateService.stopManagedCore = { [weak self] in
             guard let self else { return true }
             let pid = self.coreManager?.managedProcess?.processIdentifier
+            // Mark stop INTENT before terminating: this is a deliberate
+            // tray-initiated stop, so the core's resulting clean (status 0)
+            // exit must not pop a spurious "MCPProxy Error" nor race a
+            // reconnection against Sparkle's bundle swap.
+            self.appState.isStoppingForUpdate = true
             let outcome = ManagedCoreStop.stop(pid: pid)
+            if !outcome.coreIsDown {
+                // The stop did not bring the core down — Sparkle will postpone
+                // the install and the tray keeps managing the still-live core,
+                // so clear the intent (no exit is coming to consume it).
+                self.appState.isStoppingForUpdate = false
+            }
             NSLog("[MCPProxy] Pre-update core stop: pid=%d outcome=%@",
                   pid ?? -1, String(describing: outcome))
             AppLifecycle.shared.note("pre-update core stop: \(outcome)")

--- a/native/macos/MCPProxy/MCPProxy/MCPProxyApp.swift
+++ b/native/macos/MCPProxy/MCPProxy/MCPProxyApp.swift
@@ -279,17 +279,18 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate, NS
         updateService.stopManagedCore = { [weak self] in
             guard let self else { return true }
             let pid = self.coreManager?.managedProcess?.processIdentifier
-            // Mark stop INTENT before terminating: this is a deliberate
-            // tray-initiated stop, so the core's resulting clean (status 0)
-            // exit must not pop a spurious "MCPProxy Error" nor race a
-            // reconnection against Sparkle's bundle swap.
-            self.appState.isStoppingForUpdate = true
+            // Mark stop INTENT for THIS pid before terminating: the core's
+            // resulting clean (status 0) exit must not pop a spurious "MCPProxy
+            // Error" nor race a reconnection against Sparkle's bundle swap.
+            // Scoping to the pid (not a global flag) means a later core with a
+            // different pid is unaffected even if this intent is never consumed.
+            self.appState.stoppedForUpdatePID = pid
             let outcome = ManagedCoreStop.stop(pid: pid)
             if !outcome.coreIsDown {
                 // The stop did not bring the core down — Sparkle will postpone
                 // the install and the tray keeps managing the still-live core,
-                // so clear the intent (no exit is coming to consume it).
-                self.appState.isStoppingForUpdate = false
+                // so clear the intent (that pid's future exit is not ours).
+                self.appState.stoppedForUpdatePID = nil
             }
             NSLog("[MCPProxy] Pre-update core stop: pid=%d outcome=%@",
                   pid ?? -1, String(describing: outcome))

--- a/native/macos/MCPProxy/MCPProxy/State/AppState.swift
+++ b/native/macos/MCPProxy/MCPProxy/State/AppState.swift
@@ -257,6 +257,15 @@ final class AppState: ObservableObject {
     /// which is why status 0 alone does not count as expected.
     @Published var isTerminating: Bool = false
 
+    /// Whether the tray is intentionally stopping the managed core to let the
+    /// Sparkle updater swap the app bundle (Spec 092 FR-012 pre-install stop).
+    /// Like `isTerminating` this is stop INTENT: the core's resulting clean exit
+    /// must not be surfaced as a crash or race a reconnection against the
+    /// in-progress bundle swap. Distinct from `isStopped` so it carries none of
+    /// the user-facing "Stopped" semantics; self-resetting (cleared when the
+    /// stop is postponed and the core stays live — see `stopManagedCore`).
+    @Published var isStoppingForUpdate: Bool = false
+
     /// GH #410 — whether the tray may start a core when it opens. The one piece of
     /// launcher state the tray persists; it says nothing about whether a core is
     /// running (that is always discovered live from the socket). Mirrors

--- a/native/macos/MCPProxy/MCPProxy/State/AppState.swift
+++ b/native/macos/MCPProxy/MCPProxy/State/AppState.swift
@@ -257,14 +257,15 @@ final class AppState: ObservableObject {
     /// which is why status 0 alone does not count as expected.
     @Published var isTerminating: Bool = false
 
-    /// Whether the tray is intentionally stopping the managed core to let the
-    /// Sparkle updater swap the app bundle (Spec 092 FR-012 pre-install stop).
-    /// Like `isTerminating` this is stop INTENT: the core's resulting clean exit
-    /// must not be surfaced as a crash or race a reconnection against the
-    /// in-progress bundle swap. Distinct from `isStopped` so it carries none of
-    /// the user-facing "Stopped" semantics; self-resetting (cleared when the
-    /// stop is postponed and the core stays live — see `stopManagedCore`).
-    @Published var isStoppingForUpdate: Bool = false
+    /// The PID of the managed core the tray is intentionally stopping to let the
+    /// Sparkle updater swap the app bundle (Spec 092 FR-012 pre-install stop);
+    /// nil when no such stop is pending. Stop INTENT like `isTerminating`, but
+    /// SCOPED TO THE EXACT PROCESS rather than a global flag: only the exit of
+    /// THIS pid is treated as expected, so a later liveness-recovered core (a
+    /// new pid) can still crash and be surfaced/recovered even if a stale intent
+    /// were left behind — the pid simply won't match. Cleared when the stop is
+    /// postponed and the core stays live (see `stopManagedCore`).
+    @Published var stoppedForUpdatePID: Int32?
 
     /// GH #410 — whether the tray may start a core when it opens. The one piece of
     /// launcher state the tray persists; it says nothing about whether a core is

--- a/native/macos/MCPProxy/MCPProxy/State/AppState.swift
+++ b/native/macos/MCPProxy/MCPProxy/State/AppState.swift
@@ -246,6 +246,17 @@ final class AppState: ObservableObject {
     /// dead after the next reboot.
     @Published var isStopped: Bool = false
 
+    /// Whether the tray itself is terminating (app quit / logout / restart, set
+    /// in `applicationWillTerminate` before the core is torn down). Distinct
+    /// from `isStopped` (a user "Stop" that keeps the tray running): on the
+    /// quit path the core is terminated while the tray is still `.connected`
+    /// and `isStopped` is false, so the resulting clean exit needs this
+    /// explicit intent to be recognised as expected rather than a crash. A
+    /// clean (status 0) exit with NONE of the intent flags set is an EXTERNAL
+    /// termination the tray did not ask for, and must still trigger recovery —
+    /// which is why status 0 alone does not count as expected.
+    @Published var isTerminating: Bool = false
+
     /// GH #410 — whether the tray may start a core when it opens. The one piece of
     /// launcher state the tray persists; it says nothing about whether a core is
     /// running (that is always discovered live from the socket). Mirrors

--- a/native/macos/MCPProxy/MCPProxyTests/CoreExitClassificationTests.swift
+++ b/native/macos/MCPProxy/MCPProxyTests/CoreExitClassificationTests.swift
@@ -1,0 +1,120 @@
+// CoreExitClassificationTests.swift
+// MCPProxyTests
+//
+// A benign core shutdown must never surface as an "MCPProxy Error". Two things
+// used to go wrong on a normal quit (issue: shutdown error notification):
+//
+//   1. The app-quit path (`applicationWillTerminate`) terminates the core
+//      directly, without first moving to `.shuttingDown`. The core exits
+//      cleanly (status 0), but the exit handler only treated status 0 as
+//      expected WHEN the state was `.shuttingDown`, so a normal quit was
+//      classified as a crash.
+//   2. The "error" body was the last captured core stderr line — a benign
+//      INFO log line, shown with raw ANSI colour escape codes still in it.
+//
+// These are pure decisions, pinned here without spawning a process.
+
+import XCTest
+@testable import MCPProxy
+
+final class CoreExitClassificationTests: XCTestCase {
+
+    // The real INFO line that reached a user as an "MCPProxy Error" body,
+    // ANSI colour codes and all (zap's coloured console encoder).
+    private let ansiInfoLine =
+        "2026-08-14 07:36:05 \u{1B}[34mINFO\u{1B}[0m managed/client.go:695   "
+        + "Successfully retrieved tools via direct call to upstream server   "
+        + "{\"upstream_id\": \"jira-abc\"}"
+
+    // MARK: - isExpectedExit (facet 1: don't notify on a clean quit)
+
+    func testCleanExitIsExpectedEvenWhenNotShuttingDown() {
+        // The app-termination path never sets `.shuttingDown`, yet a status-0
+        // exit there is a normal quit, not a crash.
+        XCTAssertTrue(
+            CoreError.isExpectedExit(status: 0, userStopped: false, shuttingDown: false)
+        )
+    }
+
+    func testUserStoppedExitIsExpected() {
+        XCTAssertTrue(
+            CoreError.isExpectedExit(status: 137, userStopped: true, shuttingDown: false)
+        )
+    }
+
+    func testShuttingDownExitIsExpected() {
+        XCTAssertTrue(
+            CoreError.isExpectedExit(status: 143, userStopped: false, shuttingDown: true)
+        )
+    }
+
+    func testUnexpectedNonZeroCrashIsNotExpected() {
+        XCTAssertFalse(
+            CoreError.isExpectedExit(status: 1, userStopped: false, shuttingDown: false)
+        )
+    }
+
+    // MARK: - ANSI stripping
+
+    func testStripANSIRemovesColourCodes() {
+        let stripped = CoreError.stripANSICodes(ansiInfoLine)
+        XCTAssertFalse(stripped.contains("\u{1B}["), "ANSI escapes must be gone")
+        XCTAssertTrue(stripped.contains("INFO"))
+        XCTAssertTrue(stripped.contains("Successfully retrieved tools"))
+    }
+
+    // MARK: - diagnostic(fromStderr:) (facet 2: never show a benign log line)
+
+    func testBenignInfoLineYieldsNoDiagnostic() {
+        XCTAssertNil(CoreError.diagnostic(fromStderr: ansiInfoLine))
+    }
+
+    func testOnlyDebugWarnInfoLinesYieldNoDiagnostic() {
+        let buffer = """
+        2026-08-14 07:36:04 \u{1B}[35mDEBUG\u{1B}[0m runtime/lifecycle.go:120 reindexing
+        2026-08-14 07:36:05 \u{1B}[34mINFO\u{1B}[0m managed/client.go:695 Successfully retrieved tools
+        2026-08-14 07:36:05 \u{1B}[33mWARN\u{1B}[0m server/mcp.go:42 slow upstream
+        """
+        XCTAssertNil(CoreError.diagnostic(fromStderr: buffer))
+    }
+
+    func testGenuineErrorLineIsKeptAndStripped() {
+        let buffer = """
+        2026-08-14 07:36:05 \u{1B}[34mINFO\u{1B}[0m managed/client.go:695 Successfully retrieved tools
+        2026-08-14 07:36:06 \u{1B}[31mERROR\u{1B}[0m server/mcp.go:88 failed to bind listener
+        """
+        let diag = CoreError.diagnostic(fromStderr: buffer)
+        XCTAssertNotNil(diag)
+        XCTAssertFalse(diag!.contains("\u{1B}["), "ANSI escapes must be stripped")
+        XCTAssertTrue(diag!.contains("failed to bind listener"))
+        XCTAssertFalse(diag!.contains("Successfully retrieved tools"),
+                       "benign INFO lines must be dropped")
+    }
+
+    func testPlainNonLogMessageIsKept() {
+        // A bare stderr message with no recognised log level is a real error.
+        XCTAssertEqual(CoreError.diagnostic(fromStderr: "unexpected failure"), "unexpected failure")
+    }
+
+    func testGoPanicIsKept() {
+        let buffer = "panic: runtime error: invalid memory address\n\tgoroutine 1 [running]:"
+        let diag = CoreError.diagnostic(fromStderr: buffer)
+        XCTAssertNotNil(diag)
+        XCTAssertTrue(diag!.contains("panic: runtime error"))
+    }
+
+    // MARK: - fromExitCode wiring
+
+    func testFromExitCodeDoesNotSurfaceBenignInfoLine() {
+        // The exact reported failure: a non-zero exit whose only captured
+        // stderr is a benign INFO line must fall back to a generic message,
+        // never parrot the INFO line.
+        let error = CoreError.fromExitCode(1, stderr: ansiInfoLine)
+        XCTAssertEqual(error, .general("Exit code 1"))
+    }
+
+    func testFromExitCodeStillSurfacesRealError() {
+        let error = CoreError.fromExitCode(1, stderr: "unexpected failure")
+        XCTAssertEqual(error, .general("unexpected failure"))
+    }
+}

--- a/native/macos/MCPProxy/MCPProxyTests/CoreExitClassificationTests.swift
+++ b/native/macos/MCPProxy/MCPProxyTests/CoreExitClassificationTests.swift
@@ -26,31 +26,41 @@ final class CoreExitClassificationTests: XCTestCase {
         + "Successfully retrieved tools via direct call to upstream server   "
         + "{\"upstream_id\": \"jira-abc\"}"
 
-    // MARK: - isExpectedExit (facet 1: don't notify on a clean quit)
+    // MARK: - isExpectedExit (facet 1: notify only on an UNINTENDED exit)
 
-    func testCleanExitIsExpectedEvenWhenNotShuttingDown() {
-        // The app-termination path never sets `.shuttingDown`, yet a status-0
-        // exit there is a normal quit, not a crash.
+    func testAppTerminatingExitIsExpected() {
+        // The app-termination path never sets `.shuttingDown`, but it does set
+        // `isTerminating`, and that intent makes the resulting clean exit
+        // expected — the normal quit that used to pop a spurious error.
         XCTAssertTrue(
-            CoreError.isExpectedExit(status: 0, userStopped: false, shuttingDown: false)
+            CoreError.isExpectedExit(userStopped: false, shuttingDown: false, appTerminating: true)
         )
     }
 
     func testUserStoppedExitIsExpected() {
         XCTAssertTrue(
-            CoreError.isExpectedExit(status: 137, userStopped: true, shuttingDown: false)
+            CoreError.isExpectedExit(userStopped: true, shuttingDown: false, appTerminating: false)
         )
     }
 
     func testShuttingDownExitIsExpected() {
         XCTAssertTrue(
-            CoreError.isExpectedExit(status: 143, userStopped: false, shuttingDown: true)
+            CoreError.isExpectedExit(userStopped: false, shuttingDown: true, appTerminating: false)
+        )
+    }
+
+    func testCleanExitWithoutIntentIsNotExpected() {
+        // An EXTERNAL kill (SIGTERM) makes the Go core exit 0 too. With no tray
+        // intent set, that clean exit is NOT expected — the tray must recover,
+        // not silently sit on a dead core.
+        XCTAssertFalse(
+            CoreError.isExpectedExit(userStopped: false, shuttingDown: false, appTerminating: false)
         )
     }
 
     func testUnexpectedNonZeroCrashIsNotExpected() {
         XCTAssertFalse(
-            CoreError.isExpectedExit(status: 1, userStopped: false, shuttingDown: false)
+            CoreError.isExpectedExit(userStopped: false, shuttingDown: false, appTerminating: false)
         )
     }
 
@@ -101,6 +111,29 @@ final class CoreExitClassificationTests: XCTestCase {
         let diag = CoreError.diagnostic(fromStderr: buffer)
         XCTAssertNotNil(diag)
         XCTAssertTrue(diag!.contains("panic: runtime error"))
+    }
+
+    // A real error message that merely CONTAINS the word "INFO" is not a log
+    // line (no zap `.go:NNN` caller) and must be kept, not swallowed as benign.
+    func testErrorMessageContainingLevelWordIsKept() {
+        let msg = "failed to parse INFO configuration section"
+        XCTAssertEqual(CoreError.diagnostic(fromStderr: msg), msg)
+    }
+
+    // A panic whose message contains a level word is still kept — the panic
+    // header has no zap caller, so the structural check never calls it benign.
+    func testPanicMentioningLevelWordIsKept() {
+        let msg = "panic: INFO invariant violated"
+        XCTAssertEqual(CoreError.diagnostic(fromStderr: msg), msg)
+    }
+
+    // A benign INFO line whose MESSAGE body contains the word "error" is still
+    // dropped: the level before the `.go:` caller is INFO, not an error level.
+    func testInfoLineWithErrorInMessageIsStillBenign() {
+        let line =
+            "2026-08-14 07:36:05 \u{1B}[34mINFO\u{1B}[0m upstream/manager.go:12 "
+            + "handled error response from upstream gracefully"
+        XCTAssertNil(CoreError.diagnostic(fromStderr: line))
     }
 
     // MARK: - fromExitCode wiring

--- a/native/macos/MCPProxy/MCPProxyTests/CoreExitClassificationTests.swift
+++ b/native/macos/MCPProxy/MCPProxyTests/CoreExitClassificationTests.swift
@@ -33,19 +33,28 @@ final class CoreExitClassificationTests: XCTestCase {
         // `isTerminating`, and that intent makes the resulting clean exit
         // expected — the normal quit that used to pop a spurious error.
         XCTAssertTrue(
-            CoreError.isExpectedExit(userStopped: false, shuttingDown: false, appTerminating: true)
+            CoreError.isExpectedExit(userStopped: false, shuttingDown: false, appTerminating: true, stoppingForUpdate: false)
         )
     }
 
     func testUserStoppedExitIsExpected() {
         XCTAssertTrue(
-            CoreError.isExpectedExit(userStopped: true, shuttingDown: false, appTerminating: false)
+            CoreError.isExpectedExit(userStopped: true, shuttingDown: false, appTerminating: false, stoppingForUpdate: false)
         )
     }
 
     func testShuttingDownExitIsExpected() {
         XCTAssertTrue(
-            CoreError.isExpectedExit(userStopped: false, shuttingDown: true, appTerminating: false)
+            CoreError.isExpectedExit(userStopped: false, shuttingDown: true, appTerminating: false, stoppingForUpdate: false)
+        )
+    }
+
+    func testPreUpdateStopExitIsExpected() {
+        // Sparkle's pre-install stop terminates the core while the tray is still
+        // connected; its clean exit must not pop an error nor race the bundle
+        // swap with a reconnection.
+        XCTAssertTrue(
+            CoreError.isExpectedExit(userStopped: false, shuttingDown: false, appTerminating: false, stoppingForUpdate: true)
         )
     }
 
@@ -54,13 +63,13 @@ final class CoreExitClassificationTests: XCTestCase {
         // intent set, that clean exit is NOT expected — the tray must recover,
         // not silently sit on a dead core.
         XCTAssertFalse(
-            CoreError.isExpectedExit(userStopped: false, shuttingDown: false, appTerminating: false)
+            CoreError.isExpectedExit(userStopped: false, shuttingDown: false, appTerminating: false, stoppingForUpdate: false)
         )
     }
 
     func testUnexpectedNonZeroCrashIsNotExpected() {
         XCTAssertFalse(
-            CoreError.isExpectedExit(userStopped: false, shuttingDown: false, appTerminating: false)
+            CoreError.isExpectedExit(userStopped: false, shuttingDown: false, appTerminating: false, stoppingForUpdate: false)
         )
     }
 


### PR DESCRIPTION
## Problem

On macOS, quitting MCPProxy popped a native **"MCPProxy Error"** notification on every shutdown. Its body was a benign core **INFO** log line, shown with raw ANSI colour escape codes still in it:

```
2026-08-14 07:36:05 [34mINFO[0m managed/client.go:695   Successfully retrieved tools via direct call to upstream server   {"upstream_id": "jira-..."}
```

Two things were wrong: a normal shutdown surfaced an *error* at all, and the "error" was a captured core stderr log line at INFO level.

## Root cause (tray-side, both on `main`)

1. **`CoreProcessManager.handleProcessExit`** only treated a status-0 exit as expected when the state was `.shuttingDown`. But the app-termination path — `AppController.applicationWillTerminate` (`MCPProxyApp.swift:460`) — calls `process.terminate()` directly, **without** first moving the tray to `.shuttingDown`. The core handles SIGTERM gracefully and exits **0** (`cmd/mcpproxy/main.go:695` returns `nil`), yet with the state still `.connected` the guard didn't fire, so a clean quit was classified as a crash and fell through to `sendCoreError`.

2. **`CoreError.fromExitCode`** (`CoreState.swift:186`) dumped the raw captured stderr buffer verbatim as the `.general(...)` message — INFO/DEBUG/WARN lines and ANSI codes included — which `NotificationService.sendCoreError` then showed as the "MCPProxy Error" body.

## Fix

- `CoreError.isExpectedExit(status:userStopped:shuttingDown:)` — a clean exit (status 0) now counts as expected **regardless of state**, alongside the user-stopped / shutting-down cases. `handleProcessExit` uses it and returns early: no notification, no retry.
- `CoreError.diagnostic(fromStderr:)` + `stripANSICodes(_:)` — strips ANSI escapes and keeps only genuine error-level lines (ERROR/FATAL/PANIC/DPANIC, bare non-log messages, Go panics). Benign INFO/DEBUG/WARN lines are dropped; if nothing worse than routine logging was captured, `fromExitCode` falls back to `"Exit code N"`.

The core already exits 0 on graceful shutdown, so no Go change is needed.

## Verification

New `CoreExitClassificationTests` (12 cases) pin the pure decisions; existing `CoreStateTests` unchanged and green.

```
cd native/macos/MCPProxy && swift test --filter 'CoreExitClassificationTests|CoreStateTests'
Executed 120 tests, with 0 failures (0 unexpected)
```

Full suite: `Executed 1025 tests, with 1 failure` — the single failure is the pre-existing, environmental `AppLifecycleTests.testTheSharedJournalNeverWritesToTheRealInstanceRootUnderTests` (a real `~/.mcpproxy/tray-lifecycle.jsonl` on this machine), unrelated to this change.