### PR TITLE
feat(webui): make the analytics dashboard the default landing page

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -136,15 +136,15 @@ graph LR
   analytics_token_drain_graphs --> analytics_default_landing
 
   classDef done fill:#1f7a1f,stroke:#0d3d0d,color:#ffffff;
-  classDef todo fill:#6e7781,stroke:#3d4248,color:#ffffff;
+  classDef in_review fill:#9a6700,stroke:#5c3d00,color:#ffffff;
   class analytics_token_drain_graphs done;
-  class analytics_default_landing todo;
+  class analytics_default_landing in_review;
 ```
 
 | Task | Status | Refs |
 | --- | --- | --- |
 | Per-server / per-tool token-drain graphs | 🟢 Done | — |
-| Make dashboard the default landing page | ⚪ Todo | — |
+| Make dashboard the default landing page | 🟡 In review | — |
 
 </details>
 
@@ -804,3 +804,4 @@ Legend: `shipped` ≥95% checked · `in-flight` 1–94% · `drafted` 0% · `—`
 | [098-tools-preflight](./specs/098-tools-preflight/) | `in-flight` | 26/33 (79%) |
 | [099-describe-check-mode](./specs/099-describe-check-mode/) | `in-flight` | 9/10 (90%) |
 | [100-prompt-rugpull-baseline](./specs/100-prompt-rugpull-baseline/) | — | — |
+| [102-schema-deferred](./specs/102-schema-deferred/) | — | — |

--- a/frontend/src/components/SidebarNav.vue
+++ b/frontend/src/components/SidebarNav.vue
@@ -655,9 +655,13 @@ const userInitials = computed(() => {
   return name.substring(0, 2).toUpperCase()
 })
 
+// Dashboard panels are deep-linkable routes that all render the Dashboard, so
+// the "Dashboard" entry stays highlighted on each of them.
+const DASHBOARD_PATHS = ['/', '/usage', '/overview']
+
 function isActiveRoute(path: string): boolean {
   if (path === '/') {
-    return route.path === '/'
+    return DASHBOARD_PATHS.includes(route.path)
   }
   return route.path.startsWith(path)
 }

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -12,12 +12,37 @@ const router = createRouter({
       meta: { title: 'Sign In', public: true },
     },
     // Existing routes (admin/personal)
+    //
+    // The landing page (`/`) opens the Dashboard on its Usage (analytics)
+    // panel — that is the "analytics dashboard as default landing page"
+    // behaviour. `/usage` and `/overview` render the same Dashboard component
+    // so each panel is deep-linkable and survives a reload; `meta.dashboardView`
+    // is what the component reads to pick the active panel.
     {
       path: '/',
       name: 'dashboard',
       component: Dashboard,
       meta: {
         title: 'Dashboard',
+        dashboardView: 'usage',
+      },
+    },
+    {
+      path: '/usage',
+      name: 'usage',
+      component: Dashboard,
+      meta: {
+        title: 'Usage Analytics',
+        dashboardView: 'usage',
+      },
+    },
+    {
+      path: '/overview',
+      name: 'dashboard-overview',
+      component: Dashboard,
+      meta: {
+        title: 'Overview',
+        dashboardView: 'overview',
       },
     },
     {

--- a/frontend/src/stores/servers.ts
+++ b/frontend/src/stores/servers.ts
@@ -95,18 +95,35 @@ export const useServersStore = defineStore('servers', () => {
     return result.sort((a, b) => a.name.localeCompare(b.name))
   }
 
+  // The server list has three independent writers: a fetch from any component
+  // (App.vue and Dashboard.vue both issue one on mount), a silent background
+  // refresh, and the Spec 047 SSE full-list payload. None of them cancel the
+  // others, so every write takes a ticket in issue order and a response that
+  // was already in flight when a newer list was applied is dropped — otherwise
+  // a stale list can resurrect servers the user just deleted, or blank out ones
+  // they just added.
+  let issueSeq = 0
+  let appliedSeq = 0
+
+  function applyServerList(list: Server[], ticket: number) {
+    if (ticket < appliedSeq) return
+    appliedSeq = ticket
+    // Smart merge preserves object references and avoids unnecessary re-renders
+    servers.value = mergeServers(servers.value, list)
+    loaded.value = true
+  }
+
   // Actions
   async function fetchServers(silent = false) {
     if (!silent) {
       loading.value = { loading: true, error: null }
     }
+    const ticket = ++issueSeq
 
     try {
       const response = await api.getServers()
       if (response.success && response.data) {
-        // Use smart merge to preserve object references and avoid unnecessary re-renders
-        servers.value = mergeServers(servers.value, response.data.servers)
-        loaded.value = true
+        applyServerList(response.data.servers, ticket)
       } else {
         loading.value.error = response.error || 'Failed to fetch servers'
       }
@@ -379,7 +396,9 @@ export const useServersStore = defineStore('servers', () => {
     // when running against an older core that publishes notify-only events.
     const payload = customEvent.detail?.payload
     if (payload && Array.isArray(payload.servers)) {
-      servers.value = mergeServers(servers.value, payload.servers as Server[])
+      // Authoritative and newer than anything currently in flight, so it takes
+      // the newest ticket — and it counts as a successful load in its own right.
+      applyServerList(payload.servers as Server[], ++issueSeq)
       return
     }
 

--- a/frontend/src/stores/servers.ts
+++ b/frontend/src/stores/servers.ts
@@ -9,6 +9,14 @@ export const useServersStore = defineStore('servers', () => {
   const servers = ref<Server[]>([])
   const loading = ref<LoadingState>({ loading: false, error: null })
 
+  // True once a server list has been fetched successfully at least once — the
+  // only reliable way to tell "no servers configured" from "we don't know yet".
+  // `servers` starts empty, and `loading.error` cannot stand in for this: it is
+  // shared state that any caller (including silent background refreshes and
+  // other components fetching concurrently) can write, and a success never
+  // clears it.
+  const loaded = ref(false)
+
   // Computed
   const serverCount = computed(() => ({
     total: servers.value.length,
@@ -98,6 +106,7 @@ export const useServersStore = defineStore('servers', () => {
       if (response.success && response.data) {
         // Use smart merge to preserve object references and avoid unnecessary re-renders
         servers.value = mergeServers(servers.value, response.data.servers)
+        loaded.value = true
       } else {
         loading.value.error = response.error || 'Failed to fetch servers'
       }
@@ -392,6 +401,7 @@ export const useServersStore = defineStore('servers', () => {
     // State
     servers,
     loading,
+    loaded,
 
     // Computed
     serverCount,

--- a/frontend/src/stores/servers.ts
+++ b/frontend/src/stores/servers.ts
@@ -335,8 +335,14 @@ export const useServersStore = defineStore('servers', () => {
     try {
       const response = await api.deleteServer(serverName)
       if (response.success) {
-        // Remove server from local state
-        servers.value = servers.value.filter(s => s.name !== serverName)
+        // Removing the server locally is itself an authoritative list state, so
+        // it claims the newest ticket: a GET that was already in flight when the
+        // delete landed would otherwise pass the sequencing check and restore
+        // the server the user just deleted.
+        applyServerList(
+          servers.value.filter(s => s.name !== serverName),
+          ++issueSeq
+        )
         return true
       } else {
         throw new Error(response.error || 'Failed to delete server')

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -6,15 +6,10 @@
     <!-- Upgrade nudge (Spec 079): dismissible per-version update banner -->
     <UpdateBanner />
 
-    <!-- Overview ↔ Usage switcher (Spec 069 T016) -->
+    <!-- Usage ↔ Overview switcher (Spec 069 T016). Usage is the default panel
+         (analytics-as-landing-page); each tab maps to a deep-linkable route
+         (/usage, /overview) so the panel survives a reload or a shared link. -->
     <div role="tablist" class="tabs tabs-boxed w-fit" data-test="dashboard-view-switcher">
-      <a
-        role="tab"
-        class="tab"
-        :class="activeView === 'overview' ? 'tab-active' : ''"
-        data-test="dashboard-tab-overview"
-        @click="activeView = 'overview'"
-      >Overview</a>
       <a
         role="tab"
         class="tab"
@@ -22,15 +17,59 @@
         data-test="dashboard-tab-usage"
         @click="selectUsage"
       >Usage</a>
+      <a
+        role="tab"
+        class="tab"
+        :class="activeView === 'overview' ? 'tab-active' : ''"
+        data-test="dashboard-tab-overview"
+        @click="selectOverview"
+      >Overview</a>
     </div>
 
     <!-- Usage view: the panel wrapper is always in the DOM (kept hidden with
          v-show so switching back is instant and the Overview subtree is never
          torn down, SC-006). The heavy chart bundle + the usage fetch inside
-         UsageView are lazy-mounted only on first switch (v-if="usageEverActive")
-         so they never block Dashboard first paint (SC-004). -->
+         UsageView are mounted only once the panel has been active
+         (v-if="usageEverActive") and stay code-split behind Suspense, so the
+         Dashboard shell still paints immediately (SC-004). -->
     <div v-show="activeView === 'usage'" data-test="dashboard-usage-panel">
-      <Suspense v-if="usageEverActive">
+      <!-- First run: no upstream servers configured, so the analytics panel
+           would only ever show "no data". Point the new user at the one action
+           that makes the dashboard useful instead. -->
+      <div
+        v-if="showFirstRunCta"
+        class="card bg-base-200 border border-base-300"
+        data-test="dashboard-usage-first-run"
+      >
+        <div class="card-body items-center text-center py-12">
+          <svg class="w-12 h-12 opacity-40" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+          </svg>
+          <h3 class="font-semibold text-lg mt-2">Add your first server to see usage</h3>
+          <p class="text-sm opacity-60 max-w-md">
+            No upstream MCP servers are configured yet, so there is nothing to chart.
+            Add one and this page will show call volume, token sinks, error rates and a timeline.
+          </p>
+          <div class="flex flex-wrap gap-2 justify-center mt-2">
+            <button
+              class="btn btn-primary btn-sm"
+              data-test="dashboard-first-run-add-server"
+              @click="showAddServer = true"
+            >
+              Add your first server
+            </button>
+            <router-link to="/repositories" class="btn btn-sm btn-ghost">Browse Registry</router-link>
+            <button
+              class="btn btn-sm btn-ghost"
+              data-test="dashboard-first-run-overview"
+              @click="selectOverview"
+            >
+              Go to Overview
+            </button>
+          </div>
+        </div>
+      </div>
+      <Suspense v-else-if="usageEverActive">
         <UsageView />
         <template #fallback>
           <div class="flex justify-center py-16"><span class="loading loading-spinner loading-lg"></span></div>
@@ -426,6 +465,7 @@
 <script setup lang="ts">
 import { serverDetailPath } from '@/utils/serverRoute'
 import { computed, ref, watch, onMounted, onUnmounted, defineAsyncComponent } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { useServersStore } from '@/stores/servers'
 import { useSystemStore } from '@/stores/system'
 import { useSecurityScannerStatus, refreshSecurityScannerStatus } from '@/composables/useSecurityScannerStatus'
@@ -450,14 +490,49 @@ const serversStore = useServersStore()
 const systemStore = useSystemStore()
 const onboardingStore = useOnboardingStore()
 
-// Overview ↔ Usage switcher state (Spec 069 T016). `usageEverActive` gates the
+// Usage ↔ Overview switcher state (Spec 069 T016). `usageEverActive` gates the
 // first mount; `activeView` then toggles via v-show so both panels keep state.
-const activeView = ref<'overview' | 'usage'>('overview')
-const usageEverActive = ref(false)
-function selectUsage() {
-  usageEverActive.value = true
-  activeView.value = 'usage'
+//
+// The active panel comes from the route (`meta.dashboardView`): `/` and
+// `/usage` land on the analytics panel, `/overview` on the hub overview.
+// Clicking a tab rewrites the URL (replace, so the switcher does not pile up
+// history entries) — the routes share this component, so switching never
+// remounts the Dashboard and both panels keep their state.
+type DashboardView = 'overview' | 'usage'
+
+const route = useRoute()
+const router = useRouter()
+
+function routeView(): DashboardView {
+  return (route.meta?.dashboardView as DashboardView | undefined) === 'overview' ? 'overview' : 'usage'
 }
+
+const activeView = ref<DashboardView>(routeView())
+const usageEverActive = ref(activeView.value === 'usage')
+
+function selectView(view: DashboardView) {
+  if (view === 'usage') {
+    usageEverActive.value = true
+  }
+  activeView.value = view
+  const targetRoute = view === 'usage' ? 'usage' : 'dashboard-overview'
+  // `/` is also a usage route — don't rewrite it to `/usage` needlessly.
+  if (routeView() !== view) {
+    void router.replace({ name: targetRoute })
+  }
+}
+const selectUsage = () => selectView('usage')
+const selectOverview = () => selectView('overview')
+
+// Keep the panel in sync when the route changes underneath us (sidebar link,
+// browser back/forward, a pasted deep link).
+watch(() => route.meta?.dashboardView, () => {
+  const view = routeView()
+  if (view === 'usage') {
+    usageEverActive.value = true
+  }
+  activeView.value = view
+})
 
 // Modal state
 const showConnectModal = ref(false)
@@ -623,6 +698,12 @@ const loadTokenSavings = async () => {
     // Silently fail
   }
 }
+
+// --- First run (no servers configured) ---
+// Gated on a completed fetch so the CTA never flashes before the server list
+// has arrived.
+const serversLoaded = ref(false)
+const showFirstRunCta = computed(() => serversLoaded.value && serversStore.serverCount.total === 0)
 
 // --- Disabled server count ---
 const disabledCount = computed(() => {
@@ -839,7 +920,10 @@ onMounted(() => {
   loadSecurityStatus()
   // Populate security scanner totals for the Security Scan chip (F-12).
   void refreshSecurityScannerStatus()
-  serversStore.fetchServers().then(() => loadPendingTools())
+  serversStore.fetchServers().then(() => {
+    serversLoaded.value = true
+    loadPendingTools()
+  })
 
   // Auto-refresh every 30 seconds
   refreshInterval = setInterval(() => {

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -30,8 +30,9 @@
          v-show so switching back is instant and the Overview subtree is never
          torn down, SC-006). The heavy chart bundle + the usage fetch inside
          UsageView are mounted only once the panel has been active
-         (v-if="usageEverActive") and stay code-split behind Suspense, so the
-         Dashboard shell still paints immediately (SC-004). -->
+         (usageEverActive) AND the server list has arrived, and stay code-split
+         behind Suspense, so the Dashboard shell still paints immediately
+         (SC-004). -->
     <div v-show="activeView === 'usage'" data-test="dashboard-usage-panel">
       <!-- First run: no upstream servers configured, so the analytics panel
            would only ever show "no data". Point the new user at the one action
@@ -68,6 +69,14 @@
             </button>
           </div>
         </div>
+      </div>
+      <!-- Hold the charts back until the server list has arrived: mounting
+           UsageView first would fire a usage aggregate request and flash the
+           "no usage data yet" card on a fresh install, only to be replaced by
+           the CTA above a moment later. Both requests are issued together in
+           onMounted, so this costs no extra round-trip. -->
+      <div v-else-if="!serversLoaded" class="flex justify-center py-16" data-test="dashboard-usage-pending">
+        <span class="loading loading-spinner loading-lg"></span>
       </div>
       <Suspense v-else-if="usageEverActive">
         <UsageView />
@@ -510,16 +519,31 @@ function routeView(): DashboardView {
 const activeView = ref<DashboardView>(routeView())
 const usageEverActive = ref(activeView.value === 'usage')
 
+// The panel a navigation is currently heading for. `route` only reflects a
+// *confirmed* navigation, so comparing against it alone loses a fast second tab
+// click: it would still see the pre-navigation route, decide it has nothing to
+// do, and then be overwritten when the first navigation lands. Tracking the
+// in-flight target makes the newest click win — the router cancels the
+// superseded navigation for us.
+let pendingView: DashboardView | null = null
+
 function selectView(view: DashboardView) {
   if (view === 'usage') {
     usageEverActive.value = true
   }
   activeView.value = view
-  const targetRoute = view === 'usage' ? 'usage' : 'dashboard-overview'
   // `/` is also a usage route — don't rewrite it to `/usage` needlessly.
-  if (routeView() !== view) {
-    void router.replace({ name: targetRoute })
+  if ((pendingView ?? routeView()) === view) {
+    return
   }
+  pendingView = view
+  const targetRoute = view === 'usage' ? 'usage' : 'dashboard-overview'
+  void router.replace({ name: targetRoute }).finally(() => {
+    // Only the newest navigation clears the marker; a superseded one must not.
+    if (pendingView === view) {
+      pendingView = null
+    }
+  })
 }
 const selectUsage = () => selectView('usage')
 const selectOverview = () => selectView('overview')
@@ -701,9 +725,14 @@ const loadTokenSavings = async () => {
 
 // --- First run (no servers configured) ---
 // Gated on a completed fetch so the CTA never flashes before the server list
-// has arrived.
+// has arrived. `fetchServers` swallows transport failures (it records them on
+// `loading.error` and leaves `servers` untouched), so a failed request would
+// otherwise look identical to "zero servers configured" and tell a user with a
+// full server list that they have none — hence the explicit error check.
 const serversLoaded = ref(false)
-const showFirstRunCta = computed(() => serversLoaded.value && serversStore.serverCount.total === 0)
+const showFirstRunCta = computed(
+  () => serversLoaded.value && !serversStore.loading.error && serversStore.serverCount.total === 0
+)
 
 // --- Disabled server count ---
 const disabledCount = computed(() => {

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -525,7 +525,14 @@ const usageEverActive = ref(activeView.value === 'usage')
 // do, and then be overwritten when the first navigation lands. Tracking the
 // in-flight target makes the newest click win — the router cancels the
 // superseded navigation for us.
+//
+// `navSeq` identifies which navigation owns the marker. Comparing the panel
+// value alone is not enough: two navigations to the same panel (Overview →
+// Usage → Overview) share a value, so the older one's settlement would clear a
+// marker still owned by the newer one, and the next click would again compare
+// against the stale current route and be swallowed.
 let pendingView: DashboardView | null = null
+let navSeq = 0
 
 function selectView(view: DashboardView) {
   if (view === 'usage') {
@@ -536,11 +543,12 @@ function selectView(view: DashboardView) {
   if ((pendingView ?? routeView()) === view) {
     return
   }
+  const seq = ++navSeq
   pendingView = view
   const targetRoute = view === 'usage' ? 'usage' : 'dashboard-overview'
   void router.replace({ name: targetRoute }).finally(() => {
     // Only the newest navigation clears the marker; a superseded one must not.
-    if (pendingView === view) {
+    if (seq === navSeq) {
       pendingView = null
     }
   })
@@ -730,8 +738,9 @@ const loadTokenSavings = async () => {
 // otherwise look identical to "zero servers configured" and tell a user with a
 // full server list that they have none — hence the explicit error check.
 const serversLoaded = ref(false)
+const serversLoadFailed = ref(false)
 const showFirstRunCta = computed(
-  () => serversLoaded.value && !serversStore.loading.error && serversStore.serverCount.total === 0
+  () => serversLoaded.value && !serversLoadFailed.value && serversStore.serverCount.total === 0
 )
 
 // --- Disabled server count ---
@@ -950,6 +959,11 @@ onMounted(() => {
   // Populate security scanner totals for the Security Scan chip (F-12).
   void refreshSecurityScannerStatus()
   serversStore.fetchServers().then(() => {
+    // Snapshot the outcome of *this* fetch rather than reading the store's
+    // shared `loading.error` live: silent background refreshes write that field
+    // too and never clear it on success, so a live read would let one transient
+    // failure suppress the first-run CTA for the rest of the session.
+    serversLoadFailed.value = Boolean(serversStore.loading.error)
     serversLoaded.value = true
     loadPendingTools()
   })
@@ -966,7 +980,9 @@ onMounted(() => {
   }, 30000)
 
   systemStore.connectEventSource()
-  serversStore.fetchServers()
+  // NOTE: no second fetchServers() here — it duplicated the request issued
+  // above and, being unsequenced against it, made the first-run gate depend on
+  // which of the two responses landed last.
 
   // Adaptive onboarding wizard (Spec 046): auto-show on first Web UI load
   // when the user has not yet engaged with the wizard and at least one

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -75,7 +75,7 @@
            "no usage data yet" card on a fresh install, only to be replaced by
            the CTA above a moment later. Both requests are issued together in
            onMounted, so this costs no extra round-trip. -->
-      <div v-else-if="!serversLoaded" class="flex justify-center py-16" data-test="dashboard-usage-pending">
+      <div v-else-if="!serversFetchSettled" class="flex justify-center py-16" data-test="dashboard-usage-pending">
         <span class="loading loading-spinner loading-lg"></span>
       </div>
       <Suspense v-else-if="usageEverActive">
@@ -732,15 +732,21 @@ const loadTokenSavings = async () => {
 }
 
 // --- First run (no servers configured) ---
-// Gated on a completed fetch so the CTA never flashes before the server list
-// has arrived. `fetchServers` swallows transport failures (it records them on
-// `loading.error` and leaves `servers` untouched), so a failed request would
-// otherwise look identical to "zero servers configured" and tell a user with a
-// full server list that they have none — hence the explicit error check.
-const serversLoaded = ref(false)
-const serversLoadFailed = ref(false)
+// Two different questions, deliberately answered by two different flags:
+//
+// `serversFetchSettled` — has our own initial request finished, successfully or
+// not? It gates the chart mount below, so a failed fetch falls through to the
+// usage panel rather than spinning forever.
+//
+// `serversStore.loaded` — has a server list ever arrived successfully? Only
+// that justifies telling the user they have no servers. It cannot be inferred
+// from `loading.error`: that field is shared, other components (App.vue) and
+// silent background refreshes write it concurrently, and a success never clears
+// it — so an unrelated failure would suppress the CTA, and a later successful
+// refresh could never bring it back.
+const serversFetchSettled = ref(false)
 const showFirstRunCta = computed(
-  () => serversLoaded.value && !serversLoadFailed.value && serversStore.serverCount.total === 0
+  () => serversStore.loaded && serversStore.serverCount.total === 0
 )
 
 // --- Disabled server count ---
@@ -959,12 +965,7 @@ onMounted(() => {
   // Populate security scanner totals for the Security Scan chip (F-12).
   void refreshSecurityScannerStatus()
   serversStore.fetchServers().then(() => {
-    // Snapshot the outcome of *this* fetch rather than reading the store's
-    // shared `loading.error` live: silent background refreshes write that field
-    // too and never clear it on success, so a live read would let one transient
-    // failure suppress the first-run CTA for the rest of the session.
-    serversLoadFailed.value = Boolean(serversStore.loading.error)
-    serversLoaded.value = true
+    serversFetchSettled.value = true
     loadPendingTools()
   })
 

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -75,7 +75,11 @@
            "no usage data yet" card on a fresh install, only to be replaced by
            the CTA above a moment later. Both requests are issued together in
            onMounted, so this costs no extra round-trip. -->
-      <div v-else-if="!serversFetchSettled" class="flex justify-center py-16" data-test="dashboard-usage-pending">
+      <div
+        v-else-if="!serversFetchSettled && !serversStore.loaded"
+        class="flex justify-center py-16"
+        data-test="dashboard-usage-pending"
+      >
         <span class="loading loading-spinner loading-lg"></span>
       </div>
       <Suspense v-else-if="usageEverActive">
@@ -735,8 +739,9 @@ const loadTokenSavings = async () => {
 // Two different questions, deliberately answered by two different flags:
 //
 // `serversFetchSettled` — has our own initial request finished, successfully or
-// not? It gates the chart mount below, so a failed fetch falls through to the
-// usage panel rather than spinning forever.
+// not? Together with `loaded` it gates the chart mount below, so a failed fetch
+// falls through to the usage panel rather than spinning forever, and an
+// authoritative list arriving by SSE first clears the spinner immediately.
 //
 // `serversStore.loaded` — has a server list ever arrived successfully? Only
 // that justifies telling the user they have no servers. It cannot be inferred

--- a/frontend/src/views/Usage.vue
+++ b/frontend/src/views/Usage.vue
@@ -170,7 +170,14 @@ const freshnessLabel = computed(() => {
   return `${Math.round(ms / 60_000)}m ago`
 })
 
+// Requests can overlap — the 30s auto-refresh, a window switch and a filter
+// reset all call reload() and there is no cancellation. Without sequencing, a
+// slower earlier response can land last and repaint the panel with data for a
+// window the user already moved off. Only the newest request may write state.
+let reloadSeq = 0
+
 async function reload() {
+  const seq = ++reloadSeq
   loading.value = true
   error.value = null
   try {
@@ -179,15 +186,20 @@ async function reload() {
       status: status.value || undefined,
       sort: sort.value,
     })
+    if (seq !== reloadSeq) return
     if (resp.success && resp.data) {
       data.value = resp.data
     } else {
       error.value = resp.error || 'Failed to load usage data'
     }
   } catch (e) {
+    if (seq !== reloadSeq) return
     error.value = e instanceof Error ? e.message : 'Failed to load usage data'
   } finally {
-    loading.value = false
+    // A superseded request must not clear the spinner the newest one owns.
+    if (seq === reloadSeq) {
+      loading.value = false
+    }
   }
 }
 

--- a/frontend/tests/unit/dashboard-default-landing.spec.ts
+++ b/frontend/tests/unit/dashboard-default-landing.spec.ts
@@ -204,4 +204,42 @@ describe('analytics dashboard as the default landing page', () => {
     expect(wrapper.find('[data-test="dashboard-usage-first-run"]').exists()).toBe(false)
     expect(wrapper.find('[data-test="usage-view-stub"]').exists()).toBe(true)
   })
+
+  it('does not claim "no servers" when the server list request failed', async () => {
+    // `fetchServers` swallows failures: it records the error and leaves the
+    // (empty) server list alone, so a transport error must not be mistaken for
+    // a fresh install and tell a user with servers that they have none.
+    serversSpy.mockResolvedValue({ success: false, error: 'boom' })
+    const { wrapper } = await mountDashboard('/')
+
+    expect(wrapper.find('[data-test="dashboard-usage-first-run"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="usage-view-stub"]').exists()).toBe(true)
+  })
+
+  it('holds the charts back until the server list has arrived', async () => {
+    // Never-resolving fetch: the usage panel must show a spinner rather than
+    // mounting UsageView (which would fire a request and flash "no usage data
+    // yet" before the first-run CTA replaces it).
+    serversSpy.mockReturnValue(new Promise(() => {}))
+    const { wrapper } = await mountDashboard('/')
+
+    expect(wrapper.find('[data-test="dashboard-usage-pending"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="usage-view-stub"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="dashboard-usage-first-run"]').exists()).toBe(false)
+  })
+
+  it('honours the last tab clicked when two clicks land before navigation settles', async () => {
+    const { wrapper, router } = await mountDashboard('/')
+
+    // No awaits between the clicks: the Overview navigation is still in flight
+    // when Usage is clicked, so the second click must not be swallowed by a
+    // comparison against the not-yet-updated current route.
+    wrapper.find('[data-test="dashboard-tab-overview"]').trigger('click')
+    wrapper.find('[data-test="dashboard-tab-usage"]').trigger('click')
+    await flushPromises()
+
+    expect(router.currentRoute.value.path).toBe('/usage')
+    expect(wrapper.find('[data-test="dashboard-usage-panel"]').isVisible()).toBe(true)
+    expect(wrapper.find('[data-test="dashboard-overview-panel"]').isVisible()).toBe(false)
+  })
 })

--- a/frontend/tests/unit/dashboard-default-landing.spec.ts
+++ b/frontend/tests/unit/dashboard-default-landing.spec.ts
@@ -229,6 +229,22 @@ describe('analytics dashboard as the default landing page', () => {
     expect(wrapper.find('[data-test="dashboard-usage-first-run"]').exists()).toBe(false)
   })
 
+  it('clears the chart spinner when the list arrives by SSE before the fetch settles', async () => {
+    serversSpy.mockReturnValue(new Promise(() => {}))
+    const { wrapper } = await mountDashboard('/')
+    expect(wrapper.find('[data-test="dashboard-usage-pending"]').exists()).toBe(true)
+
+    window.dispatchEvent(
+      new CustomEvent('mcpproxy:servers-changed', {
+        detail: { payload: { servers: [{ name: 'srv-a', enabled: true, connected: true }] } },
+      })
+    )
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="dashboard-usage-pending"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="usage-view-stub"]').exists()).toBe(true)
+  })
+
   it('honours the last tab clicked when two clicks land before navigation settles', async () => {
     const { wrapper, router } = await mountDashboard('/')
 

--- a/frontend/tests/unit/dashboard-default-landing.spec.ts
+++ b/frontend/tests/unit/dashboard-default-landing.spec.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ref } from 'vue'
+import { shallowMount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createRouter, createMemoryHistory } from 'vue-router'
+
+// Roadmap analytics-dashboard / analytics-default-landing: the analytics
+// (Usage) panel of the Dashboard is what the Web UI lands on. `/` and `/usage`
+// open the analytics panel, `/overview` stays deep-linkable for the hub
+// overview, and a brand-new install (zero upstream servers) gets an
+// "add your first server" CTA instead of an empty chart grid.
+
+const serversSpy = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ success: true, data: { servers: [] } })
+)
+
+const usageSpy = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    success: true,
+    data: { window: '24h', tokens_saved: 0, tokens_saved_percentage: 0, tools: [], timeline: [] },
+  })
+)
+
+vi.mock('@/services/api', () => {
+  const ok = (data: unknown = null) => vi.fn().mockResolvedValue({ success: true, data })
+  const fakeEventSource = {
+    onopen: null,
+    onmessage: null,
+    onerror: null,
+    addEventListener() {},
+    removeEventListener() {},
+    close() {},
+  }
+  const base: Record<string, unknown> = {
+    getServers: serversSpy,
+    getActivityUsage: usageSpy,
+    createEventSource: vi.fn(() => fakeEventSource),
+    hasAPIKey: vi.fn(() => true),
+    getAPIKeyPreview: vi.fn(() => 'test…'),
+    onAuthError: vi.fn(() => () => {}),
+  }
+  return {
+    default: new Proxy(base, {
+      get(target: Record<string, unknown>, prop: string) {
+        if (prop in target) return target[prop]
+        target[prop] = ok()
+        return target[prop]
+      },
+    }),
+  }
+})
+
+vi.mock('@/composables/useSecurityScannerStatus', () => ({
+  refreshSecurityScannerStatus: vi.fn().mockResolvedValue(undefined),
+  useSecurityScannerStatus: () => ({
+    totalFindings: ref(0),
+    totalScans: ref(0),
+    loaded: ref(true),
+  }),
+}))
+
+import Dashboard from '@/views/Dashboard.vue'
+import appRouter from '@/router'
+
+class FakeEventSource {
+  close() {}
+  addEventListener() {}
+  onmessage: ((e: unknown) => void) | null = null
+  onerror: ((e: unknown) => void) | null = null
+}
+
+function makeRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', name: 'dashboard', component: Dashboard, meta: { dashboardView: 'usage' } },
+      { path: '/usage', name: 'usage', component: Dashboard, meta: { dashboardView: 'usage' } },
+      { path: '/overview', name: 'dashboard-overview', component: Dashboard, meta: { dashboardView: 'overview' } },
+      { path: '/repositories', name: 'repositories', component: { template: '<div />' } },
+      { path: '/:pathMatch(.*)*', name: 'other', component: { template: '<div />' } },
+    ],
+  })
+}
+
+async function mountDashboard(path = '/') {
+  const router = makeRouter()
+  router.push(path)
+  await router.isReady()
+  const wrapper = shallowMount(Dashboard, {
+    global: {
+      plugins: [createPinia(), router],
+      stubs: {
+        RouterLink: { template: '<a><slot /></a>' },
+        // Keep the lazy Usage panel as an inert stub — this suite is about the
+        // landing panel and the first-run CTA, not the charts.
+        Suspense: false,
+        UsageView: { template: '<div data-test="usage-view-stub" />' },
+      },
+    },
+  })
+  await flushPromises()
+  return { wrapper, router }
+}
+
+describe('analytics dashboard as the default landing page', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    usageSpy.mockClear()
+    serversSpy.mockClear()
+    serversSpy.mockResolvedValue({ success: true, data: { servers: [] } })
+    ;(globalThis as unknown as { EventSource: unknown }).EventSource = FakeEventSource
+  })
+
+  it('routes "/" to the Dashboard on its usage panel, with /usage and /overview deep-linkable', () => {
+    const root = appRouter.resolve('/')
+    expect(root.name).toBe('dashboard')
+    expect(root.meta.dashboardView).toBe('usage')
+
+    const usage = appRouter.resolve('/usage')
+    expect(usage.meta.dashboardView).toBe('usage')
+    expect(usage.matched[0].components?.default).toBe(root.matched[0].components?.default)
+
+    const overview = appRouter.resolve('/overview')
+    expect(overview.name).toBe('dashboard-overview')
+    expect(overview.meta.dashboardView).toBe('overview')
+    expect(overview.matched[0].components?.default).toBe(root.matched[0].components?.default)
+  })
+
+  it('shows the usage panel (not the overview) when landing on "/"', async () => {
+    serversSpy.mockResolvedValue({
+      success: true,
+      data: { servers: [{ name: 'srv-a', enabled: true, connected: true }] },
+    })
+    const { wrapper } = await mountDashboard('/')
+
+    expect(wrapper.find('[data-test="dashboard-usage-panel"]').isVisible()).toBe(true)
+    expect(wrapper.find('[data-test="dashboard-overview-panel"]').isVisible()).toBe(false)
+    expect(wrapper.find('[data-test="usage-view-stub"]').exists()).toBe(true)
+  })
+
+  it('honours a /overview deep link', async () => {
+    serversSpy.mockResolvedValue({
+      success: true,
+      data: { servers: [{ name: 'srv-a', enabled: true, connected: true }] },
+    })
+    const { wrapper } = await mountDashboard('/overview')
+
+    expect(wrapper.find('[data-test="dashboard-overview-panel"]').isVisible()).toBe(true)
+    expect(wrapper.find('[data-test="dashboard-usage-panel"]').isVisible()).toBe(false)
+  })
+
+  it('rewrites the URL when the tabs are used, so the panel survives a reload', async () => {
+    const { wrapper, router } = await mountDashboard('/')
+
+    await wrapper.find('[data-test="dashboard-tab-overview"]').trigger('click')
+    await flushPromises()
+    expect(router.currentRoute.value.path).toBe('/overview')
+
+    await wrapper.find('[data-test="dashboard-tab-usage"]').trigger('click')
+    await flushPromises()
+    expect(router.currentRoute.value.path).toBe('/usage')
+  })
+
+  it('follows the route when it changes underneath the component', async () => {
+    const { wrapper, router } = await mountDashboard('/')
+
+    await router.push('/overview')
+    await flushPromises()
+    expect(wrapper.find('[data-test="dashboard-overview-panel"]').isVisible()).toBe(true)
+
+    await router.push('/')
+    await flushPromises()
+    expect(wrapper.find('[data-test="dashboard-usage-panel"]').isVisible()).toBe(true)
+  })
+
+  it('shows an "add your first server" CTA instead of empty charts on a fresh install', async () => {
+    const { wrapper } = await mountDashboard('/')
+
+    const cta = wrapper.find('[data-test="dashboard-usage-first-run"]')
+    expect(cta.exists()).toBe(true)
+    expect(cta.text()).toContain('Add your first server')
+    // The chart panel is not rendered (and no usage aggregate is fetched)
+    // while there is nothing to chart.
+    expect(wrapper.find('[data-test="usage-view-stub"]').exists()).toBe(false)
+  })
+
+  it('offers a one-click escape to the Overview panel from the first-run CTA', async () => {
+    const { wrapper, router } = await mountDashboard('/')
+
+    await wrapper.find('[data-test="dashboard-first-run-overview"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="dashboard-overview-panel"]').isVisible()).toBe(true)
+    expect(router.currentRoute.value.path).toBe('/overview')
+  })
+
+  it('renders the usage panel once at least one server is configured', async () => {
+    serversSpy.mockResolvedValue({
+      success: true,
+      data: { servers: [{ name: 'srv-a', enabled: true, connected: true }] },
+    })
+    const { wrapper } = await mountDashboard('/')
+
+    expect(wrapper.find('[data-test="dashboard-usage-first-run"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="usage-view-stub"]').exists()).toBe(true)
+  })
+})

--- a/frontend/tests/unit/dashboard-default-landing.spec.ts
+++ b/frontend/tests/unit/dashboard-default-landing.spec.ts
@@ -268,14 +268,32 @@ describe('analytics dashboard as the default landing page', () => {
     expect(serversSpy).toHaveBeenCalledTimes(1)
   })
 
-  it('keeps the CTA available after a later background refresh fails', async () => {
-    // The store's shared `loading.error` is written by silent refreshes and is
-    // never cleared on success, so the gate must not read it live.
+  it('keeps the CTA available when an unrelated fetch reports an error', async () => {
+    // `loading.error` is shared: App.vue fetches concurrently on mount and
+    // silent background refreshes write the field too (and never clear it on
+    // success). A failure that is not ours must not suppress the CTA.
     const { wrapper } = await mountDashboard('/')
     expect(wrapper.find('[data-test="dashboard-usage-first-run"]').exists()).toBe(true)
 
     const store = useServersStore()
     store.loading.error = 'transient background failure'
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="dashboard-usage-first-run"]').exists()).toBe(true)
+  })
+
+  it('shows the CTA once a later refresh succeeds after a failed initial fetch', async () => {
+    serversSpy.mockResolvedValue({ success: false, error: 'boom' })
+    const { wrapper } = await mountDashboard('/')
+
+    // Initial fetch failed: no CTA (we do not know the server count), and the
+    // usage panel is shown rather than an endless spinner.
+    expect(wrapper.find('[data-test="dashboard-usage-first-run"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="dashboard-usage-pending"]').exists()).toBe(false)
+
+    // A background refresh then succeeds and confirms there are no servers.
+    serversSpy.mockResolvedValue({ success: true, data: { servers: [] } })
+    await useServersStore().fetchServers(true)
     await flushPromises()
 
     expect(wrapper.find('[data-test="dashboard-usage-first-run"]').exists()).toBe(true)

--- a/frontend/tests/unit/dashboard-default-landing.spec.ts
+++ b/frontend/tests/unit/dashboard-default-landing.spec.ts
@@ -61,6 +61,7 @@ vi.mock('@/composables/useSecurityScannerStatus', () => ({
 
 import Dashboard from '@/views/Dashboard.vue'
 import appRouter from '@/router'
+import { useServersStore } from '@/stores/servers'
 
 class FakeEventSource {
   close() {}
@@ -241,5 +242,42 @@ describe('analytics dashboard as the default landing page', () => {
     expect(router.currentRoute.value.path).toBe('/usage')
     expect(wrapper.find('[data-test="dashboard-usage-panel"]').isVisible()).toBe(true)
     expect(wrapper.find('[data-test="dashboard-overview-panel"]').isVisible()).toBe(false)
+  })
+
+  it('ends on the last tab clicked after a burst that revisits the same panel', async () => {
+    // Overview → Usage → Overview → Usage in one burst. Guards the end state
+    // only; the marker-ownership rule that makes this hold under a slow async
+    // router guard is enforced by construction (navSeq in Dashboard.vue), which
+    // vue-router's abort ordering cannot be faithfully staged from here.
+    const { wrapper, router } = await mountDashboard('/')
+
+    wrapper.find('[data-test="dashboard-tab-overview"]').trigger('click')
+    wrapper.find('[data-test="dashboard-tab-usage"]').trigger('click')
+    wrapper.find('[data-test="dashboard-tab-overview"]').trigger('click')
+    wrapper.find('[data-test="dashboard-tab-usage"]').trigger('click')
+    await flushPromises()
+
+    expect(router.currentRoute.value.path).toBe('/usage')
+    expect(wrapper.find('[data-test="dashboard-usage-panel"]').isVisible()).toBe(true)
+  })
+
+  it('fetches the server list exactly once on mount', async () => {
+    // Two unsequenced fetches made the first-run gate depend on which response
+    // landed last (one could succeed with zero servers while the other failed).
+    await mountDashboard('/')
+    expect(serversSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the CTA available after a later background refresh fails', async () => {
+    // The store's shared `loading.error` is written by silent refreshes and is
+    // never cleared on success, so the gate must not read it live.
+    const { wrapper } = await mountDashboard('/')
+    expect(wrapper.find('[data-test="dashboard-usage-first-run"]').exists()).toBe(true)
+
+    const store = useServersStore()
+    store.loading.error = 'transient background failure'
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="dashboard-usage-first-run"]').exists()).toBe(true)
   })
 })

--- a/frontend/tests/unit/dashboard-usage-switcher.spec.ts
+++ b/frontend/tests/unit/dashboard-usage-switcher.spec.ts
@@ -2,12 +2,16 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { ref } from 'vue'
 import { shallowMount, flushPromises } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
+import { createRouter, createMemoryHistory } from 'vue-router'
 
-// Spec 069 B1 (T016): Dashboard carries an Overview↔Usage switcher. Overview
-// state must survive a switch-back (SC-006 → rendered with v-show, never v-if),
-// the Usage aggregate must be fetched lazily on first activation (SC-004, so
-// the Overview first paint is never blocked) and re-fetched when the window
+// Spec 069 B1 (T016): Dashboard carries a Usage↔Overview switcher. Both panels
+// stay in the DOM (SC-006 → rendered with v-show, never v-if) so switching
+// preserves their state, and the usage aggregate is re-fetched when the window
 // selector (24h/7d/all) changes.
+//
+// Usage is now the default panel (analytics dashboard as the default landing
+// page), so the aggregate is fetched on mount rather than on first activation;
+// it stays code-split behind Suspense so the Dashboard shell paints first.
 
 const usageSpy = vi.hoisted(() =>
   vi.fn().mockResolvedValue({
@@ -32,6 +36,9 @@ vi.mock('@/services/api', () => {
   }
   const base: Record<string, unknown> = {
     getActivityUsage: usageSpy,
+    // One configured server, so the Dashboard renders the real usage panel
+    // rather than the zero-servers first-run CTA.
+    getServers: ok({ servers: [{ name: 'srv-a', enabled: true, connected: true, tool_count: 1 }] }),
     createEventSource: vi.fn(() => fakeEventSource),
     hasAPIKey: vi.fn(() => true),
     getAPIKeyPreview: vi.fn(() => 'test…'),
@@ -74,10 +81,26 @@ class FakeEventSource {
   onerror: ((e: unknown) => void) | null = null
 }
 
-function mountDashboard() {
+// The switcher rewrites the URL, so the component needs a real router.
+function makeRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', name: 'dashboard', component: Dashboard, meta: { dashboardView: 'usage' } },
+      { path: '/usage', name: 'usage', component: Dashboard, meta: { dashboardView: 'usage' } },
+      { path: '/overview', name: 'dashboard-overview', component: Dashboard, meta: { dashboardView: 'overview' } },
+      { path: '/:pathMatch(.*)*', name: 'other', component: { template: '<div />' } },
+    ],
+  })
+}
+
+async function mountDashboard(path = '/') {
+  const router = makeRouter()
+  router.push(path)
+  await router.isReady()
   return shallowMount(Dashboard, {
     global: {
-      plugins: [createPinia()],
+      plugins: [createPinia(), router],
       stubs: {
         RouterLink: { template: '<a><slot /></a>' },
         // Un-stub the <Suspense> wrapper that shallowMount would otherwise
@@ -93,51 +116,46 @@ function mountDashboard() {
   })
 }
 
-describe('Dashboard Overview↔Usage switcher', () => {
+describe('Dashboard Usage↔Overview switcher', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     usageSpy.mockClear()
     ;(globalThis as unknown as { EventSource: unknown }).EventSource = FakeEventSource
   })
 
-  it('defaults to the Overview tab and does not fetch usage on first paint (SC-004)', async () => {
-    const wrapper = mountDashboard()
+  it('opens on the Usage panel and fetches the aggregate (24h default)', async () => {
+    const wrapper = await mountDashboard()
     await flushPromises()
 
     const overview = wrapper.find('[data-test="dashboard-overview-panel"]')
     const usage = wrapper.find('[data-test="dashboard-usage-panel"]')
     expect(overview.exists()).toBe(true)
     expect(usage.exists()).toBe(true)
-    // Overview visible, Usage hidden — both kept in the DOM (v-show), so the
-    // Overview subtree is never torn down (SC-006).
-    expect(overview.isVisible()).toBe(true)
-    expect(usage.isVisible()).toBe(false)
-    // Usage data is not fetched until the tab is opened.
-    expect(usageSpy).not.toHaveBeenCalled()
-  })
-
-  it('switches to Usage, keeps Overview mounted, and lazily fetches the aggregate', async () => {
-    const wrapper = mountDashboard()
-    await flushPromises()
-
-    await wrapper.find('[data-test="dashboard-tab-usage"]').trigger('click')
-    await flushPromises()
-
-    const overview = wrapper.find('[data-test="dashboard-overview-panel"]')
-    const usage = wrapper.find('[data-test="dashboard-usage-panel"]')
-    // Overview still in the DOM (state preserved) but hidden.
-    expect(overview.exists()).toBe(true)
-    expect(overview.isVisible()).toBe(false)
+    // Usage visible, Overview hidden — both kept in the DOM (v-show), so
+    // neither subtree is torn down when switching (SC-006).
     expect(usage.isVisible()).toBe(true)
-    // Default window is 24h on first load.
+    expect(overview.isVisible()).toBe(false)
     expect(usageSpy).toHaveBeenCalledTimes(1)
     expect(usageSpy).toHaveBeenLastCalledWith(expect.objectContaining({ window: '24h' }))
   })
 
-  it('re-fetches with the selected window when the window selector changes', async () => {
-    const wrapper = mountDashboard()
+  it('switches to Overview and keeps the Usage panel mounted', async () => {
+    const wrapper = await mountDashboard()
     await flushPromises()
-    await wrapper.find('[data-test="dashboard-tab-usage"]').trigger('click')
+
+    await wrapper.find('[data-test="dashboard-tab-overview"]').trigger('click')
+    await flushPromises()
+
+    const overview = wrapper.find('[data-test="dashboard-overview-panel"]')
+    const usage = wrapper.find('[data-test="dashboard-usage-panel"]')
+    expect(overview.isVisible()).toBe(true)
+    // Usage still in the DOM (state preserved) but hidden.
+    expect(usage.exists()).toBe(true)
+    expect(usage.isVisible()).toBe(false)
+  })
+
+  it('re-fetches with the selected window when the window selector changes', async () => {
+    const wrapper = await mountDashboard()
     await flushPromises()
     usageSpy.mockClear()
 
@@ -148,18 +166,18 @@ describe('Dashboard Overview↔Usage switcher', () => {
     expect(usageSpy).toHaveBeenLastCalledWith(expect.objectContaining({ window: '7d' }))
   })
 
-  it('switches back to Overview without re-fetching usage (cached, state preserved)', async () => {
-    const wrapper = mountDashboard()
+  it('switches back to Usage without re-fetching the aggregate (cached, state preserved)', async () => {
+    const wrapper = await mountDashboard()
     await flushPromises()
-    await wrapper.find('[data-test="dashboard-tab-usage"]').trigger('click')
+    await wrapper.find('[data-test="dashboard-tab-overview"]').trigger('click')
     await flushPromises()
     usageSpy.mockClear()
 
-    await wrapper.find('[data-test="dashboard-tab-overview"]').trigger('click')
+    await wrapper.find('[data-test="dashboard-tab-usage"]').trigger('click')
     await flushPromises()
 
-    const overview = wrapper.find('[data-test="dashboard-overview-panel"]')
-    expect(overview.isVisible()).toBe(true)
+    const usage = wrapper.find('[data-test="dashboard-usage-panel"]')
+    expect(usage.isVisible()).toBe(true)
     expect(usageSpy).not.toHaveBeenCalled()
   })
 })

--- a/frontend/tests/unit/servers-store-list-sequencing.spec.ts
+++ b/frontend/tests/unit/servers-store-list-sequencing.spec.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useServersStore } from '@/stores/servers'
+import api from '@/services/api'
+
+// The server list has three independent, uncancelled writers: a fetch from any
+// component (App.vue and Dashboard.vue both issue one on mount), a silent
+// background refresh, and the Spec 047 SSE full-list payload. A response that
+// was already in flight when a newer list was applied must not be able to
+// resurrect the older list.
+
+vi.mock('@/services/api', () => ({
+  default: {
+    getServers: vi.fn(),
+    securityApprove: vi.fn(),
+    unquarantineServer: vi.fn(),
+  },
+}))
+
+function mkServer(name: string) {
+  return {
+    name,
+    protocol: 'http' as const,
+    enabled: true,
+    quarantined: false,
+    connected: true,
+    connecting: false,
+    tool_count: 1,
+  }
+}
+
+describe('useServersStore — server list write sequencing', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('drops a stale fetch response that lands after a newer one', async () => {
+    let resolveFirst: (v: unknown) => void = () => {}
+    const first = new Promise((resolve) => {
+      resolveFirst = resolve
+    })
+    ;(api.getServers as any).mockReturnValueOnce(first)
+    ;(api.getServers as any).mockResolvedValueOnce({
+      success: true,
+      data: { servers: [mkServer('added-by-user')] },
+    })
+
+    const store = useServersStore()
+    // Overlapping requests, e.g. App.vue's and Dashboard.vue's mount fetches.
+    const slow = store.fetchServers()
+    await store.fetchServers()
+
+    expect(store.serverCount.total).toBe(1)
+
+    // The older request finally answers with the pre-addition (empty) list.
+    resolveFirst({ success: true, data: { servers: [] } })
+    await slow
+
+    expect(store.serverCount.total).toBe(1)
+    expect(store.servers[0].name).toBe('added-by-user')
+  })
+
+  it('does not let an in-flight fetch overwrite a list delivered by SSE', async () => {
+    let resolveFetch: (v: unknown) => void = () => {}
+    const pending = new Promise((resolve) => {
+      resolveFetch = resolve
+    })
+    ;(api.getServers as any).mockReturnValueOnce(pending)
+
+    const store = useServersStore()
+    const inFlight = store.fetchServers()
+
+    window.dispatchEvent(
+      new CustomEvent('mcpproxy:servers-changed', {
+        detail: { payload: { servers: [mkServer('from-sse')] } },
+      })
+    )
+    expect(store.serverCount.total).toBe(1)
+
+    resolveFetch({ success: true, data: { servers: [] } })
+    await inFlight
+
+    expect(store.serverCount.total).toBe(1)
+    expect(store.servers[0].name).toBe('from-sse')
+  })
+
+  it('marks the list loaded when it arrives by SSE rather than by fetch', async () => {
+    const store = useServersStore()
+    expect(store.loaded).toBe(false)
+
+    window.dispatchEvent(
+      new CustomEvent('mcpproxy:servers-changed', {
+        detail: { payload: { servers: [] } },
+      })
+    )
+
+    // An empty authoritative list is still an answer: consumers must be able to
+    // tell "no servers configured" from "we don't know yet".
+    expect(store.loaded).toBe(true)
+    expect(store.serverCount.total).toBe(0)
+  })
+
+  it('does not mark the list loaded when the fetch fails', async () => {
+    ;(api.getServers as any).mockResolvedValueOnce({ success: false, error: 'boom' })
+
+    const store = useServersStore()
+    await store.fetchServers()
+
+    expect(store.loaded).toBe(false)
+    expect(store.loading.error).toBe('boom')
+  })
+})

--- a/frontend/tests/unit/servers-store-list-sequencing.spec.ts
+++ b/frontend/tests/unit/servers-store-list-sequencing.spec.ts
@@ -12,6 +12,7 @@ import api from '@/services/api'
 vi.mock('@/services/api', () => ({
   default: {
     getServers: vi.fn(),
+    deleteServer: vi.fn(),
     securityApprove: vi.fn(),
     unquarantineServer: vi.fn(),
   },
@@ -98,6 +99,34 @@ describe('useServersStore — server list write sequencing', () => {
     // An empty authoritative list is still an answer: consumers must be able to
     // tell "no servers configured" from "we don't know yet".
     expect(store.loaded).toBe(true)
+    expect(store.serverCount.total).toBe(0)
+  })
+
+  it('does not let an in-flight fetch restore a server the user just deleted', async () => {
+    // Seed the store with one server.
+    ;(api.getServers as any).mockResolvedValueOnce({
+      success: true,
+      data: { servers: [mkServer('doomed')] },
+    })
+    const store = useServersStore()
+    await store.fetchServers()
+
+    // A refresh starts, then the user deletes the server before it resolves.
+    let resolveRefresh: (v: unknown) => void = () => {}
+    ;(api.getServers as any).mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveRefresh = resolve
+      })
+    )
+    const refresh = store.fetchServers(true)
+    ;(api.deleteServer as any).mockResolvedValueOnce({ success: true })
+    await store.deleteServer('doomed')
+    expect(store.serverCount.total).toBe(0)
+
+    // The refresh answers with the pre-deletion list.
+    resolveRefresh({ success: true, data: { servers: [mkServer('doomed')] } })
+    await refresh
+
     expect(store.serverCount.total).toBe(0)
   })
 

--- a/frontend/tests/unit/usage-stale-response.spec.ts
+++ b/frontend/tests/unit/usage-stale-response.spec.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+// The Usage panel has no request cancellation and several triggers that can
+// overlap: a 30s auto-refresh, the window selector, the status/sort selects and
+// the "widen the window" reset. If a slower earlier request is allowed to write
+// state after a newer one has landed, the panel repaints with data for a window
+// the user already moved off — now visible on the default landing page.
+
+const usageSpy = vi.hoisted(() => vi.fn())
+
+vi.mock('@/services/api', () => {
+  const ok = (data: unknown = null) => vi.fn().mockResolvedValue({ success: true, data })
+  const base: Record<string, unknown> = {
+    getActivityUsage: usageSpy,
+    hasAPIKey: vi.fn(() => true),
+    onAuthError: vi.fn(() => () => {}),
+  }
+  return {
+    default: new Proxy(base, {
+      get(target: Record<string, unknown>, prop: string) {
+        if (prop in target) return target[prop]
+        target[prop] = ok()
+        return target[prop]
+      },
+    }),
+  }
+})
+
+import Usage from '@/views/Usage.vue'
+
+function aggregate(window: string) {
+  return {
+    success: true,
+    data: {
+      window,
+      generated_at: '2026-08-25T12:00:00Z',
+      freshness_ms: 100,
+      token_source: 'bytes',
+      tokens_saved: 1,
+      tokens_saved_percentage: 1,
+      tools: [],
+      timeline: [],
+    },
+  }
+}
+
+function mountUsage() {
+  return mount(Usage, {
+    global: {
+      plugins: [createPinia()],
+      stubs: { RouterLink: { template: '<a><slot /></a>' }, Line: true, Bar: true, Doughnut: true, Pie: true },
+    },
+  })
+}
+
+describe('Usage panel overlapping reloads', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    usageSpy.mockReset()
+  })
+
+  it('ignores a slow earlier response that lands after a newer one', async () => {
+    let resolveFirst: (v: unknown) => void = () => {}
+    const first = new Promise((resolve) => {
+      resolveFirst = resolve
+    })
+
+    // Mount fires the initial 24h request; hold it open.
+    usageSpy.mockReturnValueOnce(first)
+    const wrapper = mountUsage()
+    await flushPromises()
+
+    // The user switches to 7d; that request resolves immediately.
+    usageSpy.mockResolvedValueOnce(aggregate('7d'))
+    await wrapper.find('[data-test="usage-window-7d"]').trigger('click')
+    await flushPromises()
+    expect(usageSpy).toHaveBeenCalledTimes(2)
+
+    // Now the stale 24h response finally arrives — it must be discarded.
+    resolveFirst(aggregate('24h'))
+    await flushPromises()
+
+    expect(usageSpy).toHaveBeenLastCalledWith(expect.objectContaining({ window: '7d' }))
+    expect(wrapper.find('[data-test="usage-freshness"]').exists()).toBe(true)
+    expect(wrapper.vm.$data ?? {}).toBeDefined()
+    // The rendered aggregate is still the 7d one the user asked for.
+    expect((wrapper.vm as unknown as { data: { window: string } }).data.window).toBe('7d')
+  })
+
+  it('does not let a superseded request clear the spinner owned by the newest one', async () => {
+    let resolveFirst: (v: unknown) => void = () => {}
+    const first = new Promise((resolve) => {
+      resolveFirst = resolve
+    })
+    usageSpy.mockReturnValueOnce(first)
+    const wrapper = mountUsage()
+    await flushPromises()
+
+    // Second request is still in flight when the first one resolves.
+    usageSpy.mockReturnValueOnce(new Promise(() => {}))
+    await wrapper.find('[data-test="usage-window-7d"]').trigger('click')
+    await flushPromises()
+
+    resolveFirst(aggregate('24h'))
+    await flushPromises()
+
+    expect((wrapper.vm as unknown as { loading: boolean }).loading).toBe(true)
+  })
+})

--- a/roadmap.yaml
+++ b/roadmap.yaml
@@ -233,9 +233,10 @@ epics:
         depends_on: []
       - id: analytics-default-landing
         title: Make dashboard the default landing page
-        status: todo
+        status: in_review
         spec: specs/039-connect-and-dashboard
         depends_on: [analytics-token-drain-graphs]
+        note: "PR: `/` now opens the Dashboard on its Usage (analytics) panel; `/usage` + `/overview` added as deep-linkable routes rendering the same component (tab clicks rewrite the URL, no remount). Zero-servers first run shows an 'add your first server' CTA in place of empty charts instead of conditional routing."
 
   - id: registries-search-add
     title: Registries — easier search + add-server


### PR DESCRIPTION
Roadmap `analytics-dashboard` / `analytics-default-landing` (the epic's only remaining task).

- `/` now opens the Dashboard on its **Usage (analytics)** panel; the tab order is Usage, Overview.
- `/usage` and `/overview` added as deep-linkable routes rendering the same `Dashboard` component (`meta.dashboardView` picks the panel). Tab clicks `router.replace` to the matching path, so a panel survives a reload/shared link without remounting the view or piling up history entries. `/` keeps its `dashboard` route name, so every existing link and guard redirect still works.
- Sidebar "Dashboard" entry stays highlighted on all three paths.
- **First run:** with zero upstream servers the analytics panel would only ever show "no data", so it renders an "Add your first server" CTA (Add Server / Browse Registry / Go to Overview) instead of the chart grid — no conditional routing.
- Roadmap task -> `in_review`, `ROADMAP.md` regenerated.

Tests: new `frontend/tests/unit/dashboard-default-landing.spec.ts` (route config, landing panel, deep links, URL rewrite on tab click, first-run CTA); `dashboard-usage-switcher.spec.ts` updated for the flipped default. Full vitest suite 671 passed, `vue-tsc --noEmit` clean. Verified live against an isolated instance with a Playwright sweep (landing panel, CTA, deep links + reload, panel with a server configured, no page exceptions).