### PR TITLE
feat(webui): calmer, more compact Activity Log

### DIFF
--- a/frontend/src/components/ActivityWidget.vue
+++ b/frontend/src/components/ActivityWidget.vue
@@ -19,7 +19,8 @@
         </div>
         <div class="stat py-2 px-4">
           <div class="stat-title text-xs">Success</div>
-          <div class="stat-value text-lg text-success">{{ summary.success_count }}</div>
+          <!-- Success is the norm — it gets no colour, so Errors can have it. -->
+          <div class="stat-value text-lg text-base-content/70">{{ summary.success_count }}</div>
         </div>
         <div class="stat py-2 px-4">
           <div class="stat-title text-xs">Errors</div>
@@ -67,10 +68,11 @@
               <div class="flex items-center gap-2">
                 <div class="text-xs text-base-content/60">{{ formatRelativeTime(activity.timestamp) }}</div>
                 <!-- Sub-call of a code_execution run (see utils/activity). -->
+                <!-- Context, not an alert: ghost chip, muted text. -->
                 <span
                   v-if="isChildCall(activity)"
                   data-test="widget-child-badge"
-                  class="badge badge-xs badge-ghost"
+                  class="badge badge-xs badge-ghost font-normal text-base-content/60"
                   title="Sub-call dispatched by a code_execution run"
                 >
                   ↳ via code_execution
@@ -78,12 +80,13 @@
               </div>
             </div>
           </div>
-          <div
-            class="badge badge-sm"
-            :class="getStatusBadgeClass(activity.status)"
+          <!-- Same quiet-success treatment as the Activity Log table. -->
+          <span
+            data-test="widget-activity-status"
+            :class="statusPresentation(activity.status).className"
           >
-            {{ activity.status }}
-          </div>
+            {{ statusPresentation(activity.status).label }}
+          </span>
         </div>
       </div>
     </div>
@@ -95,7 +98,12 @@ import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import api from '@/services/api'
 import type { ActivityRecord, ActivitySummaryResponse } from '@/types/api'
-import { formatPreflightSummary, isChildCall, isPreflightActivity } from '@/utils/activity'
+import {
+  formatPreflightSummary,
+  isChildCall,
+  isPreflightActivity,
+  statusPresentation,
+} from '@/utils/activity'
 
 const router = useRouter()
 
@@ -158,17 +166,6 @@ const getTypeIcon = (type: string): string => {
     'preflight': '🛫'
   }
   return typeIcons[type] || '📋'
-}
-
-const getStatusBadgeClass = (status: string): string => {
-  const statusClasses: Record<string, string> = {
-    'success': 'badge-success',
-    'error': 'badge-error',
-    'blocked': 'badge-warning',
-    // Spec 093: shed by a concurrency limit (backpressure, not an upstream fault).
-    'rejected': 'badge-info'
-  }
-  return statusClasses[status] || 'badge-ghost'
 }
 
 // Lifecycle

