### PR TITLE
fix(docs-site): scrollable tables + cell code wrapping (completes #1003)

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -55,12 +55,24 @@
   font-size: 14px;
 }
 
-/* Tables: keep Infima's default display:block + overflow-x:auto so wide
-   tables scroll INSIDE the content column instead of sliding under the right
-   TOC (the old display:table override broke this — see the telemetry page).
-   width:100% only makes the scroll container span the column. */
-table {
-  width: 100%;
+/* Markdown tables: this Infima version sets `display: table`, on which its
+   own `overflow: auto` is inert (overflow needs a block container), so wide
+   tables blew past the content column and under the right TOC (telemetry
+   page). display:block turns the table into a real scroll container: narrow
+   tables shrink-wrap, wide ones cap at the column and scroll inside it. */
+.markdown table {
+  display: block;
+  width: fit-content;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+/* Long code tokens in table cells (JSON examples, hashes) otherwise force a
+   column to its full unbroken width, starving the other columns into
+   multi-line slivers with tall rows. Let them wrap inside cells. */
+.markdown table code {
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 /* Better sidebar navigation */


### PR DESCRIPTION
Follow-up to #1003, which was based on a wrong assumption: this Infima version ships `table { display: table }` (its `overflow: auto` is inert on that display type — verified from live computed styles), so wide tables still slid under the right TOC after #1003 deployed.

Real fix, scoped to `.markdown table`:
- `display: block; width: fit-content; max-width: 100%; overflow-x: auto` — tables become genuine scroll containers clipped to the content column.
- `.markdown table code { white-space: pre-wrap; word-break: break-word }` — long code tokens (JSON examples, hashes) wrap inside cells instead of forcing one column to full unbroken width and starving the rest (this was the 156px-row-height cause).

**Verified on a local build** with browser computed styles + screenshots: telemetry table now fits the column exactly (643/643px, was 1364px overflowing), all three columns visible, rows 156→79px, TOC clear.