### PR TITLE
fix: sandbox result shape, empty tool schemas, CLI exec 2s deadline, retrieve_tools response limit, tool-id normalization (#981–#985)

### DIFF
--- a/cmd/mcpproxy/code_cmd.go
+++ b/cmd/mcpproxy/code_cmd.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -167,18 +168,38 @@ func runCodeExec(_ *cobra.Command, _ []string) error {
 	return runCodeExecStandalone(globalConfig, code, inputData, logger)
 }
 
+// codeExecClientSlack is the head-room added to the server-side execution
+// budget when deriving the client-side deadline: transport, queueing and
+// (de)serialization all happen outside the daemon's own timeout accounting.
+const codeExecClientSlack = 30 * time.Second
+
+// codeExecClientTimeout returns how long the CLI waits for the daemon to
+// answer a code execution request. The daemon enforces the --timeout budget
+// itself, so the client deadline only has to outlive it.
+func codeExecClientTimeout(timeoutMS int) time.Duration {
+	return time.Duration(timeoutMS)*time.Millisecond + codeExecClientSlack
+}
+
 // runCodeExecClientMode executes code via the daemon HTTP API.
 func runCodeExecClientMode(client *cliclient.Client, code string, input map[string]interface{}, logger *zap.Logger) error {
 	// Ping daemon to verify connectivity
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	if err := client.Ping(ctx); err != nil {
+	pingCtx, pingCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer pingCancel()
+	if err := client.Ping(pingCtx); err != nil {
 		logger.Warn("Failed to ping daemon, falling back to standalone mode",
 			zap.Error(err),
 			zap.Duration("ping_timeout", 2*time.Second),
 			zap.String("fallback_mode", "standalone"))
-		// Fall back to standalone mode
-		cfg, _ := loadCodeConfig()
+		// Fall back to standalone mode, which needs a usable configuration of
+		// its own (data dir, limits) - without one there is nothing to run.
+		cfg, cfgErr := loadCodeConfig()
+		if cfgErr == nil && cfg == nil {
+			cfgErr = errors.New("no configuration available")
+		}
+		if cfgErr != nil {
+			fmt.Fprintf(os.Stderr, "Error loading configuration for standalone fallback: %v\n", cfgErr)
+			return exitError(2)
+		}
 		return runCodeExecStandalone(cfg, code, input, logger)
 	}
 
@@ -186,8 +207,12 @@ func runCodeExecClientMode(client *cliclient.Client, code string, input map[stri
 	fmt.Fprintf(os.Stderr, "ℹ️  Using daemon mode - fast execution\n")
 
 	// Execute code via daemon
+	clientTimeout := codeExecClientTimeout(codeTimeout)
+	execCtx, execCancel := context.WithTimeout(context.Background(), clientTimeout)
+	defer execCancel()
+
 	result, err := client.CodeExec(
-		ctx,
+		execCtx,
 		code,
 		input,
 		codeTimeout,
@@ -196,6 +221,12 @@ func runCodeExecClientMode(client *cliclient.Client, code string, input map[stri
 		cliclient.CodeExecOptions{Language: codeLanguage},
 	)
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			fmt.Fprintf(os.Stderr,
+				"Error: client-side timeout after %s waiting for the daemon to return results (execution budget --timeout=%dms); the daemon may still be running the code\n",
+				clientTimeout, codeTimeout)
+			return exitError(1)
+		}
 		// T029: Use formatErrorWithRequestID to include request_id in error output
 		fmt.Fprintf(os.Stderr, "Error calling daemon: %s\n", formatErrorWithRequestID(err))
 		return exitError(1)

--- a/cmd/mcpproxy/code_cmd_test.go
+++ b/cmd/mcpproxy/code_cmd_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/cliclient"
+
+	"go.uber.org/zap"
+)
+
+// TestCodeExecClientTimeout_TracksServerBudget pins that the client-side
+// deadline for a daemon code execution always outlives the server-side
+// execution budget requested with --timeout.
+func TestCodeExecClientTimeout_TracksServerBudget(t *testing.T) {
+	tests := []struct {
+		name      string
+		timeoutMS int
+		want      time.Duration
+	}{
+		{"default budget", 120000, 150 * time.Second},
+		{"smallest budget still gets slack", 1, 30*time.Second + time.Millisecond},
+		{"largest allowed budget", 600000, 630 * time.Second},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := codeExecClientTimeout(tc.timeoutMS)
+			if got != tc.want {
+				t.Fatalf("codeExecClientTimeout(%d) = %s, want %s", tc.timeoutMS, got, tc.want)
+			}
+			if got <= time.Duration(tc.timeoutMS)*time.Millisecond {
+				t.Fatalf("codeExecClientTimeout(%d) = %s, must exceed the server budget", tc.timeoutMS, got)
+			}
+		})
+	}
+}
+
+const (
+	codeExecChildEnv         = "MCPPROXY_TEST_CODE_EXEC_CHILD"
+	codeExecFallbackChildEnv = "MCPPROXY_TEST_CODE_EXEC_FALLBACK_CHILD"
+)
+
+// useMissingCodeConfig points the code command at a config file that does not
+// exist, so a child process can never read the developer's real
+// ~/.mcpproxy/mcp_config.json (and never open the real DataDir BBolt store)
+// when a flaked daemon ping sends it down the standalone fallback.
+func useMissingCodeConfig(t *testing.T) string {
+	t.Helper()
+
+	missing := filepath.Join(t.TempDir(), "absent", "mcp_config.json")
+	previous := codeConfigPath
+	codeConfigPath = missing
+	t.Cleanup(func() { codeConfigPath = previous })
+	return missing
+}
+
+// TestRunCodeExecClientMode_ExecOutlivesPingDeadline pins that the short
+// daemon-connectivity ping deadline does not bound the execution request:
+// daemon mode must keep waiting for a result that arrives long after the ping
+// budget has elapsed. The command path calls os.Exit on failure, so the real
+// path runs in a child process and this test asserts on its exit code.
+func TestRunCodeExecClientMode_ExecOutlivesPingDeadline(t *testing.T) {
+	const execDelay = 3 * time.Second
+
+	if os.Getenv(codeExecChildEnv) == "1" {
+		codeTimeout = 60000
+		codeMaxToolCalls = 0
+		codeAllowedSrvs = nil
+		codeLanguage = "javascript"
+		useMissingCodeConfig(t)
+
+		client := cliclient.NewClientWithAPIKey(os.Getenv(codeExecChildEnv+"_ENDPOINT"), "", nil)
+		if err := runCodeExecClientMode(client, "({ value: 42 })", map[string]interface{}{}, zap.NewNop()); err != nil {
+			t.Fatalf("runCodeExecClientMode returned error: %v", err)
+		}
+		return
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/status":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"success": true})
+		case "/api/v1/code/exec":
+			select {
+			case <-time.After(execDelay):
+			case <-r.Context().Done():
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok":     true,
+				"result": map[string]interface{}{"value": 42},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRunCodeExecClientMode_ExecOutlivesPingDeadline$", "-test.timeout=60s")
+	cmd.Env = append(os.Environ(),
+		codeExecChildEnv+"=1",
+		codeExecChildEnv+"_ENDPOINT="+srv.URL,
+	)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("daemon-mode code exec aborted before the daemon replied (%v)\nchild output:\n%s", err, out)
+	}
+	// A flaked ping would silently fall back to standalone mode, where the
+	// trivial script also succeeds - the child would exit 0 without ever
+	// exercising the daemon path this test pins. Require the evidence.
+	if !strings.Contains(string(out), "Using daemon mode") {
+		t.Fatalf("child never took the daemon path (ping likely fell back to standalone)\nchild output:\n%s", out)
+	}
+}
+
+// TestRunCodeExecClientMode_PingFailureFallbackWithoutConfig pins that when the
+// daemon ping fails and no configuration can be loaded, the standalone fallback
+// reports a configuration error instead of dereferencing a nil config.
+func TestRunCodeExecClientMode_PingFailureFallbackWithoutConfig(t *testing.T) {
+	if os.Getenv(codeExecFallbackChildEnv) == "1" {
+		codeTimeout = 1000
+		codeMaxToolCalls = 0
+		codeAllowedSrvs = nil
+		codeLanguage = "javascript"
+		useMissingCodeConfig(t)
+
+		// Port 1 refuses connections immediately, so the ping fails fast and
+		// the standalone fallback runs with no loadable configuration.
+		client := cliclient.NewClientWithAPIKey("http://127.0.0.1:1", "", nil)
+		_ = runCodeExecClientMode(client, "({ value: 42 })", map[string]interface{}{}, zap.NewNop())
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRunCodeExecClientMode_PingFailureFallbackWithoutConfig$", "-test.timeout=60s")
+	cmd.Env = append(os.Environ(), codeExecFallbackChildEnv+"=1")
+
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected the fallback to exit non-zero without a loadable config\nchild output:\n%s", out)
+	}
+	if strings.Contains(string(out), "panic:") {
+		t.Fatalf("standalone fallback panicked instead of reporting a config error\nchild output:\n%s", out)
+	}
+	if !strings.Contains(string(out), "Error loading configuration") {
+		t.Fatalf("expected a configuration error from the standalone fallback\nchild output:\n%s", out)
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,7 +104,7 @@ A running MCPProxy core watches `mcp_config.json` and hot-reloads external edits
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `tools_limit` | integer | `15` | Maximum number of tools to return per request (1-1000) |
-| `tool_response_limit` | integer | `20000` | Maximum characters in tool responses (0 = unlimited) |
+| `tool_response_limit` | integer | `20000` | Maximum characters in tool responses (0 = unlimited). Applies to built-in tools too: an oversize `retrieve_tools` result is truncated and the full payload is retrievable via `read_cache` (except on the code-execution surface, which does not expose `read_cache`) |
 | `call_tool_timeout` | string | `"2m"` | Timeout for tool calls (e.g., `"30s"`, `"2m"`, `"5m"`). **Note**: When using agents like Codex or Claude as MCP servers, you may need to increase this timeout significantly, even up to 10 minutes (`"10m"`), as these agents may require longer processing times for complex operations |
 | `init_timeout` | duration | `"30s"` | Deadline for an upstream's MCP `initialize` handshake (e.g. `"30s"`, `"120s"`, `"3m"`). Raise this for servers that do legitimate first-run warmup — building a cache/index or prefetching — before they answer `initialize`, so they are not killed mid-startup. Global default; can be overridden per server (see [Server Fields](#server-fields)). Range: `1s`–`30m`; `"0s"`/unset uses the 30s default. |
 

--- a/internal/cliclient/client.go
+++ b/internal/cliclient/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -211,6 +212,17 @@ func parseAPIError(errorMsg, requestID string) error {
 	return &APIError{Message: errorMsg, RequestID: requestID}
 }
 
+// execHTTPClient returns a shallow copy of the shared HTTP client with no
+// blanket timeout, so a long-running request is bounded by its context alone.
+// The shared client keeps a generous timeout as a safety net for ordinary
+// commands, but that net is shorter than the largest execution budget the
+// daemon accepts.
+func (c *Client) execHTTPClient() *http.Client {
+	clone := *c.httpClient
+	clone.Timeout = 0
+	return &clone
+}
+
 // CodeExecOptions contains optional parameters for code execution via the daemon API.
 type CodeExecOptions struct {
 	Language string // Source language: "javascript" (default) or "typescript"
@@ -256,8 +268,11 @@ func (c *Client) CodeExec(
 	req.Header.Set("Content-Type", "application/json")
 
 	// Send request
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.execHTTPClient().Do(req)
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, fmt.Errorf("client-side timeout waiting for the daemon to return code execution results: %w", err)
+		}
 		return nil, fmt.Errorf("failed to call code execution API: %w", err)
 	}
 	defer resp.Body.Close()

--- a/internal/cliclient/code_exec_timeout_test.go
+++ b/internal/cliclient/code_exec_timeout_test.go
@@ -1,0 +1,104 @@
+package cliclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestClient_CodeExec_ClientSideTimeoutIsExplicit pins that a deadline that
+// expires before the daemon answers is reported as a client-side timeout
+// rather than as an opaque transport failure, and that the sentinel stays
+// inspectable with errors.Is.
+func TestClient_CodeExec_ClientSideTimeoutIsExplicit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(time.Second):
+		case <-r.Context().Done():
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": true})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := client.CodeExec(ctx, "code", map[string]interface{}{}, 60000, 0, nil)
+	if err == nil {
+		t.Fatal("expected an error when the client deadline expires first")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error %v does not wrap context.DeadlineExceeded", err)
+	}
+	if !strings.Contains(err.Error(), "client-side timeout") {
+		t.Fatalf("error %q does not name the client-side timeout", err.Error())
+	}
+}
+
+// TestClient_CodeExec_NotCappedBySharedClientTimeout pins that code execution
+// is bounded by the caller's context alone: the shared HTTP client's blanket
+// timeout would otherwise cut off executions whose --timeout budget is larger.
+func TestClient_CodeExec_NotCappedBySharedClientTimeout(t *testing.T) {
+	client := NewClient("http://127.0.0.1:1", nil)
+
+	execClient := client.execHTTPClient()
+	if execClient.Timeout != 0 {
+		t.Fatalf("exec HTTP client Timeout = %s, want 0 so the request context governs", execClient.Timeout)
+	}
+	if execClient.Transport != client.httpClient.Transport {
+		t.Fatal("exec HTTP client must reuse the shared transport (headers, socket dialer)")
+	}
+	if client.httpClient.Timeout == 0 {
+		t.Fatal("the shared client should keep its blanket timeout for other commands")
+	}
+}
+
+// TestClient_CodeExec_OutlivesSharedClientTimeout drives the real call site: a
+// daemon that answers well after the shared client's blanket timeout must still
+// produce a result, because CodeExec is expected to dispatch on the uncapped
+// exec client. Reverting the request to c.httpClient.Do turns this red.
+func TestClient_CodeExec_OutlivesSharedClientTimeout(t *testing.T) {
+	const serverDelay = 200 * time.Millisecond
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/code/exec" {
+			t.Errorf("unexpected request path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		select {
+		case <-time.After(serverDelay):
+		case <-r.Context().Done():
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok":     true,
+			"result": "done",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, nil)
+	// Shorter than the daemon's response time: only a request that escapes the
+	// shared client's blanket timeout can succeed here.
+	client.httpClient.Timeout = 50 * time.Millisecond
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := client.CodeExec(ctx, "code", map[string]interface{}{}, 600000, 0, nil)
+	if err != nil {
+		t.Fatalf("CodeExec must be bounded by the context, not the shared client timeout: %v", err)
+	}
+	if !result.OK {
+		t.Fatalf("CodeExec result = %+v, want OK", result)
+	}
+}

--- a/internal/httpapi/code_exec.go
+++ b/internal/httpapi/code_exec.go
@@ -14,12 +14,9 @@ import (
 )
 
 const (
-	// defaultCodeExecTimeoutMS bounds the HTTP request when the caller sent no
-	// timeout_ms. It is only a request-level fallback — the execution's own
-	// budget comes from the configured code_execution_timeout_ms.
-	defaultCodeExecTimeoutMS = 120000
-	// maxCodeExecTimeoutMS mirrors the ceiling the code_execution tool enforces
-	// on timeout_ms.
+	// minCodeExecTimeoutMS and maxCodeExecTimeoutMS mirror the bounds the
+	// code_execution tool enforces on timeout_ms.
+	minCodeExecTimeoutMS = 1
 	maxCodeExecTimeoutMS = 600000
 )
 
@@ -32,10 +29,17 @@ type CodeExecRequest struct {
 }
 
 // CodeExecOptions represents execution options.
+//
+// Every field is a pointer so the handler can tell an option the caller sent
+// from one they left out. Inferring that from the zero value conflated the
+// two: an explicit "timeout_ms": 0 (out of range, and rejected as such over
+// MCP) was read as "unset" and silently replaced by the configured budget,
+// while an explicit "max_tool_calls": 0 or "allowed_servers": [] was dropped
+// instead of reaching the tool as the caller wrote it.
 type CodeExecOptions struct {
-	TimeoutMS      int      `json:"timeout_ms"`
-	MaxToolCalls   int      `json:"max_tool_calls"`
-	AllowedServers []string `json:"allowed_servers"`
+	TimeoutMS      *int      `json:"timeout_ms,omitempty"`
+	MaxToolCalls   *int      `json:"max_tool_calls,omitempty"`
+	AllowedServers *[]string `json:"allowed_servers,omitempty"`
 }
 
 // CodeExecResponse represents the response format.
@@ -93,16 +97,17 @@ func (h *CodeExecHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate execution options against the same bounds the code_execution
-	// tool enforces. The tool reports a violation as a plain-text tool error
-	// rather than the JSON envelope parseResult expects, so catching it here
-	// keeps the caller's answer a proper 400 instead of a parse failure.
-	if req.Options.TimeoutMS < 0 || req.Options.TimeoutMS > maxCodeExecTimeoutMS {
+	// Validate the options the caller actually sent against the same bounds the
+	// code_execution tool enforces. The tool reports a violation as a plain-text
+	// tool error rather than the JSON envelope parseResult expects, so catching
+	// it here keeps the caller's answer a proper 400 instead of a parse failure.
+	if req.Options.TimeoutMS != nil &&
+		(*req.Options.TimeoutMS < minCodeExecTimeoutMS || *req.Options.TimeoutMS > maxCodeExecTimeoutMS) {
 		h.writeError(w, r, http.StatusBadRequest, "INVALID_OPTIONS",
-			fmt.Sprintf("timeout_ms must be between 1 and %d milliseconds", maxCodeExecTimeoutMS))
+			fmt.Sprintf("timeout_ms must be between %d and %d milliseconds", minCodeExecTimeoutMS, maxCodeExecTimeoutMS))
 		return
 	}
-	if req.Options.MaxToolCalls < 0 {
+	if req.Options.MaxToolCalls != nil && *req.Options.MaxToolCalls < 0 {
 		h.writeError(w, r, http.StatusBadRequest, "INVALID_OPTIONS", "max_tool_calls cannot be negative")
 		return
 	}
@@ -113,28 +118,37 @@ func (h *CodeExecHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create context with timeout. This bounds the HTTP request; the
-	// code_execution tool applies its own deadline from timeout_ms inside it.
-	timeoutMS := req.Options.TimeoutMS
-	if timeoutMS == 0 {
-		timeoutMS = defaultCodeExecTimeoutMS
+	// code_execution tool applies its own precise deadline inside it.
+	//
+	// A caller-named timeout_ms bounds the request exactly. Without one the
+	// tool resolves the budget from the configured code_execution_timeout_ms,
+	// which may legally be anything up to maxCodeExecTimeoutMS — and a context
+	// only ever shrinks against its parent, so the parent has to cover that
+	// ceiling. A narrower fallback here silently cancelled every configured
+	// budget above it. The route's own deadline (codeExecRequestTimeout, which
+	// adds IO slack on top of the ceiling) still bounds the request overall.
+	timeoutMS := maxCodeExecTimeoutMS
+	if req.Options.TimeoutMS != nil {
+		timeoutMS = *req.Options.TimeoutMS
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), time.Duration(timeoutMS)*time.Millisecond)
 	defer cancel()
 
-	// Build arguments for code_execution tool. Only options the caller actually
-	// supplied are forwarded: a zero value means "unset" to the tool, which
-	// resolves timeout_ms and max_tool_calls from config and reads an absent
-	// allowed_servers as "no restriction". Sending this endpoint's own fallback
-	// would override the configured code_execution_timeout_ms instead.
+	// Build arguments for code_execution tool. Exactly the options the caller
+	// sent are forwarded, zero values included: to the tool an ABSENT option
+	// means "resolve it" — timeout_ms and max_tool_calls come from config, and
+	// a missing allowed_servers is read as "no restriction" — while a present
+	// one is the caller's own choice. Sending this endpoint's request-level
+	// fallback would override the configured code_execution_timeout_ms instead.
 	execOptions := make(map[string]interface{}, 3)
-	if req.Options.TimeoutMS > 0 {
-		execOptions["timeout_ms"] = req.Options.TimeoutMS
+	if req.Options.TimeoutMS != nil {
+		execOptions["timeout_ms"] = *req.Options.TimeoutMS
 	}
-	if req.Options.MaxToolCalls > 0 {
-		execOptions["max_tool_calls"] = req.Options.MaxToolCalls
+	if req.Options.MaxToolCalls != nil {
+		execOptions["max_tool_calls"] = *req.Options.MaxToolCalls
 	}
-	if len(req.Options.AllowedServers) > 0 {
-		execOptions["allowed_servers"] = req.Options.AllowedServers
+	if req.Options.AllowedServers != nil {
+		execOptions["allowed_servers"] = *req.Options.AllowedServers
 	}
 	args := map[string]interface{}{
 		"code":    req.Code,

--- a/internal/httpapi/code_exec.go
+++ b/internal/httpapi/code_exec.go
@@ -13,6 +13,16 @@ import (
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/reqcontext"
 )
 
+const (
+	// defaultCodeExecTimeoutMS bounds the HTTP request when the caller sent no
+	// timeout_ms. It is only a request-level fallback — the execution's own
+	// budget comes from the configured code_execution_timeout_ms.
+	defaultCodeExecTimeoutMS = 120000
+	// maxCodeExecTimeoutMS mirrors the ceiling the code_execution tool enforces
+	// on timeout_ms.
+	maxCodeExecTimeoutMS = 600000
+)
+
 // CodeExecRequest represents the request body for code execution.
 type CodeExecRequest struct {
 	Code     string                 `json:"code"`
@@ -83,28 +93,53 @@ func (h *CodeExecHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validate execution options against the same bounds the code_execution
+	// tool enforces. The tool reports a violation as a plain-text tool error
+	// rather than the JSON envelope parseResult expects, so catching it here
+	// keeps the caller's answer a proper 400 instead of a parse failure.
+	if req.Options.TimeoutMS < 0 || req.Options.TimeoutMS > maxCodeExecTimeoutMS {
+		h.writeError(w, r, http.StatusBadRequest, "INVALID_OPTIONS",
+			fmt.Sprintf("timeout_ms must be between 1 and %d milliseconds", maxCodeExecTimeoutMS))
+		return
+	}
+	if req.Options.MaxToolCalls < 0 {
+		h.writeError(w, r, http.StatusBadRequest, "INVALID_OPTIONS", "max_tool_calls cannot be negative")
+		return
+	}
+
 	// Set defaults
 	if req.Input == nil {
 		req.Input = make(map[string]interface{})
 	}
-	if req.Options.TimeoutMS == 0 {
-		req.Options.TimeoutMS = 120000 // 2 minutes default
-	}
 
-	// Create context with timeout
-	timeout := time.Duration(req.Options.TimeoutMS) * time.Millisecond
-	ctx, cancel := context.WithTimeout(r.Context(), timeout)
+	// Create context with timeout. This bounds the HTTP request; the
+	// code_execution tool applies its own deadline from timeout_ms inside it.
+	timeoutMS := req.Options.TimeoutMS
+	if timeoutMS == 0 {
+		timeoutMS = defaultCodeExecTimeoutMS
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), time.Duration(timeoutMS)*time.Millisecond)
 	defer cancel()
 
-	// Build arguments for code_execution tool
+	// Build arguments for code_execution tool. Only options the caller actually
+	// supplied are forwarded: a zero value means "unset" to the tool, which
+	// resolves timeout_ms and max_tool_calls from config and reads an absent
+	// allowed_servers as "no restriction". Sending this endpoint's own fallback
+	// would override the configured code_execution_timeout_ms instead.
+	execOptions := make(map[string]interface{}, 3)
+	if req.Options.TimeoutMS > 0 {
+		execOptions["timeout_ms"] = req.Options.TimeoutMS
+	}
+	if req.Options.MaxToolCalls > 0 {
+		execOptions["max_tool_calls"] = req.Options.MaxToolCalls
+	}
+	if len(req.Options.AllowedServers) > 0 {
+		execOptions["allowed_servers"] = req.Options.AllowedServers
+	}
 	args := map[string]interface{}{
-		"code":  req.Code,
-		"input": req.Input,
-		"options": map[string]interface{}{
-			"timeout_ms":      req.Options.TimeoutMS,
-			"max_tool_calls":  req.Options.MaxToolCalls,
-			"allowed_servers": req.Options.AllowedServers,
-		},
+		"code":    req.Code,
+		"input":   req.Input,
+		"options": execOptions,
 	}
 
 	// Pass language if specified

--- a/internal/httpapi/code_exec_budget_test.go
+++ b/internal/httpapi/code_exec_budget_test.go
@@ -1,0 +1,68 @@
+package httpapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// dispatchCodeExecBudget runs one body through the handler and reports the
+// deadline the handler left on the context it gave the code_execution tool,
+// measured from just before the request was served.
+func dispatchCodeExecBudget(t *testing.T, body map[string]interface{}) (budget time.Duration, status int) {
+	t.Helper()
+
+	bodyBytes, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	ctrl := &codeExecDeadlineController{}
+	req := httptest.NewRequest(http.MethodPost, codeExecPath, bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+
+	start := time.Now()
+	NewCodeExecHandler(ctrl, zap.NewNop().Sugar()).ServeHTTP(recorder, req)
+
+	require.True(t, ctrl.hasDL, "the dispatched context carried no deadline")
+	return ctrl.deadline.Sub(start), recorder.Code
+}
+
+// TestCodeExecHandler_UnsetTimeoutCoversTheLargestResolvableBudget covers the
+// case where the caller sends no timeout_ms. The tool then resolves the budget
+// from code_execution_timeout_ms, which may legally be anything up to
+// maxCodeExecTimeoutMS — but a context only ever shrinks against its parent, so
+// a parent cut at this endpoint's own fallback silently capped every longer
+// configured budget (a 300000ms config was cancelled at 120000ms).
+func TestCodeExecHandler_UnsetTimeoutCoversTheLargestResolvableBudget(t *testing.T) {
+	budget, status := dispatchCodeExecBudget(t, map[string]interface{}{
+		"code": "({ result: 1 })",
+	})
+
+	require.Equal(t, http.StatusOK, status)
+	assert.GreaterOrEqual(t, budget, time.Duration(maxCodeExecTimeoutMS)*time.Millisecond,
+		"an omitted timeout_ms must leave room for the largest budget the tool can resolve from config")
+	assert.LessOrEqual(t, budget, codeExecRequestTimeout,
+		"the parent deadline must stay inside the route's own budget")
+}
+
+// TestCodeExecHandler_ExplicitTimeoutKeepsPreciseBudget is the other half of the
+// contract: when the caller names a budget, that is what bounds the request —
+// the ceiling above applies only to the resolve-from-config path.
+func TestCodeExecHandler_ExplicitTimeoutKeepsPreciseBudget(t *testing.T) {
+	budget, status := dispatchCodeExecBudget(t, map[string]interface{}{
+		"code":    "({ result: 1 })",
+		"options": map[string]interface{}{"timeout_ms": 5000},
+	})
+
+	require.Equal(t, http.StatusOK, status)
+	assert.Less(t, budget, 6*time.Second,
+		"a caller-named budget must not be widened to the resolve-from-config ceiling")
+	assert.Greater(t, budget, 4*time.Second)
+}

--- a/internal/httpapi/code_exec_cli_roundtrip_test.go
+++ b/internal/httpapi/code_exec_cli_roundtrip_test.go
@@ -1,0 +1,100 @@
+package httpapi_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/cliclient"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/httpapi"
+)
+
+// TestCodeExecHandler_CLIDaemonModeRoundTrip drives the real CLI client against
+// the real handler with the flag values `mcpproxy code exec` ships by default:
+// --timeout=120000, --max-tool-calls=0 (unlimited) and an empty
+// --allowed-servers. The CLI always sends all three, so the option-presence
+// rules on the server side have to keep accepting that request and preserve
+// each flag's meaning.
+func TestCodeExecHandler_CLIDaemonModeRoundTrip(t *testing.T) {
+	var dispatched map[string]interface{}
+	ctrl := &mockController{
+		callToolFunc: func(_ context.Context, _ string, args map[string]interface{}) (interface{}, error) {
+			dispatched = args
+			resultJSON, err := json.Marshal(map[string]interface{}{"ok": true, "value": "done"})
+			require.NoError(t, err)
+			return []interface{}{map[string]interface{}{"type": "text", "text": string(resultJSON)}}, nil
+		},
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/api/v1/code/exec", httpapi.NewCodeExecHandler(ctrl, zap.NewNop().Sugar()))
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	// The CLI's own defaults, as validateOptions() lets them through.
+	const cliTimeoutMS = 120000
+	const cliMaxToolCalls = 0
+	cliAllowedServers := []string{}
+
+	result, err := cliclient.NewClient(server.URL, nil).CodeExec(
+		context.Background(),
+		"({ result: 1 })",
+		map[string]interface{}{},
+		cliTimeoutMS,
+		cliMaxToolCalls,
+		cliAllowedServers,
+	)
+	require.NoError(t, err)
+	require.True(t, result.OK, "the CLI's default flags were rejected: %+v", result.Error)
+
+	require.NotNil(t, dispatched, "the request never reached the tool")
+	options, ok := dispatched["options"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, cliTimeoutMS, options["timeout_ms"])
+	assert.Equal(t, cliMaxToolCalls, options["max_tool_calls"],
+		"--max-tool-calls=0 means unlimited and must reach the tool as sent")
+	assert.Equal(t, cliAllowedServers, options["allowed_servers"])
+}
+
+// TestCodeExecHandler_CLIFlagsReachTheTool asserts the dispatched options carry
+// exactly what the CLI asked for.
+func TestCodeExecHandler_CLIFlagsReachTheTool(t *testing.T) {
+	var dispatched map[string]interface{}
+	ctrl := &mockController{
+		callToolFunc: func(_ context.Context, _ string, args map[string]interface{}) (interface{}, error) {
+			dispatched = args
+			resultJSON, err := json.Marshal(map[string]interface{}{"ok": true, "value": "done"})
+			require.NoError(t, err)
+			return []interface{}{map[string]interface{}{"type": "text", "text": string(resultJSON)}}, nil
+		},
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/api/v1/code/exec", httpapi.NewCodeExecHandler(ctrl, zap.NewNop().Sugar()))
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	result, err := cliclient.NewClient(server.URL, nil).CodeExec(
+		context.Background(),
+		"({ result: 1 })",
+		map[string]interface{}{},
+		60000,
+		5,
+		[]string{"github"},
+	)
+	require.NoError(t, err)
+	require.True(t, result.OK, "CLI round trip failed: %+v", result.Error)
+
+	require.NotNil(t, dispatched)
+	options, ok := dispatched["options"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, 60000, options["timeout_ms"])
+	assert.Equal(t, 5, options["max_tool_calls"])
+	assert.Equal(t, []string{"github"}, options["allowed_servers"])
+}

--- a/internal/httpapi/code_exec_options_test.go
+++ b/internal/httpapi/code_exec_options_test.go
@@ -1,0 +1,132 @@
+package httpapi_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/httpapi"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// execCodeRequest runs one request through the code exec handler and returns
+// the recorder plus the arguments the handler dispatched (nil when it never
+// reached the tool).
+func execCodeRequest(t *testing.T, body map[string]interface{}) (*httptest.ResponseRecorder, map[string]interface{}) {
+	t.Helper()
+
+	bodyBytes, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	var dispatched map[string]interface{}
+	mockCtrl := &mockController{
+		callToolFunc: func(_ context.Context, _ string, args map[string]interface{}) (interface{}, error) {
+			dispatched = args
+			resultJSON, err := json.Marshal(map[string]interface{}{"ok": true, "value": nil})
+			require.NoError(t, err)
+			return []interface{}{map[string]interface{}{"type": "text", "text": string(resultJSON)}}, nil
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/code/exec", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	httpapi.NewCodeExecHandler(mockCtrl, zap.NewNop().Sugar()).ServeHTTP(recorder, req)
+
+	return recorder, dispatched
+}
+
+// TestCodeExecHandler_ForwardsRestrictions proves the execution restrictions a
+// REST caller sends reach the code_execution tool. They used to be built into
+// the arguments in a shape the tool's parser rejected, so a caller that scoped
+// its script to one server got an unrestricted run.
+func TestCodeExecHandler_ForwardsRestrictions(t *testing.T) {
+	recorder, args := execCodeRequest(t, map[string]interface{}{
+		"code": "({ result: 1 })",
+		"options": map[string]interface{}{
+			"timeout_ms":      300000,
+			"max_tool_calls":  1,
+			"allowed_servers": []string{"github"},
+		},
+	})
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.NotNil(t, args)
+
+	options, ok := args["options"].(map[string]interface{})
+	require.True(t, ok, "options must be dispatched as an object")
+	assert.Equal(t, 300000, options["timeout_ms"])
+	assert.Equal(t, 1, options["max_tool_calls"])
+	assert.Equal(t, []string{"github"}, options["allowed_servers"])
+}
+
+// TestCodeExecHandler_OmitsUnsetOptions pins the default semantics: an option
+// the caller left out must not be dispatched at all, so the tool resolves it
+// from config rather than from this endpoint's request-level fallback.
+func TestCodeExecHandler_OmitsUnsetOptions(t *testing.T) {
+	recorder, args := execCodeRequest(t, map[string]interface{}{
+		"code": "({ result: 1 })",
+	})
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.NotNil(t, args)
+
+	options, ok := args["options"].(map[string]interface{})
+	require.True(t, ok)
+	assert.NotContains(t, options, "timeout_ms")
+	assert.NotContains(t, options, "max_tool_calls")
+	assert.NotContains(t, options, "allowed_servers")
+}
+
+// TestCodeExecHandler_RejectsOutOfRangeOptions covers the bounds the
+// code_execution tool enforces. Left to the tool they come back as a plain-text
+// tool error the response parser cannot read, so the endpoint checks them
+// itself and answers 400.
+func TestCodeExecHandler_RejectsOutOfRangeOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		options map[string]interface{}
+		message string
+	}{
+		{
+			name:    "timeout_ms above the maximum",
+			options: map[string]interface{}{"timeout_ms": 600001},
+			message: "timeout_ms must be between 1 and 600000 milliseconds",
+		},
+		{
+			name:    "negative timeout_ms",
+			options: map[string]interface{}{"timeout_ms": -1},
+			message: "timeout_ms must be between 1 and 600000 milliseconds",
+		},
+		{
+			name:    "negative max_tool_calls",
+			options: map[string]interface{}{"max_tool_calls": -1},
+			message: "max_tool_calls cannot be negative",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder, args := execCodeRequest(t, map[string]interface{}{
+				"code":    "({ result: 1 })",
+				"options": tc.options,
+			})
+
+			assert.Equal(t, http.StatusBadRequest, recorder.Code)
+			assert.Nil(t, args, "an invalid request must not reach the tool")
+
+			var response map[string]interface{}
+			require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+			errorMap, ok := response["error"].(map[string]interface{})
+			require.True(t, ok)
+			assert.Equal(t, "INVALID_OPTIONS", errorMap["code"])
+			assert.Equal(t, tc.message, errorMap["message"])
+		})
+	}
+}

--- a/internal/httpapi/code_exec_options_test.go
+++ b/internal/httpapi/code_exec_options_test.go
@@ -84,6 +84,72 @@ func TestCodeExecHandler_OmitsUnsetOptions(t *testing.T) {
 	assert.NotContains(t, options, "allowed_servers")
 }
 
+// TestCodeExecHandler_ForwardsExplicitZeroOptions pins that presence, not
+// value, decides what is dispatched. A zero is a value the caller chose:
+// max_tool_calls 0 means "no limit of my own" and must reach the tool, which
+// applies its own default resolution to it. Inferring "unset" from the zero
+// dropped it, so a configured limit kept applying to a request that opted out.
+func TestCodeExecHandler_ForwardsExplicitZeroOptions(t *testing.T) {
+	recorder, args := execCodeRequest(t, map[string]interface{}{
+		"code": "({ result: 1 })",
+		"options": map[string]interface{}{
+			"max_tool_calls": 0,
+		},
+	})
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.NotNil(t, args)
+
+	options, ok := args["options"].(map[string]interface{})
+	require.True(t, ok)
+	require.Contains(t, options, "max_tool_calls", "an explicitly sent option must be forwarded")
+	assert.Equal(t, 0, options["max_tool_calls"])
+	assert.NotContains(t, options, "timeout_ms", "an omitted option must still be absent")
+}
+
+// TestCodeExecHandler_ForwardsExplicitEmptyAllowedServers pins the nil-vs-empty
+// distinction on the list option. An explicit empty array is forwarded as an
+// empty array, which the tool reads exactly as it reads one over MCP — the two
+// surfaces must not disagree about what `"allowed_servers": []` means.
+func TestCodeExecHandler_ForwardsExplicitEmptyAllowedServers(t *testing.T) {
+	recorder, args := execCodeRequest(t, map[string]interface{}{
+		"code": "({ result: 1 })",
+		"options": map[string]interface{}{
+			"allowed_servers": []string{},
+		},
+	})
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.NotNil(t, args)
+
+	options, ok := args["options"].(map[string]interface{})
+	require.True(t, ok)
+	require.Contains(t, options, "allowed_servers")
+	assert.Equal(t, []string{}, options["allowed_servers"])
+}
+
+// TestCodeExecHandler_NullOptionsAreUnset pins that a JSON null is absence, not
+// a value: it must dispatch nothing rather than an empty restriction.
+func TestCodeExecHandler_NullOptionsAreUnset(t *testing.T) {
+	recorder, args := execCodeRequest(t, map[string]interface{}{
+		"code": "({ result: 1 })",
+		"options": map[string]interface{}{
+			"timeout_ms":      nil,
+			"max_tool_calls":  nil,
+			"allowed_servers": nil,
+		},
+	})
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.NotNil(t, args)
+
+	options, ok := args["options"].(map[string]interface{})
+	require.True(t, ok)
+	assert.NotContains(t, options, "timeout_ms")
+	assert.NotContains(t, options, "max_tool_calls")
+	assert.NotContains(t, options, "allowed_servers")
+}
+
 // TestCodeExecHandler_RejectsOutOfRangeOptions covers the bounds the
 // code_execution tool enforces. Left to the tool they come back as a plain-text
 // tool error the response parser cannot read, so the endpoint checks them
@@ -108,6 +174,15 @@ func TestCodeExecHandler_RejectsOutOfRangeOptions(t *testing.T) {
 			name:    "negative max_tool_calls",
 			options: map[string]interface{}{"max_tool_calls": -1},
 			message: "max_tool_calls cannot be negative",
+		},
+		{
+			// The tool rejects a present timeout_ms of 0 (valid range is
+			// 1-600000). Inferring "unset" from the zero value made this
+			// endpoint accept it and silently substitute the configured
+			// budget instead.
+			name:    "explicit zero timeout_ms",
+			options: map[string]interface{}{"timeout_ms": 0},
+			message: "timeout_ms must be between 1 and 600000 milliseconds",
 		},
 	}
 

--- a/internal/httpapi/code_exec_route_timeout_test.go
+++ b/internal/httpapi/code_exec_route_timeout_test.go
@@ -1,0 +1,121 @@
+package httpapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+)
+
+// codeExecDeadlineController records the deadline the router left on the
+// request context by the time the code_execution tool is dispatched.
+type codeExecDeadlineController struct {
+	baseController
+	cfg      *config.Config
+	deadline time.Time
+	hasDL    bool
+}
+
+func (c *codeExecDeadlineController) GetCurrentConfig() interface{} { return c.cfg }
+
+func (c *codeExecDeadlineController) CallTool(ctx context.Context, _ string, _ map[string]interface{}) (interface{}, error) {
+	c.deadline, c.hasDL = ctx.Deadline()
+	resultJSON, err := json.Marshal(map[string]interface{}{"ok": true, "value": nil})
+	if err != nil {
+		return nil, err
+	}
+	return []interface{}{map[string]interface{}{"type": "text", "text": string(resultJSON)}}, nil
+}
+
+// TestCodeExecRouteGetsItsOwnTimeoutBudget proves POST /api/v1/code/exec is not
+// held to the blanket /api/v1 deadline. The handler derives its own context
+// from the caller's timeout_ms (up to 600000ms), but a context can only shrink
+// against its parent: under the shared 60s middleware every longer execution
+// was cancelled at 60s no matter what the caller asked for.
+func TestCodeExecRouteGetsItsOwnTimeoutBudget(t *testing.T) {
+	const apiKey = "test-api-key"
+	ctrl := &codeExecDeadlineController{cfg: &config.Config{APIKey: apiKey}}
+	srv := NewServer(ctrl, zap.NewNop().Sugar(), nil)
+
+	body, err := json.Marshal(map[string]interface{}{
+		"code":    "({ result: 1 })",
+		"options": map[string]interface{}{"timeout_ms": maxCodeExecTimeoutMS},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/code/exec", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	recorder := httptest.NewRecorder()
+
+	start := time.Now()
+	srv.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code, "body: %s", recorder.Body.String())
+	require.True(t, ctrl.hasDL, "the request context carried no deadline")
+
+	requested := time.Duration(maxCodeExecTimeoutMS) * time.Millisecond
+	budget := ctrl.deadline.Sub(start)
+	assert.Greater(t, budget, requested-time.Second,
+		"a %v execution budget was clipped to the blanket %v /api/v1 deadline", requested, defaultAPIRequestTimeout)
+	assert.LessOrEqual(t, budget, codeExecRequestTimeout,
+		"the request outlives its route budget")
+}
+
+// TestAPIRequestTimeoutPerRouteBudgets covers the middleware itself with
+// compressed durations: a path with its own budget survives work that the
+// default deadline would cancel, and every other path keeps the default.
+func TestAPIRequestTimeoutPerRouteBudgets(t *testing.T) {
+	const (
+		defaultBudget = 30 * time.Millisecond
+		longBudget    = 5 * time.Second
+		work          = 120 * time.Millisecond
+	)
+
+	var cancelled bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+			cancelled = true
+		case <-time.After(work):
+			cancelled = false
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := apiRequestTimeout(defaultBudget, map[string]time.Duration{
+		"/api/v1/long": longBudget,
+	})(next)
+
+	t.Run("a route with its own budget runs to completion", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/long", http.NoBody)
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+		assert.False(t, cancelled, "the long-running route was cancelled by the default deadline")
+	})
+
+	t.Run("every other route keeps the default deadline", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/status", http.NoBody)
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+		assert.True(t, cancelled, "an ordinary route escaped the default deadline")
+	})
+}
+
+// TestCodeExecRouteBudgetCoversTheLongestExecution keeps the route budget ahead
+// of the longest timeout_ms the code_execution tool accepts, so the parent
+// deadline is never the thing that ends an execution.
+func TestCodeExecRouteBudgetCoversTheLongestExecution(t *testing.T) {
+	budgets := longRunningAPIBudgets()
+	budget, ok := budgets[codeExecPath]
+	require.True(t, ok, "%s has no timeout budget of its own", codeExecPath)
+	assert.Greater(t, budget, time.Duration(maxCodeExecTimeoutMS)*time.Millisecond,
+		"the route budget must leave slack above the maximum timeout_ms")
+}

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -44,7 +44,51 @@ import (
 const (
 	asyncToggleTimeout = 5 * time.Second
 	secretTypeKeyring  = "keyring"
+
+	// defaultAPIRequestTimeout bounds an ordinary /api/v1 request.
+	defaultAPIRequestTimeout = 60 * time.Second
+
+	// codeExecPath is the one REST route that runs caller-supplied code.
+	codeExecPath = "/api/v1/code/exec"
+
+	// codeExecRequestTimeout is the parent deadline for POST /api/v1/code/exec.
+	// The handler derives the precise budget from the caller's timeout_ms, but
+	// a context only ever shrinks against its parent, so the parent has to
+	// cover the longest execution the code_execution tool accepts (600000ms)
+	// plus slack for request and response IO. Under the blanket 60s deadline
+	// every longer execution was cancelled at 60s regardless of what the
+	// caller asked for.
+	codeExecRequestTimeout = 630 * time.Second
 )
+
+// longRunningAPIBudgets lists the /api/v1 paths that need more than
+// defaultAPIRequestTimeout, keyed by request path.
+func longRunningAPIBudgets() map[string]time.Duration {
+	return map[string]time.Duration{
+		codeExecPath: codeExecRequestTimeout,
+	}
+}
+
+// apiRequestTimeout builds the /api/v1 request-deadline middleware. Paths
+// listed in budgets get their own deadline; everything else gets
+// defaultBudget. Each budget's handler chain is built once at setup rather
+// than per request.
+func apiRequestTimeout(defaultBudget time.Duration, budgets map[string]time.Duration) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		fallback := middleware.Timeout(defaultBudget)(next)
+		wrapped := make(map[string]http.Handler, len(budgets))
+		for path, budget := range budgets {
+			wrapped[path] = middleware.Timeout(budget)(next)
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if handler, ok := wrapped[r.URL.Path]; ok {
+				handler.ServeHTTP(w, r)
+				return
+			}
+			fallback.ServeHTTP(w, r)
+		})
+	}
+}
 
 // ServerController defines the interface for core server functionality
 type ServerController interface {
@@ -644,8 +688,10 @@ func (s *Server) setupRoutes() {
 
 	// API v1 routes with timeout and authentication middleware
 	s.router.Route("/api/v1", func(r chi.Router) {
-		// Apply timeout and API key authentication middleware to API routes only
-		r.Use(middleware.Timeout(60 * time.Second))
+		// Apply timeout and API key authentication middleware to API routes only.
+		// The deadline is per-route: the long-running routes carry their own
+		// budget, everything else gets defaultAPIRequestTimeout.
+		r.Use(apiRequestTimeout(defaultAPIRequestTimeout, longRunningAPIBudgets()))
 		r.Use(s.apiKeyAuthMiddleware())
 		// Spec 042: Tier 2 telemetry middlewares. Both fetch the registry via
 		// a closure so the registry can be installed after route setup.

--- a/internal/jsruntime/runtime.go
+++ b/internal/jsruntime/runtime.go
@@ -387,14 +387,52 @@ func (ec *ExecutionContext) makeCallToolFunction(vm *goja.Runtime) func(goja.Fun
 
 		// Tool call succeeded
 		record.Success = true
-		record.Result = result
+
+		// Expose the result under its wire (JSON) shape rather than the live Go
+		// value: goja would otherwise surface Go field names and exported methods.
+		plain, nerr := normalizeToolResult(result)
+		if nerr != nil {
+			record.Success = false
+			record.ErrorDetail = nerr.Error()
+			ec.ToolCalls = append(ec.ToolCalls, record)
+
+			return vm.ToValue(map[string]interface{}{
+				"ok": false,
+				"error": map[string]interface{}{
+					"code":    string(ErrorCodeSerializationError),
+					"message": "tool result is not JSON-serializable: " + nerr.Error(),
+				},
+			})
+		}
+
+		record.Result = plain
 		ec.ToolCalls = append(ec.ToolCalls, record)
 
 		return vm.ToValue(map[string]interface{}{
 			"ok":     true,
-			"result": result,
+			"result": plain,
 		})
 	}
+}
+
+// normalizeToolResult converts an upstream tool result into its JSON wire shape
+// so scripts see the documented field names (content[0].text) instead of Go
+// struct fields, and custom MarshalJSON semantics are preserved.
+func normalizeToolResult(v interface{}) (interface{}, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+
+	var plain interface{}
+	if err := json.Unmarshal(data, &plain); err != nil {
+		return nil, err
+	}
+	return plain, nil
 }
 
 // validateSerializable checks if a value can be JSON-serialized

--- a/internal/jsruntime/tool_result_test.go
+++ b/internal/jsruntime/tool_result_test.go
@@ -1,0 +1,163 @@
+package jsruntime
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// TestCallToolResultExposesJSONTagNames verifies that call_tool() results are
+// visible to scripts under their wire (JSON tag) names, not Go field names, and
+// that Go methods do not leak onto the result object.
+func TestCallToolResultExposesJSONTagNames(t *testing.T) {
+	caller := newMockToolCaller()
+	caller.results["s:t"] = &mcp.CallToolResult{
+		Content: []mcp.Content{
+			mcp.TextContent{Type: "text", Text: `{"hello":"world"}`},
+		},
+	}
+
+	code := `
+		const r = call_tool("s", "t", {});
+		if (!r.ok) throw new Error("call_tool failed: " + JSON.stringify(r.error));
+		({
+			hello: JSON.parse(r.result.content[0].text).hello,
+			pascal: typeof r.result.Content,
+			method: typeof r.result.MarshalJSON
+		})
+	`
+
+	result := Execute(context.Background(), caller, code, ExecutionOptions{})
+	if !result.Ok {
+		t.Fatalf("expected ok=true, got error: %v", result.Error)
+	}
+
+	resultMap, ok := result.Value.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected result to be a map, got %T", result.Value)
+	}
+
+	if resultMap["hello"] != "world" {
+		t.Errorf("expected hello='world', got %v", resultMap["hello"])
+	}
+	if resultMap["pascal"] != "undefined" {
+		t.Errorf("expected Go field name Content to be absent, got typeof=%v", resultMap["pascal"])
+	}
+	if resultMap["method"] != "undefined" {
+		t.Errorf("expected Go method MarshalJSON to be absent, got typeof=%v", resultMap["method"])
+	}
+}
+
+// TestCallToolResultMatchesWireShape verifies the shape scripts see is
+// byte-for-byte the shape the tool result marshals to on the wire, including
+// the custom MarshalJSON semantics (isError omitted when false,
+// structuredContent present).
+func TestCallToolResultMatchesWireShape(t *testing.T) {
+	raw := &mcp.CallToolResult{
+		Content: []mcp.Content{
+			mcp.TextContent{Type: "text", Text: `{"count":3}`},
+		},
+		StructuredContent: map[string]interface{}{"count": 3},
+		IsError:           false,
+	}
+
+	caller := newMockToolCaller()
+	caller.results["s:t"] = raw
+
+	// Object.assign copies the properties the script can actually see, so the
+	// comparison is against the sandbox-visible shape, not the wrapped Go value.
+	code := `
+		const r = call_tool("s", "t", {});
+		if (!r.ok) throw new Error("call_tool failed: " + JSON.stringify(r.error));
+		Object.assign({}, r.result)
+	`
+
+	result := Execute(context.Background(), caller, code, ExecutionOptions{})
+	if !result.Ok {
+		t.Fatalf("expected ok=true, got error: %v", result.Error)
+	}
+
+	gotBytes, err := json.Marshal(result.Value)
+	if err != nil {
+		t.Fatalf("failed to marshal script result: %v", err)
+	}
+	wantBytes, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatalf("failed to marshal upstream result: %v", err)
+	}
+
+	got := unmarshalObject(t, gotBytes)
+	want := unmarshalObject(t, wantBytes)
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("script sees a different shape than the wire\n got: %s\nwant: %s", gotBytes, wantBytes)
+	}
+	if _, hasIsError := got["isError"]; hasIsError {
+		t.Errorf("expected isError to be omitted when false, got: %s", gotBytes)
+	}
+	if _, hasStructured := got["structuredContent"]; !hasStructured {
+		t.Errorf("expected structuredContent to be present, got: %s", gotBytes)
+	}
+}
+
+// TestCallToolResultNotSerializable verifies that an upstream result which
+// cannot be JSON-encoded surfaces as a call_tool error rather than leaking a
+// live Go value into the sandbox.
+func TestCallToolResultNotSerializable(t *testing.T) {
+	caller := newMockToolCaller()
+	caller.results["s:t"] = map[string]interface{}{"ch": make(chan int)}
+
+	code := `
+		const r = call_tool("s", "t", {});
+		({ ok: r.ok, code: r.error && r.error.code })
+	`
+
+	result := Execute(context.Background(), caller, code, ExecutionOptions{})
+	if !result.Ok {
+		t.Fatalf("expected ok=true, got error: %v", result.Error)
+	}
+
+	resultMap := result.Value.(map[string]interface{})
+	if resultMap["ok"] != false {
+		t.Errorf("expected call_tool ok=false, got %v", resultMap["ok"])
+	}
+	if resultMap["code"] != string(ErrorCodeSerializationError) {
+		t.Errorf("expected code=%s, got %v", ErrorCodeSerializationError, resultMap["code"])
+	}
+}
+
+// TestCallToolPlainMapResultUnchanged guards the existing behaviour for callers
+// that already return plain maps.
+func TestCallToolPlainMapResultUnchanged(t *testing.T) {
+	caller := newMockToolCaller()
+
+	code := `
+		const r = call_tool("s", "t", {});
+		({ ok: r.ok, success: r.result.success })
+	`
+
+	result := Execute(context.Background(), caller, code, ExecutionOptions{})
+	if !result.Ok {
+		t.Fatalf("expected ok=true, got error: %v", result.Error)
+	}
+
+	resultMap := result.Value.(map[string]interface{})
+	if resultMap["ok"] != true {
+		t.Errorf("expected call_tool ok=true, got %v", resultMap["ok"])
+	}
+	if resultMap["success"] != true {
+		t.Errorf("expected result.success=true, got %v", resultMap["success"])
+	}
+}
+
+func unmarshalObject(t *testing.T, data []byte) map[string]interface{} {
+	t.Helper()
+	var out map[string]interface{}
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("failed to unmarshal %s: %v", data, err)
+	}
+	return out
+}

--- a/internal/runtime/supervisor/supervisor.go
+++ b/internal/runtime/supervisor/supervisor.go
@@ -2,6 +2,7 @@ package supervisor
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"sync"
@@ -848,13 +849,13 @@ func toolInfosFromMetadata(tools []*config.ToolMetadata) []stateview.ToolInfo {
 	}
 	infos := make([]stateview.ToolInfo, len(tools))
 	for i, tool := range tools {
-		// Parse ParamsJSON into InputSchema
+		// Parse ParamsJSON into InputSchema. StateView is served verbatim by the
+		// REST/CLI tool listings, so a malformed schema must stay nil (field
+		// omitted downstream) rather than become a misleading empty object.
 		var inputSchema map[string]interface{}
 		if tool.ParamsJSON != "" {
-			// ParamsJSON is already a JSON string; the API endpoint parses it if needed.
-			inputSchema = map[string]interface{}{
-				"type":       "object",
-				"properties": map[string]interface{}{}, // TODO: Parse ParamsJSON
+			if err := json.Unmarshal([]byte(tool.ParamsJSON), &inputSchema); err != nil {
+				inputSchema = nil
 			}
 		}
 

--- a/internal/runtime/supervisor/supervisor_test.go
+++ b/internal/runtime/supervisor/supervisor_test.go
@@ -1007,3 +1007,105 @@ func TestSupervisor_StopBeforeInitialReconcileIsBarrier(t *testing.T) {
 	require.Zero(t, notifierAfterStop.Load(),
 		"error-code notifier fired after Supervisor.Stop() returned")
 }
+
+// TestToolInfosFromMetadata_ParsesParamsJSON verifies that the cached upstream
+// schema (ToolMetadata.ParamsJSON) is actually parsed into StateView's
+// InputSchema. The REST/CLI tool listings serve StateView verbatim, so a
+// fabricated placeholder here surfaces to users as an empty
+// {"type":"object","properties":{}} schema for every tool.
+func TestToolInfosFromMetadata_ParsesParamsJSON(t *testing.T) {
+	tools := []*config.ToolMetadata{
+		{
+			Name:        "read_file",
+			ServerName:  "fs",
+			Description: "Read a file",
+			ParamsJSON:  `{"type":"object","properties":{"path":{"type":"string","description":"file path"}},"required":["path"]}`,
+		},
+	}
+
+	infos := toolInfosFromMetadata(tools)
+	require.Len(t, infos, 1)
+
+	schema := infos[0].InputSchema
+	require.NotNil(t, schema, "InputSchema must be populated from ParamsJSON")
+	require.Equal(t, "object", schema["type"])
+
+	props, ok := schema["properties"].(map[string]interface{})
+	require.True(t, ok, "properties must be an object, got %#v", schema["properties"])
+	require.Contains(t, props, "path", "parsed schema must carry the upstream properties")
+
+	pathProp, ok := props["path"].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, "string", pathProp["type"])
+	require.Equal(t, "file path", pathProp["description"])
+
+	required, ok := schema["required"].([]interface{})
+	require.True(t, ok, "required must round-trip, got %#v", schema["required"])
+	require.Equal(t, []interface{}{"path"}, required)
+}
+
+// TestToolInfosFromMetadata_EmptyAndMalformed asserts we never fabricate a
+// placeholder schema: an absent or unparsable ParamsJSON leaves InputSchema
+// nil so the field is omitted downstream rather than reported as an empty
+// object schema.
+func TestToolInfosFromMetadata_EmptyAndMalformed(t *testing.T) {
+	tools := []*config.ToolMetadata{
+		{Name: "no_schema", ServerName: "srv", ParamsJSON: ""},
+		{Name: "broken_schema", ServerName: "srv", ParamsJSON: `{not json`},
+		{Name: "non_object_schema", ServerName: "srv", ParamsJSON: `"just a string"`},
+	}
+
+	infos := toolInfosFromMetadata(tools)
+	require.Len(t, infos, 3)
+
+	for _, info := range infos {
+		require.Nil(t, info.InputSchema, "tool %q should have no InputSchema", info.Name)
+	}
+}
+
+// TestSupervisor_RefreshToolsFromDiscovery_StateViewCarriesSchema covers the
+// end-to-end StateView population path that the REST tool listings read: after
+// discovery, the per-server StateView entry must carry the real upstream
+// schema, not a placeholder.
+func TestSupervisor_RefreshToolsFromDiscovery_StateViewCarriesSchema(t *testing.T) {
+	cfg := &config.Config{
+		Listen: "127.0.0.1:8080",
+		Servers: []*config.ServerConfig{
+			{Name: "server1", Enabled: true},
+		},
+	}
+
+	configSvc := configsvc.NewService(cfg, "/tmp/config.json", zap.NewNop())
+	defer configSvc.Close()
+
+	mockUpstream := NewMockUpstreamAdapter()
+	defer mockUpstream.Close()
+
+	supervisor := New(configSvc, mockUpstream, zap.NewNop())
+
+	_ = supervisor.reconcile(configSvc.Current())
+	time.Sleep(50 * time.Millisecond)
+
+	tools := []*config.ToolMetadata{
+		{
+			Name:        "search",
+			ServerName:  "server1",
+			Description: "Search things",
+			ParamsJSON:  `{"type":"object","properties":{"query":{"type":"string"},"limit":{"type":"integer"}},"required":["query"]}`,
+		},
+	}
+
+	require.NoError(t, supervisor.RefreshToolsFromDiscovery(tools))
+
+	snapshot := supervisor.StateView().Snapshot()
+	server1, ok := snapshot.Servers["server1"]
+	require.True(t, ok, "expected server1 in StateView snapshot")
+	require.Len(t, server1.Tools, 1)
+
+	schema := server1.Tools[0].InputSchema
+	require.NotNil(t, schema)
+	props, ok := schema["properties"].(map[string]interface{})
+	require.True(t, ok, "properties must be an object, got %#v", schema["properties"])
+	require.Contains(t, props, "query")
+	require.Contains(t, props, "limit")
+}

--- a/internal/server/code_execution_options_test.go
+++ b/internal/server/code_execution_options_test.go
@@ -184,3 +184,37 @@ func TestRESTCodeExecOmittedOptionsKeepConfigDefaults(t *testing.T) {
 	assert.Zero(t, options.MaxToolCalls, "an unsent max_tool_calls must fall through to the configured default")
 	assert.Empty(t, options.AllowedServers, "an unsent allowed_servers must not restrict anything")
 }
+
+// TestResolveCodeExecutionDefaults pins default resolution against the
+// documented contract that max_tool_calls: 0 means unlimited. An absent option
+// (the unset sentinel) takes the configured value; an explicit zero is the
+// caller's unlimited override and must survive — flooring it to the config
+// limit made the override impossible to express on any transport.
+func TestResolveCodeExecutionDefaults(t *testing.T) {
+	t.Run("absent max_tool_calls takes the configured limit", func(t *testing.T) {
+		opts := jsruntime.ExecutionOptions{MaxToolCalls: codeExecMaxToolCallsUnset}
+		resolveCodeExecutionDefaults(&opts, 120000, 5)
+		assert.Equal(t, 5, opts.MaxToolCalls)
+	})
+
+	t.Run("explicit zero survives as the unlimited override", func(t *testing.T) {
+		opts := jsruntime.ExecutionOptions{MaxToolCalls: codeExecMaxToolCallsUnset}
+		require.Empty(t, applyCodeExecutionOptions(map[string]interface{}{"max_tool_calls": 0}, &opts))
+		resolveCodeExecutionDefaults(&opts, 120000, 5)
+		assert.Equal(t, 0, opts.MaxToolCalls)
+	})
+
+	t.Run("explicit positive value wins over config", func(t *testing.T) {
+		opts := jsruntime.ExecutionOptions{MaxToolCalls: codeExecMaxToolCallsUnset}
+		require.Empty(t, applyCodeExecutionOptions(map[string]interface{}{"max_tool_calls": 2}, &opts))
+		resolveCodeExecutionDefaults(&opts, 120000, 5)
+		assert.Equal(t, 2, opts.MaxToolCalls)
+	})
+
+	t.Run("absent timeout takes the configured budget", func(t *testing.T) {
+		opts := jsruntime.ExecutionOptions{MaxToolCalls: codeExecMaxToolCallsUnset}
+		resolveCodeExecutionDefaults(&opts, 300000, 0)
+		assert.Equal(t, 300000, opts.TimeoutMs)
+		assert.Equal(t, 0, opts.MaxToolCalls)
+	})
+}

--- a/internal/server/code_execution_options_test.go
+++ b/internal/server/code_execution_options_test.go
@@ -1,0 +1,186 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/httpapi"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/jsruntime"
+)
+
+// TestApplyCodeExecutionOptionsValueShapes pins the option shapes the parser
+// must accept. Arguments reach handleCodeExecution either JSON-decoded (over
+// the MCP transport: float64 and []interface{}) or as Go-typed values from an
+// in-process caller that builds the arguments map directly — the REST handler
+// behind POST /api/v1/code/exec is one. Accepting only the JSON shapes made
+// every Go-typed restriction vanish silently.
+func TestApplyCodeExecutionOptionsValueShapes(t *testing.T) {
+	tests := []struct {
+		name    string
+		options map[string]interface{}
+		want    jsruntime.ExecutionOptions
+		errMsg  string
+	}{
+		{
+			name: "JSON-decoded values",
+			options: map[string]interface{}{
+				"timeout_ms":      float64(300000),
+				"max_tool_calls":  float64(1),
+				"allowed_servers": []interface{}{"github", "slack"},
+			},
+			want: jsruntime.ExecutionOptions{
+				TimeoutMs:      300000,
+				MaxToolCalls:   1,
+				AllowedServers: []string{"github", "slack"},
+			},
+		},
+		{
+			name: "Go-typed values from an in-process caller",
+			options: map[string]interface{}{
+				"timeout_ms":      300000,
+				"max_tool_calls":  1,
+				"allowed_servers": []string{"github", "slack"},
+			},
+			want: jsruntime.ExecutionOptions{
+				TimeoutMs:      300000,
+				MaxToolCalls:   1,
+				AllowedServers: []string{"github", "slack"},
+			},
+		},
+		{
+			name: "json.Number values from a UseNumber decoder",
+			options: map[string]interface{}{
+				"timeout_ms":     json.Number("300000"),
+				"max_tool_calls": json.Number("1"),
+			},
+			want: jsruntime.ExecutionOptions{TimeoutMs: 300000, MaxToolCalls: 1},
+		},
+		{
+			name:    "absent options leave the zero values for config defaults",
+			options: map[string]interface{}{},
+			want:    jsruntime.ExecutionOptions{},
+		},
+		{
+			name:    "timeout_ms above the maximum is rejected",
+			options: map[string]interface{}{"timeout_ms": 600001},
+			errMsg:  "timeout_ms must be between 1 and 600000 milliseconds",
+		},
+		{
+			name:    "negative max_tool_calls is rejected",
+			options: map[string]interface{}{"max_tool_calls": -1},
+			errMsg:  "max_tool_calls cannot be negative",
+		},
+		{
+			name:    "allowed_servers with a non-string element is rejected",
+			options: map[string]interface{}{"allowed_servers": []interface{}{"github", 42}},
+			errMsg:  "allowed_servers must be an array of strings",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got jsruntime.ExecutionOptions
+			errMsg := applyCodeExecutionOptions(tc.options, &got)
+
+			if tc.errMsg != "" {
+				assert.Equal(t, tc.errMsg, errMsg)
+				return
+			}
+			require.Empty(t, errMsg)
+			assert.Equal(t, tc.want.TimeoutMs, got.TimeoutMs, "timeout_ms")
+			assert.Equal(t, tc.want.MaxToolCalls, got.MaxToolCalls, "max_tool_calls")
+			assert.Equal(t, tc.want.AllowedServers, got.AllowedServers, "allowed_servers")
+		})
+	}
+}
+
+// codeExecArgsCapture records the arguments the REST handler dispatches to the
+// code_execution tool, standing in for the controller's CallTool.
+type codeExecArgsCapture struct {
+	args map[string]interface{}
+}
+
+func (c *codeExecArgsCapture) CallTool(_ context.Context, _ string, args map[string]interface{}) (interface{}, error) {
+	c.args = args
+	resultJSON, err := json.Marshal(map[string]interface{}{"ok": true, "value": nil})
+	if err != nil {
+		return nil, err
+	}
+	return []interface{}{map[string]interface{}{"type": "text", "text": string(resultJSON)}}, nil
+}
+
+// TestRESTCodeExecOptionsReachTheParser joins the two halves of the REST code
+// execution path: the httpapi handler builds the code_execution arguments, and
+// handleCodeExecution parses them. The restrictions a caller sends over REST
+// must survive that handoff — when they did not, a request that limited itself
+// to one tool call on one server actually ran unrestricted.
+func TestRESTCodeExecOptionsReachTheParser(t *testing.T) {
+	body, err := json.Marshal(map[string]interface{}{
+		"code":  "({ result: 1 })",
+		"input": map[string]interface{}{},
+		"options": map[string]interface{}{
+			"timeout_ms":      300000,
+			"max_tool_calls":  1,
+			"allowed_servers": []string{"github"},
+		},
+	})
+	require.NoError(t, err)
+
+	capture := &codeExecArgsCapture{}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/code/exec", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	httpapi.NewCodeExecHandler(capture, zap.NewNop().Sugar()).ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.NotNil(t, capture.args, "handler did not dispatch to code_execution")
+
+	optionsObj, ok := capture.args["options"].(map[string]interface{})
+	require.True(t, ok, "code_execution arguments carry no options object")
+
+	var options jsruntime.ExecutionOptions
+	require.Empty(t, applyCodeExecutionOptions(optionsObj, &options))
+
+	assert.Equal(t, 300000, options.TimeoutMs, "timeout_ms was dropped between REST and the tool")
+	assert.Equal(t, 1, options.MaxToolCalls, "max_tool_calls was dropped between REST and the tool")
+	assert.Equal(t, []string{"github"}, options.AllowedServers, "allowed_servers was dropped between REST and the tool")
+}
+
+// TestRESTCodeExecOmittedOptionsKeepConfigDefaults guards the other direction:
+// options the caller did not send must stay unset so handleCodeExecution
+// resolves them from config (code_execution_timeout_ms / max_tool_calls) and
+// leaves allowed_servers meaning "no restriction".
+func TestRESTCodeExecOmittedOptionsKeepConfigDefaults(t *testing.T) {
+	body, err := json.Marshal(map[string]interface{}{
+		"code":  "({ result: 1 })",
+		"input": map[string]interface{}{},
+	})
+	require.NoError(t, err)
+
+	capture := &codeExecArgsCapture{}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/code/exec", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	httpapi.NewCodeExecHandler(capture, zap.NewNop().Sugar()).ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.NotNil(t, capture.args)
+
+	optionsObj, ok := capture.args["options"].(map[string]interface{})
+	require.True(t, ok)
+
+	var options jsruntime.ExecutionOptions
+	require.Empty(t, applyCodeExecutionOptions(optionsObj, &options))
+
+	assert.Zero(t, options.TimeoutMs, "an unsent timeout_ms must fall through to the configured default")
+	assert.Zero(t, options.MaxToolCalls, "an unsent max_tool_calls must fall through to the configured default")
+	assert.Empty(t, options.AllowedServers, "an unsent allowed_servers must not restrict anything")
+}

--- a/internal/server/code_execution_options_test.go
+++ b/internal/server/code_execution_options_test.go
@@ -218,3 +218,26 @@ func TestResolveCodeExecutionDefaults(t *testing.T) {
 		assert.Equal(t, 0, opts.MaxToolCalls)
 	})
 }
+
+// TestApplyCodeExecutionOptionsRejectsNonIntegers: a fractional or non-numeric
+// option must be rejected, not silently converted — max_tool_calls: 0.5
+// truncated to 0 would flip a caller's intended limit into the unlimited
+// override, and timeout_ms: 1.9 would run with a 1ms budget.
+func TestApplyCodeExecutionOptionsRejectsNonIntegers(t *testing.T) {
+	cases := []struct {
+		name    string
+		options map[string]interface{}
+		errMsg  string
+	}{
+		{"fractional max_tool_calls", map[string]interface{}{"max_tool_calls": 0.5}, "max_tool_calls must be an integer"},
+		{"fractional timeout_ms", map[string]interface{}{"timeout_ms": 1.9}, "timeout_ms must be an integer"},
+		{"non-numeric timeout_ms", map[string]interface{}{"timeout_ms": "5000"}, "timeout_ms must be an integer"},
+		{"fractional json.Number", map[string]interface{}{"max_tool_calls": json.Number("0.5")}, "max_tool_calls must be an integer"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got jsruntime.ExecutionOptions
+			assert.Equal(t, tc.errMsg, applyCodeExecutionOptions(tc.options, &got))
+		})
+	}
+}

--- a/internal/server/content_forward.go
+++ b/internal/server/content_forward.go
@@ -148,8 +148,9 @@ func forwardContentResult(result interface{}, truncator *truncate.Truncator, cac
 // may themselves be paginating (notably read_cache). If paginableUnits <= 1
 // the caller has nothing further to subdivide — caching a fresh key here would
 // just hand the agent a new key resolving to the same oversize payload, an
-// inescapable loop. In that case the text is returned as-is (still over the
-// limit) and the caller decides what to do.
+// inescapable loop. That case still respects the limit, just without a
+// pagination contract: the text is cut plainly and carries the
+// "cache not available" notice instead of a read_cache banner.
 //
 // Termination is therefore agent-driven, not strictly algorithmic: a level
 // whose records all fit individually but overflow collectively keeps minting
@@ -190,9 +191,12 @@ func maybeTruncateAndCacheTextPinned(text, toolName string, args map[string]inte
 	}
 	if paginableUnits <= 1 {
 		// Cannot subdivide further; recursive caching here would just hand the
-		// agent a new key that resolves to the exact same payload. Return the
-		// oversize text intact and let the caller (and the agent) handle it.
-		return text, false
+		// agent a new key that resolves to the exact same payload. The response
+		// limit still holds, so cut plainly: the standard truncation notice, no
+		// read_cache banner and no cache write. Returning the oversize text
+		// intact would have let a single fat record (one tool with a sprawling
+		// schema) pass tool_response_limit unbounded.
+		return truncator.SimpleTruncate(text), true
 	}
 	tr := truncator.TruncateWithRecordPath(text, toolName, args, pinnedRecordPath)
 	if tr.CacheAvailable && cacheStore != nil {

--- a/internal/server/content_forward.go
+++ b/internal/server/content_forward.go
@@ -167,6 +167,24 @@ func forwardContentResult(result interface{}, truncator *truncate.Truncator, cac
 // logger is optional; receives a zap.Warn if cacheStore.Store fails so the
 // resulting "cache key not found" can be debugged. Pass nil to silence.
 func maybeTruncateAndCacheText(text, toolName string, args map[string]interface{}, paginableUnits int, truncator *truncate.Truncator, cacheStore CacheStore, logger *zap.Logger) (out string, wasTruncated bool) {
+	return maybeTruncateAndCacheTextPinned(text, toolName, args, paginableUnits, "", truncator, cacheStore, logger)
+}
+
+// maybeTruncateAndCacheTextPinned is maybeTruncateAndCacheText for callers that
+// compose their own payload and therefore know which array the banner they emit
+// promises to page. pinnedRecordPath forces that array to be the pagination
+// record path instead of letting the truncator's heuristic pick whichever array
+// happens to hold the most elements — for retrieve_tools that heuristic can land
+// on the Spec 049 "disabled" list or on an array nested inside a tool's input
+// schema, so read_cache would page non-tool records under a banner that
+// advertises tools.
+//
+// The pin is also what makes paginableUnits meaningful: the guard counts units
+// of the SAME array the key pages. If the pinned path is not an array in the
+// payload the truncator emits no cache handle at all (plain truncation), so the
+// banner can never advertise a contract that does not hold. An empty
+// pinnedRecordPath keeps the inferred behaviour.
+func maybeTruncateAndCacheTextPinned(text, toolName string, args map[string]interface{}, paginableUnits int, pinnedRecordPath string, truncator *truncate.Truncator, cacheStore CacheStore, logger *zap.Logger) (out string, wasTruncated bool) {
 	if truncator == nil || !truncator.ShouldTruncate(text) {
 		return text, false
 	}
@@ -176,7 +194,7 @@ func maybeTruncateAndCacheText(text, toolName string, args map[string]interface{
 		// oversize text intact and let the caller (and the agent) handle it.
 		return text, false
 	}
-	tr := truncator.Truncate(text, toolName, args)
+	tr := truncator.TruncateWithRecordPath(text, toolName, args, pinnedRecordPath)
 	if tr.CacheAvailable && cacheStore != nil {
 		if storeErr := cacheStore.Store(tr.CacheKey, toolName, args, text, tr.RecordPath, tr.TotalRecords); storeErr != nil {
 			logCacheStoreFailure(logger, storeErr, toolName, tr.CacheKey, tr.TotalRecords, len(text))

--- a/internal/server/content_forward_test.go
+++ b/internal/server/content_forward_test.go
@@ -371,10 +371,13 @@ func TestMaybeTruncateAndCacheText_HappyPathStores(t *testing.T) {
 // single-huge-record edge case. When read_cache returns one record bigger than
 // the truncator limit, recursively caching it would produce a new key that
 // resolves to the exact same oversized payload — an infinite loop the agent
-// can never escape. paginableUnits=1 must short-circuit that.
+// can never escape. paginableUnits=1 must short-circuit that, but the response
+// limit still applies: the payload is cut plainly, with the notice that says so
+// and no cache handle to chase.
 func TestMaybeTruncateAndCacheText_NoRecurseOnSingleRecord(t *testing.T) {
 	// A response shaped like a single huge record (e.g. one CodeRabbit review
 	// body of ~70 KB) wrapped in a 1-element records array.
+	const limit = 500
 	body := `{"records":[{"body":"` + strings.Repeat("z", 5000) + `"}],"meta":{"total":1}}`
 	store := &captureStore{}
 
@@ -383,12 +386,14 @@ func TestMaybeTruncateAndCacheText_NoRecurseOnSingleRecord(t *testing.T) {
 		"read_cache",
 		map[string]interface{}{"key": "AAA", "offset": 0, "limit": 1},
 		1, // single record — no further pagination axis available
-		truncate.NewTruncator(500),
+		truncate.NewTruncator(limit),
 		store,
 		nil,
 	)
-	assert.False(t, wasTruncated, "single-record path must NOT recurse")
-	assert.Equal(t, body, out, "single-record body must pass through unchanged")
+	assert.True(t, wasTruncated, "an oversize single record is still truncated")
+	assert.LessOrEqual(t, len(out), limit, "the response limit holds with or without a pagination axis")
+	assert.Contains(t, out, "[truncated by mcpproxy, cache not available]")
+	assert.NotContains(t, out, `key="`, "a key here would resolve to the same payload")
 
 	store.mu.Lock()
 	defer store.mu.Unlock()

--- a/internal/server/http_timeouts_test.go
+++ b/internal/server/http_timeouts_test.go
@@ -178,6 +178,79 @@ func TestHTTPWriteTimeoutRealBehavior(t *testing.T) {
 	})
 }
 
+// TestCodeExecRouteEscapesServerDeadlines is the third deadline a REST code
+// execution has to clear. POST /api/v1/code/exec runs caller-supplied code for
+// up to its own timeout_ms budget (600s), which outlives both http.Server
+// deadlines: WriteTimeout caps the whole response, and ReadTimeout cancels the
+// request context mid-handler. Relaxing the chi middleware alone would have
+// left every execution past the configured deadlines dying at the transport.
+func TestCodeExecRouteEscapesServerDeadlines(t *testing.T) {
+	const (
+		handlerDelay = 600 * time.Millisecond
+		serverDeadln = 200 * time.Millisecond // < handlerDelay on purpose
+		completed    = "execution-finished"
+		cancelled    = "execution-cancelled"
+	)
+
+	// Stands in for the chi REST router: slow enough to outlast the server
+	// deadlines, and it reports a cancelled request context rather than
+	// ignoring it.
+	restAPI := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(handlerDelay):
+			fmt.Fprint(w, completed)
+		case <-r.Context().Done():
+			fmt.Fprint(w, cancelled)
+		}
+	})
+
+	mux := http.NewServeMux()
+	(&Server{logger: zap.NewNop()}).registerHTTPHandlers(mux, restAPI)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 60 * time.Second,
+		ReadTimeout:       serverDeadln,
+		WriteTimeout:      serverDeadln,
+	}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	post := func(t *testing.T, path string) (string, error) {
+		t.Helper()
+		client := &http.Client{Timeout: 10 * time.Second}
+		resp, err := client.Post("http://"+ln.Addr().String()+path, //nolint:noctx // short-lived test client
+			"application/json", strings.NewReader(`{"code":"1"}`))
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+		data, err := io.ReadAll(resp.Body)
+		return string(data), err
+	}
+
+	t.Run("an ordinary API route still dies on the server deadlines", func(t *testing.T) {
+		got, err := post(t, "/api/v1/tools/call")
+		if err == nil && got == completed {
+			t.Fatalf("expected the server deadlines to end the request, got %q", got)
+		}
+	})
+
+	t.Run("the code exec route runs past them", func(t *testing.T) {
+		got, err := post(t, "/api/v1/code/exec")
+		if err != nil {
+			t.Fatalf("POST /api/v1/code/exec failed: %v", err)
+		}
+		if got != completed {
+			t.Fatalf("body = %q, want %q", got, completed)
+		}
+	})
+}
+
 // TestStreamingNoDeadlineKeepsGETStreamAlive is the SSE half of the GH #965 fix.
 // A long-lived GET stream is killed by BOTH http.Server deadlines: WriteTimeout
 // caps the whole response, and ReadTimeout (armed when the request is read) fires

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -1790,10 +1790,48 @@ func (p *MCPProxyServer) handleRetrieveToolsWithMode(ctx context.Context, reques
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to serialize results: %v", err)), nil
 	}
 
-	// Emit success event with args and response (Spec 024)
+	// A discovery response is a tool response like any other: enforce
+	// tool_response_limit and park the full payload behind a read_cache key.
+	// The record path is PINNED to "tools" rather than inferred: the banner
+	// promises tool entries, and the inference heuristic prefers the array with
+	// the most elements — which here can be the Spec 049 "disabled" list (it
+	// can outnumber the callable results) or, with ≤2 results, an array nested
+	// inside a tool's input schema. Pinning is what makes paginableUnits =
+	// len(mcpTools) the right guard too: it counts units of the same array the
+	// key pages, so the single-record short-circuit (0 or 1 entries: nothing to
+	// subdivide, text flows through unchanged) applies to the right array.
+	// `args` (not activityArgs) is the cache-key derivation input.
+	text := string(jsonResult)
+	var wasTruncated bool
+	if routingMode != config.RoutingModeCodeExecution {
+		// The code-execution surface does not register read_cache (see
+		// buildCodeExecModeTools), so a banner there would point the agent
+		// at an unavailable tool — the same reasoning that pins it to full mode.
+		text, wasTruncated = maybeTruncateAndCacheTextPinned(
+			text,
+			"retrieve_tools",
+			args,
+			len(mcpTools),
+			"tools",
+			p.currentTruncator(),
+			p.cacheManager,
+			p.logger,
+		)
+	}
+	if wasTruncated {
+		p.logger.Info("retrieve_tools output exceeded the response limit and was truncated-and-cached",
+			zap.String("query", query),
+			zap.Int("tools", len(mcpTools)),
+			zap.Int("full_bytes", len(jsonResult)),
+		)
+	}
+
+	// Emit success event with args and response (Spec 024). The FULL response
+	// goes to the activity log — truncation only shapes what the agent sees
+	// (same order handleReadCache uses).
 	p.emitActivityInternalToolCall("retrieve_tools", "", "", "", sessionID, requestID, "success", "", time.Since(startTime).Milliseconds(), activityArgs, response, nil, "")
 
-	return mcp.NewToolResultText(string(jsonResult)), nil
+	return mcp.NewToolResultText(text), nil
 }
 
 // handleCallToolRead implements the call_tool_read functionality (Spec 018)
@@ -1844,15 +1882,20 @@ func (p *MCPProxyServer) handleCallToolVariant(ctx context.Context, request mcp.
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Missing required parameter 'name': %v", err)), nil
 	}
+	// Whitespace is never significant in a canonical id; case is (every gate
+	// below keys on the exact name), so padding is trimmed and nothing else.
+	toolName = strings.TrimSpace(toolName)
 
-	// Parse server and tool name early for activity logging
+	// Parse server and tool name early for activity logging, through the same
+	// splitServerTool the describe_tool path uses: it trims EACH segment, so
+	// "github: create_issue" resolves exactly like "github:create_issue"
+	// instead of missing every exact-name gate below and being dispatched
+	// upstream padded. The canonical id is rebuilt from the trimmed segments
+	// so the validator cache key and every message see the normalized form.
 	var serverName, actualToolName string
-	if strings.Contains(toolName, ":") {
-		parts := strings.SplitN(toolName, ":", 2)
-		if len(parts) == 2 {
-			serverName = parts[0]
-			actualToolName = parts[1]
-		}
+	if parsedServer, parsedTool, ok := splitServerTool(toolName); ok {
+		serverName, actualToolName = parsedServer, parsedTool
+		toolName = parsedServer + ":" + parsedTool
 	}
 
 	// Helper to get session ID for activity logging
@@ -5467,6 +5510,13 @@ func (p *MCPProxyServer) CallToolDirect(ctx context.Context, request mcp.CallToo
 		result, err = p.handleCallToolDestructive(ctx, request)
 	case "retrieve_tools":
 		result, err = p.handleRetrieveTools(ctx, request)
+	case "read_cache":
+		// Truncated responses on this path carry the same "use read_cache"
+		// banner the MCP surface emits, so the follow-up has to be routable
+		// here too — otherwise REST/CLI/Web-UI/tray callers are told to call a
+		// tool that answers "unknown tool: read_cache" (HTTP 500) and the
+		// parked payload is unreachable outside an MCP session.
+		result, err = p.handleReadCache(ctx, request)
 	case "quarantine_security":
 		result, err = p.handleQuarantineSecurity(ctx, request)
 	case "code_execution":

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -1819,7 +1819,7 @@ func (p *MCPProxyServer) handleRetrieveToolsWithMode(ctx context.Context, reques
 		)
 	}
 	if wasTruncated {
-		p.logger.Info("retrieve_tools output exceeded the response limit and was truncated-and-cached",
+		p.logger.Info("retrieve_tools output exceeded the response limit and was truncated",
 			zap.String("query", query),
 			zap.Int("tools", len(mcpTools)),
 			zap.Int("full_bytes", len(jsonResult)),
@@ -5097,7 +5097,7 @@ func (p *MCPProxyServer) handleReadCache(ctx context.Context, request mcp.CallTo
 	// operators, so surface it as a structured log: it signals the agent is
 	// walking a payload deep enough that even one cache page overflows.
 	if reTruncated {
-		p.logger.Info("read_cache output exceeded the response limit and was recursively truncated-and-cached",
+		p.logger.Info("read_cache output exceeded the response limit and was truncated",
 			zap.String("requested_key", key),
 			zap.Int("offset", offset),
 			zap.Int("limit", limit),

--- a/internal/server/mcp_call_tool_direct_test.go
+++ b/internal/server/mcp_call_tool_direct_test.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Every truncation banner mcpproxy emits points the caller at read_cache. That
+// banner reaches REST/CLI/Web-UI/tray callers too (POST /api/v1/tools/call →
+// CallToolDirect), so read_cache has to be routable there — otherwise the
+// advertised follow-up answers "unknown tool: read_cache" with an HTTP 500 and
+// the full payload is unreachable outside the MCP surface.
+
+func TestCallToolDirect_ReadCacheIsRoutable(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "read_cache"
+	request.Params.Arguments = map[string]interface{}{
+		"key": "no-such-key", "offset": float64(0), "limit": float64(50),
+	}
+
+	_, err := proxy.CallToolDirect(context.Background(), request)
+	require.Error(t, err, "an unresolvable key is still a read_cache answer, not a routing miss")
+	assert.NotContains(t, err.Error(), "unknown tool",
+		"read_cache must be routed by CallToolDirect, not fall through to the default branch")
+	assert.Contains(t, err.Error(), "cache key not found")
+}
+
+func TestCallToolDirect_ReadCachePagesStoredRecords(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+
+	const key = "cache-key-direct"
+	content := `{"tools":[{"name":"github:get_repo"},{"name":"github:list_issues"}]}`
+	require.NoError(t, proxy.cacheManager.Store(key, "retrieve_tools", map[string]interface{}{"query": "manage"}, content, "tools", 2))
+
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "read_cache"
+	request.Params.Arguments = map[string]interface{}{
+		"key": key, "offset": float64(0), "limit": float64(50),
+	}
+
+	result, err := proxy.CallToolDirect(context.Background(), request)
+	require.NoError(t, err)
+
+	blocks, ok := result.([]mcp.Content)
+	require.True(t, ok, "CallToolDirect returns the raw content blocks")
+	require.NotEmpty(t, blocks)
+	text, ok := blocks[0].(mcp.TextContent)
+	require.True(t, ok)
+
+	var page struct {
+		Records []map[string]interface{} `json:"records"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(text.Text), &page))
+	require.Len(t, page.Records, 2)
+	assert.Equal(t, "github:get_repo", page.Records[0]["name"])
+}

--- a/internal/server/mcp_call_tool_trim_test.go
+++ b/internal/server/mcp_call_tool_trim_test.go
@@ -1,0 +1,80 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/contracts"
+)
+
+// A padded 'name' must resolve to the same target as the canonical id: the
+// server segment is parsed from the trimmed id, so gates and errors key on
+// "github", never " github". Interior padding around the ':' separator counts
+// too — the call path shares splitServerTool with describe_tool, so
+// "github: get_repo" resolves exactly like "github:get_repo" instead of
+// missing every exact-name gate and being dispatched upstream padded.
+func TestCallToolVariant_TrimsWhitespaceInToolName(t *testing.T) {
+	cases := []struct {
+		name string
+		id   string
+	}{
+		{"canonical", "github:get_repo"},
+		{"outer padding", " github:get_repo "},
+		{"padding after separator", "github: get_repo"},
+		{"padding before separator", "github :get_repo"},
+		{"padding on both segments", "  github : get_repo  "},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			proxy := createTestMCPProxyServer(t)
+			seedEntryBuilderFixture(t, proxy)
+
+			request := mcp.CallToolRequest{}
+			request.Params.Arguments = map[string]interface{}{"name": tc.id}
+
+			result, err := proxy.handleCallToolVariant(context.Background(), request, contracts.ToolVariantRead)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.True(t, result.IsError, "no upstream client is connected in this fixture")
+
+			text := result.Content[0].(mcp.TextContent).Text
+			assert.NotContains(t, text, "Invalid tool name format")
+			assert.Contains(t, text, "No client found for server: github.",
+				"the padded id must resolve to server 'github', not a padded variant")
+		})
+	}
+}
+
+// The same normalization has to hold at the gates, not just in the final error
+// string: an agent-scoped session that allows "github" must not see a padded
+// id rejected as an out-of-scope server.
+func TestCallToolVariant_InteriorPaddingPassesAgentScope(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+	seedEntryBuilderFixture(t, proxy)
+
+	agentCtx := &auth.AuthContext{
+		Type:           auth.AuthTypeAgent,
+		AgentName:      "test-bot",
+		AllowedServers: []string{"github"},
+		Permissions:    []string{auth.PermRead},
+	}
+	ctx := auth.WithAuthContext(context.Background(), agentCtx)
+
+	request := mcp.CallToolRequest{}
+	request.Params.Arguments = map[string]interface{}{"name": "github : get_repo"}
+
+	result, err := proxy.handleCallToolVariant(ctx, request, contracts.ToolVariantRead)
+	require.NoError(t, err)
+	require.True(t, result.IsError, "no upstream client is connected in this fixture")
+
+	text := result.Content[0].(mcp.TextContent).Text
+	assert.NotContains(t, text, "not in scope",
+		"'github ' must normalize to 'github' before the agent-scope gate")
+	assert.Contains(t, text, "No client found for server: github.")
+}

--- a/internal/server/mcp_code_execution.go
+++ b/internal/server/mcp_code_execution.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -416,7 +417,13 @@ func resolveCodeExecutionDefaults(opts *jsruntime.ExecutionOptions, configTimeou
 
 func applyCodeExecutionOptions(optionsObj map[string]interface{}, opts *jsruntime.ExecutionOptions) string {
 	// Parse timeout_ms
-	if timeoutMs, ok := codeExecOptionInt(optionsObj["timeout_ms"]); ok {
+	if raw, present := optionsObj["timeout_ms"]; present && raw != nil {
+		timeoutMs, ok := codeExecOptionInt(raw)
+		if !ok {
+			// A fractional 1.9 silently becoming a 1ms budget is worse than an
+			// error; same for non-numeric values.
+			return "timeout_ms must be an integer"
+		}
 		opts.TimeoutMs = timeoutMs
 		// Validate timeout range
 		if opts.TimeoutMs < 1 || opts.TimeoutMs > 600000 {
@@ -425,7 +432,13 @@ func applyCodeExecutionOptions(optionsObj map[string]interface{}, opts *jsruntim
 	}
 
 	// Parse max_tool_calls
-	if maxToolCalls, ok := codeExecOptionInt(optionsObj["max_tool_calls"]); ok {
+	if raw, present := optionsObj["max_tool_calls"]; present && raw != nil {
+		maxToolCalls, ok := codeExecOptionInt(raw)
+		if !ok {
+			// 0.5 truncated to 0 would flip a caller's limit into the
+			// unlimited override.
+			return "max_tool_calls must be an integer"
+		}
 		opts.MaxToolCalls = maxToolCalls
 		// Validate max_tool_calls
 		if opts.MaxToolCalls < 0 {
@@ -458,9 +471,16 @@ func applyCodeExecutionOptions(optionsObj map[string]interface{}, opts *jsruntim
 func codeExecOptionInt(value interface{}) (int, bool) {
 	switch v := value.(type) {
 	case float64:
+		if v != math.Trunc(v) {
+			return 0, false
+		}
 		return int(v), true
 	case float32:
-		return int(v), true
+		f := float64(v)
+		if f != math.Trunc(f) {
+			return 0, false
+		}
+		return int(f), true
 	case int:
 		return v, true
 	case int32:

--- a/internal/server/mcp_code_execution.go
+++ b/internal/server/mcp_code_execution.go
@@ -52,35 +52,8 @@ func (p *MCPProxyServer) handleCodeExecution(ctx context.Context, request mcp.Ca
 
 	// Extract options object (optional)
 	if optionsObj, ok := args["options"].(map[string]interface{}); ok && optionsObj != nil {
-		// Parse timeout_ms
-		if timeoutMs, ok := optionsObj["timeout_ms"].(float64); ok {
-			options.TimeoutMs = int(timeoutMs)
-			// Validate timeout range
-			if options.TimeoutMs < 1 || options.TimeoutMs > 600000 {
-				return mcp.NewToolResultError("timeout_ms must be between 1 and 600000 milliseconds"), nil
-			}
-		}
-
-		// Parse max_tool_calls
-		if maxToolCalls, ok := optionsObj["max_tool_calls"].(float64); ok {
-			options.MaxToolCalls = int(maxToolCalls)
-			// Validate max_tool_calls
-			if options.MaxToolCalls < 0 {
-				return mcp.NewToolResultError("max_tool_calls cannot be negative"), nil
-			}
-		}
-
-		// Parse allowed_servers
-		if allowedServers, ok := optionsObj["allowed_servers"].([]interface{}); ok {
-			serverNames := make([]string, 0, len(allowedServers))
-			for _, serverVal := range allowedServers {
-				if serverName, ok := serverVal.(string); ok {
-					serverNames = append(serverNames, serverName)
-				} else {
-					return mcp.NewToolResultError("allowed_servers must be an array of strings"), nil
-				}
-			}
-			options.AllowedServers = serverNames
+		if errMsg := applyCodeExecutionOptions(optionsObj, &options); errMsg != "" {
+			return mcp.NewToolResultError(errMsg), nil
 		}
 	}
 
@@ -413,6 +386,80 @@ func (p *MCPProxyServer) handleCodeExecution(ctx context.Context, request mcp.Ca
 			mcp.NewTextContent(string(resultJSON)),
 		},
 	}, nil
+}
+
+// applyCodeExecutionOptions parses the `options` object of a code_execution
+// call into opts, returning a user-facing message when a value is out of range
+// or the wrong type (empty string means the options were applied).
+//
+// Values arrive in two shapes: JSON-decoded over the MCP transport (float64,
+// []interface{}) and Go-typed from an in-process caller that builds the
+// arguments map directly — the REST handler behind POST /api/v1/code/exec is
+// one. Both are accepted; matching only the JSON shapes dropped every
+// restriction a REST caller set, so a request limited to specific servers ran
+// unrestricted.
+func applyCodeExecutionOptions(optionsObj map[string]interface{}, opts *jsruntime.ExecutionOptions) string {
+	// Parse timeout_ms
+	if timeoutMs, ok := codeExecOptionInt(optionsObj["timeout_ms"]); ok {
+		opts.TimeoutMs = timeoutMs
+		// Validate timeout range
+		if opts.TimeoutMs < 1 || opts.TimeoutMs > 600000 {
+			return "timeout_ms must be between 1 and 600000 milliseconds"
+		}
+	}
+
+	// Parse max_tool_calls
+	if maxToolCalls, ok := codeExecOptionInt(optionsObj["max_tool_calls"]); ok {
+		opts.MaxToolCalls = maxToolCalls
+		// Validate max_tool_calls
+		if opts.MaxToolCalls < 0 {
+			return "max_tool_calls cannot be negative"
+		}
+	}
+
+	// Parse allowed_servers
+	switch allowedServers := optionsObj["allowed_servers"].(type) {
+	case []string:
+		opts.AllowedServers = append(make([]string, 0, len(allowedServers)), allowedServers...)
+	case []interface{}:
+		serverNames := make([]string, 0, len(allowedServers))
+		for _, serverVal := range allowedServers {
+			serverName, ok := serverVal.(string)
+			if !ok {
+				return "allowed_servers must be an array of strings"
+			}
+			serverNames = append(serverNames, serverName)
+		}
+		opts.AllowedServers = serverNames
+	}
+
+	return ""
+}
+
+// codeExecOptionInt normalises the numeric shapes a code_execution option can
+// arrive in: float64 from a JSON decode, json.Number from a decoder using
+// UseNumber, and the integer types an in-process caller passes through.
+func codeExecOptionInt(value interface{}) (int, bool) {
+	switch v := value.(type) {
+	case float64:
+		return int(v), true
+	case float32:
+		return int(v), true
+	case int:
+		return v, true
+	case int32:
+		return int(v), true
+	case int64:
+		return int(v), true
+	case json.Number:
+		parsed, err := v.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return int(parsed), true
+	default:
+		return 0, false
+	}
 }
 
 // toolCallRecord tracks information about a single tool call for observability

--- a/internal/server/mcp_code_execution.go
+++ b/internal/server/mcp_code_execution.go
@@ -26,8 +26,10 @@ func (p *MCPProxyServer) handleCodeExecution(ctx context.Context, request mcp.Ca
 	p.recordBuiltinTool("code_execution")
 	p.logger.Debug("code_execution tool called")
 
-	// Parse arguments
-	var options jsruntime.ExecutionOptions
+	// Parse arguments. MaxToolCalls starts at the unset sentinel so an explicit
+	// max_tool_calls: 0 — the documented unlimited override — survives default
+	// resolution instead of being floored to the configured limit.
+	options := jsruntime.ExecutionOptions{MaxToolCalls: codeExecMaxToolCallsUnset}
 
 	// Extract code (required)
 	code, err := request.RequireString("code")
@@ -57,13 +59,7 @@ func (p *MCPProxyServer) handleCodeExecution(ctx context.Context, request mcp.Ca
 		}
 	}
 
-	// Apply defaults from config if not specified in request
-	if options.TimeoutMs == 0 {
-		options.TimeoutMs = p.config.CodeExecutionTimeoutMs
-	}
-	if options.MaxToolCalls == 0 {
-		options.MaxToolCalls = p.config.CodeExecutionMaxToolCalls
-	}
+	resolveCodeExecutionDefaults(&options, p.config.CodeExecutionTimeoutMs, p.config.CodeExecutionMaxToolCalls)
 
 	// Extract session information from context
 	var sessionID, clientName, clientVersion string
@@ -398,6 +394,26 @@ func (p *MCPProxyServer) handleCodeExecution(ctx context.Context, request mcp.Ca
 // one. Both are accepted; matching only the JSON shapes dropped every
 // restriction a REST caller set, so a request limited to specific servers ran
 // unrestricted.
+// codeExecMaxToolCallsUnset marks max_tool_calls as not supplied by the
+// caller. Zero cannot be the sentinel: an explicit 0 is the documented
+// unlimited override, distinct from "use the configured limit". Negative
+// caller values are rejected during parsing, so the sentinel can never arrive
+// from outside.
+const codeExecMaxToolCallsUnset = -1
+
+// resolveCodeExecutionDefaults fills config defaults for the options the
+// caller left unset. timeout_ms uses zero as its unset marker (0 is out of
+// range and rejected during parsing); max_tool_calls uses the sentinel so an
+// explicit zero survives.
+func resolveCodeExecutionDefaults(opts *jsruntime.ExecutionOptions, configTimeoutMs, configMaxToolCalls int) {
+	if opts.TimeoutMs == 0 {
+		opts.TimeoutMs = configTimeoutMs
+	}
+	if opts.MaxToolCalls == codeExecMaxToolCallsUnset {
+		opts.MaxToolCalls = configMaxToolCalls
+	}
+}
+
 func applyCodeExecutionOptions(optionsObj map[string]interface{}, opts *jsruntime.ExecutionOptions) string {
 	// Parse timeout_ms
 	if timeoutMs, ok := codeExecOptionInt(optionsObj["timeout_ms"]); ok {

--- a/internal/server/mcp_describe_tool.go
+++ b/internal/server/mcp_describe_tool.go
@@ -142,6 +142,11 @@ func (p *MCPProxyServer) handleDescribeTool(ctx context.Context, request mcp.Cal
 		visible, reason := p.toolVisibleToSession(ctx, serverName, toolName)
 		if !visible {
 			code, remediation := p.describeVisibilityError(reason, serverName, toolName)
+			if reason == visReasonNotIndexed {
+				if canonical, ok := p.suggestCanonicalToolID(ctx, serverName, toolName); ok {
+					remediation = fmt.Sprintf("Tool not found. Tool ids are case-sensitive — did you mean '%s'?", canonical)
+				}
+			}
 			idErrors = append(idErrors, describeToolIDError(id, code, remediation))
 			continue
 		}

--- a/internal/server/mcp_describe_tool_test.go
+++ b/internal/server/mcp_describe_tool_test.go
@@ -232,6 +232,108 @@ func TestDescribeTool_VisibilityParityWithRetrieve(t *testing.T) {
 	}
 }
 
+// Whitespace is never significant in a canonical tool id: ids copied out of a
+// transcript with stray padding must resolve to the same definition.
+func TestDescribeTool_TrimsWhitespaceInIDs(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+	seedEntryBuilderFixture(t, proxy)
+
+	resp := callDescribe(t, proxy, context.Background(), []interface{}{
+		"github:create_issue ",
+		" github:create_issue",
+		"github: create_issue",
+	})
+
+	assert.Empty(t, resp.Errors, "padded ids must resolve, not error")
+	require.Len(t, resp.Definitions, 3)
+	for _, def := range resp.Definitions {
+		assert.Equal(t, "github:create_issue", def["name"],
+			"the definition always carries the canonical id")
+	}
+}
+
+// Server/tool ids are case-sensitive by design (approval, quarantine and
+// agent-scope stores all key on exact case). A miscased id must therefore NOT
+// resolve, but the remediation must name the canonical id instead of the
+// generic "re-run retrieve_tools" hint.
+func TestDescribeTool_CaseMismatchDidYouMean(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+	seedEntryBuilderFixture(t, proxy)
+
+	resp := callDescribe(t, proxy, context.Background(), []interface{}{"GITHUB:create_issue"})
+
+	assert.Empty(t, resp.Definitions, "a miscased id must not silently resolve")
+	require.Len(t, resp.Errors, 1)
+	e := resp.Errors[0]
+	assert.Equal(t, "GITHUB:create_issue", e["id"], "the error echoes the raw id the caller sent")
+	assert.Equal(t, "not_found", e["error"])
+	remediation, _ := e["remediation"].(string)
+	assert.Contains(t, remediation, "case-sensitive")
+	assert.Contains(t, remediation, "did you mean 'github:create_issue'")
+}
+
+// The same holds for a miscased tool segment.
+func TestDescribeTool_ToolCaseMismatchDidYouMean(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+	seedEntryBuilderFixture(t, proxy)
+
+	resp := callDescribe(t, proxy, context.Background(), []interface{}{"github:Create_Issue"})
+
+	assert.Empty(t, resp.Definitions)
+	require.Len(t, resp.Errors, 1)
+	remediation, _ := resp.Errors[0]["remediation"].(string)
+	assert.Contains(t, remediation, "did you mean 'github:create_issue'")
+}
+
+// Security invariant: a did-you-mean suggestion may never confirm the
+// existence of a tool this session cannot see. Out-of-scope and quarantined
+// ids keep the generic not-found remediation even when the only difference
+// from a real id is case.
+func TestDescribeTool_CaseMismatchNoScopeLeak(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+	seedVisibilityFixture(t, proxy)
+
+	agentCtx := &auth.AuthContext{
+		Type:           auth.AuthTypeAgent,
+		AgentName:      "parity-bot",
+		AllowedServers: []string{"github", "quarry"},
+		Permissions:    []string{auth.PermRead, auth.PermWrite},
+	}
+	ctx := auth.WithAuthContext(context.Background(), agentCtx)
+
+	for _, c := range []struct{ id, leak string }{
+		{"GITLAB:scoped_tool", "gitlab"},    // out of agent scope
+		{"QUARRY:lingering_tool", "quarry"}, // server quarantined
+	} {
+		t.Run(c.id, func(t *testing.T) {
+			resp := callDescribe(t, proxy, ctx, []interface{}{c.id})
+
+			assert.Empty(t, resp.Definitions)
+			require.Len(t, resp.Errors, 1)
+			assert.Equal(t, "not_found", resp.Errors[0]["error"])
+			remediation, _ := resp.Errors[0]["remediation"].(string)
+			assert.Equal(t, describeNotFoundRemediation, remediation,
+				"a suggestion would confirm that a tool the session cannot see exists")
+			assert.NotContains(t, remediation, c.leak)
+		})
+	}
+}
+
+// A genuinely absent tool keeps the generic remediation — no invented
+// suggestion.
+func TestDescribeTool_GenuinelyMissingKeepsGenericRemediation(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+	seedEntryBuilderFixture(t, proxy)
+
+	resp := callDescribe(t, proxy, context.Background(), []interface{}{"github:no_such_tool_at_all"})
+
+	require.Len(t, resp.Errors, 1)
+	assert.Equal(t, "not_found", resp.Errors[0]["error"])
+	remediation, _ := resp.Errors[0]["remediation"].(string)
+	assert.Equal(t, describeNotFoundRemediation, remediation)
+	assert.NotContains(t, remediation, "did you mean")
+}
+
 // T028 (FR-011): describe_tool is registered in the retrieve_tools routing
 // mode only — the default server and buildCallToolModeTools — and absent from
 // code_execution and direct mode.

--- a/internal/server/mcp_retrieve_tools_truncation_test.go
+++ b/internal/server/mcp_retrieve_tools_truncation_test.go
@@ -234,7 +234,11 @@ func TestRetrieveTools_CodeExecModeNeverTruncated(t *testing.T) {
 	assert.Greater(t, len(raw), len(full)/2)
 }
 
-func TestRetrieveTools_SingleOversizeEntryPassesThrough(t *testing.T) {
+// A single tool with a sprawling schema has no pagination axis: a cache key
+// minted here would resolve to the same oversize payload, an inescapable loop.
+// The response limit still holds, though — so the terminal case is a plain cut
+// with the "cache not available" notice, never an unbounded pass-through.
+func TestRetrieveTools_SingleOversizeEntryIsPlainTruncated(t *testing.T) {
 	proxy := createTestMCPProxyServer(t)
 
 	require.NoError(t, proxy.storage.SaveUpstreamServer(&config.ServerConfig{
@@ -255,11 +259,15 @@ func TestRetrieveTools_SingleOversizeEntryPassesThrough(t *testing.T) {
 	full := callRetrieveRaw(t, proxy, args)
 	require.Greater(t, len(full), 2000)
 
-	setTruncateLimit(proxy, 2000)
+	const limit = 2000
+	setTruncateLimit(proxy, limit)
 	raw := callRetrieveRaw(t, proxy, args)
 
-	// Nothing to subdivide with a single record — the oversize text flows
-	// through intact rather than minting a key that resolves to itself.
-	assert.Equal(t, full, raw)
-	assert.NotContains(t, raw, "[truncated by mcpproxy]")
+	assert.LessOrEqual(t, len(raw), limit,
+		"an unpaginable response is still bound by tool_response_limit")
+	assert.Contains(t, raw, "[truncated by mcpproxy, cache not available]",
+		"the notice must be honest about there being no cache handle")
+	assert.NotContains(t, raw, `key="`,
+		"a key here would resolve to the same oversize payload")
+	assert.NotEqual(t, full, raw)
 }

--- a/internal/server/mcp_retrieve_tools_truncation_test.go
+++ b/internal/server/mcp_retrieve_tools_truncation_test.go
@@ -1,0 +1,265 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/truncate"
+)
+
+// retrieve_tools is subject to tool_response_limit like every other tool
+// response: an oversize discovery payload is cut at the limit and the full
+// payload is parked in the cache behind a read_cache key. Responses that fit
+// under the limit stay byte-for-byte what they were before.
+//
+// The code-execution surface is exempt because it does not register read_cache
+// (mcp_routing.go), so a banner there would point at an unavailable tool.
+
+// setTruncateLimit swaps the proxy's live truncator for one with the given
+// character limit. It sets truncatorFn (not a captured *Truncator) so the
+// handler keeps resolving through currentTruncator(), exactly as production
+// does for hot-reloaded limits.
+func setTruncateLimit(proxy *MCPProxyServer, limit int) {
+	tr := truncate.NewTruncator(limit)
+	proxy.truncatorFn = func() *truncate.Truncator { return tr }
+}
+
+// cacheKeyRE extracts the cache key from the truncation banner.
+var cacheKeyRE = regexp.MustCompile(`key="([^"]+)"`)
+
+func TestRetrieveTools_OversizeResponseTruncatedWithReadCacheHandle(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+	seedEntryBuilderFixture(t, proxy)
+
+	// Baseline: the full-mode response for this fixture, untruncated.
+	full := callRetrieveRaw(t, proxy, map[string]interface{}{
+		"query": "manage", "limit": float64(10),
+	})
+
+	limit := len(full) / 2
+	require.Greater(t, limit, 400, "fixture must be large enough to exercise truncation")
+	setTruncateLimit(proxy, limit)
+
+	raw := callRetrieveRaw(t, proxy, map[string]interface{}{
+		"query": "manage", "limit": float64(10),
+	})
+
+	assert.Contains(t, raw, "[truncated by mcpproxy]")
+	assert.Contains(t, raw, `Use read_cache tool: key="`)
+	assert.LessOrEqual(t, len(raw), limit, "truncated response must fit within tool_response_limit")
+}
+
+func TestRetrieveTools_TruncatedPayloadReadableViaReadCache(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+	seedEntryBuilderFixture(t, proxy)
+
+	args := map[string]interface{}{"query": "manage", "limit": float64(10)}
+	full := callRetrieveRaw(t, proxy, args)
+
+	var fullResp retrieveToolsResponse
+	require.NoError(t, json.Unmarshal([]byte(full), &fullResp))
+	require.NotEmpty(t, fullResp.Tools)
+
+	setTruncateLimit(proxy, len(full)/2)
+	raw := callRetrieveRaw(t, proxy, args)
+
+	match := cacheKeyRE.FindStringSubmatch(raw)
+	require.Len(t, match, 2, "truncated response must carry a read_cache key")
+
+	// Raise the limit for the read-back so the assertion is about what landed
+	// in the cache, not about read_cache's own (separately covered) recursive
+	// truncation — the fixture's page is larger than this test's tiny limit.
+	setTruncateLimit(proxy, 1_000_000)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{
+		"key": match[1], "offset": float64(0), "limit": float64(50),
+	}
+	result, err := proxy.handleReadCache(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError, "read_cache must resolve the key minted by retrieve_tools")
+
+	var cached struct {
+		Records []map[string]interface{} `json:"records"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(result.Content[0].(mcp.TextContent).Text), &cached))
+
+	// The cache holds the pre-truncation payload, paginated over the tools array.
+	require.Len(t, cached.Records, len(fullResp.Tools))
+	assert.Equal(t, fullResp.Tools[0]["name"], cached.Records[0]["name"])
+	assert.Contains(t, cached.Records[0], "inputSchema")
+}
+
+// seedLockedHeavyFixture builds the payload shape that breaks a heuristic
+// record-path pick: few callable tools with fat schemas, many locked entries
+// with thin ones. The "disabled" array outnumbers "tools" by more than 2x, so
+// the truncator's chooseBestArray prefers it — but the banner retrieve_tools
+// emits promises tool entries.
+func seedLockedHeavyFixture(t *testing.T, proxy *MCPProxyServer) {
+	t.Helper()
+	require.NoError(t, proxy.storage.SaveUpstreamServer(&config.ServerConfig{Name: "s", Enabled: true}))
+
+	props := make([]string, 0, 40)
+	for i := 0; i < 40; i++ {
+		props = append(props, fmt.Sprintf(`"field_%d":{"type":"string","description":"padding padding padding padding"}`, i))
+	}
+	fatSchema := `{"type":"object","properties":{` + strings.Join(props, ",") + `}}`
+
+	for _, name := range []string{"callable_one", "callable_two"} {
+		require.NoError(t, proxy.index.IndexTool(&config.ToolMetadata{
+			Name: "s:" + name, ServerName: "s",
+			Description: "widget helper thing",
+			ParamsJSON:  fatSchema,
+			Hash:        "hash-" + name,
+		}))
+	}
+	for i := 0; i < 10; i++ {
+		name := fmt.Sprintf("locked_%02d", i)
+		require.NoError(t, proxy.storage.SaveToolApproval(&storage.ToolApprovalRecord{
+			ServerName: "s", ToolName: name,
+			Status: storage.ToolApprovalStatusApproved, Disabled: true,
+		}))
+		require.NoError(t, proxy.index.IndexTool(&config.ToolMetadata{
+			Name: "s:" + name, ServerName: "s",
+			Description: "widget helper thing",
+			ParamsJSON:  `{"type":"object"}`,
+			Hash:        "hash-" + name,
+		}))
+	}
+}
+
+// The truncation banner advertises exactly one pagination contract: read_cache
+// pages the tool entries the response would have carried. It must never hand
+// back the Spec 049 locked entries (or a schema's nested array) under that
+// promise — an agent paging a truncated discovery result would silently read
+// records that are not tools, and the tools past the cut would be unreachable.
+func TestRetrieveTools_TruncationPagesToolsNotLockedEntries(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+	seedLockedHeavyFixture(t, proxy)
+
+	args := map[string]interface{}{
+		"query": "widget helper thing", "limit": float64(20), "include_disabled": true,
+	}
+	full := callRetrieveRaw(t, proxy, args)
+
+	var fullResp retrieveToolsResponse
+	require.NoError(t, json.Unmarshal([]byte(full), &fullResp))
+	require.Len(t, fullResp.Tools, 2, "fixture must keep the tools array small")
+	require.Greater(t, len(fullResp.Disabled), 2*len(fullResp.Tools),
+		"fixture must make the locked array outnumber the tools array by >2x")
+
+	limit := len(full) / 2
+	require.Greater(t, limit, 400, "fixture must be large enough to exercise truncation")
+	setTruncateLimit(proxy, limit)
+
+	raw := callRetrieveRaw(t, proxy, args)
+	require.Contains(t, raw, "[truncated by mcpproxy]")
+	assert.Contains(t, raw, fmt.Sprintf("records: %d", len(fullResp.Tools)),
+		"the banner's record count must describe the tools array it promises")
+
+	match := cacheKeyRE.FindStringSubmatch(raw)
+	require.Len(t, match, 2, "truncated response must carry a read_cache key")
+
+	setTruncateLimit(proxy, 1_000_000)
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{
+		"key": match[1], "offset": float64(0), "limit": float64(50),
+	}
+	result, err := proxy.handleReadCache(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var cached struct {
+		Records []map[string]interface{} `json:"records"`
+		Meta    struct {
+			RecordPath   string `json:"record_path"`
+			TotalRecords int    `json:"total_records"`
+		} `json:"meta"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(result.Content[0].(mcp.TextContent).Text), &cached))
+
+	assert.Equal(t, "tools", cached.Meta.RecordPath)
+	require.Len(t, cached.Records, len(fullResp.Tools))
+	for i, rec := range cached.Records {
+		assert.Equal(t, fullResp.Tools[i]["name"], rec["name"])
+		assert.Contains(t, rec, "inputSchema", "a paged record must be a tool entry")
+		assert.NotContains(t, rec, "status", "a paged record must not be a locked entry")
+	}
+}
+
+func TestRetrieveTools_UnderLimitByteIdentical(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+	seedEntryBuilderFixture(t, proxy)
+
+	args := map[string]interface{}{"query": "manage", "limit": float64(10)}
+
+	// Truncation disabled (the shipped default when tool_response_limit is 0).
+	disabled := callRetrieveRaw(t, proxy, args)
+
+	// A limit far above the response size must leave it untouched.
+	setTruncateLimit(proxy, 1_000_000)
+	underLimit := callRetrieveRaw(t, proxy, args)
+
+	assert.Equal(t, disabled, underLimit, "responses under the limit must be byte-identical")
+	assert.NotContains(t, underLimit, "[truncated by mcpproxy]")
+}
+
+func TestRetrieveTools_CodeExecModeNeverTruncated(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+	seedEntryBuilderFixture(t, proxy)
+
+	args := map[string]interface{}{"query": "manage", "limit": float64(10)}
+	full := callRetrieveRaw(t, proxy, args)
+	setTruncateLimit(proxy, len(full)/2)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+	result, err := proxy.handleRetrieveToolsWithMode(context.Background(), req, config.RoutingModeCodeExecution)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	raw := result.Content[0].(mcp.TextContent).Text
+	assert.NotContains(t, raw, "[truncated by mcpproxy]",
+		"the code-execution surface has no read_cache tool, so its responses stay whole")
+	assert.Greater(t, len(raw), len(full)/2)
+}
+
+func TestRetrieveTools_SingleOversizeEntryPassesThrough(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+
+	require.NoError(t, proxy.storage.SaveUpstreamServer(&config.ServerConfig{
+		Name: "bulky", Enabled: true,
+	}))
+	props := make([]string, 0, 200)
+	for i := 0; i < 200; i++ {
+		props = append(props, fmt.Sprintf(`"field_%d":{"type":"string","description":"padding padding padding"}`, i))
+	}
+	require.NoError(t, proxy.index.IndexTool(&config.ToolMetadata{
+		Name: "bulky:megaschema", ServerName: "bulky",
+		Description: "A singular sprawling tool used to manage everything.",
+		ParamsJSON:  `{"type":"object","properties":{` + strings.Join(props, ",") + `}}`,
+		Hash:        "hash-megaschema",
+	}))
+
+	args := map[string]interface{}{"query": "megaschema", "limit": float64(10)}
+	full := callRetrieveRaw(t, proxy, args)
+	require.Greater(t, len(full), 2000)
+
+	setTruncateLimit(proxy, 2000)
+	raw := callRetrieveRaw(t, proxy, args)
+
+	// Nothing to subdivide with a single record — the oversize text flows
+	// through intact rather than minting a key that resolves to itself.
+	assert.Equal(t, full, raw)
+	assert.NotContains(t, raw, "[truncated by mcpproxy]")
+}

--- a/internal/server/mcp_visibility.go
+++ b/internal/server/mcp_visibility.go
@@ -179,12 +179,51 @@ func (p *MCPProxyServer) lookupIndexedTool(serverName, toolName string) *config.
 	return nil
 }
 
-// splitServerTool splits a "<server>:<tool>" id. ok=false when the id has no
-// server prefix.
+// splitServerTool splits a "<server>:<tool>" id. Whitespace is never
+// significant in a canonical id, so both segments are trimmed. ok=false when
+// the id has no server prefix or either segment is blank.
 func splitServerTool(id string) (serverName, toolName string, ok bool) {
-	parts := strings.SplitN(id, ":", 2)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+	parts := strings.SplitN(strings.TrimSpace(id), ":", 2)
+	if len(parts) != 2 {
 		return "", "", false
 	}
-	return parts[0], parts[1], true
+	serverName, toolName = strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+	if serverName == "" || toolName == "" {
+		return "", "", false
+	}
+	return serverName, toolName, true
+}
+
+// suggestCanonicalToolID resolves an id that differs from an indexed one only
+// by letter case to its canonical form. Case is NOT folded on any resolution
+// path: server and tool names are exact keys in the approval, quarantine,
+// profile and agent-scope stores, so accepting a miscased id would route a
+// call around gates keyed on the exact name. The correction is therefore only
+// ever suggested — and only when the corrected pair is visible to this
+// session, so a suggestion can never confirm that an out-of-scope or
+// quarantined tool exists.
+func (p *MCPProxyServer) suggestCanonicalToolID(ctx context.Context, serverName, toolName string) (string, bool) {
+	servers, err := p.index.GetAllIndexedServerNames()
+	if err != nil {
+		return "", false
+	}
+	for _, server := range servers {
+		if !strings.EqualFold(server, serverName) {
+			continue
+		}
+		tools, terr := p.index.GetToolsByServer(server)
+		if terr != nil {
+			continue
+		}
+		for _, tool := range tools {
+			_, bare := normalizeServerTool(server, tool.Name)
+			if !strings.EqualFold(bare, toolName) || (server == serverName && bare == toolName) {
+				continue
+			}
+			if visible, _ := p.toolVisibleToSession(ctx, server, bare); visible {
+				return server + ":" + bare, true
+			}
+		}
+	}
+	return "", false
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2066,6 +2066,12 @@ func (s *Server) registerHTTPHandlers(mux *http.ServeMux, httpAPIServer http.Han
 	// /events is a long-lived SSE stream: it must escape http.Server.WriteTimeout
 	// (and, being a GET, ReadTimeout) or the connection dies mid-stream (GH #965).
 	mux.Handle("/events", s.streamingNoDeadline(httpAPIServer))
+	// POST /api/v1/code/exec runs caller-supplied code for up to its own
+	// timeout_ms budget (600s), well past both http.Server deadlines: at 120s
+	// by default WriteTimeout destroys the response and ReadTimeout cancels the
+	// request context mid-execution. Unlike the streaming routes this one is a
+	// bounded POST, so it gets a wider deadline rather than none at all.
+	mux.Handle(codeExecAPIPath, s.extendedDeadline(codeExecRequestDeadline, httpAPIServer))
 
 	// Mount health endpoints directly on main mux at root level
 	healthEndpoints := []string{"/healthz", "/readyz", "/livez", "/ready", "/health"}
@@ -2083,6 +2089,48 @@ func (s *Server) registerHTTPHandlers(mux *http.ServeMux, httpAPIServer http.Han
 		mux.Handle("/metrics", httpAPIServer)
 		s.logger.Info("Registered metrics endpoint", zap.String("endpoint", "/metrics"))
 	}
+}
+
+const (
+	// codeExecAPIPath is the REST code-execution endpoint, the one route whose
+	// handler legitimately outlives the process-wide http.Server deadlines.
+	codeExecAPIPath = "/api/v1/code/exec"
+
+	// codeExecRequestDeadline is the wall-clock budget that route gets: the
+	// longest timeout_ms the code_execution tool accepts (600s) plus slack for
+	// reading the request and writing the reply. It matches the router-level
+	// budget in internal/httpapi so neither layer is the one that ends a
+	// legal execution.
+	codeExecRequestDeadline = 630 * time.Second
+)
+
+// extendedDeadline widens the per-request read and write deadlines a route
+// inherits from http.Server.ReadTimeout/WriteTimeout, for handlers that
+// legitimately run longer than the process-wide defaults.
+//
+// Unlike streamingNoDeadline this sets an absolute deadline instead of
+// clearing it: the routes that need it are bounded requests, so they stay
+// bounded — including a deployment that disabled the deadlines entirely, where
+// this caps the route at d. It must likewise be the OUTERMOST wrapper on a
+// route (http.NewResponseController only unwraps ResponseWriters implementing
+// Unwrap), and a controller error is logged at Debug and ignored: failing to
+// relax a deadline must never fail the request.
+func (s *Server) extendedDeadline(d time.Duration, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		deadline := time.Now().Add(d)
+		rc := http.NewResponseController(w)
+		if err := rc.SetWriteDeadline(deadline); err != nil {
+			s.logger.Debug("Could not extend the write deadline for a long-running route",
+				zap.String("path", r.URL.Path),
+				zap.Error(err))
+		}
+		if err := rc.SetReadDeadline(deadline); err != nil {
+			s.logger.Debug("Could not extend the read deadline for a long-running route",
+				zap.String("path", r.URL.Path),
+				zap.Error(err))
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // httpServerTimeouts resolves the Read/Write/Idle deadlines applied to the

--- a/internal/truncate/truncator.go
+++ b/internal/truncate/truncator.go
@@ -28,8 +28,26 @@ func NewTruncator(limit int) *Truncator {
 	return &Truncator{limit: limit}
 }
 
-// Truncate analyzes and truncates a tool response if it exceeds the limit
+// Truncate analyzes and truncates a tool response if it exceeds the limit.
+// The record array the resulting cache handle pages is inferred from the
+// payload; callers that already know which array their truncation banner
+// promises should use TruncateWithRecordPath instead.
 func (t *Truncator) Truncate(content, toolName string, args map[string]interface{}) *TruncationResult {
+	return t.TruncateWithRecordPath(content, toolName, args, "")
+}
+
+// TruncateWithRecordPath truncates like Truncate but pins the pagination
+// contract to pinnedPath instead of inferring it. Inference prefers whichever
+// array has the most elements, which for a caller-composed payload can be a
+// sibling array (retrieve_tools' Spec 049 "disabled" list) or an array nested
+// inside a record (an input schema's "required"). read_cache would then page
+// records the banner never advertised, and the records it did advertise would
+// be unreachable past the cut.
+//
+// An empty pinnedPath keeps the inferred behaviour. A pinnedPath that is not
+// an array in content falls back to simple truncation with no cache handle at
+// all, so a banner can never advertise a contract that does not hold.
+func (t *Truncator) TruncateWithRecordPath(content, toolName string, args map[string]interface{}, pinnedPath string) *TruncationResult {
 	result := &TruncationResult{
 		TotalSize: len(content),
 	}
@@ -41,7 +59,7 @@ func (t *Truncator) Truncate(content, toolName string, args map[string]interface
 	}
 
 	// Try to analyze JSON structure for record splitting
-	recordPath, totalRecords, err := t.analyzeJSONStructure(content)
+	recordPath, totalRecords, err := t.analyzeJSONStructure(content, pinnedPath)
 	if err != nil {
 		// JSON analysis failed, do simple truncation
 		result.TruncatedContent = t.simpleTruncate(content)
@@ -212,8 +230,12 @@ func (t *Truncator) chooseBestArray(arrays []ArrayInfo, _ string) ArrayInfo {
 	return bestArray
 }
 
-// analyzeJSONStructure analyzes JSON content to find record arrays
-func (t *Truncator) analyzeJSONStructure(content string) (recordPath string, totalRecords int, err error) {
+// analyzeJSONStructure analyzes JSON content to find record arrays. A
+// non-empty pinnedPath selects that array instead of the heuristic pick and
+// errors when it is not one of the arrays found — the caller then falls back
+// to simple truncation rather than emitting a cache handle for the wrong
+// records.
+func (t *Truncator) analyzeJSONStructure(content, pinnedPath string) (recordPath string, totalRecords int, err error) {
 	var data interface{}
 	if err := json.Unmarshal([]byte(content), &data); err != nil {
 		return "", 0, fmt.Errorf("invalid JSON: %w", err)
@@ -223,6 +245,15 @@ func (t *Truncator) analyzeJSONStructure(content string) (recordPath string, tot
 	arrays := t.findArraysRecursive(data, "", 0, 4)
 	if len(arrays) == 0 {
 		return "", 0, fmt.Errorf("no record array found")
+	}
+
+	if pinnedPath != "" {
+		for _, arr := range arrays {
+			if arr.Path == pinnedPath {
+				return arr.Path, arr.Count, nil
+			}
+		}
+		return "", 0, fmt.Errorf("pinned record path %q is not an array in the payload", pinnedPath)
 	}
 
 	// Choose the largest array by size

--- a/internal/truncate/truncator.go
+++ b/internal/truncate/truncator.go
@@ -275,11 +275,17 @@ func (t *Truncator) SimpleTruncate(content string) string {
 	return t.simpleTruncate(content)
 }
 
+// simpleTruncateNotice is the suffix simpleTruncate appends. Its length is
+// part of the retained-prefix math mirrored by SimpleTruncateBudget.
+const simpleTruncateNotice = "\n\n... [truncated by mcpproxy, cache not available]"
+
 // simpleTruncate performs basic truncation without caching
 func (t *Truncator) simpleTruncate(content string) string {
 	if len(content) <= t.limit {
 		return content
 	}
+
+	const notice = simpleTruncateNotice
 
 	messageSpace := 200
 	if t.limit < messageSpace {
@@ -291,8 +297,16 @@ func (t *Truncator) simpleTruncate(content string) string {
 		truncatePoint = 0
 	}
 
-	truncated := content[:truncatePoint]
-	return truncated + "\n\n... [truncated by mcpproxy, cache not available]"
+	if truncatePoint+len(notice) > t.limit {
+		// The limit is the contract; when the notice itself cannot fit under
+		// it, a bare content prefix wins over an over-limit response.
+		if t.limit <= len(notice) {
+			return content[:t.limit]
+		}
+		truncatePoint = t.limit - len(notice)
+	}
+
+	return content[:truncatePoint] + notice
 }
 
 // createTruncatedWithCache creates a truncated response with cache instructions
@@ -343,8 +357,10 @@ func (t *Truncator) ShouldTruncate(content string) bool {
 // too-small-budget guard must match the truncator's REAL retained prefix, not
 // the raw limit — an encoded TOON block is not valid JSON, so Truncate always
 // falls into simpleTruncate for it, which keeps limit - messageSpace bytes
-// (messageSpace = 200, or limit/2 when limit < 200). This mirrors
-// simpleTruncate exactly; keep the two in sync.
+// (messageSpace = 200, or limit/2 when limit < 200, and the limit itself is a
+// hard ceiling: when the notice cannot fit under it the notice is dropped and
+// a bare limit-sized prefix is kept). This mirrors simpleTruncate exactly;
+// keep the two in sync.
 func (t *Truncator) SimpleTruncateBudget() int {
 	if t.limit == 0 {
 		return 0
@@ -356,6 +372,12 @@ func (t *Truncator) SimpleTruncateBudget() int {
 	budget := t.limit - messageSpace
 	if budget < 0 {
 		budget = 0
+	}
+	if budget+len(simpleTruncateNotice) > t.limit {
+		if t.limit <= len(simpleTruncateNotice) {
+			return t.limit
+		}
+		return t.limit - len(simpleTruncateNotice)
 	}
 	return budget
 }

--- a/internal/truncate/truncator.go
+++ b/internal/truncate/truncator.go
@@ -73,7 +73,16 @@ func (t *Truncator) TruncateWithRecordPath(content, toolName string, args map[st
 	cacheKey := cache.GenerateKey(toolName, args, timestamp)
 
 	// Create truncated content with cache instructions
-	result.TruncatedContent = t.createTruncatedWithCache(content, cacheKey, totalRecords, len(content))
+	truncated := t.createTruncatedWithCache(content, cacheKey, totalRecords, len(content))
+	if len(truncated) > t.limit {
+		// The limit is too small to carry even the cache banner. The limit is
+		// the contract, so fall back to bounded simple truncation and mint no
+		// handle — a banner that itself violates the ceiling helps nobody.
+		result.TruncatedContent = t.simpleTruncate(content)
+		result.CacheAvailable = false
+		return result
+	}
+	result.TruncatedContent = truncated
 	result.CacheKey = cacheKey
 	result.RecordPath = recordPath
 	result.TotalRecords = totalRecords

--- a/internal/truncate/truncator.go
+++ b/internal/truncate/truncator.go
@@ -261,6 +261,20 @@ func (t *Truncator) analyzeJSONStructure(content, pinnedPath string) (recordPath
 	return bestArray.Path, bestArray.Count, nil
 }
 
+// SimpleTruncate cuts content to the limit and appends the plain
+// "cache not available" notice, minting no pagination handle at all. It is the
+// terminal path for a caller that has nothing left to subdivide: a cache key
+// there would resolve to the same oversize payload, so the honest answer is a
+// bounded response that says pagination is not on offer. Content already inside
+// the limit — and any content when truncation is disabled (limit 0) — is
+// returned untouched.
+func (t *Truncator) SimpleTruncate(content string) string {
+	if t.limit == 0 {
+		return content
+	}
+	return t.simpleTruncate(content)
+}
+
 // simpleTruncate performs basic truncation without caching
 func (t *Truncator) simpleTruncate(content string) string {
 	if len(content) <= t.limit {

--- a/internal/truncate/truncator_budget_test.go
+++ b/internal/truncate/truncator_budget_test.go
@@ -50,3 +50,25 @@ func TestSimpleTruncateBudget_MatchesSimpleTruncate(t *testing.T) {
 		}
 	}
 }
+
+// TestTruncateWithCache_TinyLimitStaysBounded: the limit is a hard ceiling on
+// the cached-truncation path too. When even the cache banner cannot fit under
+// the limit, the truncator must fall back to bounded simple truncation instead
+// of returning a banner larger than the limit it enforces.
+func TestTruncateWithCache_TinyLimitStaysBounded(t *testing.T) {
+	tr := NewTruncator(100)
+	records := make([]string, 0, 40)
+	for i := 0; i < 40; i++ {
+		records = append(records, `{"name":"tool-name-that-is-reasonably-long","description":"padding padding padding"}`)
+	}
+	content := `{"tools":[` + strings.Join(records, ",") + `]}`
+
+	result := tr.Truncate(content, "retrieve_tools", map[string]interface{}{"q": "x"})
+
+	if len(result.TruncatedContent) > 100 {
+		t.Errorf("truncated content is %d bytes, over the 100-byte limit", len(result.TruncatedContent))
+	}
+	if result.CacheAvailable {
+		t.Error("a response too small to carry the cache banner must not advertise a cache handle")
+	}
+}

--- a/internal/truncate/truncator_test.go
+++ b/internal/truncate/truncator_test.go
@@ -210,7 +210,9 @@ func TestTruncateWithinLimit(t *testing.T) {
 }
 
 func TestTruncateSimpleMode(t *testing.T) {
-	truncator := NewTruncator(50) // Very small limit
+	// Small, but with room for the notice under the limit — at or below
+	// len(simpleTruncateNotice) the notice is dropped to keep the bound.
+	truncator := NewTruncator(60)
 	content := `{"message": "this is a simple response that doesn't have structured records"}`
 	args := map[string]interface{}{"param": "value"}
 
@@ -218,6 +220,10 @@ func TestTruncateSimpleMode(t *testing.T) {
 
 	if !strings.Contains(result.TruncatedContent, "truncated by mcpproxy, cache not available") {
 		t.Error("Simple truncation message not found")
+	}
+
+	if len(result.TruncatedContent) > 60 {
+		t.Errorf("Truncated content exceeds the limit: %d bytes", len(result.TruncatedContent))
 	}
 
 	if result.CacheAvailable {
@@ -610,6 +616,18 @@ func TestSimpleTruncate_ExportedEntryPoint(t *testing.T) {
 		truncator := NewTruncator(0)
 		if out := truncator.SimpleTruncate(content); out != content {
 			t.Errorf("A limit of 0 disables truncation; got %d bytes back", len(out))
+		}
+	})
+
+	// The bound must hold for every legal limit, including ones smaller than
+	// the truncation notice itself — there the notice is dropped rather than
+	// letting the output exceed the limit it exists to enforce.
+	t.Run("small limits stay bounded", func(t *testing.T) {
+		for _, limit := range []int{10, 50, 100, 120} {
+			truncator := NewTruncator(limit)
+			if out := truncator.SimpleTruncate(content); len(out) > limit {
+				t.Errorf("limit %d: output is %d bytes", limit, len(out))
+			}
 		}
 	})
 }

--- a/internal/truncate/truncator_test.go
+++ b/internal/truncate/truncator_test.go
@@ -1,6 +1,7 @@
 package truncate
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -236,8 +237,15 @@ func TestTruncateSimpleMode(t *testing.T) {
 }
 
 func TestTruncateWithCache(t *testing.T) {
-	truncator := NewTruncator(100) // Small limit to trigger truncation
-	content := `{"data": [{"id": 1, "name": "item1"}, {"id": 2, "name": "item2"}, {"id": 3, "name": "item3"}], "total": 3}`
+	// The limit must have room for the ~300-byte cache banner — below that the
+	// truncator falls back to bounded simple truncation with no handle.
+	truncator := NewTruncator(500)
+	items := make([]string, 0, 3)
+	for i := 1; i <= 3; i++ {
+		items = append(items, fmt.Sprintf(`{"id": %d, "name": "item%d", "description": %q}`,
+			i, i, strings.Repeat("padding ", 30)))
+	}
+	content := `{"data": [` + strings.Join(items, ", ") + `], "total": 3}`
 	args := map[string]interface{}{"param": "value"}
 
 	result := truncator.Truncate(content, "test_tool", args)
@@ -272,8 +280,13 @@ func TestTruncateWithCache(t *testing.T) {
 }
 
 func TestTruncateRootArray(t *testing.T) {
-	truncator := NewTruncator(30) // Small limit to trigger truncation
-	content := `[{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}]`
+	// Same banner-room constraint as TestTruncateWithCache.
+	truncator := NewTruncator(500)
+	items := make([]string, 0, 4)
+	for i := 1; i <= 4; i++ {
+		items = append(items, fmt.Sprintf(`{"id": %d, "payload": %q}`, i, strings.Repeat("padding ", 25)))
+	}
+	content := `[` + strings.Join(items, ", ") + `]`
 	args := map[string]interface{}{}
 
 	result := truncator.Truncate(content, "test_tool", args)

--- a/internal/truncate/truncator_test.go
+++ b/internal/truncate/truncator_test.go
@@ -577,6 +577,43 @@ func TestTruncateWithRecordPath_PinBeatsHeuristic(t *testing.T) {
 	}
 }
 
+// SimpleTruncate is the terminal path for callers that have nothing left to
+// subdivide: it enforces the limit with the plain notice and never mints a
+// pagination handle. Content already inside the limit — and a limit of 0, which
+// disables truncation entirely — must come back untouched.
+func TestSimpleTruncate_ExportedEntryPoint(t *testing.T) {
+	content := `{"tool":"` + strings.Repeat("x", 1000) + `"}`
+
+	t.Run("over the limit", func(t *testing.T) {
+		truncator := NewTruncator(300)
+		out := truncator.SimpleTruncate(content)
+
+		if len(out) > 300 {
+			t.Errorf("Output length %d exceeds limit 300", len(out))
+		}
+		if !strings.Contains(out, "truncated by mcpproxy, cache not available") {
+			t.Errorf("Expected the plain-truncation notice, got: %s", out)
+		}
+		if strings.Contains(out, `key="`) {
+			t.Error("Plain truncation must not advertise a cache key")
+		}
+	})
+
+	t.Run("within the limit", func(t *testing.T) {
+		truncator := NewTruncator(100000)
+		if out := truncator.SimpleTruncate(content); out != content {
+			t.Error("Content within the limit must pass through unchanged")
+		}
+	})
+
+	t.Run("truncation disabled", func(t *testing.T) {
+		truncator := NewTruncator(0)
+		if out := truncator.SimpleTruncate(content); out != content {
+			t.Errorf("A limit of 0 disables truncation; got %d bytes back", len(out))
+		}
+	})
+}
+
 // An unresolvable pin must never fall back to the heuristic: the banner would
 // then advertise pagination over records the caller never promised. Plain
 // truncation with no cache handle is the safe answer.

--- a/internal/truncate/truncator_test.go
+++ b/internal/truncate/truncator_test.go
@@ -164,7 +164,7 @@ func TestAnalyzeJSONStructure(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			path, count, err := truncator.analyzeJSONStructure(tt.content)
+			path, count, err := truncator.analyzeJSONStructure(tt.content, "")
 
 			if tt.expectError {
 				if err == nil {
@@ -354,7 +354,7 @@ func TestMultipleArrayFields(t *testing.T) {
 		"results": [{"name": "x"}]
 	}`
 
-	path, count, err := truncator.analyzeJSONStructure(content)
+	path, count, err := truncator.analyzeJSONStructure(content, "")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -545,5 +545,53 @@ func TestChooseBestArray(t *testing.T) {
 				t.Errorf("Expected path '%s', got '%s'", tt.expected, best.Path)
 			}
 		})
+	}
+}
+
+// A caller that composes its own payload knows which array its truncation
+// banner promises. Pinning that path keeps read_cache paging those records
+// even when a sibling array has more elements and would win the heuristic.
+func TestTruncateWithRecordPath_PinBeatsHeuristic(t *testing.T) {
+	truncator := NewTruncator(400)
+	content := `{"tools":[{"name":"a"},{"name":"b"}],` +
+		`"disabled":[{"n":1},{"n":2},{"n":3},{"n":4},{"n":5},{"n":6},{"n":7},{"n":8},{"n":9},{"n":10}],` +
+		`"padding":"` + strings.Repeat("x", 600) + `"}`
+
+	inferred := truncator.Truncate(content, "retrieve_tools", nil)
+	if inferred.RecordPath != "disabled" {
+		t.Fatalf("fixture no longer exercises the heuristic: got record path %q", inferred.RecordPath)
+	}
+
+	pinned := truncator.TruncateWithRecordPath(content, "retrieve_tools", nil, "tools")
+	if !pinned.CacheAvailable {
+		t.Fatal("Expected a cache handle for a resolvable pinned path")
+	}
+	if pinned.RecordPath != "tools" {
+		t.Errorf("Expected record path 'tools', got '%s'", pinned.RecordPath)
+	}
+	if pinned.TotalRecords != 2 {
+		t.Errorf("Expected 2 records (the pinned array), got %d", pinned.TotalRecords)
+	}
+	if !strings.Contains(pinned.TruncatedContent, "records: 2") {
+		t.Error("Banner must report the pinned array's record count")
+	}
+}
+
+// An unresolvable pin must never fall back to the heuristic: the banner would
+// then advertise pagination over records the caller never promised. Plain
+// truncation with no cache handle is the safe answer.
+func TestTruncateWithRecordPath_UnresolvablePinDropsCacheHandle(t *testing.T) {
+	truncator := NewTruncator(300)
+	content := `{"disabled":[{"n":1},{"n":2},{"n":3}],"padding":"` + strings.Repeat("x", 400) + `"}`
+
+	result := truncator.TruncateWithRecordPath(content, "retrieve_tools", nil, "tools")
+	if result.CacheAvailable {
+		t.Error("Expected no cache handle when the pinned path is absent")
+	}
+	if result.RecordPath != "" || result.CacheKey != "" {
+		t.Errorf("Expected no pagination contract, got path '%s' key '%s'", result.RecordPath, result.CacheKey)
+	}
+	if !strings.Contains(result.TruncatedContent, "cache not available") {
+		t.Error("Expected the plain-truncation notice")
 	}
 }


### PR DESCRIPTION
Fixes the five bugs filed against v0.56.0. Each fix was implemented TDD (failing test observed first), then the whole diff went through an adversarial multi-lens review; all confirmed findings are folded in.

Fixes #981, fixes #982, fixes #983, fixes #984, fixes #985

## What changed

### #981 — sandbox `call_tool()` exposed Go field names
`internal/jsruntime/runtime.go` now JSON round-trips every `call_tool` result before handing it to goja, so scripts see the documented wire shape (`res.result.content[0].text`) instead of the live Go value (`Content`/`Text`, leaked `MarshalJSON` methods). A non-serializable result returns `{ok:false, error:{code:"SERIALIZATION_ERROR"}}` instead of a live pointer. The server-side activity/history classification still receives the raw typed result — unchanged.

**Back-compat note:** scripts that adapted to the bug with PascalCase access (`r.result.Content[0].Text`) will break; that shape was never documented, and the tool description has always instructed the lowercase form. The `JSON.parse(JSON.stringify(r))` workaround remains valid.

### #982 — empty `{"properties":{},"type":"object"}` schema for all tools
`toolInfosFromMetadata` (supervisor StateView) fabricated a hardcoded empty schema stub (literal `// TODO: Parse ParamsJSON`) on every population path. It now parses `ToolMetadata.ParamsJSON`; a malformed schema omits the field rather than emitting a truthful-looking empty object. This single choke point fixes `GET /api/v1/tools`, `GET /api/v1/servers/{name}/tools`, and all `mcpproxy tools list` formats. No payload shape change, so no swagger/contracts regen.

### #983 — `code exec` daemon mode hard ~2s abort
The 2s daemon-detection context was reused for the exec POST. Now: separate ping context (2s, as before) and exec context derived from `--timeout` + 30s slack; `CodeExec` dispatches through an uncapped clone of the shared HTTP client (same transport/auth), so the CLI-wide 5-minute blanket timeout no longer caps legal 10-minute budgets; a client-side deadline is reported as an explicit client-side timeout instead of a bare `context deadline exceeded` against `http://localhost`. Also hardened a pre-existing nil-config deref on the standalone fallback path.

### #984 — `retrieve_tools` exempt from `tool_response_limit` (~55k chars/call)
`retrieve_tools` responses now go through the standard truncate-and-cache path: over-limit output is cut at `tool_response_limit` with the usual `read_cache` banner, and the full payload is retrievable via `read_cache`. Details that came out of review:
- The record path is **pinned to the `tools` array** — the truncator can no longer pick the Spec-049 `disabled` list or a nested schema array as the pagination target; if the pin can't resolve, the banner is dropped rather than advertising a wrong contract (`TruncateWithRecordPath` in `internal/truncate`).
- The **code-execution surface is exempt** (it has no `read_cache` tool, and Spec 085 pins it to full mode).
- `CallToolDirect` gained a `read_cache` case, so the banner is followable from REST/CLI/Web-UI/tray — this also cures the pre-existing dead-end for truncated `call_tool_*` results over REST.
- Default `detail` mode is unchanged (Spec 085 byte-identity guarantees hold; `compact` remains opt-in per call or via `tool_response_mode`).

**Behavior notes:** with the default `tool_response_limit=20000`, large catalogs will see truncated discovery responses by default — the truncated text is not parseable JSON (same long-standing contract as truncated `call_tool_*` responses), and each truncated call now writes the full payload to the BBolt cache (TTL-bounded, 2h). Anything `strings.Contains`-polling raw retrieve_tools output (e.g. `release-gate`'s `waitToolDiscoverable`) can miss tools that fall past the cut.

### #985 — `describe_tool` exact-match `not_found` for near-miss ids
Tool ids are whitespace-trimmed (outer and around the `:`) on both `describe_tool` and `call_tool_*` via the shared `splitServerTool`. A case-mismatched id (server or tool segment) now gets `"Tool not found. Tool ids are case-sensitive — did you mean '<canonical>'?"` — the suggestion is gated on session visibility for the corrected pair, so it can never confirm an out-of-scope, quarantined, or pending tool (pinned by a dedicated no-scope-leak test). Case is never silently accepted: every approval/quarantine/scope gate keys on exact names, and silent folding would bypass them.

## Verification (all local, Apple Silicon)

- `go build` both editions (personal + `-tags server`)
- `go test -race -count=1` green: `internal/jsruntime`, `internal/runtime/supervisor`, `cmd/mcpproxy`, `internal/cliclient`, `internal/server` (full suite), `internal/truncate`, `internal/cache`, `internal/serveredition` (`-tags server`)
- `golangci-lint` v2 with `.github/.golangci.yml` (CI config): **0 issues** repo-wide
- `./scripts/test-api-e2e.sh`: **65/65 passed**
- Adversarial review: 3 lenses → 8 raw findings → 6 confirmed after refutation attempts → all fixed (the read_cache REST dead-end, record-path pinning, interior-whitespace divergence, two test-coverage gaps, child-test isolation from the real `~/.mcpproxy`), plus a follow-up correctness pass that reported no surviving logic defects.

Out of scope: #986 (stored scripts) and #987 (batched `call_tool`) are feature requests that go through the spec process separately.

## Follow-up from cross-model review (second commit)

Codex review of the branch surfaced two adjacent defects on the REST code-exec path, both verified and fixed here because they gate the #983 fix:

- **REST-path execution options were silently dropped**: `handleCodeExecution` only accepted JSON-decoded option shapes (`float64`, `[]interface{}`), so the Go-typed args built by `POST /api/v1/code/exec` (and therefore `mcpproxy code exec` daemon mode) never matched — `max_tool_calls`/`allowed_servers` restrictions ran unrestricted. Parsing now accepts both shapes, and the REST handler forwards only options the caller actually supplied so config defaults keep their meaning.
- **`/api/v1/code/exec` was capped by the blanket HTTP deadlines**: the 60s `/api/v1` middleware timeout and the process-wide `http.Server` read/write deadlines (~120s) cancelled any execution past them regardless of `timeout_ms` — defeating the raised client deadline. The route now carries its own 630s budget (600s tool ceiling + IO slack) at both layers; every other API route keeps the 60s deadline.