--- a/frontend/src/utils/activity.ts
+++ b/frontend/src/utils/activity.ts
@@ -6,6 +6,10 @@
 // Activity type labels
 const typeLabels: Record<string, string> = {
   'tool_call': 'Tool Call',
+  'system_start': 'System Start',
+  'system_stop': 'System Stop',
+  'internal_tool_call': 'Internal Tool Call',
+  'config_change': 'Config Change',
   'policy_decision': 'Policy Decision',
   'quarantine_change': 'Quarantine Change',
   'server_change': 'Server Change',
@@ -16,6 +20,10 @@ const typeLabels: Record<string, string> = {
 // Activity type icons
 const typeIcons: Record<string, string> = {
   'tool_call': '🔧',
+  'system_start': '🚀',
+  'system_stop': '🛑',
+  'internal_tool_call': '⚙️',
+  'config_change': '⚡',
   'policy_decision': '🛡️',
   'quarantine_change': '⚠️',
   'server_change': '🔄',
@@ -77,9 +85,86 @@ export const formatStatus = (status: string): string => {
 
 /**
  * Get badge CSS class for status
+ *
+ * @deprecated Prefer {@link statusPresentation}, which also decides whether the
+ * status deserves a pill at all. Kept for the few places that still want a raw
+ * DaisyUI badge modifier.
  */
 export const getStatusBadgeClass = (status: string): string => {
   return statusClasses[status] || 'badge-ghost'
+}
+
+// --- status presentation ----------------------------------------------------
+//
+// The activity table is SCANNED, not read. Success is the norm — roughly 90% of
+// rows — so painting it green makes the whole column shout and buries the two
+// rows that actually need a human. Semantic colour is therefore spent only on
+// states that need attention:
+//
+//   success            plain muted text, no pill      ("this is fine, move on")
+//   error              red pill                       (upstream fault)
+//   blocked            amber pill                     (policy stopped it)
+//   rejected / other   neutral grey pill              (odd, but not an alarm)
+//
+// Both the table column and the dashboard widget render from this one mapping so
+// they cannot drift apart.
+
+/** How loudly a status is allowed to speak. */
+export type StatusTone = 'muted' | 'error' | 'warning' | 'neutral'
+
+export interface StatusPresentation {
+  /** Human label, e.g. "Success". Unknown statuses keep their raw value. */
+  label: string
+  tone: StatusTone
+  /** False = render as plain text (success only); true = render as a pill. */
+  pill: boolean
+  /** Full class list for the rendered element, pill or text. */
+  className: string
+}
+
+const statusPresentations: Record<string, StatusPresentation> = {
+  // No pill, no colour: the default outcome must not compete for attention.
+  success: {
+    label: 'Success',
+    tone: 'muted',
+    pill: false,
+    className: 'text-sm text-base-content/60',
+  },
+  error: {
+    label: 'Error',
+    tone: 'error',
+    pill: true,
+    className: 'badge badge-sm badge-error',
+  },
+  blocked: {
+    label: 'Blocked',
+    tone: 'warning',
+    pill: true,
+    className: 'badge badge-sm badge-warning',
+  },
+  // Spec 093: shed by a concurrency limit. Worth noticing, not worth alarming —
+  // badge-ghost is a neutral chip that reads in both light and dark themes.
+  rejected: {
+    label: 'Rejected',
+    tone: 'neutral',
+    pill: true,
+    className: 'badge badge-sm badge-ghost',
+  },
+}
+
+/**
+ * Pure status -> presentation mapping. Anything unrecognised is an oddity, not
+ * an alarm: neutral grey pill carrying the raw status value.
+ */
+export const statusPresentation = (status: string): StatusPresentation => {
+  const known = statusPresentations[status]
+  if (known) return known
+  return {
+    label: statusLabels[status] || status,
+    tone: 'neutral',
+    pill: true,
+    className: 'badge badge-sm badge-ghost',
+  }
 }
 
 /**
@@ -91,9 +176,64 @@ export const getIntentIcon = (operationType: string): string => {
 
 /**
  * Get badge CSS class for intent operation type
+ *
+ * @deprecated The table renders intent through {@link intentPresentation} (glyph
+ * + reason, no coloured pill). Still used by the detail drawer, where a single
+ * badge has room to be explicit.
  */
 export const getIntentBadgeClass = (operationType: string): string => {
   return intentClasses[operationType] || 'badge-ghost'
+}
+
+// --- intent presentation ----------------------------------------------------
+//
+// Spec 018/024 intent: {operation_type, reason, data_sensitivity}. The old table
+// cell rendered a coloured `read` pill with the glyph crammed inside it (the
+// glyph overflowed the badge box) and hid the REASON — the only part an operator
+// actually wants — behind a tooltip. The reason is the payload; the operation is
+// a one-character prefix.
+
+/** The intent object as it is stored on `metadata.intent`. */
+export interface ActivityIntent {
+  operation_type?: string
+  reason?: string
+  data_sensitivity?: string
+}
+
+export interface IntentPresentation {
+  /** False when the record declared no operation type — render a muted dash. */
+  present: boolean
+  /** Operation glyph: book / pencil / warning. Empty when absent. */
+  icon: string
+  /** Operation type, e.g. "read". Exposed for screen readers, not painted. */
+  label: string
+  /** Declared reason, single line in the cell. Empty when none was given. */
+  reason: string
+  /** Full hover text (`title`), so a truncated reason is still readable. */
+  title: string
+}
+
+const EMPTY_INTENT: IntentPresentation = { present: false, icon: '', label: '', reason: '', title: '' }
+
+/**
+ * Pure intent -> presentation mapping: glyph + reason text, never a colour pill.
+ * A missing operation type means "no intent declared", which the caller renders
+ * as a muted dash rather than a `❓` chip.
+ */
+export const intentPresentation = (intent?: ActivityIntent | null): IntentPresentation => {
+  const operationType = intent?.operation_type
+  if (!operationType) return EMPTY_INTENT
+
+  const reason = (intent?.reason ?? '').trim()
+  return {
+    present: true,
+    icon: getIntentIcon(operationType),
+    label: operationType,
+    reason,
+    // Hover shows the operation too — the glyph alone is ambiguous, and the
+    // reason may be ellipsised in the cell.
+    title: reason ? `${operationType} — ${reason}` : operationType,
+  }
 }
 
 // --- Spec 098: preflight activity records -----------------------------------
@@ -163,6 +303,230 @@ export const isCodeExecutionActivity = (a?: ActivityLinkFields | null): boolean 
 
 /** True for a sub-call: a record that names the parent it was dispatched from. */
 export const isChildCall = (a?: ActivityLinkFields | null): boolean => Boolean(a?.parent_id)
+
+/**
+ * What the table's Details column will print for a record. Extracted so the Type
+ * column can tell whether its `code_execution` marker would be a second copy of
+ * the same six characters on the same row.
+ */
+export const activityDetailsText = (
+  a?: (ActivityLinkFields & { metadata?: Record<string, any> | null }) | null
+): string => {
+  if (!a) return ''
+  if (a.tool_name) return a.tool_name
+  if (isPreflightActivity(a as { type?: string })) {
+    const summary = formatPreflightSummary(a.metadata)
+    if (summary) return summary
+  }
+  const action = a.metadata?.action
+  return action ? String(action) : ''
+}
+
+/**
+ * True when the Type column should still carry the `code_execution` badge: the
+ * record IS a sandbox parent and the Details column is not already saying so.
+ * When this is false the row shows a single quiet puzzle glyph beside the
+ * Details text instead — one marker per row, never the same word twice.
+ */
+export const showParentBadgeInTypeColumn = (
+  a?: (ActivityLinkFields & { metadata?: Record<string, any> | null }) | null
+): boolean => {
+  if (!isCodeExecutionActivity(a)) return false
+  return !activityDetailsText(a).includes('code_execution')
+}
+
+/** Last 8 chars of a correlation id — enough to recognise, short enough to fit. */
+export const shortId = (id: string): string => (id.length > 8 ? `…${id.slice(-8)}` : id)
+
+// --- compact header: counts strip + active-filter chips ---------------------
+//
+// Five stat cards plus an always-open nine-control filter grid pushed the first
+// activity row below the fold. The default view is now one line: the total plus
+// only the counts that want attention, and a Filters button carrying a count of
+// what is currently narrowing the list. The cards and the controls still exist —
+// they just wait until they are asked for.
+
+/** One segment of the compact counts strip. */
+export interface CompactSummaryPart {
+  key: 'total' | 'error' | 'blocked' | 'rejected'
+  label: string
+  tone: StatusTone
+  /** Status value this segment filters to; '' clears the status filter. */
+  status: string
+}
+
+interface ActivitySummaryCounts {
+  total_count?: number
+  error_count?: number
+  blocked_count?: number
+  rejected_count?: number
+}
+
+const plural = (n: number, one: string, many: string): string => `${n} ${n === 1 ? one : many}`
+
+/**
+ * Compact counts strip, e.g. "54 calls · 6 errors · 1 blocked". The total is
+ * always present and muted; a zero attention count is omitted entirely rather
+ * than rendered as a reassuring "0 errors" that costs a line of scanning.
+ */
+export const compactSummaryParts = (
+  summary?: ActivitySummaryCounts | null
+): CompactSummaryPart[] => {
+  if (!summary) return []
+
+  const parts: CompactSummaryPart[] = [
+    {
+      key: 'total',
+      label: plural(summary.total_count ?? 0, 'call', 'calls'),
+      tone: 'muted',
+      status: '',
+    },
+  ]
+
+  if ((summary.error_count ?? 0) > 0) {
+    parts.push({
+      key: 'error',
+      label: plural(summary.error_count as number, 'error', 'errors'),
+      tone: 'error',
+      status: 'error',
+    })
+  }
+  if ((summary.blocked_count ?? 0) > 0) {
+    parts.push({
+      key: 'blocked',
+      label: `${summary.blocked_count} blocked`,
+      tone: 'warning',
+      status: 'blocked',
+    })
+  }
+  if ((summary.rejected_count ?? 0) > 0) {
+    parts.push({
+      key: 'rejected',
+      label: `${summary.rejected_count} rejected`,
+      tone: 'neutral',
+      status: 'rejected',
+    })
+  }
+
+  return parts
+}
+
+/** Every filter the Activity Log can apply, in one plain object. */
+export interface ActivityFilterState {
+  types?: string[]
+  parentId?: string
+  server?: string
+  status?: string
+  authType?: string
+  agentName?: string
+  sensitiveData?: string
+  severity?: string
+  session?: string
+  /** Resolved display label for `session`; falls back to a shortened id. */
+  sessionLabel?: string
+  startDate?: string
+  endDate?: string
+}
+
+/** A dismissable chip in the compact strip. `kind` selects the clear action. */
+export interface ActiveFilterChip {
+  kind:
+    | 'type'
+    | 'parent'
+    | 'server'
+    | 'status'
+    | 'auth'
+    | 'agent'
+    | 'sensitive'
+    | 'severity'
+    | 'session'
+    | 'start'
+    | 'end'
+  /** Unique within one render, so it can key a v-for. */
+  key: string
+  label: string
+  /** Payload the clear action needs (the type value for a type chip). */
+  value?: string
+  title?: string
+}
+
+const localDateLabel = (value: string): string => {
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString()
+}
+
+/**
+ * The active filters, as chips. Pure and order-stable: types first (they are
+ * multi-select), then the sub-call view, then the single-value filters in the
+ * order the expanded controls present them.
+ */
+export const activeFilterChips = (state: ActivityFilterState): ActiveFilterChip[] => {
+  const chips: ActiveFilterChip[] = []
+
+  for (const type of state.types ?? []) {
+    chips.push({
+      kind: 'type',
+      key: `type:${type}`,
+      label: `${getTypeIcon(type)} ${formatType(type)}`,
+      value: type,
+    })
+  }
+
+  if (state.parentId) {
+    chips.push({
+      kind: 'parent',
+      key: 'parent',
+      label: `↳ Sub-calls of ${shortId(state.parentId)}`,
+      value: state.parentId,
+      title: `Sub-calls of code_execution ${state.parentId}`,
+    })
+  }
+  if (state.server) {
+    chips.push({ kind: 'server', key: 'server', label: `Server: ${state.server}` })
+  }
+  if (state.status) {
+    chips.push({ kind: 'status', key: 'status', label: `Status: ${state.status}` })
+  }
+  if (state.authType) {
+    chips.push({
+      kind: 'auth',
+      key: 'auth',
+      label: `Auth: ${state.authType === 'admin' ? '🔑 Admin' : '🤖 Agent'}`,
+    })
+  }
+  if (state.agentName) {
+    chips.push({ kind: 'agent', key: 'agent', label: `Agent: ${state.agentName}` })
+  }
+  if (state.sensitiveData) {
+    chips.push({
+      kind: 'sensitive',
+      key: 'sensitive',
+      label: `Sensitive: ${state.sensitiveData === 'true' ? '⚠️ Detected' : 'Clean'}`,
+    })
+  }
+  if (state.severity) {
+    chips.push({ kind: 'severity', key: 'severity', label: `Severity: ${state.severity}` })
+  }
+  if (state.session) {
+    chips.push({
+      kind: 'session',
+      key: 'session',
+      label: `Session: ${state.sessionLabel || shortId(state.session)}`,
+    })
+  }
+  if (state.startDate) {
+    chips.push({ kind: 'start', key: 'start', label: `From: ${localDateLabel(state.startDate)}` })
+  }
+  if (state.endDate) {
+    chips.push({ kind: 'end', key: 'end', label: `To: ${localDateLabel(state.endDate)}` })
+  }
+
+  return chips
+}
+
+/** Badge count for the Filters toggle: how many filters are narrowing the list. */
+export const activeFilterCount = (state: ActivityFilterState): number =>
+  activeFilterChips(state).length
 
 /**
  * Read `metadata.reasons` into a DETERMINISTIC order: most frequent first, ties

--- a/frontend/src/utils/activity.ts
+++ b/frontend/src/utils/activity.ts
@@ -504,7 +504,11 @@ export const activeFilterChips = (state: ActivityFilterState): ActiveFilterChip[
       label: `Sensitive: ${state.sensitiveData === 'true' ? '⚠️ Detected' : 'Clean'}`,
     })
   }
-  if (state.severity) {
+  // Severity only narrows the list while the sensitive-data filter is
+  // "Detected" (the view applies it under that same condition) — a severity
+  // value left behind after switching sensitive-data off must not read as an
+  // active filter.
+  if (state.severity && state.sensitiveData === 'true') {
     chips.push({ kind: 'severity', key: 'severity', label: `Severity: ${state.severity}` })
   }
   if (state.session) {

--- a/frontend/src/views/Activity.vue
+++ b/frontend/src/views/Activity.vue
@@ -30,8 +30,115 @@
       </div>
     </div>
 
+    <!--
+      Compact header strip (default view). Five stat cards plus a nine-control
+      filter grid pushed the first activity row below the fold; the default is
+      now ONE line — the total, the counts that want attention, and a Filters
+      toggle. Active filters stay visible as dismissable chips even collapsed,
+      so the list is never silently narrowed.
+    -->
+    <div class="card bg-base-100 shadow-sm">
+      <div class="card-body py-3 gap-3">
+        <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
+          <!-- Counts: total muted; only non-zero error/blocked/rejected speak up. -->
+          <div
+            v-if="summaryParts.length > 0"
+            data-test="activity-compact-summary"
+            class="flex flex-wrap items-center gap-x-2 gap-y-1"
+          >
+            <template v-for="(part, idx) in summaryParts" :key="part.key">
+              <span v-if="idx > 0" class="text-base-content/25" aria-hidden="true">·</span>
+              <button
+                type="button"
+                :data-test="`activity-compact-${part.key}`"
+                :class="[
+                  'text-sm hover:underline underline-offset-2 transition-colors',
+                  summaryToneClass(part.tone),
+                  filterStatus === part.status && part.status !== '' ? 'font-semibold underline' : '',
+                ]"
+                :aria-pressed="filterStatus === part.status"
+                @click="applySummaryFilter(part)"
+              >
+                {{ part.label }}
+              </button>
+            </template>
+          </div>
+
+          <div class="flex-1"></div>
+
+          <!-- Filters toggle — the expanded cards + controls hang off this. -->
+          <button
+            type="button"
+            data-test="activity-filters-toggle"
+            class="btn btn-sm btn-ghost gap-2"
+            :aria-expanded="showFilterPanel"
+            @click="showFilterPanel = !showFilterPanel"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+            </svg>
+            Filters
+            <span
+              v-if="activeChips.length > 0"
+              data-test="activity-filters-count"
+              class="badge badge-xs badge-neutral"
+            >
+              {{ activeChips.length }}
+            </span>
+            <svg
+              class="w-3 h-3 transition-transform"
+              :class="showFilterPanel ? 'rotate-180' : ''"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+
+          <!-- Export is not a filter — it belongs on the strip, not inside the grid. -->
+          <div class="dropdown dropdown-end">
+            <div tabindex="0" role="button" class="btn btn-sm btn-outline">
+              <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              </svg>
+              Export
+            </div>
+            <ul tabindex="0" class="dropdown-content z-[1] menu p-2 shadow-lg bg-base-200 rounded-box w-40">
+              <li><a @click="exportActivities('json')">Export as JSON</a></li>
+              <li><a @click="exportActivities('csv')">Export as CSV</a></li>
+            </ul>
+          </div>
+        </div>
+
+        <!-- Active filters — always shown, collapsed or not. -->
+        <div
+          v-if="activeChips.length > 0"
+          data-test="activity-active-filters"
+          class="flex flex-wrap items-center gap-2 pt-2 border-t border-base-300"
+        >
+          <span class="text-xs text-base-content/50">Filters:</span>
+          <button
+            v-for="chip in activeChips"
+            :key="chip.key"
+            type="button"
+            :data-test="chipTestId(chip)"
+            class="badge badge-sm badge-ghost gap-1 hover:bg-base-300"
+            :title="chip.title || chip.label"
+            @click="clearChip(chip)"
+          >
+            {{ chip.label }}
+            <svg class="w-3 h-3 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+          <button type="button" class="btn btn-xs btn-ghost" @click="clearFilters">Clear all</button>
+        </div>
+      </div>
+    </div>
+
     <!-- Summary Stats — clickable, drive the Status filter (issue #436) -->
-    <div v-if="summary" class="stats shadow bg-base-100 w-full">
+    <div v-if="showFilterPanel && summary" class="stats shadow bg-base-100 w-full">
       <button
         type="button"
         data-test="kpi-card-total"
@@ -50,7 +157,8 @@
         @click="filterStatus = filterStatus === 'success' ? '' : 'success'"
       >
         <div class="stat-title">Success</div>
-        <div class="stat-value text-2xl text-success">{{ summary.success_count }}</div>
+        <!-- Success is the norm — no colour, so Errors/Blocked keep theirs. -->
+        <div class="stat-value text-2xl text-base-content/70">{{ summary.success_count }}</div>
       </button>
       <button
         type="button"
@@ -80,12 +188,13 @@
         @click="filterStatus = filterStatus === 'rejected' ? '' : 'rejected'"
       >
         <div class="stat-title">Rejected</div>
-        <div class="stat-value text-2xl text-info">{{ summary.rejected_count }}</div>
+        <!-- Backpressure, not an alarm: neutral, like its pill. -->
+        <div class="stat-value text-2xl text-base-content/70">{{ summary.rejected_count }}</div>
       </button>
     </div>
 
-    <!-- Filters -->
-    <div class="card bg-base-100 shadow-md">
+    <!-- Filters — rendered only when the compact strip's toggle asks for them. -->
+    <div v-if="showFilterPanel" data-test="activity-filter-panel" class="card bg-base-100 shadow-md">
       <div class="card-body py-4">
         <div class="flex flex-wrap gap-4 items-end">
           <!-- Type Filter (Multi-select dropdown) -->
@@ -254,63 +363,6 @@
           >
             Clear Filters
           </button>
-
-          <!-- Spacer -->
-          <div class="flex-1"></div>
-
-          <!-- Export Dropdown -->
-          <div class="dropdown dropdown-end">
-            <div tabindex="0" role="button" class="btn btn-sm btn-outline">
-              <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-              </svg>
-              Export
-            </div>
-            <ul tabindex="0" class="dropdown-content z-[1] menu p-2 shadow-lg bg-base-200 rounded-box w-40">
-              <li><a @click="exportActivities('json')">Export as JSON</a></li>
-              <li><a @click="exportActivities('csv')">Export as CSV</a></li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Active Filters Summary -->
-        <div v-if="hasActiveFilters" class="flex flex-wrap gap-2 mt-2 pt-2 border-t border-base-300">
-          <span class="text-xs text-base-content/60">Active filters:</span>
-          <span
-            v-for="type in selectedTypes"
-            :key="type"
-            class="badge badge-sm badge-outline gap-1 cursor-pointer hover:badge-error"
-            @click="toggleTypeFilter(type)"
-          >
-            {{ getTypeIcon(type) }} {{ formatType(type) }}
-            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </span>
-          <!-- Sub-call view: click to leave it and restore the normal list. -->
-          <span
-            v-if="filterParentId"
-            data-test="activity-parent-filter-chip"
-            class="badge badge-sm badge-outline gap-1 cursor-pointer hover:badge-error"
-            :title="`Sub-calls of code_execution ${filterParentId}`"
-            @click="clearParentFilter"
-          >
-            ↳ Sub-calls of {{ shortId(filterParentId) }}
-            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </span>
-          <span v-if="filterServer" class="badge badge-sm badge-outline">Server: {{ filterServer }}</span>
-          <span v-if="filterStatus" class="badge badge-sm badge-outline">Status: {{ filterStatus }}</span>
-          <span v-if="filterAuthType" class="badge badge-sm badge-outline">Auth: {{ filterAuthType === 'admin' ? '🔑 Admin' : '🤖 Agent' }}</span>
-          <span v-if="filterAgentName" class="badge badge-sm badge-outline">Agent: {{ filterAgentName }}</span>
-          <span v-if="filterSensitiveData" class="badge badge-sm badge-outline">
-            Sensitive: {{ filterSensitiveData === 'true' ? '⚠️ Detected' : 'Clean' }}
-          </span>
-          <span v-if="filterSeverity" class="badge badge-sm badge-outline">Severity: {{ filterSeverity }}</span>
-          <span v-if="filterSession" class="badge badge-sm badge-outline">Session: {{ getSessionLabel(filterSession) }}</span>
-          <span v-if="filterStartDate" class="badge badge-sm badge-outline">From: {{ new Date(filterStartDate).toLocaleString() }}</span>
-          <span v-if="filterEndDate" class="badge badge-sm badge-outline">To: {{ new Date(filterEndDate).toLocaleString() }}</span>
         </div>
       </div>
     </div>
@@ -357,7 +409,8 @@
                 </th>
                 <th>Details</th>
                 <th>Sensitive</th>
-                <th>Intent</th>
+                <!-- Intent carries the declared reason, not a 52px icon slot. -->
+                <th class="min-w-[11rem]">Intent</th>
                 <th class="cursor-pointer hover:bg-base-200" @click="sortBy('status')">
                   Status {{ getSortIndicator('status') }}
                 </th>
@@ -389,20 +442,24 @@
                     <!--
                       code_execution linkage: a sub-call names the run that
                       dispatched it, a parent advertises that it fans out. Both
-                      badges are the entry point to the drawer's navigation.
+                      markers are the entry point to the drawer's navigation.
+                      The child badge is CONTEXT, not an alert — ghost, not accent.
+                      The parent badge appears here only when the Details column
+                      is not already printing "code_execution"; otherwise the row
+                      carries a single puzzle glyph beside that text instead.
                     -->
                     <span
                       v-if="isChildCall(activity)"
                       data-test="activity-child-badge"
-                      class="badge badge-xs badge-ghost w-fit"
+                      class="badge badge-xs badge-ghost w-fit font-normal text-base-content/60"
                       title="Sub-call dispatched by a code_execution run"
                     >
                       ↳ via code_execution
                     </span>
                     <span
-                      v-else-if="isCodeExecutionActivity(activity)"
+                      v-else-if="showParentBadgeInTypeColumn(activity)"
                       data-test="activity-parent-badge"
-                      class="badge badge-xs badge-accent w-fit"
+                      class="badge badge-xs badge-ghost w-fit font-normal text-base-content/60"
                       title="Sandboxed script run — may have dispatched sub-calls"
                     >
                       🧩 code_execution
@@ -421,8 +478,21 @@
                   <span v-else class="text-base-content/40">-</span>
                 </td>
                 <td>
-                  <div class="max-w-xs truncate">
-                    <code v-if="activity.tool_name" class="text-sm bg-base-200 px-2 py-1 rounded">
+                  <div class="max-w-xs truncate flex items-center gap-1.5">
+                    <!--
+                      The parent marker, when the Details text already says
+                      "code_execution": a quiet glyph instead of a second copy of
+                      the word one column to the left.
+                    -->
+                    <span
+                      v-if="isCodeExecutionActivity(activity) && !showParentBadgeInTypeColumn(activity)"
+                      data-test="activity-parent-badge"
+                      class="text-sm opacity-50 shrink-0"
+                      title="Sandboxed script run — may have dispatched sub-calls"
+                    >
+                      🧩
+                    </span>
+                    <code v-if="activity.tool_name" class="text-sm bg-base-200 px-2 py-1 rounded truncate">
                       {{ activity.tool_name }}
                     </code>
                     <!--
@@ -457,27 +527,42 @@
                   </div>
                   <span v-else class="text-base-content/40">-</span>
                 </td>
-                <!-- Intent column (Spec 024: US5) -->
-                <td>
+                <!--
+                  Intent column (Spec 024: US5). The REASON is what an operator
+                  wants; the operation type is a glyph in front of it. The old
+                  coloured `read` pill spent semantic colour on the most common
+                  case and clipped its own icon.
+                -->
+                <td class="max-w-[18rem]">
                   <div
-                    v-if="activity.metadata?.intent?.operation_type"
-                    class="tooltip tooltip-top"
-                    :data-tip="activity.metadata?.intent?.reason || 'No reason provided'"
+                    v-if="intentOf(activity).present"
+                    data-test="activity-intent"
+                    class="flex items-center gap-1.5 min-w-0"
+                    :title="intentOf(activity).title"
                   >
-                    <span class="badge badge-sm gap-1" :class="getIntentBadgeClass(activity.metadata.intent.operation_type)">
-                      {{ getIntentIcon(activity.metadata.intent.operation_type) }}
-                      {{ activity.metadata.intent.operation_type }}
+                    <span class="text-sm leading-none shrink-0" aria-hidden="true">{{ intentOf(activity).icon }}</span>
+                    <span class="sr-only">{{ intentOf(activity).label }}</span>
+                    <span
+                      v-if="intentOf(activity).reason"
+                      data-test="activity-intent-reason"
+                      class="text-xs text-base-content/70 truncate"
+                    >
+                      {{ intentOf(activity).reason }}
                     </span>
                   </div>
                   <span v-else class="text-base-content/40">-</span>
                 </td>
+                <!--
+                  Status: success is the norm and stays quiet (muted text, no
+                  pill); only error / blocked / oddities get a chip.
+                -->
                 <td>
-                  <div
-                    class="badge badge-sm"
-                    :class="getStatusBadgeClass(activity.status)"
+                  <span
+                    data-test="activity-status"
+                    :class="statusPresentation(activity.status).className"
                   >
-                    {{ formatStatus(activity.status) }}
-                  </div>
+                    {{ statusPresentation(activity.status).label }}
+                  </span>
                 </td>
                 <td>
                   <span v-if="activity.duration_ms !== undefined" class="text-sm">
@@ -570,12 +655,15 @@
               </button>
             </div>
 
-            <!-- Status Badge -->
+            <!-- Status — same quiet-success treatment as the table column. -->
             <div class="flex items-center gap-2">
               <span class="text-sm text-base-content/60">Status:</span>
-              <div class="badge" :class="getStatusBadgeClass(selectedActivity.status)">
-                {{ formatStatus(selectedActivity.status) }}
-              </div>
+              <span
+                data-test="activity-detail-status"
+                :class="statusPresentation(selectedActivity.status).className"
+              >
+                {{ statusPresentation(selectedActivity.status).label }}
+              </span>
             </div>
 
             <!-- Metadata -->
@@ -856,14 +944,26 @@ import {
 // Spec 098: preflight records carry their verdict in metadata; the renderers
 // are shared (and unit-tested) rather than re-derived in the template.
 import {
+  activeFilterChips,
+  compactSummaryParts,
   formatPreflightSummary,
+  formatType,
+  getIntentBadgeClass,
+  getIntentIcon,
   getPreflightVerdictBadgeClass,
+  getTypeIcon,
+  intentPresentation,
   isChildCall,
   isCodeExecutionActivity,
   isPreflightActivity,
   preflightIdsCount,
   preflightPerTool,
   preflightReasonRollup,
+  showParentBadgeInTypeColumn,
+  statusPresentation,
+  type ActiveFilterChip,
+  type CompactSummaryPart,
+  type StatusTone,
 } from '@/utils/activity'
 import JsonViewer from '@/components/JsonViewer.vue'
 
@@ -1107,6 +1207,116 @@ const hasActiveFilters = computed(() => {
   return selectedTypes.value.length > 0 || filterServer.value || filterSession.value || filterStatus.value || filterSensitiveData.value || filterSeverity.value || filterAuthType.value || filterAgentName.value || filterStartDate.value || filterEndDate.value || filterParentId.value
 })
 
+// --- compact header ---------------------------------------------------------
+
+/**
+ * Whether the stat cards + full filter grid are shown. Persisted per browser so
+ * an operator who wants the controls open keeps them open, while a first visit
+ * lands on the compact strip. localStorage can throw outright (private windows,
+ * blocked site data), so every touch is guarded and falls back to collapsed.
+ */
+const FILTER_PANEL_STORAGE_KEY = 'mcpproxy.activity.filtersExpanded'
+
+const readFilterPanelPref = (): boolean => {
+  try {
+    return window.localStorage.getItem(FILTER_PANEL_STORAGE_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+const showFilterPanel = ref(readFilterPanelPref())
+
+watch(showFilterPanel, expanded => {
+  try {
+    window.localStorage.setItem(FILTER_PANEL_STORAGE_KEY, expanded ? 'true' : 'false')
+  } catch {
+    // Preference is a convenience; never let a storage failure break the page.
+  }
+})
+
+/** "54 calls · 6 errors · 1 blocked" — zeros omitted. */
+const summaryParts = computed(() => compactSummaryParts(summary.value))
+
+/** Only error/blocked spend colour; the total and oddities stay quiet. */
+const summaryToneClass = (tone: StatusTone): string => {
+  switch (tone) {
+    case 'error':
+      return 'text-error font-medium'
+    case 'warning':
+      return 'text-warning font-medium'
+    case 'neutral':
+      return 'text-base-content/70'
+    default:
+      return 'text-base-content/60'
+  }
+}
+
+/** Clicking a count drives the Status filter (issue #436, kept from the cards). */
+const applySummaryFilter = (part: CompactSummaryPart) => {
+  filterStatus.value = filterStatus.value === part.status ? '' : part.status
+}
+
+/** Active filters as dismissable chips — visible whether or not the grid is. */
+const activeChips = computed(() =>
+  activeFilterChips({
+    types: selectedTypes.value,
+    parentId: filterParentId.value,
+    server: filterServer.value,
+    status: filterStatus.value,
+    authType: filterAuthType.value,
+    agentName: filterAgentName.value,
+    sensitiveData: filterSensitiveData.value,
+    severity: filterSeverity.value,
+    session: filterSession.value,
+    sessionLabel: filterSession.value ? getSessionLabel(filterSession.value) : undefined,
+    startDate: filterStartDate.value,
+    endDate: filterEndDate.value,
+  })
+)
+
+/** The sub-call chip keeps its own hook — it is the code_execution exit door. */
+const chipTestId = (chip: ActiveFilterChip): string =>
+  chip.kind === 'parent' ? 'activity-parent-filter-chip' : `activity-filter-chip-${chip.kind}`
+
+const clearChip = (chip: ActiveFilterChip) => {
+  switch (chip.kind) {
+    case 'type':
+      if (chip.value) toggleTypeFilter(chip.value)
+      break
+    case 'parent':
+      void clearParentFilter()
+      break
+    case 'server':
+      filterServer.value = ''
+      break
+    case 'status':
+      filterStatus.value = ''
+      break
+    case 'auth':
+      filterAuthType.value = ''
+      break
+    case 'agent':
+      filterAgentName.value = ''
+      break
+    case 'sensitive':
+      filterSensitiveData.value = ''
+      break
+    case 'severity':
+      filterSeverity.value = ''
+      break
+    case 'session':
+      filterSession.value = ''
+      break
+    case 'start':
+      filterStartDate.value = ''
+      break
+    case 'end':
+      filterEndDate.value = ''
+      break
+  }
+}
+
 const filteredActivities = computed(() => {
   let result = activities.value
 
@@ -1246,9 +1456,6 @@ const clearFilters = () => {
   filterParentId.value = ''
   if (hadParentFilter) void loadActivities()
 }
-
-/** Last 8 chars of a correlation id — enough to recognise, short enough to fit. */
-const shortId = (id: string): string => (id.length > 8 ? `…${id.slice(-8)}` : id)
 
 /** Sub-calls of this run among the rows we hold. */
 const subCallCount = (parent: ActivityRecord): number => {
@@ -1435,60 +1642,8 @@ const formatRelativeTime = (timestamp: string): string => {
   return `${Math.floor(diff / 86400000)}d ago`
 }
 
-const formatType = (type: string): string => {
-  // Spec 024: Include new activity types
-  const typeLabels: Record<string, string> = {
-    'tool_call': 'Tool Call',
-    'system_start': 'System Start',
-    'system_stop': 'System Stop',
-    'internal_tool_call': 'Internal Tool Call',
-    'config_change': 'Config Change',
-    'policy_decision': 'Policy Decision',
-    'quarantine_change': 'Quarantine Change',
-    'server_change': 'Server Change',
-    // Spec 098
-    'preflight': 'Preflight'
-  }
-  return typeLabels[type] || type
-}
-
-const getTypeIcon = (type: string): string => {
-  // Spec 024: Include new activity types
-  const typeIcons: Record<string, string> = {
-    'tool_call': '🔧',
-    'system_start': '🚀',
-    'system_stop': '🛑',
-    'internal_tool_call': '⚙️',
-    'config_change': '⚡',
-    'policy_decision': '🛡️',
-    'quarantine_change': '⚠️',
-    'server_change': '🔄',
-    // Spec 098
-    'preflight': '🛫'
-  }
-  return typeIcons[type] || '📋'
-}
-
-const formatStatus = (status: string): string => {
-  const statusLabels: Record<string, string> = {
-    'success': 'Success',
-    'error': 'Error',
-    'blocked': 'Blocked',
-    'rejected': 'Rejected'
-  }
-  return statusLabels[status] || status
-}
-
-const getStatusBadgeClass = (status: string): string => {
-  const statusClasses: Record<string, string> = {
-    'success': 'badge-success',
-    'error': 'badge-error',
-    'blocked': 'badge-warning',
-    // Spec 093: shed by a concurrency limit (backpressure, not an upstream fault).
-    'rejected': 'badge-info'
-  }
-  return statusClasses[status] || 'badge-ghost'
-}
+// Type / status / intent renderers are imported from @/utils/activity so the
+// table, the dashboard widget and the unit tests share ONE mapping.
 
 const formatDuration = (ms: number): string => {
   if (ms < 1000) return `${Math.round(ms)}ms`
@@ -1526,23 +1681,9 @@ const getSeverityBadgeClass = (severity?: string): string => {
   return classes[severity || ''] || 'badge-warning'
 }
 
-const getIntentIcon = (operationType: string): string => {
-  const icons: Record<string, string> = {
-    'read': '📖',
-    'write': '✏️',
-    'destructive': '⚠️'
-  }
-  return icons[operationType] || '❓'
-}
-
-const getIntentBadgeClass = (operationType: string): string => {
-  const classes: Record<string, string> = {
-    'read': 'badge-info',
-    'write': 'badge-warning',
-    'destructive': 'badge-error'
-  }
-  return classes[operationType] || 'badge-ghost'
-}
+/** Intent as the table renders it: glyph + reason, no coloured pill. */
+const intentOf = (activity: ActivityRecord) =>
+  intentPresentation(activity.metadata?.intent as Parameters<typeof intentPresentation>[0])
 
 // Check if there's additional metadata beyond what we show in dedicated sections
 const hasAdditionalMetadata = (activity: ActivityRecord): boolean => {

--- a/frontend/tests/unit/activity-compact-view.spec.ts
+++ b/frontend/tests/unit/activity-compact-view.spec.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createRouter, createWebHistory } from 'vue-router'
+
+// Activity Log density (user feedback): five stat cards plus a permanently open
+// nine-control filter grid ate half the viewport before the first row. The page
+// now opens on ONE compact strip — total + non-zero attention counts, a Filters
+// toggle carrying a count badge, and the active-filter chips. The cards and the
+// controls are still there, one click away, and the choice is remembered.
+//
+// The same pass de-coloured success (plain muted text, no pill) and removed the
+// duplicated "code_execution" that appeared in Type AND Details on one row.
+
+const PARENT = {
+  id: 'act-parent',
+  type: 'internal_tool_call',
+  status: 'success',
+  timestamp: '2026-08-21T10:00:00Z',
+  tool_name: 'code_execution',
+  request_id: 'req-parent-abcdefgh',
+  duration_ms: 900,
+  metadata: { internal_tool_name: 'code_execution' },
+}
+
+const OK_CALL = {
+  id: 'act-ok',
+  type: 'tool_call',
+  status: 'success',
+  timestamp: '2026-08-21T09:59:00Z',
+  server_name: 'github',
+  tool_name: 'list_repos',
+  request_id: 'req-ok',
+  duration_ms: 40,
+  metadata: { intent: { operation_type: 'read', reason: 'enumerate repositories for the release notes' } },
+}
+
+const FAILED_CALL = {
+  id: 'act-bad',
+  type: 'tool_call',
+  status: 'error',
+  timestamp: '2026-08-21T09:58:00Z',
+  server_name: 'slack',
+  tool_name: 'post_message',
+  request_id: 'req-bad',
+  duration_ms: 80,
+  metadata: { intent: { operation_type: 'write' } },
+}
+
+vi.mock('@/services/api', () => {
+  const ok = (data: unknown) => Promise.resolve({ success: true, data })
+  return {
+    default: {
+      getActivities: vi.fn(() => {
+        const activities = [PARENT, OK_CALL, FAILED_CALL]
+        return ok({ activities, total: activities.length, limit: 200, offset: 0 })
+      }),
+      getActivitySummary: vi.fn(() =>
+        ok({
+          period: '24h',
+          total_count: 54,
+          success_count: 47,
+          error_count: 6,
+          blocked_count: 1,
+          rejected_count: 0,
+        })
+      ),
+      getSessions: vi.fn(() => ok({ sessions: [] })),
+      getActivityExportUrl: vi.fn(() => 'http://localhost/api/v1/activity/export?format=json'),
+    },
+  }
+})
+
+async function mountActivity() {
+  const Activity = (await import('@/views/Activity.vue')).default
+  const router = createRouter({
+    history: createWebHistory(),
+    routes: [
+      { path: '/activity', component: { template: '<div/>' } },
+      { path: '/servers/:serverName', component: { template: '<div/>' } },
+    ],
+  })
+  await router.push('/activity')
+  await router.isReady()
+  const wrapper = mount(Activity, { global: { plugins: [createPinia(), router] } })
+  await flushPromises()
+  return wrapper
+}
+
+type Wrapper = Awaited<ReturnType<typeof mountActivity>>
+
+const rows = (wrapper: Wrapper) => wrapper.findAll('[data-test="activity-row"]')
+const rowFor = (wrapper: Wrapper, text: string) => rows(wrapper).find(r => r.text().includes(text))!
+
+describe('Activity Log — compact header', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    window.localStorage.clear()
+  })
+
+  it('opens collapsed: one counts strip, no stat cards, no filter grid', async () => {
+    const wrapper = await mountActivity()
+
+    const strip = wrapper.find('[data-test="activity-compact-summary"]')
+    expect(strip.exists()).toBe(true)
+    expect(strip.text()).toContain('54 calls')
+    expect(strip.text()).toContain('6 errors')
+    expect(strip.text()).toContain('1 blocked')
+    // Zero rejected never earns a segment.
+    expect(strip.text()).not.toContain('rejected')
+
+    expect(wrapper.find('[data-test="kpi-card-total"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="activity-filter-panel"]').exists()).toBe(false)
+  })
+
+  it('colours only the attention counts', async () => {
+    const wrapper = await mountActivity()
+
+    expect(wrapper.find('[data-test="activity-compact-total"]').classes().join(' ')).not.toMatch(/text-(error|warning|success)/)
+    expect(wrapper.find('[data-test="activity-compact-error"]').classes()).toContain('text-error')
+    expect(wrapper.find('[data-test="activity-compact-blocked"]').classes()).toContain('text-warning')
+  })
+
+  it('a count segment drives the Status filter, and clicking it again clears it', async () => {
+    const wrapper = await mountActivity()
+
+    await wrapper.find('[data-test="activity-compact-error"]').trigger('click')
+    await flushPromises()
+    expect(rows(wrapper)).toHaveLength(1)
+    expect(wrapper.find('[data-test="activity-filter-chip-status"]').text()).toContain('Status: error')
+
+    await wrapper.find('[data-test="activity-compact-error"]').trigger('click')
+    await flushPromises()
+    expect(rows(wrapper)).toHaveLength(3)
+  })
+
+  it('reveals the stat cards and the filter grid on toggle, and persists the choice', async () => {
+    const wrapper = await mountActivity()
+
+    await wrapper.find('[data-test="activity-filters-toggle"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="kpi-card-total"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="activity-filter-panel"]').exists()).toBe(true)
+    expect(window.localStorage.getItem('mcpproxy.activity.filtersExpanded')).toBe('true')
+
+    // A fresh mount honours the stored preference.
+    const reopened = await mountActivity()
+    expect(reopened.find('[data-test="activity-filter-panel"]').exists()).toBe(true)
+  })
+
+  it('survives a localStorage that throws (private window / blocked site data)', async () => {
+    // Scoped to OUR key: the shared system store touches localStorage too and is
+    // not what this test is about.
+    const KEY = 'mcpproxy.activity.filtersExpanded'
+    const realGet = Storage.prototype.getItem
+    const realSet = Storage.prototype.setItem
+    const getItem = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(function (this: Storage, key: string) {
+      if (key === KEY) throw new Error('SecurityError')
+      return realGet.call(this, key)
+    })
+    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key: string, value: string) {
+      if (key === KEY) throw new Error('SecurityError')
+      return realSet.call(this, key, value)
+    })
+
+    try {
+      const wrapper = await mountActivity()
+      // Defaults to collapsed rather than blowing up the page.
+      expect(wrapper.find('[data-test="activity-filter-panel"]').exists()).toBe(false)
+      await wrapper.find('[data-test="activity-filters-toggle"]').trigger('click')
+      await flushPromises()
+      expect(wrapper.find('[data-test="activity-filter-panel"]').exists()).toBe(true)
+    } finally {
+      getItem.mockRestore()
+      setItem.mockRestore()
+    }
+  })
+
+  it('shows active filters as dismissable chips with a count badge, even collapsed', async () => {
+    const wrapper = await mountActivity()
+
+    expect(wrapper.find('[data-test="activity-active-filters"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="activity-filters-count"]').exists()).toBe(false)
+
+    await wrapper.find('[data-test="activity-compact-blocked"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="activity-filter-panel"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="activity-active-filters"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="activity-filters-count"]').text()).toBe('1')
+
+    await wrapper.find('[data-test="activity-filter-chip-status"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-test="activity-active-filters"]').exists()).toBe(false)
+  })
+})
+
+describe('Activity Log — row treatment', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    window.localStorage.clear()
+  })
+
+  it('renders success as plain muted text and error as a red pill', async () => {
+    const wrapper = await mountActivity()
+
+    const okStatus = rowFor(wrapper, 'list_repos').find('[data-test="activity-status"]')
+    expect(okStatus.text()).toBe('Success')
+    expect(okStatus.classes().join(' ')).not.toContain('badge')
+    expect(okStatus.classes().join(' ')).not.toContain('success')
+
+    const badStatus = rowFor(wrapper, 'post_message').find('[data-test="activity-status"]')
+    expect(badStatus.text()).toBe('Error')
+    expect(badStatus.classes()).toContain('badge-error')
+  })
+
+  it('says code_execution once on the parent row, not twice', async () => {
+    const wrapper = await mountActivity()
+
+    const parentRow = rowFor(wrapper, 'code_execution')
+    const occurrences = parentRow.text().split('code_execution').length - 1
+    expect(occurrences).toBe(1)
+
+    // The marker survives as a quiet glyph beside the Details text.
+    const marker = parentRow.find('[data-test="activity-parent-badge"]')
+    expect(marker.exists()).toBe(true)
+    expect(marker.text()).toBe('🧩')
+    expect(marker.classes().join(' ')).not.toContain('badge-accent')
+  })
+
+  it('shows the intent reason inline, glyph first, no coloured pill', async () => {
+    const wrapper = await mountActivity()
+
+    const intent = rowFor(wrapper, 'list_repos').find('[data-test="activity-intent"]')
+    expect(intent.exists()).toBe(true)
+    expect(intent.attributes('title')).toBe('read — enumerate repositories for the release notes')
+    expect(intent.text()).toContain('enumerate repositories for the release notes')
+    expect(intent.classes().join(' ')).not.toContain('badge')
+    expect(intent.find('[data-test="activity-intent-reason"]').classes()).toContain('truncate')
+
+    // Declared operation with no reason: glyph only, no dangling text node.
+    const noReason = rowFor(wrapper, 'post_message').find('[data-test="activity-intent"]')
+    expect(noReason.attributes('title')).toBe('write')
+    expect(noReason.find('[data-test="activity-intent-reason"]').exists()).toBe(false)
+
+    // No intent at all: a muted dash, not a "❓" chip.
+    expect(rowFor(wrapper, 'code_execution').find('[data-test="activity-intent"]').exists()).toBe(false)
+  })
+})

