### PR TITLE
fix(tray): hide Docker isolation for URL-based (HTTP/SSE) servers in the Add Server form

### DIFF
--- a/native/macos/MCPProxy/MCPProxy/Views/AddServerView.swift
+++ b/native/macos/MCPProxy/MCPProxy/Views/AddServerView.swift
@@ -269,7 +269,9 @@ struct ManualServerForm: View {
     @State private var envText = ""
     @State private var workingDir = ""
     @State private var isEnabled = true
-    @State private var dockerIsolation = true
+    // Docker isolation applies only to local stdio servers; default off (matches
+    // the Web UI's AddServerModal.vue) so a URL server never starts pre-checked.
+    @State private var dockerIsolation = false
     @State private var quarantined = false
     @State private var submitPhase: SubmitPhase = .idle
     @State private var lastSavedServerName: String?  // Track what was saved so Retry can clean up
@@ -396,11 +398,18 @@ struct ManualServerForm: View {
                                     .foregroundStyle(.tertiary)
                             }
 
-                            VStack(alignment: .leading, spacing: 2) {
-                                Toggle("Docker Isolation", isOn: $dockerIsolation)
-                                Text("Runs the server in an isolated Docker container. Prevents access to your filesystem, network, and other system resources. Recommended for untrusted servers.")
-                                    .font(.scaled(.caption2, scale: fontScale))
-                                    .foregroundStyle(.tertiary)
+                            // Docker isolation sandboxes a LOCAL child process, so it
+                            // only makes sense for command-based (stdio) servers. A
+                            // remote URL server has no local process to isolate — hide
+                            // the toggle for http/sse/streamable-http (mirrors the Web
+                            // UI's `:disabled="formData.type !== 'stdio'"`).
+                            if Self.showsDockerIsolation(forProtocol: selectedProtocol) {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Toggle("Docker Isolation", isOn: $dockerIsolation)
+                                    Text("Runs the server in an isolated Docker container. Prevents access to your filesystem, network, and other system resources. Recommended for untrusted servers.")
+                                        .font(.scaled(.caption2, scale: fontScale))
+                                        .foregroundStyle(.tertiary)
+                                }
                             }
 
                             VStack(alignment: .leading, spacing: 2) {
@@ -540,47 +549,18 @@ struct ManualServerForm: View {
             lastSavedServerName = nil
         }
 
-        var config: [String: Any] = [
-            "name": name.trimmingCharacters(in: .whitespaces),
-            "protocol": selectedProtocol,
-            "enabled": isEnabled,
-            "docker_isolation": dockerIsolation,
-            "quarantined": quarantined,
-        ]
-
-        if selectedProtocol == "http" {
-            config["url"] = url.trimmingCharacters(in: .whitespaces)
-        } else {
-            config["command"] = command.trimmingCharacters(in: .whitespaces)
-            let args = argsText.components(separatedBy: "\n")
-                .map { $0.trimmingCharacters(in: .whitespaces) }
-                .filter { !$0.isEmpty }
-            if !args.isEmpty {
-                config["args"] = args
-            }
-        }
-
-        let trimmedDir = workingDir.trimmingCharacters(in: .whitespaces)
-        if !trimmedDir.isEmpty {
-            config["working_dir"] = trimmedDir
-        }
-
-        // Parse env vars
-        let envLines = envText.components(separatedBy: "\n")
-            .map { $0.trimmingCharacters(in: .whitespaces) }
-            .filter { !$0.isEmpty }
-        if !envLines.isEmpty {
-            var envDict: [String: String] = [:]
-            for line in envLines {
-                let parts = line.split(separator: "=", maxSplits: 1)
-                if parts.count == 2 {
-                    envDict[String(parts[0])] = String(parts[1])
-                }
-            }
-            if !envDict.isEmpty {
-                config["env"] = envDict
-            }
-        }
+        let config = Self.makeServerConfig(
+            name: name,
+            selectedProtocol: selectedProtocol,
+            enabled: isEnabled,
+            dockerIsolation: dockerIsolation,
+            quarantined: quarantined,
+            url: url,
+            command: command,
+            argsText: argsText,
+            workingDir: workingDir,
+            envText: envText
+        )
 
         let serverName = name.trimmingCharacters(in: .whitespaces)
 
@@ -700,5 +680,83 @@ struct ManualServerForm: View {
             // Can't get logs — that's fine, just return empty
         }
         return ""
+    }
+}
+
+// MARK: - Pure field-gating seam (unit-testable without a running app)
+
+extension ManualServerForm {
+    /// Whether the "Docker Isolation" toggle applies to the selected transport.
+    /// Docker isolation sandboxes a LOCAL child process, so it is meaningful only
+    /// for command-based (stdio) servers. URL transports (http / sse /
+    /// streamable-http) are just a remote endpoint the proxy connects to — there
+    /// is no local process to isolate, so the toggle is hidden and its value is
+    /// never persisted. Mirrors the Web UI's `formData.type !== 'stdio'` gate.
+    static func showsDockerIsolation(forProtocol proto: String) -> Bool {
+        proto == "stdio"
+    }
+
+    /// Builds the `POST /api/v1/servers` request body from the form's fields.
+    /// Extracted as a pure function so the field-gating rules (isolation is
+    /// stdio-only; url vs command by transport) are unit-testable without a
+    /// running app or API client. `docker_isolation` is emitted ONLY for stdio
+    /// transports so a URL-based server can never carry an isolation flag.
+    static func makeServerConfig(
+        name: String,
+        selectedProtocol: String,
+        enabled: Bool,
+        dockerIsolation: Bool,
+        quarantined: Bool,
+        url: String,
+        command: String,
+        argsText: String,
+        workingDir: String,
+        envText: String
+    ) -> [String: Any] {
+        var config: [String: Any] = [
+            "name": name.trimmingCharacters(in: .whitespaces),
+            "protocol": selectedProtocol,
+            "enabled": enabled,
+            "quarantined": quarantined,
+        ]
+
+        if showsDockerIsolation(forProtocol: selectedProtocol) {
+            // stdio only — a local process to sandbox.
+            config["command"] = command.trimmingCharacters(in: .whitespaces)
+            let args = argsText.components(separatedBy: "\n")
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .filter { !$0.isEmpty }
+            if !args.isEmpty {
+                config["args"] = args
+            }
+            config["docker_isolation"] = dockerIsolation
+        } else {
+            // URL transports carry no command and no isolation flag.
+            config["url"] = url.trimmingCharacters(in: .whitespaces)
+        }
+
+        let trimmedDir = workingDir.trimmingCharacters(in: .whitespaces)
+        if !trimmedDir.isEmpty {
+            config["working_dir"] = trimmedDir
+        }
+
+        // Parse env vars
+        let envLines = envText.components(separatedBy: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        if !envLines.isEmpty {
+            var envDict: [String: String] = [:]
+            for line in envLines {
+                let parts = line.split(separator: "=", maxSplits: 1)
+                if parts.count == 2 {
+                    envDict[String(parts[0])] = String(parts[1])
+                }
+            }
+            if !envDict.isEmpty {
+                config["env"] = envDict
+            }
+        }
+
+        return config
     }
 }

--- a/native/macos/MCPProxy/MCPProxy/Views/AddServerView.swift
+++ b/native/macos/MCPProxy/MCPProxy/Views/AddServerView.swift
@@ -699,8 +699,8 @@ extension ManualServerForm {
     /// Builds the `POST /api/v1/servers` request body from the form's fields.
     /// Extracted as a pure function so the field-gating rules (isolation is
     /// stdio-only; url vs command by transport) are unit-testable without a
-    /// running app or API client. `docker_isolation` is emitted ONLY for stdio
-    /// transports so a URL-based server can never carry an isolation flag.
+    /// running app or API client. The `isolation` override is emitted ONLY for
+    /// stdio transports so a URL-based server can never carry an isolation flag.
     static func makeServerConfig(
         name: String,
         selectedProtocol: String,
@@ -729,7 +729,11 @@ extension ManualServerForm {
             if !args.isEmpty {
                 config["args"] = args
             }
-            config["docker_isolation"] = dockerIsolation
+            // The backend server-create payload takes an `isolation` object
+            // ({"enabled": …}); the old top-level `docker_isolation` bool it
+            // never read, so the toggle silently did nothing. Emit the real
+            // field so an stdio server actually records its isolation choice.
+            config["isolation"] = ["enabled": dockerIsolation]
         } else {
             // URL transports carry no command and no isolation flag.
             config["url"] = url.trimmingCharacters(in: .whitespaces)

--- a/native/macos/MCPProxy/MCPProxyTests/AddServerIsolationFieldTests.swift
+++ b/native/macos/MCPProxy/MCPProxyTests/AddServerIsolationFieldTests.swift
@@ -49,9 +49,10 @@ final class AddServerIsolationFieldTests: XCTestCase {
         )
         XCTAssertEqual(config["command"] as? String, "npx")
         XCTAssertNil(config["url"], "a stdio server must not carry a url")
+        let isolation = config["isolation"] as? [String: Any]
         XCTAssertEqual(
-            config["docker_isolation"] as? Bool, true,
-            "a stdio server may carry its isolation choice"
+            isolation?["enabled"] as? Bool, true,
+            "a stdio server records its isolation choice via the backend `isolation` object"
         )
     }
 
@@ -74,8 +75,12 @@ final class AddServerIsolationFieldTests: XCTestCase {
         XCTAssertEqual(config["url"] as? String, "https://api.example.com/mcp")
         XCTAssertNil(config["command"], "an http server must not carry a command")
         XCTAssertNil(
-            config["docker_isolation"],
+            config["isolation"],
             "a URL-based server must never persist an isolation flag — there is no local process"
+        )
+        XCTAssertNil(
+            config["docker_isolation"],
+            "and never the legacy dead key either"
         )
     }
 }

--- a/native/macos/MCPProxy/MCPProxyTests/AddServerIsolationFieldTests.swift
+++ b/native/macos/MCPProxy/MCPProxyTests/AddServerIsolationFieldTests.swift
@@ -1,0 +1,81 @@
+// AddServerIsolationFieldTests.swift
+// MCPProxyTests
+//
+// Docker isolation only applies to local stdio (command-based) servers — there
+// is a child process to sandbox. A URL-based transport (http / sse /
+// streamable-http) is just a remote endpoint the proxy connects to, so the
+// "Docker Isolation" toggle is meaningless and must neither appear nor be
+// persisted for those servers. These tests pin the pure gating seam behind the
+// Add Server sheet so the rule is enforced without a running app or API client.
+// Mirrors the Web UI's `:disabled="formData.type !== 'stdio'"` gating in
+// AddServerModal.vue (and its stdio-only `isolation_json` emission).
+
+import XCTest
+@testable import MCPProxy
+
+final class AddServerIsolationFieldTests: XCTestCase {
+
+    // (a) stdio → the isolation field is offered.
+    func testIsolationFieldVisibleForStdio() {
+        XCTAssertTrue(
+            ManualServerForm.showsDockerIsolation(forProtocol: "stdio"),
+            "Docker isolation applies to local command-based servers — the toggle must show"
+        )
+    }
+
+    // (b) URL transports → the isolation field is hidden.
+    func testIsolationFieldHiddenForURLTransports() {
+        for proto in ["http", "sse", "streamable-http"] {
+            XCTAssertFalse(
+                ManualServerForm.showsDockerIsolation(forProtocol: proto),
+                "\(proto) is a remote URL — there is no local process to isolate; the toggle must not show"
+            )
+        }
+    }
+
+    // (c-1) A stdio server config carries the isolation field.
+    func testStdioConfigCarriesIsolationField() {
+        let config = ManualServerForm.makeServerConfig(
+            name: "local-fs",
+            selectedProtocol: "stdio",
+            enabled: true,
+            dockerIsolation: true,
+            quarantined: false,
+            url: "",
+            command: "npx",
+            argsText: "@modelcontextprotocol/server-filesystem",
+            workingDir: "",
+            envText: ""
+        )
+        XCTAssertEqual(config["command"] as? String, "npx")
+        XCTAssertNil(config["url"], "a stdio server must not carry a url")
+        XCTAssertEqual(
+            config["docker_isolation"] as? Bool, true,
+            "a stdio server may carry its isolation choice"
+        )
+    }
+
+    // (c-2) A brand-new HTTP server config never carries an enabled isolation,
+    // even when the (stale) toggle value is still true — i.e. switching an
+    // in-progress form from stdio→http must not leak isolation into the config.
+    func testHTTPConfigOmitsIsolationEvenWhenToggleTrue() {
+        let config = ManualServerForm.makeServerConfig(
+            name: "remote-api",
+            selectedProtocol: "http",
+            enabled: true,
+            dockerIsolation: true, // stale value carried over from a stdio selection
+            quarantined: false,
+            url: "https://api.example.com/mcp",
+            command: "",
+            argsText: "",
+            workingDir: "",
+            envText: ""
+        )
+        XCTAssertEqual(config["url"] as? String, "https://api.example.com/mcp")
+        XCTAssertNil(config["command"], "an http server must not carry a command")
+        XCTAssertNil(
+            config["docker_isolation"],
+            "a URL-based server must never persist an isolation flag — there is no local process"
+        )
+    }
+}


### PR DESCRIPTION
## Root cause

The macOS **Add Server** sheet (`ManualServerForm` in `native/macos/MCPProxy/MCPProxy/Views/AddServerView.swift`) rendered the **Docker Isolation** toggle for every transport and defaulted it to *checked* (`dockerIsolation = true`, was line 272), then wrote `docker_isolation` into the POST body unconditionally (was line 547) — including for URL-based (`http`/`sse`/`streamable-http`) servers.

Docker isolation sandboxes a **local child process**, so it only applies to command-based (stdio) servers. A remote HTTP/SSE server is just a URL the proxy connects to — there is no local process to isolate, so the toggle is meaningless there. (The backend's `AddServerRequest` doesn't even have a `docker_isolation` field — it uses `isolation` — so the value was silently ignored, but the checked toggle was still misleading.)

The Web UI's `frontend/src/components/AddServerModal.vue` already gates this correctly (`:disabled="formData.type !== 'stdio'"`, default `isolated: false`, `isolation_json` emitted only in the stdio branch); the native form was a hand-port that missed the gate. No web change needed.

## Fix

- Gate the toggle to stdio-only via a pure `ManualServerForm.showsDockerIsolation(forProtocol:)` — the toggle is hidden for `http`/`sse`/`streamable-http`.
- Default `dockerIsolation` to `false` so a brand-new server never starts pre-checked.
- Extract a pure `ManualServerForm.makeServerConfig(...)` seam that emits `docker_isolation` **only** for stdio transports, so a URL-based server can never persist an isolation flag. `submitServer()` now calls it.

## Verification

New `AddServerIsolationFieldTests`:
- `testIsolationFieldVisibleForStdio`
- `testIsolationFieldHiddenForURLTransports`
- `testStdioConfigCarriesIsolationField`
- `testHTTPConfigOmitsIsolationEvenWhenToggleTrue`

```
Executed 1017 tests, with 1 failure (0 unexpected)
```

The single failure is the pre-existing, environmental `AppLifecycleTests.testTheSharedJournalNeverWritesToTheRealInstanceRootUnderTests` (a real `~/.mcpproxy/tray-lifecycle.jsonl` on the dev machine), unrelated to this change. The 4 new tests and all other 1012 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWV9Kn4ryJWEKug6PA3DKH