### PR TITLE
fix(docs-site): restore scrollable tables (layout overflow under right TOC)

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -55,9 +55,11 @@
   font-size: 14px;
 }
 
-/* Improve table styling */
+/* Tables: keep Infima's default display:block + overflow-x:auto so wide
+   tables scroll INSIDE the content column instead of sliding under the right
+   TOC (the old display:table override broke this — see the telemetry page).
+   width:100% only makes the scroll container span the column. */
 table {
-  display: table;
   width: 100%;
 }
 


### PR DESCRIPTION
The custom.css global `table { display: table; width: 100%; }` override disabled Docusaurus/Infima's default `display: block; overflow-x: auto` markdown-table behavior. Result (visible on /features/telemetry/): wide tables escaped the content column, slid under the right-hand TOC, and the squeezed trailing column produced extreme row heights.

Fix: drop the `display` override (framework default restored — wide tables scroll inside the column); keep `width: 100%` so the scroll container spans the column. Site-wide effect is a return to stock Docusaurus table behavior. Docusaurus build clean (165 docs).