--- a/frontend/tests/unit/activity.spec.ts
+++ b/frontend/tests/unit/activity.spec.ts
@@ -646,3 +646,25 @@ describe('Relative Time Formatting', () => {
     })
   })
 })
+
+
+describe('activeFilterChips severity gating', () => {
+  it('does not count a leftover severity as active once sensitive-data is off', () => {
+    const chips = activeFilterChips({
+      types: [],
+      sensitiveData: '',
+      severity: 'critical',
+    })
+    expect(chips.find(c => c.kind === 'severity')).toBeUndefined()
+    expect(activeFilterCount({ types: [], sensitiveData: '', severity: 'critical' })).toBe(0)
+  })
+
+  it('counts severity while sensitive-data is Detected', () => {
+    const chips = activeFilterChips({
+      types: [],
+      sensitiveData: 'true',
+      severity: 'critical',
+    })
+    expect(chips.map(c => c.kind)).toEqual(['sensitive', 'severity'])
+  })
+})

--- a/frontend/tests/unit/activity.spec.ts
+++ b/frontend/tests/unit/activity.spec.ts
@@ -11,6 +11,14 @@ import {
   filterActivities,
   paginateActivities,
   calculateTotalPages,
+  statusPresentation,
+  intentPresentation,
+  compactSummaryParts,
+  activeFilterChips,
+  activeFilterCount,
+  activityDetailsText,
+  showParentBadgeInTypeColumn,
+  shortId,
   type ActivityRecord,
   type ActivityFilterOptions
 } from '../../src/utils/activity'
@@ -134,6 +142,225 @@ describe('Status Badge Colors', () => {
     it('returns badge-ghost for unknown operation', () => {
       expect(getIntentBadgeClass('unknown')).toBe('badge-ghost')
     })
+  })
+})
+
+// Status treatment: success is the norm and must NOT shout. Colour is reserved
+// for the rows that need a human; everything else is quiet.
+describe('statusPresentation', () => {
+  it('renders success as plain muted text — no pill, no green', () => {
+    const p = statusPresentation('success')
+    expect(p.label).toBe('Success')
+    expect(p.pill).toBe(false)
+    expect(p.tone).toBe('muted')
+    expect(p.className).not.toContain('badge')
+    expect(p.className).not.toContain('success')
+    expect(p.className).toContain('text-base-content/60')
+  })
+
+  it('keeps a red pill for error', () => {
+    const p = statusPresentation('error')
+    expect(p).toMatchObject({ label: 'Error', pill: true, tone: 'error' })
+    expect(p.className).toContain('badge-error')
+  })
+
+  it('keeps an amber pill for blocked', () => {
+    const p = statusPresentation('blocked')
+    expect(p).toMatchObject({ label: 'Blocked', pill: true, tone: 'warning' })
+    expect(p.className).toContain('badge-warning')
+  })
+
+  it('gives rejected a NEUTRAL pill, not the old info blue', () => {
+    const p = statusPresentation('rejected')
+    expect(p).toMatchObject({ label: 'Rejected', pill: true, tone: 'neutral' })
+    expect(p.className).toContain('badge-ghost')
+    expect(p.className).not.toContain('badge-info')
+  })
+
+  it('treats any other status as a neutral oddity, keeping its raw label', () => {
+    const p = statusPresentation('timeout')
+    expect(p).toMatchObject({ label: 'timeout', pill: true, tone: 'neutral' })
+    expect(p.className).toContain('badge-ghost')
+  })
+
+  it('only ever colours statuses that need attention', () => {
+    const coloured = ['success', 'error', 'blocked', 'rejected', 'weird']
+      .filter(s => statusPresentation(s).tone === 'error' || statusPresentation(s).tone === 'warning')
+    expect(coloured).toEqual(['error', 'blocked'])
+  })
+})
+
+// Intent: the REASON is the payload, the operation type is a glyph in front of
+// it. The old cell showed a coloured `read` pill and hid the reason in a tooltip.
+describe('intentPresentation', () => {
+  it('renders glyph + reason and a full hover title', () => {
+    const p = intentPresentation({ operation_type: 'read', reason: 'list open issues' })
+    expect(p.present).toBe(true)
+    expect(p.icon).toBe('📖')
+    expect(p.label).toBe('read')
+    expect(p.reason).toBe('list open issues')
+    expect(p.title).toBe('read — list open issues')
+  })
+
+  it('uses the pencil glyph for write and the warning glyph for destructive', () => {
+    expect(intentPresentation({ operation_type: 'write' }).icon).toBe('✏️')
+    expect(intentPresentation({ operation_type: 'destructive' }).icon).toBe('⚠️')
+  })
+
+  it('falls back to just the glyph when no reason was declared', () => {
+    const p = intentPresentation({ operation_type: 'write' })
+    expect(p.present).toBe(true)
+    expect(p.reason).toBe('')
+    expect(p.title).toBe('write')
+  })
+
+  it('ignores a whitespace-only reason', () => {
+    expect(intentPresentation({ operation_type: 'read', reason: '   ' }).reason).toBe('')
+  })
+
+  it('is absent when no operation type was declared (caller renders a dash)', () => {
+    expect(intentPresentation(undefined).present).toBe(false)
+    expect(intentPresentation(null).present).toBe(false)
+    expect(intentPresentation({}).present).toBe(false)
+    expect(intentPresentation({ reason: 'orphan reason' }).present).toBe(false)
+  })
+})
+
+// Compact header strip: total plus only the counts that want attention.
+describe('compactSummaryParts', () => {
+  it('shows the total plus non-zero attention counts', () => {
+    const parts = compactSummaryParts({
+      total_count: 54,
+      error_count: 6,
+      blocked_count: 1,
+      rejected_count: 0,
+    })
+    expect(parts.map(p => p.label)).toEqual(['54 calls', '6 errors', '1 blocked'])
+    expect(parts.map(p => p.tone)).toEqual(['muted', 'error', 'warning'])
+  })
+
+  it('omits zero counts entirely rather than printing a reassuring "0 errors"', () => {
+    const parts = compactSummaryParts({ total_count: 12, error_count: 0, blocked_count: 0 })
+    expect(parts).toHaveLength(1)
+    expect(parts[0]).toMatchObject({ key: 'total', label: '12 calls', status: '' })
+  })
+
+  it('gives rejected a neutral tone', () => {
+    const parts = compactSummaryParts({ total_count: 3, rejected_count: 2 })
+    expect(parts[1]).toMatchObject({ key: 'rejected', label: '2 rejected', tone: 'neutral' })
+  })
+
+  it('singularises', () => {
+    expect(compactSummaryParts({ total_count: 1, error_count: 1 }).map(p => p.label))
+      .toEqual(['1 call', '1 error'])
+  })
+
+  it('carries the status each segment filters to', () => {
+    const parts = compactSummaryParts({ total_count: 9, error_count: 1, blocked_count: 1 })
+    expect(parts.map(p => p.status)).toEqual(['', 'error', 'blocked'])
+  })
+
+  it('returns nothing when the summary has not loaded', () => {
+    expect(compactSummaryParts(null)).toEqual([])
+    expect(compactSummaryParts(undefined)).toEqual([])
+  })
+})
+
+// Compact-strip active-filter summary: what is narrowing the list is visible
+// even when the filter grid itself is collapsed.
+describe('activeFilterChips', () => {
+  it('is empty when nothing is filtered', () => {
+    expect(activeFilterChips({})).toEqual([])
+    expect(activeFilterCount({})).toBe(0)
+  })
+
+  it('emits one chip per selected type, icon included', () => {
+    const chips = activeFilterChips({ types: ['tool_call', 'preflight'] })
+    expect(chips.map(c => c.label)).toEqual(['🔧 Tool Call', '🛫 Preflight'])
+    expect(chips.map(c => c.kind)).toEqual(['type', 'type'])
+    expect(chips.map(c => c.value)).toEqual(['tool_call', 'preflight'])
+  })
+
+  it('always includes the sub-call chip, shortening the correlation id', () => {
+    const chips = activeFilterChips({ parentId: 'req-parent-abcdefgh' })
+    expect(chips).toHaveLength(1)
+    expect(chips[0].kind).toBe('parent')
+    expect(chips[0].label).toBe(`↳ Sub-calls of ${shortId('req-parent-abcdefgh')}`)
+    expect(chips[0].title).toContain('req-parent-abcdefgh')
+  })
+
+  it('labels the single-value filters', () => {
+    const chips = activeFilterChips({
+      server: 'github',
+      status: 'error',
+      authType: 'agent',
+      agentName: 'claude',
+      sensitiveData: 'true',
+      severity: 'critical',
+      session: 'sess-0123456789',
+      sessionLabel: 'Claude Code · 14:32',
+      startDate: '',
+      endDate: '',
+    })
+    expect(chips.map(c => c.label)).toEqual([
+      'Server: github',
+      'Status: error',
+      'Auth: 🤖 Agent',
+      'Agent: claude',
+      'Sensitive: ⚠️ Detected',
+      'Severity: critical',
+      'Session: Claude Code · 14:32',
+    ])
+  })
+
+  it('falls back to a shortened session id when no label resolved', () => {
+    const chips = activeFilterChips({ session: 'sess-0123456789' })
+    expect(chips[0].label).toBe(`Session: ${shortId('sess-0123456789')}`)
+  })
+
+  it('counts every active filter for the Filters toggle badge', () => {
+    expect(
+      activeFilterCount({ types: ['tool_call', 'preflight'], server: 'github', parentId: 'req-1' })
+    ).toBe(4)
+  })
+
+  it('keys are unique so the chips can drive a v-for', () => {
+    const chips = activeFilterChips({ types: ['tool_call', 'preflight'], server: 'a', status: 'error' })
+    expect(new Set(chips.map(c => c.key)).size).toBe(chips.length)
+  })
+})
+
+// De-duplication of the code_execution marker: one line, once.
+describe('code_execution marker placement', () => {
+  const PARENT_WITH_TOOL_NAME = {
+    type: 'internal_tool_call',
+    tool_name: 'code_execution',
+    metadata: { internal_tool_name: 'code_execution' },
+  }
+
+  it('reads the Details text a row will print', () => {
+    expect(activityDetailsText(PARENT_WITH_TOOL_NAME)).toBe('code_execution')
+    expect(activityDetailsText({ type: 'server_change', metadata: { action: 'enabled' } })).toBe('enabled')
+    expect(activityDetailsText({ type: 'tool_call' })).toBe('')
+    expect(activityDetailsText(null)).toBe('')
+  })
+
+  it('drops the Type-column badge when Details already says code_execution', () => {
+    expect(showParentBadgeInTypeColumn(PARENT_WITH_TOOL_NAME)).toBe(false)
+  })
+
+  it('keeps the Type-column badge when Details would say nothing', () => {
+    expect(
+      showParentBadgeInTypeColumn({
+        type: 'internal_tool_call',
+        metadata: { internal_tool_name: 'code_execution' },
+      })
+    ).toBe(true)
+  })
+
+  it('never badges a non-parent row', () => {
+    expect(showParentBadgeInTypeColumn({ type: 'tool_call', tool_name: 'code_execution' })).toBe(false)
+    expect(showParentBadgeInTypeColumn(null)).toBe(false)
   })
 })
 


### PR DESCRIPTION
Owner design feedback on the Activity Log page: too colorful, too much chrome.

- **Success is quiet now**: plain muted text — pills only where attention is due (red error, amber blocked, ghost rejected). KPI numbers follow (only errors/blocked colored).
- **No more double "code_execution"**: the Type-cell badge yields when Details already says it; parent rows carry a quiet 🧩 glyph, child "via code_execution" badge restyled ghost.
- **Compact by default**: one summary strip ("54 calls · 6 errors · 1 blocked") + a Filters toggle with an active-count badge; stat cards + filter grid render only when expanded (choice persisted in localStorage, guarded). Active filters always visible as dismissable chips.
- **Intent column earns its width**: icon-only operation glyph + the intent reason text with ellipsis and hover title — the overflowing colored "read" pill is gone.

New pure helpers (statusPresentation, intent/details presentation) in utils/activity.ts with unit tests: 655 vitest green, vue-tsc clean.

Known follow-up: the Playwright sweep spec 04-activity.spec.ts asserts the KPI card is visible on load — needs a toggle click added (spec lives outside frontend/, left untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)