### PR TITLE
fix(webui): first-run call to action, onboarding path for a fresh setup, and "what needs me" on the landing page

### DIFF
--- a/frontend/src/components/OnboardingWizard.vue
+++ b/frontend/src/components/OnboardingWizard.vue
@@ -200,10 +200,48 @@
           <div v-if="loadingImportSources" class="flex justify-center py-4">
             <span class="loading loading-spinner loading-md"></span>
           </div>
-          <div v-else-if="importSourcesWithServers.length === 0" class="text-sm opacity-60 py-4 text-center">
-            No client configs with importable servers detected on this machine.
+          <!-- Nothing to import. Step 2 is otherwise entirely about picking
+               servers out of an existing MCP setup, which leaves a user who has
+               none — the exact user this wizard matters most to — staring at a
+               dead end. Give that user the two ways to get a first server. -->
+          <div
+            v-else-if="importSourcesWithServers.length === 0"
+            class="border border-base-300 rounded-lg p-6 text-center mb-5"
+            data-test="servers-nothing-to-import"
+          >
+            <div class="text-3xl opacity-40 mb-2">📦</div>
+            <div class="font-semibold">Nothing to import</div>
+            <p class="text-sm opacity-70 mt-1 max-w-md mx-auto">
+              We found no MCP servers in your AI clients' configs on this machine —
+              so there is nothing to bring across. Start from the registry instead,
+              or add a server yourself.
+            </p>
+            <div class="flex flex-wrap gap-2 justify-center mt-4">
+              <button
+                class="btn btn-primary btn-sm"
+                data-test="nothing-to-import-registry"
+                @click="goToRegistry"
+              >
+                Browse the registry
+              </button>
+              <button
+                class="btn btn-outline btn-sm"
+                data-test="nothing-to-import-manual"
+                @click="openAddServer"
+              >
+                Add a server manually
+              </button>
+            </div>
+            <p v-if="serverAddedJustNow" class="text-xs text-success mt-3">
+              ✓ Server added — it's currently in quarantine. Review it on the Servers page after this wizard.
+            </p>
           </div>
-          <div v-else class="border border-base-300 rounded-lg overflow-hidden mb-5">
+          <!-- The list is capped and scrolls in place. Uncapped it ran off the
+               bottom of the modal body and clipped its last row with no hint
+               that more existed; the cap also leaves the security panel below
+               it partly on screen, so the choice it offers is visible rather
+               than something the user has to go looking for. -->
+          <div v-else class="border border-base-300 rounded-lg overflow-hidden mb-4 max-h-[32vh] overflow-y-auto">
             <div
               v-for="(src, idx) in importSourcesWithServers"
               :key="src.path"
@@ -266,7 +304,87 @@
             <span class="text-sm">{{ selectionImportMessage }}</span>
           </div>
 
-          <details class="border border-base-300 rounded-lg p-3 text-sm" data-test="manual-add-details">
+          <!-- The security choice lives in the step body, not the sticky
+               footer: expanded (it must not hide) it is tall enough that a
+               footer would eat the modal and squeeze the import list back down
+               to the clipped single row this step started with. Here it simply
+               scrolls with the rest of the step. -->
+          <details class="group border border-base-300 rounded-lg overflow-hidden bg-base-200/40 mb-4" data-test="security-panel" open>
+            <summary class="cursor-pointer flex items-center gap-2 px-4 py-2.5 select-none hover:bg-base-200/70 transition-colors">
+              <span class="transition-transform inline-block group-open:rotate-90 opacity-60">▸</span>
+              <span class="text-sm font-medium">Runtime isolation and MCP server quarantine</span>
+              <span class="ml-auto inline-flex items-center gap-2">
+                <span class="badge badge-primary badge-sm font-semibold">Global settings</span>
+                <span class="text-xs opacity-70 hidden sm:inline">saved to your mcpproxy config</span>
+              </span>
+            </summary>
+            <div class="px-4 py-4 space-y-4 bg-base-100 border-t border-base-300">
+              <!-- Docker isolation -->
+              <label class="flex items-start gap-3 p-3 rounded-lg border border-base-300 cursor-pointer">
+                <input
+                  type="checkbox"
+                  class="checkbox checkbox-sm mt-0.5"
+                  :checked="dockerIsolationDefault"
+                  :disabled="securityBusy || dockerStatus === false"
+                  @change="onToggleDockerIsolation(($event.target as HTMLInputElement).checked)"
+                  data-test="toggle-docker-isolation"
+                />
+                <div class="flex-1 min-w-0">
+                  <div class="font-medium text-sm">Docker isolation</div>
+                  <p class="text-xs opacity-70 mt-1 leading-relaxed">
+                    Sandboxes every stdio server in a throwaway Docker container so a compromised server can't read or write your host files, env vars, or SSH keys. Recommended whenever you import servers from sources you don't fully control.
+                  </p>
+                  <p
+                    v-if="dockerStatus === false"
+                    class="text-xs text-warning mt-2"
+                    data-test="docker-install-hint"
+                  >
+                    Docker isn't running on this machine. Install
+                    <a href="https://www.docker.com/products/docker-desktop/" target="_blank" rel="noopener" class="link">Docker Desktop</a>
+                    (or start the Docker daemon) then come back to enable this — stdio servers run unsandboxed otherwise.
+                  </p>
+                  <p class="text-[11px] mt-2">
+                    <a href="https://docs.mcpproxy.app/security/docker-isolation/" target="_blank" rel="noopener" class="link link-primary">Learn more about Docker isolation →</a>
+                  </p>
+                </div>
+              </label>
+
+              <!-- Quarantine new servers -->
+              <label class="flex items-start gap-3 p-3 rounded-lg border border-base-300 cursor-pointer">
+                <input
+                  type="checkbox"
+                  class="checkbox checkbox-sm mt-0.5"
+                  :checked="quarantineEnabled"
+                  :disabled="securityBusy"
+                  @change="onToggleQuarantine(($event.target as HTMLInputElement).checked)"
+                  data-test="toggle-quarantine"
+                />
+                <div class="flex-1 min-w-0">
+                  <div class="font-medium text-sm">Quarantine new servers</div>
+                  <p class="text-xs mt-1 leading-relaxed">
+                    <strong>Recommended.</strong> Holds every newly added server in a quarantine zone until you explicitly approve it. Defends against tool-poisoning attacks where a malicious server smuggles instructions into tool descriptions. <strong>Important:</strong> your AI agent itself can add upstream servers via mcpproxy's built-in MCP tools — your approval is the only safety net.
+                  </p>
+                  <p class="text-xs opacity-70 mt-1.5 leading-relaxed">
+                    Combine with security scanners (Trivy, Semgrep, MCP Scan) on the
+                    <router-link to="/servers" class="link link-primary">Servers</router-link>
+                    page for deeper supply-chain checks before approving.
+                  </p>
+                  <p class="text-[11px] mt-2">
+                    <a href="https://docs.mcpproxy.app/security/quarantine/" target="_blank" rel="noopener" class="link link-primary">Learn more about quarantine →</a>
+                  </p>
+                </div>
+              </label>
+            </div>
+          </details>
+
+          <!-- Only an alternative when there is something to import; the
+               nothing-to-import branch above already offers manual add as a
+               first-class action, so this would just repeat it. -->
+          <details
+            v-if="importSourcesWithServers.length > 0"
+            class="border border-base-300 rounded-lg p-3 text-sm"
+            data-test="manual-add-details"
+          >
             <summary class="cursor-pointer font-medium flex items-center gap-2 select-none">
               <span class="transition-transform group-open:rotate-90">▸</span>
               Add a single server manually instead
@@ -383,111 +501,44 @@
       </div>
 
       <!-- Footer (sticky, non-scrollable) -->
-      <!-- Servers tab gets a dedicated import-action footer when at least one
-           detectable server source exists. The action buttons stay visible
-           even as the list above scrolls. Above the buttons sits a
-           collapsed-by-default panel exposing global security settings
-           (Docker isolation + per-server quarantine) so the user can opt
-           into stricter or looser defaults without leaving the wizard. -->
+      <!-- Servers tab gets a dedicated import-action footer so the import
+           buttons stay visible as the list above scrolls. The security panel
+           itself sits in the step body, not here — see the comment there. -->
       <div
-        v-if="activeTab === 'servers' && importSourcesWithServers.length > 0"
+        v-if="activeTab === 'servers'"
         class="border-t border-base-300 shrink-0 bg-base-200/40"
       >
-        <details class="border-b border-base-300" data-test="security-panel">
-          <summary class="cursor-pointer flex items-center gap-2 px-6 py-2.5 select-none hover:bg-base-200/70 transition-colors">
-            <span class="transition-transform inline-block group-open:rotate-90 opacity-60">▸</span>
-            <span class="text-sm font-medium">Runtime isolation and MCP server quarantine</span>
-            <span class="ml-auto inline-flex items-center gap-2">
-              <span class="badge badge-primary badge-sm font-semibold">Global settings</span>
-              <span class="text-xs opacity-70 hidden sm:inline">saved to your mcpproxy config</span>
-            </span>
-          </summary>
-          <div class="px-6 py-4 space-y-4 bg-base-100">
-            <!-- Docker isolation -->
-            <label class="flex items-start gap-3 p-3 rounded-lg border border-base-300 cursor-pointer">
-              <input
-                type="checkbox"
-                class="checkbox checkbox-sm mt-0.5"
-                :checked="dockerIsolationDefault"
-                :disabled="securityBusy || dockerStatus === false"
-                @change="onToggleDockerIsolation(($event.target as HTMLInputElement).checked)"
-                data-test="toggle-docker-isolation"
-              />
-              <div class="flex-1 min-w-0">
-                <div class="font-medium text-sm">Docker isolation</div>
-                <p class="text-xs opacity-70 mt-1 leading-relaxed">
-                  Sandboxes every stdio server in a throwaway Docker container so a compromised server can't read or write your host files, env vars, or SSH keys. Recommended whenever you import servers from sources you don't fully control.
-                </p>
-                <p
-                  v-if="dockerStatus === false"
-                  class="text-xs text-warning mt-2"
-                  data-test="docker-install-hint"
-                >
-                  Docker isn't running on this machine. Install
-                  <a href="https://www.docker.com/products/docker-desktop/" target="_blank" rel="noopener" class="link">Docker Desktop</a>
-                  (or start the Docker daemon) then come back to enable this — stdio servers run unsandboxed otherwise.
-                </p>
-                <p class="text-[11px] mt-2">
-                  <a href="https://docs.mcpproxy.app/security/docker-isolation/" target="_blank" rel="noopener" class="link link-primary">Learn more about Docker isolation →</a>
-                </p>
-              </div>
-            </label>
-
-            <!-- Quarantine new servers -->
-            <label class="flex items-start gap-3 p-3 rounded-lg border border-base-300 cursor-pointer">
-              <input
-                type="checkbox"
-                class="checkbox checkbox-sm mt-0.5"
-                :checked="quarantineEnabled"
-                :disabled="securityBusy"
-                @change="onToggleQuarantine(($event.target as HTMLInputElement).checked)"
-                data-test="toggle-quarantine"
-              />
-              <div class="flex-1 min-w-0">
-                <div class="font-medium text-sm">Quarantine new servers</div>
-                <p class="text-xs mt-1 leading-relaxed">
-                  <strong>Recommended.</strong> Holds every newly added server in a quarantine zone until you explicitly approve it. Defends against tool-poisoning attacks where a malicious server smuggles instructions into tool descriptions. <strong>Important:</strong> your AI agent itself can add upstream servers via mcpproxy's built-in MCP tools — your approval is the only safety net.
-                </p>
-                <p class="text-xs opacity-70 mt-1.5 leading-relaxed">
-                  Combine with security scanners (Trivy, Semgrep, MCP Scan) on the
-                  <router-link to="/servers" class="link link-primary">Servers</router-link>
-                  page for deeper supply-chain checks before approving.
-                </p>
-                <p class="text-[11px] mt-2">
-                  <a href="https://docs.mcpproxy.app/security/quarantine/" target="_blank" rel="noopener" class="link link-primary">Learn more about quarantine →</a>
-                </p>
-              </div>
-            </label>
-          </div>
-        </details>
-
-        <!-- Action footer -->
-        <div class="flex items-center justify-between gap-3 px-6 py-3">
-          <div class="text-xs">
-            <span v-if="selectedCount === 0" class="opacity-50">Select at least one server to import</span>
-            <span v-else>
-              <span class="font-semibold text-primary">{{ selectedCount }}</span>
-              <span class="opacity-70"> selected</span>
-              <span v-if="conflictCount > 0" class="opacity-70">
-                · <span class="text-warning">{{ conflictCount }} renamed</span>
+        <!-- Action footer. Only shown when there is something to import — the
+             nothing-to-import branch has its own actions in the body. -->
+        <div v-if="importSourcesWithServers.length > 0" class="flex items-center justify-between gap-3 px-6 py-3">
+          <div class="flex items-center gap-3 min-w-0">
+            <button class="btn btn-ghost btn-sm" @click="goBack" data-test="wizard-back">← Back</button>
+            <div class="text-xs">
+              <span v-if="selectedCount === 0" class="opacity-50">Select at least one server to import</span>
+              <span v-else>
+                <span class="font-semibold text-primary">{{ selectedCount }}</span>
+                <span class="opacity-70"> selected</span>
+                <span v-if="conflictCount > 0" class="opacity-70">
+                  · <span class="text-warning">{{ conflictCount }} renamed</span>
+                </span>
               </span>
-            </span>
+            </div>
           </div>
-          <div class="flex items-center gap-2">
+          <!-- One primary, and it is the safe one. Two equally-weighted
+               primaries made the user guess which import was safer, with the
+               reviewed path rendered as the weaker of the pair. Importing
+               without review stays available, as a link — the cost of choosing
+               it should be a deliberate read, not a symmetric coin flip. -->
+          <div class="flex items-center gap-3">
             <button
-              class="btn btn-ghost btn-sm"
-              @click="dismiss"
-              data-test="close-wizard"
-            >Close</button>
-            <button
-              class="btn btn-secondary btn-sm gap-1 min-w-[180px]"
+              class="btn btn-link btn-sm px-1 no-underline hover:underline text-base-content/70"
               :disabled="selectedCount === 0 || importBusyAny"
+              title="Skips quarantine — the servers connect and expose their tools immediately, with no review"
               @click="onBulkImport(false)"
               data-test="bulk-import-active"
             >
               <span v-if="bulkImportBusy === 'active'" class="loading loading-spinner loading-xs"></span>
-              <span v-else>⚡</span>
-              Import as active
+              Import without review
             </button>
             <button
               class="btn btn-primary btn-sm gap-1 min-w-[180px]"
@@ -502,14 +553,30 @@
             </button>
           </div>
         </div>
+        <!-- Nothing to import: no import action to offer, but the step still
+             needs a way forward and back. -->
+        <div v-else class="flex items-center justify-between px-6 py-3">
+          <button class="btn btn-ghost btn-sm" @click="goBack" data-test="wizard-back">← Back</button>
+          <button class="btn btn-primary btn-sm" @click="dismiss" data-test="close-wizard">
+            {{ onboarding.incompleteTabCount === 0 ? 'Done' : 'Close for now' }}
+          </button>
+        </div>
       </div>
-      <!-- Default footer for other tabs / empty server state -->
+      <!-- Default footer for other tabs -->
       <div
         v-else
-        class="flex items-center justify-between px-6 py-3 border-t border-base-300 shrink-0"
+        class="flex items-center justify-between gap-3 px-6 py-3 border-t border-base-300 shrink-0"
       >
-        <div class="text-xs opacity-50">
-          Tip: you can always re-open this from the sidebar's <span class="font-medium">Setup</span> entry.
+        <div class="flex items-center gap-3 min-w-0">
+          <button
+            v-if="canGoBack"
+            class="btn btn-ghost btn-sm"
+            @click="goBack"
+            data-test="wizard-back"
+          >← Back</button>
+          <div class="text-xs opacity-50 truncate">
+            Tip: you can always re-open this from the sidebar's <span class="font-medium">Setup</span> entry.
+          </div>
         </div>
         <button class="btn btn-primary btn-sm" @click="dismiss" data-test="close-wizard">
           {{ onboarding.incompleteTabCount === 0 ? 'Done' : 'Close for now' }}
@@ -529,6 +596,7 @@
 
 <script setup lang="ts">
 import { ref, reactive, computed, watch, onMounted, onUnmounted, h, type FunctionalComponent } from 'vue'
+import { useRouter } from 'vue-router'
 import api from '@/services/api'
 import { useOnboardingStore } from '@/stores/onboarding'
 import { useSystemStore } from '@/stores/system'
@@ -550,6 +618,7 @@ const emit = defineEmits<Emits>()
 const onboarding = useOnboardingStore()
 const systemStore = useSystemStore()
 const serversStore = useServersStore()
+const router = useRouter()
 
 type TabID = 'clients' | 'servers' | 'verify'
 const activeTab = ref<TabID>('clients')
@@ -781,10 +850,34 @@ watch(() => props.show, async (open) => {
 })
 
 function pickInitialTab(): TabID {
+  // An explicit request from the opener wins — "Import from your AI client
+  // configs" on the Servers page means that step, not whichever one the
+  // predicates would have chosen. Consumed here so it applies once.
+  const requested = onboarding.consumeWizardInitialTab()
+  if (requested) return requested
   if (!onboarding.hasConnectedClient) return 'clients'
   if (!onboarding.hasConfiguredServer) return 'servers'
   if (!onboarding.firstMCPClientEver) return 'verify'
   return 'clients'
+}
+
+// --- Step navigation ---
+// The tabs double as steps, so Back is just "the previous tab". Without it the
+// only way out of a step was the tab strip, which reads as navigation rather
+// than as a way to undo a wrong turn.
+const tabOrder: TabID[] = ['clients', 'servers', 'verify']
+const canGoBack = computed(() => tabOrder.indexOf(activeTab.value) > 0)
+function goBack() {
+  const i = tabOrder.indexOf(activeTab.value)
+  if (i > 0) activeTab.value = tabOrder[i - 1]
+}
+
+// Leaving the wizard for the registry: the wizard is a modal owned by the
+// Dashboard, so it has to close before the route changes or it would hang over
+// the registry page.
+function goToRegistry() {
+  dismiss()
+  void router.push('/repositories')
 }
 
 function startPolling() {

--- a/frontend/src/components/OnboardingWizard.vue
+++ b/frontend/src/components/OnboardingWizard.vue
@@ -857,7 +857,7 @@ async function onOpened() {
   await onboarding.fetchState()
   await Promise.all([
     fetchClients(),
-    fetchSecurityState(),
+    fetchSecurityState(seq),
     fetchDockerStatus(),
     fetchImportSources(),
     fetchRecentActivity(),
@@ -986,9 +986,15 @@ function formatTime(ts: string): string {
   return d.toLocaleDateString()
 }
 
-async function fetchSecurityState() {
+// `seq` (when given) ties this read to one open sequence. Unlike the other
+// fetches, what this one writes is user-editable: the quarantine and Docker
+// isolation checkboxes. A read left over from a superseded open landing after
+// the user has already toggled one would silently flip it back to the old
+// server value, so a stale read must not commit.
+async function fetchSecurityState(seq?: number) {
   try {
     const res = await api.getConfig()
+    if (seq !== undefined && seq !== openSeq) return
     if (res.success && res.data) {
       const cfg = res.data.config ?? {}
       requireMcpAuth.value = !!cfg.require_mcp_auth

--- a/frontend/src/components/OnboardingWizard.vue
+++ b/frontend/src/components/OnboardingWizard.vue
@@ -530,6 +530,10 @@
                without review stays available, as a link — the cost of choosing
                it should be a deliberate read, not a symmetric coin flip. -->
           <div class="flex items-center gap-3">
+            <!-- Every step offers a way out, this one included: the sweep and
+                 the header ✕ both depend on it, and a step whose only exits are
+                 "import" is a trap. -->
+            <button class="btn btn-ghost btn-sm" @click="dismiss" data-test="close-wizard">Close</button>
             <button
               class="btn btn-link btn-sm px-1 no-underline hover:underline text-base-content/70"
               :disabled="selectedCount === 0 || importBusyAny"
@@ -818,42 +822,60 @@ const serverCountLabel = computed(() => {
 })
 
 // Open lifecycle: refresh state, fetch clients + config, start polling.
-watch(() => props.show, async (open) => {
+//
+// The caller's tab request is read FIRST, before any await. Two reasons: a
+// request must never outlive the open it was made for (a wizard torn down
+// mid-load would otherwise leak it into the next plain open), and reading it
+// after five round-trips would let a second open consume the same request.
+async function onOpened() {
+  const requested = onboarding.consumeWizardInitialTab()
+  serverAddedJustNow.value = false
+  connectMessage.value = ''
+  // Backup lines are session-scoped (Spec 078 US2): don't replay backup
+  // rows from connects performed in a previous wizard session.
+  for (const k of Object.keys(connectBackups)) delete connectBackups[k]
+  copiedBackupClient.value = null
+  // Spec 078 US1: previews are session-scoped too — don't replay a stale
+  // confirm/cancel panel from a previous wizard session.
+  for (const k of Object.keys(previews)) delete previews[k]
+  for (const k of Object.keys(previewErrors)) delete previewErrors[k]
+  // Spec 078 US3: undo is session-scoped (it reverts the connect performed
+  // in THIS wizard session) — a reopened wizard starts without undo state.
+  for (const k of Object.keys(undoPreviews)) delete undoPreviews[k]
+  for (const k of Object.keys(undoOpen)) delete undoOpen[k]
+  // The requested tab applies immediately so the wizard never paints the
+  // wrong step while the fetches below are in flight.
+  if (requested) activeTab.value = requested
+  await onboarding.fetchState()
+  await Promise.all([
+    fetchClients(),
+    fetchSecurityState(),
+    fetchDockerStatus(),
+    fetchImportSources(),
+    fetchRecentActivity(),
+  ])
+  activeTab.value = pickInitialTab(requested)
+  startPolling()
+}
+
+// `immediate` matters: an opener can set `wizardOpen` BEFORE this component
+// exists — the Servers page's import link flips the store flag and then routes
+// to the Dashboard, which is what mounts the wizard. A plain watcher would not
+// fire for that (`show` is already true at mount), leaving the wizard rendered
+// but never initialised. This replaces the old onMounted fallback, which
+// kicked off the fetches but skipped the tab choice entirely.
+watch(() => props.show, (open) => {
   if (open) {
-    serverAddedJustNow.value = false
-    connectMessage.value = ''
-    // Backup lines are session-scoped (Spec 078 US2): don't replay backup
-    // rows from connects performed in a previous wizard session.
-    for (const k of Object.keys(connectBackups)) delete connectBackups[k]
-    copiedBackupClient.value = null
-    // Spec 078 US1: previews are session-scoped too — don't replay a stale
-    // confirm/cancel panel from a previous wizard session.
-    for (const k of Object.keys(previews)) delete previews[k]
-    for (const k of Object.keys(previewErrors)) delete previewErrors[k]
-    // Spec 078 US3: undo is session-scoped (it reverts the connect performed
-    // in THIS wizard session) — a reopened wizard starts without undo state.
-    for (const k of Object.keys(undoPreviews)) delete undoPreviews[k]
-    for (const k of Object.keys(undoOpen)) delete undoOpen[k]
-    await onboarding.fetchState()
-    await Promise.all([
-      fetchClients(),
-      fetchSecurityState(),
-      fetchDockerStatus(),
-      fetchImportSources(),
-      fetchRecentActivity(),
-    ])
-    activeTab.value = pickInitialTab()
-    startPolling()
+    void onOpened()
   } else {
     stopPolling()
   }
-})
+}, { immediate: true })
 
-function pickInitialTab(): TabID {
+function pickInitialTab(requested: TabID | null): TabID {
   // An explicit request from the opener wins — "Import from your AI client
   // configs" on the Servers page means that step, not whichever one the
-  // predicates would have chosen. Consumed here so it applies once.
-  const requested = onboarding.consumeWizardInitialTab()
+  // predicates would have chosen.
   if (requested) return requested
   if (!onboarding.hasConnectedClient) return 'clients'
   if (!onboarding.hasConfiguredServer) return 'servers'
@@ -874,10 +896,13 @@ function goBack() {
 
 // Leaving the wizard for the registry: the wizard is a modal owned by the
 // Dashboard, so it has to close before the route changes or it would hang over
-// the registry page.
-function goToRegistry() {
-  dismiss()
-  void router.push('/repositories')
+// the registry page. The await is load-bearing — `dismiss()` awaits its
+// mark-skipped calls before it emits `close`, and routing away first unmounts
+// the Dashboard that owns the `wizardOpen` flag, so the emit could land with
+// nothing left to clear it and the wizard would spring back open on return.
+async function goToRegistry() {
+  await dismiss()
+  await router.push('/repositories')
 }
 
 function startPolling() {
@@ -1368,18 +1393,10 @@ async function dismiss() {
   emit('close')
 }
 
-onMounted(() => {
-  // If wizard is already open at mount time (rare; usually opened reactively
-  // via :show), kick off initial load.
-  if (props.show) {
-    void onboarding.fetchState()
-    void fetchClients()
-    void fetchSecurityState()
-    void fetchDockerStatus()
-    void fetchImportSources()
-    startPolling()
-  }
-})
+// NOTE: no onMounted open-fallback here. The `immediate` watcher above already
+// covers "already open at mount time", and covers it completely — the old
+// fallback started the fetches but never chose the tab, so a wizard opened
+// that way landed on Clients regardless of what the opener asked for.
 
 // --- ClientRow component ------------------------------------------------
 // Inlined as a functional component to keep this file self-contained while

--- a/frontend/src/components/OnboardingWizard.vue
+++ b/frontend/src/components/OnboardingWizard.vue
@@ -827,7 +827,15 @@ const serverCountLabel = computed(() => {
 // request must never outlive the open it was made for (a wizard torn down
 // mid-load would otherwise leak it into the next plain open), and reading it
 // after five round-trips would let a second open consume the same request.
+//
+// `openSeq` makes each run abandonable. Nothing cancels the fetches below, so
+// a close (or a close-then-reopen) while one is in flight would otherwise let
+// the old run finish and stamp its tab over the new one — and call
+// startPolling() on a wizard that is no longer open, leaving a 5s poll running
+// until unmount. Every run checks it still owns the wizard before it writes.
+let openSeq = 0
 async function onOpened() {
+  const seq = ++openSeq
   const requested = onboarding.consumeWizardInitialTab()
   serverAddedJustNow.value = false
   connectMessage.value = ''
@@ -854,6 +862,8 @@ async function onOpened() {
     fetchImportSources(),
     fetchRecentActivity(),
   ])
+  // Superseded (or closed) while we were loading — leave the wizard alone.
+  if (seq !== openSeq || !props.show) return
   activeTab.value = pickInitialTab(requested)
   startPolling()
 }
@@ -868,6 +878,8 @@ watch(() => props.show, (open) => {
   if (open) {
     void onOpened()
   } else {
+    // Retire any in-flight open so it cannot resurrect polling behind us.
+    openSeq++
     stopPolling()
   }
 }, { immediate: true })
@@ -926,7 +938,12 @@ function stopPolling() {
   }
 }
 
-onUnmounted(() => stopPolling())
+onUnmounted(() => {
+  // Same reason as the close path: an open still awaiting its fetches must not
+  // start a poll on a component that no longer exists.
+  openSeq++
+  stopPolling()
+})
 
 async function fetchClients() {
   loadingClients.value = true

--- a/frontend/src/stores/onboarding.ts
+++ b/frontend/src/stores/onboarding.ts
@@ -17,6 +17,9 @@ import api from '@/services/api'
  *     onboarding.openWizard()
  *   }
  */
+/** Tabs the wizard renders, in order. */
+export type WizardTab = 'clients' | 'servers' | 'verify'
+
 export const useOnboardingStore = defineStore('onboarding', () => {
   // State fetched from backend
   const state = ref<OnboardingStateResponse | null>(null)
@@ -28,6 +31,14 @@ export const useOnboardingStore = defineStore('onboarding', () => {
   // the wizard via the "Run setup wizard" link even when both predicates
   // are satisfied.
   const wizardOpen = ref(false)
+
+  // Which tab the wizard should land on when it next opens. Callers that mean
+  // a *specific* step ("Import from your AI client configs" on the Servers
+  // page) set it; everything else leaves it null and gets the default first
+  // tab. It is a one-shot request: the wizard consumes it on open and clears
+  // it, so a later plain `openWizard()` is never silently redirected to a tab
+  // some earlier caller asked for.
+  const wizardInitialTab = ref<WizardTab | null>(null)
 
   // Computed
   const shouldShowWizard = computed(() => state.value?.should_show_wizard ?? false)
@@ -146,10 +157,18 @@ export const useOnboardingStore = defineStore('onboarding', () => {
     await mark({ engaged: true })
   }
 
-  function openWizard(): void {
+  function openWizard(tab: WizardTab | null = null): void {
+    wizardInitialTab.value = tab
     wizardOpen.value = true
     // Best-effort first-shown stamp.
     void markShown()
+  }
+
+  /** Read and clear the one-shot initial-tab request. */
+  function consumeWizardInitialTab(): WizardTab | null {
+    const tab = wizardInitialTab.value
+    wizardInitialTab.value = null
+    return tab
   }
 
   function closeWizard(): void {
@@ -161,6 +180,7 @@ export const useOnboardingStore = defineStore('onboarding', () => {
     loading,
     error,
     wizardOpen,
+    wizardInitialTab,
     shouldShowWizard,
     hasConnectedClient,
     hasConfiguredServer,
@@ -179,6 +199,7 @@ export const useOnboardingStore = defineStore('onboarding', () => {
     markServerSkipped,
     markEngaged,
     openWizard,
+    consumeWizardInitialTab,
     closeWizard,
   }
 })

--- a/frontend/src/stores/servers.ts
+++ b/frontend/src/stores/servers.ts
@@ -111,6 +111,11 @@ export const useServersStore = defineStore('servers', () => {
     // Smart merge preserves object references and avoids unnecessary re-renders
     servers.value = mergeServers(servers.value, list)
     loaded.value = true
+    // A list that arrived is proof the previous failure is over. Without this
+    // an error is write-only: silent background refreshes set it and nothing
+    // ever clears it, so one transient blip pins an error banner on the
+    // Servers page for the rest of the session.
+    loading.value.error = null
   }
 
   // Actions

--- a/frontend/src/stores/servers.ts
+++ b/frontend/src/stores/servers.ts
@@ -105,9 +105,19 @@ export const useServersStore = defineStore('servers', () => {
   let issueSeq = 0
   let appliedSeq = 0
 
-  function applyServerList(list: Server[], ticket: number) {
-    if (ticket < appliedSeq) return
+  // A request settles when it produces an outcome — a list OR a failure. Both
+  // advance the mark, because both are news about the same list: if only
+  // successes advanced it, a newer request failing would leave the mark behind
+  // and an older list arriving afterwards would still be accepted, overwriting
+  // the newer outcome with stale data.
+  function claimTicket(ticket: number): boolean {
+    if (ticket < appliedSeq) return false
     appliedSeq = ticket
+    return true
+  }
+
+  function applyServerList(list: Server[], ticket: number) {
+    if (!claimTicket(ticket)) return
     // Smart merge preserves object references and avoids unnecessary re-renders
     servers.value = mergeServers(servers.value, list)
     loaded.value = true
@@ -125,12 +135,12 @@ export const useServersStore = defineStore('servers', () => {
     }
     const ticket = ++issueSeq
 
-    // Failures take the same ticket as successes. Without that, an older
-    // request failing after a newer one already delivered a list would raise a
-    // stale error over fresh data — the mirror image of the stale-list problem
-    // the sequencing exists to prevent.
+    // Failures are sequenced exactly like successes: an older request failing
+    // after a newer one already delivered a list must not raise a stale error
+    // over fresh data — the mirror image of the stale-list problem the
+    // sequencing exists to prevent.
     const recordError = (message: string) => {
-      if (ticket < appliedSeq) return
+      if (!claimTicket(ticket)) return
       loading.value.error = message
     }
 

--- a/frontend/src/stores/servers.ts
+++ b/frontend/src/stores/servers.ts
@@ -125,15 +125,24 @@ export const useServersStore = defineStore('servers', () => {
     }
     const ticket = ++issueSeq
 
+    // Failures take the same ticket as successes. Without that, an older
+    // request failing after a newer one already delivered a list would raise a
+    // stale error over fresh data — the mirror image of the stale-list problem
+    // the sequencing exists to prevent.
+    const recordError = (message: string) => {
+      if (ticket < appliedSeq) return
+      loading.value.error = message
+    }
+
     try {
       const response = await api.getServers()
       if (response.success && response.data) {
         applyServerList(response.data.servers, ticket)
       } else {
-        loading.value.error = response.error || 'Failed to fetch servers'
+        recordError(response.error || 'Failed to fetch servers')
       }
     } catch (error) {
-      loading.value.error = error instanceof Error ? error.message : 'Unknown error'
+      recordError(error instanceof Error ? error.message : 'Unknown error')
     } finally {
       if (!silent) {
         loading.value.loading = false

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -6,92 +6,12 @@
     <!-- Upgrade nudge (Spec 079): dismissible per-version update banner -->
     <UpdateBanner />
 
-    <!-- Usage ↔ Overview switcher (Spec 069 T016). Usage is the default panel
-         (analytics-as-landing-page); each tab maps to a deep-linkable route
-         (/usage, /overview) so the panel survives a reload or a shared link. -->
-    <div role="tablist" class="tabs tabs-boxed w-fit" data-test="dashboard-view-switcher">
-      <a
-        role="tab"
-        class="tab"
-        :class="activeView === 'usage' ? 'tab-active' : ''"
-        data-test="dashboard-tab-usage"
-        @click="selectUsage"
-      >Usage</a>
-      <a
-        role="tab"
-        class="tab"
-        :class="activeView === 'overview' ? 'tab-active' : ''"
-        data-test="dashboard-tab-overview"
-        @click="selectOverview"
-      >Overview</a>
-    </div>
-
-    <!-- Usage view: the panel wrapper is always in the DOM (kept hidden with
-         v-show so switching back is instant and the Overview subtree is never
-         torn down, SC-006). The heavy chart bundle + the usage fetch inside
-         UsageView are mounted only once the panel has been active
-         (usageEverActive) AND the server list has arrived, and stay code-split
-         behind Suspense, so the Dashboard shell still paints immediately
-         (SC-004). -->
-    <div v-show="activeView === 'usage'" data-test="dashboard-usage-panel">
-      <!-- First run: no upstream servers configured, so the analytics panel
-           would only ever show "no data". Point the new user at the one action
-           that makes the dashboard useful instead. -->
-      <div
-        v-if="showFirstRunCta"
-        class="card bg-base-200 border border-base-300"
-        data-test="dashboard-usage-first-run"
-      >
-        <div class="card-body items-center text-center py-12">
-          <svg class="w-12 h-12 opacity-40" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-          </svg>
-          <h3 class="font-semibold text-lg mt-2">Add your first server to see usage</h3>
-          <p class="text-sm opacity-60 max-w-md">
-            No upstream MCP servers are configured yet, so there is nothing to chart.
-            Add one and this page will show call volume, token sinks, error rates and a timeline.
-          </p>
-          <div class="flex flex-wrap gap-2 justify-center mt-2">
-            <button
-              class="btn btn-primary btn-sm"
-              data-test="dashboard-first-run-add-server"
-              @click="showAddServer = true"
-            >
-              Add your first server
-            </button>
-            <router-link to="/repositories" class="btn btn-sm btn-ghost">Browse Registry</router-link>
-            <button
-              class="btn btn-sm btn-ghost"
-              data-test="dashboard-first-run-overview"
-              @click="selectOverview"
-            >
-              Go to Overview
-            </button>
-          </div>
-        </div>
-      </div>
-      <!-- Hold the charts back until the server list has arrived: mounting
-           UsageView first would fire a usage aggregate request and flash the
-           "no usage data yet" card on a fresh install, only to be replaced by
-           the CTA above a moment later. Both requests are issued together in
-           onMounted, so this costs no extra round-trip. -->
-      <div
-        v-else-if="!serversFetchSettled && !serversStore.loaded"
-        class="flex justify-center py-16"
-        data-test="dashboard-usage-pending"
-      >
-        <span class="loading loading-spinner loading-lg"></span>
-      </div>
-      <Suspense v-else-if="usageEverActive">
-        <UsageView />
-        <template #fallback>
-          <div class="flex justify-center py-16"><span class="loading loading-spinner loading-lg"></span></div>
-        </template>
-      </Suspense>
-    </div>
-
-    <!-- Overview: v-show (not v-if) so its state survives a switch to Usage and back (SC-006). -->
-    <div v-show="activeView === 'overview'" class="space-y-6" data-test="dashboard-overview-panel">
+    <!-- "What needs me": servers in a bad state and tools awaiting approval.
+         These live above the panel switcher rather than inside a panel — they
+         are the one thing on this page the user is expected to act on, and
+         burying them under a tab means the landing page can look calm while a
+         server is down or an unreviewed tool is waiting. Each renders only
+         when it has something to say, so a healthy install sees neither. -->
     <!-- Servers Needing Attention Banner (using unified health status) -->
     <div
       v-if="serversNeedingAttention.length > 0"
@@ -179,6 +99,92 @@
       </router-link>
     </div>
 
+    <!-- Usage ↔ Overview switcher (Spec 069 T016). Usage is the default panel
+         (analytics-as-landing-page); each tab maps to a deep-linkable route
+         (/usage, /overview) so the panel survives a reload or a shared link. -->
+    <div role="tablist" class="tabs tabs-boxed w-fit" data-test="dashboard-view-switcher">
+      <a
+        role="tab"
+        class="tab"
+        :class="activeView === 'usage' ? 'tab-active' : ''"
+        data-test="dashboard-tab-usage"
+        @click="selectUsage"
+      >Usage</a>
+      <a
+        role="tab"
+        class="tab"
+        :class="activeView === 'overview' ? 'tab-active' : ''"
+        data-test="dashboard-tab-overview"
+        @click="selectOverview"
+      >Overview</a>
+    </div>
+
+    <!-- Usage view: the panel wrapper is always in the DOM (kept hidden with
+         v-show so switching back is instant and the Overview subtree is never
+         torn down, SC-006). The heavy chart bundle + the usage fetch inside
+         UsageView are mounted only once the panel has been active
+         (usageEverActive) AND the server list has arrived, and stay code-split
+         behind Suspense, so the Dashboard shell still paints immediately
+         (SC-004). -->
+    <div v-show="activeView === 'usage'" data-test="dashboard-usage-panel">
+      <!-- First run: no upstream servers configured, so the analytics panel
+           would only ever show "no data". Point the new user at the one action
+           that makes the dashboard useful instead. -->
+      <div
+        v-if="showFirstRunCta"
+        class="card bg-base-200 border border-base-300"
+        data-test="dashboard-usage-first-run"
+      >
+        <div class="card-body items-center text-center py-12">
+          <svg class="w-12 h-12 opacity-40" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+          </svg>
+          <h3 class="font-semibold text-lg mt-2">Add your first server to see usage</h3>
+          <p class="text-sm opacity-60 max-w-md">
+            No upstream MCP servers are configured yet, so there is nothing to chart.
+            Add one and this page will show call volume, token sinks, error rates and a timeline.
+          </p>
+          <div class="flex flex-wrap gap-2 justify-center mt-2">
+            <button
+              class="btn btn-primary btn-sm"
+              data-test="dashboard-first-run-add-server"
+              @click="showAddServer = true"
+            >
+              Add your first server
+            </button>
+            <router-link to="/repositories" class="btn btn-sm btn-ghost">Browse Registry</router-link>
+            <button
+              class="btn btn-sm btn-ghost"
+              data-test="dashboard-first-run-overview"
+              @click="selectOverview"
+            >
+              Go to Overview
+            </button>
+          </div>
+        </div>
+      </div>
+      <!-- Hold the charts back until the server list has arrived: mounting
+           UsageView first would fire a usage aggregate request and flash the
+           "no usage data yet" card on a fresh install, only to be replaced by
+           the CTA above a moment later. Both requests are issued together in
+           onMounted, so this costs no extra round-trip. -->
+      <div
+        v-else-if="!serversFetchSettled && !serversStore.loaded"
+        class="flex justify-center py-16"
+        data-test="dashboard-usage-pending"
+      >
+        <span class="loading loading-spinner loading-lg"></span>
+      </div>
+      <Suspense v-else-if="usageEverActive">
+        <UsageView />
+        <template #fallback>
+          <div class="flex justify-center py-16"><span class="loading loading-spinner loading-lg"></span></div>
+        </template>
+      </Suspense>
+    </div>
+
+    <!-- Overview: v-show (not v-if) so its state survives a switch to Usage and back (SC-006). -->
+    <div v-show="activeView === 'overview'" class="space-y-6" data-test="dashboard-overview-panel">
     <!-- Hub Visualization -->
     <div class="grid grid-cols-1 lg:grid-cols-[280px_1fr_280px] gap-0 min-h-[520px] relative">
 

--- a/frontend/src/views/Servers.vue
+++ b/frontend/src/views/Servers.vue
@@ -122,14 +122,33 @@
       </div>
     </div>
 
+    <!-- A refresh failed but we still hold a list. Say so without throwing the
+         servers away — the cached grid is still the most useful thing on the
+         page, and the failure is about freshness, not about the servers. This
+         is additive, so it sits outside the state chain below. -->
+    <div
+      v-if="hasServers && serversStore.loading.error"
+      class="alert alert-warning"
+      data-test="servers-refresh-error"
+    >
+      <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+      <div class="flex-1 text-sm">
+        Couldn't refresh the server list — showing the last known state.
+        <span class="opacity-70">{{ serversStore.loading.error }}</span>
+      </div>
+      <button @click="refreshServers" class="btn btn-sm">Retry</button>
+    </div>
+
     <!-- Loading State -->
     <div v-if="serversStore.loading.loading" class="text-center py-12">
       <span class="loading loading-spinner loading-lg"></span>
       <p class="mt-4">Loading servers...</p>
     </div>
 
-    <!-- Error State -->
-    <div v-else-if="serversStore.loading.error" class="alert alert-error">
+    <!-- Error State: the load failed and we have nothing to fall back on. -->
+    <div v-else-if="serversStore.loading.error && !hasServers" class="alert alert-error">
       <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
       </svg>

--- a/frontend/src/views/Servers.vue
+++ b/frontend/src/views/Servers.vue
@@ -188,6 +188,20 @@
       </p>
     </div>
 
+    <!-- Nothing to show and no list has arrived. This view does not fetch on
+         mount — App.vue and the Dashboard do — so on a direct load there is a
+         window where `loading` is still false and `servers` is still empty,
+         and neither empty state is true yet. Say "not yet" rather than pick
+         one of them and be wrong. Servers we already hold are a list by
+         definition, so this never gates the grid below. -->
+    <div
+      v-else-if="!hasServers && !serversStore.loaded"
+      class="text-center py-12"
+      data-test="servers-pending"
+    >
+      <span class="loading loading-spinner loading-lg"></span>
+    </div>
+
     <!-- Filter/search empty state: servers exist, none match the current view. -->
     <div v-else-if="filteredServers.length === 0" class="text-center py-12" data-test="servers-filter-empty">
       <svg class="w-24 h-24 mx-auto mb-4 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/frontend/src/views/Servers.vue
+++ b/frontend/src/views/Servers.vue
@@ -33,8 +33,13 @@
       </div>
     </div>
 
+    <!-- Everything between the header and the server grid describes a list that
+         does not exist yet on a fresh install: four zero-valued stat tiles,
+         four zero-count filter pills and a search box with nothing to search.
+         They are hidden until the first server is configured so the empty
+         state below is the only thing on the page. -->
     <!-- Summary Stats — clickable cards drive the filter row (issue #436) -->
-    <div class="stats shadow bg-base-100 w-full">
+    <div v-if="hasServers" class="stats shadow bg-base-100 w-full">
       <button
         type="button"
         data-test="kpi-card-total"
@@ -79,7 +84,7 @@
     </div>
 
     <!-- Filters -->
-    <div class="flex flex-wrap gap-4 items-center justify-between">
+    <div v-if="hasServers" class="flex flex-wrap gap-4 items-center justify-between">
       <div class="flex flex-wrap gap-2">
         <button
           @click="filter = 'all'"
@@ -137,8 +142,54 @@
       </button>
     </div>
 
-    <!-- Empty State -->
-    <div v-else-if="filteredServers.length === 0" class="text-center py-12">
+    <!-- First-run empty state: no servers configured at all. This is the page a
+         new user lands on after closing the setup wizard, so it has to offer
+         the next action rather than restate that the list is empty. Kept
+         distinct from the filter/search empty state below — "you have nothing
+         yet" and "nothing matched" need different answers. -->
+    <div v-else-if="isFirstRun" class="text-center py-12" data-test="servers-first-run-empty">
+      <svg class="w-24 h-24 mx-auto mb-4 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2" />
+      </svg>
+      <h3 class="text-xl font-semibold mb-2">No servers yet</h3>
+      <p class="text-base-content/70 mb-4 max-w-lg mx-auto">
+        Upstream MCP servers are where your tools come from. Add one and MCPProxy
+        indexes its tools, so your AI agent can find them without loading every
+        schema into its context.
+      </p>
+      <div class="flex flex-wrap gap-2 justify-center">
+        <button
+          @click="showAddServer = true"
+          class="btn btn-primary"
+          data-test="servers-empty-add"
+        >
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+          </svg>
+          Add Server
+        </button>
+        <router-link
+          to="/repositories"
+          class="btn btn-outline"
+          data-test="servers-empty-registry"
+        >
+          Browse Registry
+        </router-link>
+      </div>
+      <p class="mt-4 text-sm">
+        <button
+          type="button"
+          class="link link-primary"
+          data-test="servers-empty-import"
+          @click="openImportWizard"
+        >
+          Import from your AI client configs
+        </button>
+      </p>
+    </div>
+
+    <!-- Filter/search empty state: servers exist, none match the current view. -->
+    <div v-else-if="filteredServers.length === 0" class="text-center py-12" data-test="servers-filter-empty">
       <svg class="w-24 h-24 mx-auto mb-4 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2" />
       </svg>
@@ -148,6 +199,9 @@
       </p>
       <button v-if="searchQuery" @click="searchQuery = ''" class="btn btn-outline">
         Clear Search
+      </button>
+      <button v-else @click="filter = 'all'" class="btn btn-outline">
+        Show all servers
       </button>
     </div>
 
@@ -179,25 +233,57 @@
 
     <!-- Hints Panel (Bottom of Page) -->
     <CollapsibleHintsPanel :hints="serversHints" />
+
+    <AddServerModal :show="showAddServer" @close="showAddServer = false" @added="onServerAdded" />
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+import { useRouter } from 'vue-router'
 import { useServersStore } from '@/stores/servers'
 import { useSystemStore } from '@/stores/system'
+import { useOnboardingStore } from '@/stores/onboarding'
 import api from '@/services/api'
 import ServerCard from '@/components/ServerCard.vue'
+import AddServerModal from '@/components/AddServerModal.vue'
 import CollapsibleHintsPanel from '@/components/CollapsibleHintsPanel.vue'
 import type { Hint } from '@/components/CollapsibleHintsPanel.vue'
 import { useSecurityScannerStatus } from '@/composables/useSecurityScannerStatus'
 
 const serversStore = useServersStore()
 const systemStore = useSystemStore()
+const onboardingStore = useOnboardingStore()
+const router = useRouter()
 const filter = ref<'all' | 'connected' | 'enabled' | 'quarantined'>('all')
 const searchQuery = ref('')
 const scanAllRunning = ref(false)
+const showAddServer = ref(false)
 const { hasEnabledScanners } = useSecurityScannerStatus()
+
+// The page chrome (stat tiles, filter pills, search) only describes a list that
+// exists. `servers.length` — not `loaded` — is the right gate: it is also false
+// while the very first fetch is in flight, so a fresh install never flashes a
+// row of zeroes before the empty state resolves.
+const hasServers = computed(() => serversStore.servers.length > 0)
+
+// Telling the user "you have no servers" is a claim, and only a list that
+// actually arrived can support it. `loaded` (set once any successful list has
+// been applied) is what distinguishes "none configured" from "we don't know
+// yet" — `servers` starts empty either way.
+const isFirstRun = computed(() => serversStore.loaded && serversStore.servers.length === 0)
+
+function onServerAdded() {
+  showAddServer.value = false
+  void serversStore.fetchServers()
+}
+
+// The setup wizard is mounted by Dashboard.vue, so opening it from here means
+// navigating there first; the store carries the tab request across the hop.
+function openImportWizard() {
+  onboardingStore.openWizard('servers')
+  void router.push('/')
+}
 
 const filteredServers = computed(() => {
   let servers = serversStore.servers

--- a/frontend/tests/unit/dashboard-attention-banners.spec.ts
+++ b/frontend/tests/unit/dashboard-attention-banners.spec.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ref } from 'vue'
+import { shallowMount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createRouter, createMemoryHistory } from 'vue-router'
+
+// UX audit F4 (residual after #1044): the analytics panel is now the default
+// landing page and the hub diagram is demoted to the Overview tab — but the two
+// banners that answer "what needs me" (servers in a bad state, tools awaiting
+// approval) went down with it. A landing page that renders charts while a
+// server is down and an unreviewed tool is waiting, and says neither, is only
+// half of the finding's fix.
+//
+// These tests pin the banners above the panel switcher: visible on whichever
+// panel is active, and absent when there is genuinely nothing to act on.
+
+const pendingSpy = vi.hoisted(() => vi.fn())
+
+vi.mock('@/services/api', () => {
+  const ok = (data: unknown = null) => vi.fn().mockResolvedValue({ success: true, data })
+  const fakeEventSource = {
+    onopen: null,
+    onmessage: null,
+    onerror: null,
+    addEventListener() {},
+    removeEventListener() {},
+    close() {},
+  }
+  const base: Record<string, unknown> = {
+    getServers: ok({
+      servers: [
+        {
+          name: 'broken',
+          enabled: true,
+          connected: false,
+          quarantined: false,
+          tool_count: 0,
+          health: {
+            level: 'unhealthy',
+            admin_state: 'enabled',
+            summary: 'Connection refused',
+            action: 'restart',
+          },
+        },
+      ],
+    }),
+    getToolApprovals: pendingSpy,
+    createEventSource: vi.fn(() => fakeEventSource),
+    hasAPIKey: vi.fn(() => true),
+    getAPIKeyPreview: vi.fn(() => 'test…'),
+    onAuthError: vi.fn(() => () => {}),
+  }
+  return {
+    default: new Proxy(base, {
+      get(target: Record<string, unknown>, prop: string) {
+        if (prop in target) return target[prop]
+        target[prop] = ok()
+        return target[prop]
+      },
+    }),
+  }
+})
+
+vi.mock('@/composables/useSecurityScannerStatus', () => ({
+  refreshSecurityScannerStatus: vi.fn().mockResolvedValue(undefined),
+  useSecurityScannerStatus: () => ({
+    totalFindings: ref(0),
+    totalScans: ref(0),
+    loaded: ref(true),
+  }),
+}))
+
+import Dashboard from '@/views/Dashboard.vue'
+import { useServersStore } from '@/stores/servers'
+
+class FakeEventSource {
+  close() {}
+  addEventListener() {}
+  onmessage: ((e: unknown) => void) | null = null
+  onerror: ((e: unknown) => void) | null = null
+}
+
+function makeRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', name: 'dashboard', component: Dashboard, meta: { dashboardView: 'usage' } },
+      { path: '/usage', name: 'usage', component: Dashboard, meta: { dashboardView: 'usage' } },
+      { path: '/overview', name: 'dashboard-overview', component: Dashboard, meta: { dashboardView: 'overview' } },
+      { path: '/:pathMatch(.*)*', name: 'other', component: { template: '<div />' } },
+    ],
+  })
+}
+
+async function mountDashboard(path = '/') {
+  const router = makeRouter()
+  router.push(path)
+  await router.isReady()
+  const wrapper = shallowMount(Dashboard, {
+    global: {
+      plugins: [createPinia(), router],
+      stubs: {
+        RouterLink: { template: '<a><slot /></a>' },
+      },
+    },
+  })
+  await flushPromises()
+  return wrapper
+}
+
+/**
+ * The banners must not be inside either panel wrapper — a `v-show`-hidden
+ * ancestor would render them into the DOM while keeping them invisible, which
+ * an `exists()` assertion alone would happily pass.
+ */
+function isOutsidePanels(el: Element): boolean {
+  let node: Element | null = el.parentElement
+  while (node) {
+    const dt = node.getAttribute?.('data-test')
+    if (dt === 'dashboard-usage-panel' || dt === 'dashboard-overview-panel') return false
+    node = node.parentElement
+  }
+  return true
+}
+
+describe('Dashboard "what needs me" banners (F4 residual)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    pendingSpy.mockReset()
+    pendingSpy.mockResolvedValue({ success: true, data: { tools: [] } })
+    ;(globalThis as unknown as { EventSource: unknown }).EventSource = FakeEventSource
+  })
+
+  it('shows the servers-needing-attention banner on the default landing panel', async () => {
+    const wrapper = await mountDashboard('/')
+
+    const banner = wrapper.findAll('.alert-warning').find(w => w.text().includes('needs attention'))
+    expect(banner, 'attention banner missing from the default landing page').toBeTruthy()
+    expect(banner!.text()).toContain('broken')
+    expect(banner!.text()).toContain('Connection refused')
+  })
+
+  it('renders the banner outside both panel wrappers, so no tab can hide it', async () => {
+    const wrapper = await mountDashboard('/')
+
+    const banner = wrapper.findAll('.alert-warning').find(w => w.text().includes('needs attention'))
+    expect(banner).toBeTruthy()
+    expect(isOutsidePanels(banner!.element)).toBe(true)
+  })
+
+  it('still shows it on the Overview panel', async () => {
+    const wrapper = await mountDashboard('/overview')
+
+    const banner = wrapper.findAll('.alert-warning').find(w => w.text().includes('needs attention'))
+    expect(banner).toBeTruthy()
+  })
+
+  it('shows the pending-tools banner on the default landing panel', async () => {
+    pendingSpy.mockResolvedValue({
+      success: true,
+      data: { tools: [{ name: 'broken:danger', server_name: 'broken', status: 'pending' }] },
+    })
+    const wrapper = await mountDashboard('/')
+
+    const banner = wrapper.findAll('.alert-warning').find(w => w.text().includes('pending approval'))
+    expect(banner, 'pending-tools banner missing from the default landing page').toBeTruthy()
+    expect(isOutsidePanels(banner!.element)).toBe(true)
+  })
+
+  it('stays silent when nothing needs attention', async () => {
+    const wrapper = await mountDashboard('/')
+    const store = useServersStore()
+    store.servers = [
+      { name: 'ok', enabled: true, connected: true, quarantined: false, tool_count: 3 } as never,
+    ]
+    await flushPromises()
+
+    const banner = wrapper.findAll('.alert-warning').find(w => w.text().includes('needs attention'))
+    expect(banner).toBeUndefined()
+  })
+})

--- a/frontend/tests/unit/onboarding-wizard-servers-step.spec.ts
+++ b/frontend/tests/unit/onboarding-wizard-servers-step.spec.ts
@@ -147,6 +147,27 @@ describe('OnboardingWizard servers step (F19)', () => {
       expect(router.currentRoute.value.path).toBe('/repositories')
     })
 
+    it('emits close BEFORE the route changes, not after', async () => {
+      // `dismiss()` awaits its mark-skipped calls before emitting. If the route
+      // moved first it would unmount the Dashboard that owns the open flag, and
+      // the late emit could find nothing left to clear it — the wizard would
+      // spring back open on return. Sample the emit state from inside the
+      // navigation itself, which is the only way to see the real ordering.
+      const { wrapper, router } = await openServersTab([])
+
+      let closeAlreadyEmitted: boolean | null = null
+      router.beforeEach(() => {
+        closeAlreadyEmitted = Boolean(wrapper.emitted('close'))
+        return true
+      })
+
+      await wrapper.find('[data-test="nothing-to-import-registry"]').trigger('click')
+      await flushPromises()
+
+      expect(closeAlreadyEmitted, 'navigation started before close was emitted').toBe(true)
+      expect(router.currentRoute.value.path).toBe('/repositories')
+    })
+
     it('still exposes the security choice', async () => {
       const { wrapper } = await openServersTab([])
 
@@ -208,6 +229,16 @@ describe('OnboardingWizard servers step (F19)', () => {
       expect(wrapper.find('[data-test="wizard-back"]').exists()).toBe(true)
     })
 
+    it('keeps a Close, so the step is never a trap', async () => {
+      // A step whose only exits are "import" strands the user, and the
+      // committed e2e sweep dismisses an auto-opened wizard through exactly
+      // this control — on a fresh instance the wizard can land here.
+      const { wrapper } = await openServersTab(['memory'])
+      const close = wrapper.find('[data-test="close-wizard"]')
+      expect(close.exists()).toBe(true)
+      expect(close.attributes('disabled')).toBeUndefined()
+    })
+
     it('Back returns to the previous step', async () => {
       const { wrapper } = await openServersTab(['memory'])
 
@@ -228,5 +259,65 @@ describe('OnboardingWizard servers step (F19)', () => {
     // The request is one-shot: a later plain open must not be redirected.
     expect(store.wizardInitialTab).toBe(null)
     expect(wrapper.find('[data-test="panel-servers"]').exists()).toBe(true)
+  })
+})
+
+// The Servers page's import link flips the store flag and THEN routes to the
+// Dashboard — which is the component that mounts the wizard. So the wizard can
+// come into existence with `show` already true, and never see a change to
+// watch. It must still initialise, and still honour the requested step.
+describe('OnboardingWizard mounted already-open', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    ;(api.getActivities as any).mockResolvedValue({ success: true, data: { activities: [] } })
+    ;(api.getConfig as any).mockResolvedValue({ success: true, data: {} })
+    ;(api.getDockerStatus as any).mockResolvedValue({ success: true, data: { available: true } })
+    ;(api.getConnectStatus as any).mockResolvedValue({ success: true, data: { clients: [] } })
+    ;(api.getCanonicalConfigPaths as any).mockResolvedValue({ success: true, data: { paths: [] } })
+    ;(api.getOnboardingState as any).mockResolvedValue(onboardingState())
+    ;(api.markOnboardingState as any).mockResolvedValue(onboardingState())
+  })
+
+  async function mountAlreadyOpen() {
+    const router = makeRouter()
+    router.push('/')
+    await router.isReady()
+    const wrapper = mount(OnboardingWizard, {
+      // Already open at mount — no false→true transition ever happens.
+      props: { show: true },
+      global: {
+        plugins: [router],
+        stubs: {
+          RouterLink: { template: '<a><slot /></a>' },
+          AddServerModal: { name: 'AddServerModal', props: ['show'], template: '<div />' },
+        },
+      },
+    })
+    await flushPromises()
+    return wrapper
+  }
+
+  it('lands on the requested step and consumes the request', async () => {
+    const store = useOnboardingStore()
+    store.openWizard('servers')
+
+    const wrapper = await mountAlreadyOpen()
+
+    expect(wrapper.find('[data-test="panel-servers"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="panel-clients"]').exists()).toBe(false)
+    // Not left behind to hijack the next plain open.
+    expect(store.wizardInitialTab).toBe(null)
+  })
+
+  it('still initialises (fetches its state) with no request pending', async () => {
+    const store = useOnboardingStore()
+    store.openWizard()
+
+    await mountAlreadyOpen()
+
+    expect(api.getOnboardingState).toHaveBeenCalled()
+    expect(api.getConnectStatus).toHaveBeenCalled()
+    expect(store.wizardInitialTab).toBe(null)
   })
 })

--- a/frontend/tests/unit/onboarding-wizard-servers-step.spec.ts
+++ b/frontend/tests/unit/onboarding-wizard-servers-step.spec.ts
@@ -310,6 +310,46 @@ describe('OnboardingWizard mounted already-open', () => {
     expect(store.wizardInitialTab).toBe(null)
   })
 
+  it('an open that is still loading when the wizard closes does not stamp its tab', async () => {
+    // Nothing cancels the open sequence's fetches. A close (or a close then a
+    // reopen) mid-flight must not let the old run choose the tab or restart
+    // polling behind the newer state.
+    let releaseState: (v: unknown) => void = () => {}
+    ;(api.getOnboardingState as any).mockReturnValue(
+      new Promise((resolve) => { releaseState = resolve })
+    )
+
+    const router = makeRouter()
+    router.push('/')
+    await router.isReady()
+    const wrapper = mount(OnboardingWizard, {
+      props: { show: true },
+      global: {
+        plugins: [router],
+        stubs: {
+          RouterLink: { template: '<a><slot /></a>' },
+          AddServerModal: { name: 'AddServerModal', props: ['show'], template: '<div />' },
+        },
+      },
+    })
+    await flushPromises()
+
+    // Close while the first fetch is still outstanding.
+    await wrapper.setProps({ show: false })
+    await flushPromises()
+
+    // Now let the stale run finish. Its predicates would pick 'servers'
+    // (has_connected_client true, has_configured_server false).
+    releaseState({ success: true, data: onboardingState().data })
+    await flushPromises()
+
+    // The dialog keeps its content in the DOM when closed (only the `open`
+    // attribute goes), so the invariant to check is which tab it is on: the
+    // abandoned run must not have moved it off the default.
+    expect(wrapper.find('[data-test="panel-servers"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="panel-clients"]').exists()).toBe(true)
+  })
+
   it('still initialises (fetches its state) with no request pending', async () => {
     const store = useOnboardingStore()
     store.openWizard()

--- a/frontend/tests/unit/onboarding-wizard-servers-step.spec.ts
+++ b/frontend/tests/unit/onboarding-wizard-servers-step.spec.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import OnboardingWizard from '@/components/OnboardingWizard.vue'
+import { useOnboardingStore } from '@/stores/onboarding'
+import api from '@/services/api'
+
+// UX audit F19: the wizard's Servers step was entirely "pick which servers from
+// your existing AI clients to import".
+//
+//   - A user with no prior MCP config saw an empty list and no alternative —
+//     a dead end on the step that decides whether the product gets used.
+//   - The footer offered two similar primaries ("Import as active" /
+//     "Import & quarantine") with the safer one rendered as the weaker.
+//   - The security choice (Docker isolation, quarantine) sat behind a
+//     collapsed disclosure, and was absent entirely when nothing was
+//     importable.
+//   - There was no Back.
+
+vi.mock('@/services/api', () => ({
+  default: {
+    getConnectStatus: vi.fn(),
+    getOnboardingState: vi.fn(),
+    markOnboardingState: vi.fn(),
+    getActivities: vi.fn(),
+    getConfig: vi.fn(),
+    getDockerStatus: vi.fn(),
+    getCanonicalConfigPaths: vi.fn(),
+    getConnectPreview: vi.fn(),
+    connectClient: vi.fn(),
+    importServersFromPath: vi.fn(),
+  },
+}))
+
+function onboardingState() {
+  return {
+    success: true,
+    data: {
+      has_connected_client: true,
+      has_configured_server: false,
+      connected_client_count: 1,
+      connected_client_ids: ['cursor'],
+      configured_server_count: 0,
+      state: { engaged: false },
+      should_show_wizard: true,
+      first_mcp_client_ever: false,
+      mcp_clients_seen_ever: [],
+      incomplete_tab_count: 1,
+    },
+  }
+}
+
+const CURSOR_PATH = '/Users/test/.cursor/mcp.json'
+
+function makeRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', name: 'dashboard', component: { template: '<div />' } },
+      { path: '/repositories', name: 'repositories', component: { template: '<div />' } },
+      { path: '/:pathMatch(.*)*', name: 'other', component: { template: '<div />' } },
+    ],
+  })
+}
+
+/**
+ * Mount the wizard and land on the Servers tab.
+ *
+ * `importable` drives the only axis these tests care about: whether any client
+ * config on this machine has servers to import.
+ */
+async function openServersTab(importable: string[]) {
+  const paths = importable.length > 0
+    ? [{ name: 'Cursor', format: 'json', path: CURSOR_PATH, exists: true }]
+    : []
+  ;(api.getCanonicalConfigPaths as any).mockResolvedValue({ success: true, data: { paths } })
+  ;(api.importServersFromPath as any).mockResolvedValue({
+    success: true,
+    data: { imported: importable.map(name => ({ name })) },
+  })
+
+  const router = makeRouter()
+  router.push('/')
+  await router.isReady()
+
+  const wrapper = mount(OnboardingWizard, {
+    props: { show: false },
+    global: {
+      plugins: [router],
+      stubs: {
+        RouterLink: { template: '<a><slot /></a>' },
+        AddServerModal: {
+          name: 'AddServerModal',
+          props: ['show'],
+          template: '<div class="add-server-modal" :data-show="String(show)" />',
+        },
+      },
+    },
+  })
+  await wrapper.setProps({ show: true })
+  await flushPromises()
+  await wrapper.find('[data-test="tab-servers"]').trigger('click')
+  await flushPromises()
+  return { wrapper, router }
+}
+
+describe('OnboardingWizard servers step (F19)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    ;(api.getActivities as any).mockResolvedValue({ success: true, data: { activities: [] } })
+    ;(api.getConfig as any).mockResolvedValue({ success: true, data: {} })
+    ;(api.getDockerStatus as any).mockResolvedValue({ success: true, data: { available: true } })
+    ;(api.getConnectStatus as any).mockResolvedValue({ success: true, data: { clients: [] } })
+    ;(api.getOnboardingState as any).mockResolvedValue(onboardingState())
+    ;(api.markOnboardingState as any).mockResolvedValue(onboardingState())
+  })
+
+  describe('with nothing to import', () => {
+    it('offers a registry branch and a manual-add branch instead of a dead end', async () => {
+      const { wrapper } = await openServersTab([])
+
+      const panel = wrapper.find('[data-test="servers-nothing-to-import"]')
+      expect(panel.exists()).toBe(true)
+      expect(panel.text()).toContain('Nothing to import')
+      expect(wrapper.find('[data-test="nothing-to-import-registry"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="nothing-to-import-manual"]').exists()).toBe(true)
+    })
+
+    it('the manual branch opens the add-server form', async () => {
+      const { wrapper } = await openServersTab([])
+
+      expect(wrapper.find('.add-server-modal').attributes('data-show')).toBe('false')
+      await wrapper.find('[data-test="nothing-to-import-manual"]').trigger('click')
+      expect(wrapper.find('.add-server-modal').attributes('data-show')).toBe('true')
+    })
+
+    it('the registry branch closes the wizard before navigating away', async () => {
+      const { wrapper, router } = await openServersTab([])
+
+      await wrapper.find('[data-test="nothing-to-import-registry"]').trigger('click')
+      await flushPromises()
+
+      // A modal left open would hang over the registry page.
+      expect(wrapper.emitted('close')).toBeTruthy()
+      expect(router.currentRoute.value.path).toBe('/repositories')
+    })
+
+    it('still exposes the security choice', async () => {
+      const { wrapper } = await openServersTab([])
+
+      const security = wrapper.find('[data-test="security-panel"]')
+      expect(security.exists()).toBe(true)
+      expect(security.attributes('open')).toBeDefined()
+      expect(wrapper.find('[data-test="toggle-quarantine"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="toggle-docker-isolation"]').exists()).toBe(true)
+    })
+
+    it('offers Back', async () => {
+      const { wrapper } = await openServersTab([])
+      expect(wrapper.find('[data-test="wizard-back"]').exists()).toBe(true)
+    })
+
+    it('does not repeat manual-add as a second collapsed disclosure', async () => {
+      const { wrapper } = await openServersTab([])
+      expect(wrapper.find('[data-test="manual-add-details"]').exists()).toBe(false)
+    })
+  })
+
+  describe('with servers to import', () => {
+    it('expands the security choice by default rather than hiding it', async () => {
+      const { wrapper } = await openServersTab(['memory', 'everything'])
+
+      const security = wrapper.find('[data-test="security-panel"]')
+      expect(security.exists()).toBe(true)
+      // A `<details>` the user has to think to click is not a surfaced choice.
+      expect(security.attributes('open')).toBeDefined()
+    })
+
+    it('makes the reviewed import the single primary action', async () => {
+      const { wrapper } = await openServersTab(['memory'])
+
+      const quarantine = wrapper.find('[data-test="bulk-import-quarantine"]')
+      const active = wrapper.find('[data-test="bulk-import-active"]')
+      expect(quarantine.exists()).toBe(true)
+      expect(active.exists()).toBe(true)
+
+      // Exactly one primary, and it is the one that holds servers for review.
+      expect(quarantine.classes()).toContain('btn-primary')
+      expect(active.classes()).not.toContain('btn-primary')
+      expect(active.classes()).not.toContain('btn-secondary')
+      expect(active.classes()).toContain('btn-link')
+      // …and the unreviewed path says what it skips.
+      expect(active.text()).toContain('Import without review')
+    })
+
+    it('caps the import list so the last row is not clipped without a scrollbar', async () => {
+      const { wrapper } = await openServersTab(['memory'])
+
+      const list = wrapper.find('[data-test="import-section-json"]').element.parentElement!
+      expect(list.className).toContain('overflow-y-auto')
+      expect(list.className).toMatch(/max-h-/)
+    })
+
+    it('offers Back', async () => {
+      const { wrapper } = await openServersTab(['memory'])
+      expect(wrapper.find('[data-test="wizard-back"]').exists()).toBe(true)
+    })
+
+    it('Back returns to the previous step', async () => {
+      const { wrapper } = await openServersTab(['memory'])
+
+      await wrapper.find('[data-test="wizard-back"]').trigger('click')
+      await flushPromises()
+
+      expect(wrapper.find('[data-test="panel-clients"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="panel-servers"]').exists()).toBe(false)
+    })
+  })
+
+  it('opens on the step the caller asked for, once', async () => {
+    setActivePinia(createPinia())
+    const store = useOnboardingStore()
+    store.openWizard('servers')
+
+    const { wrapper } = await openServersTab([])
+    // The request is one-shot: a later plain open must not be redirected.
+    expect(store.wizardInitialTab).toBe(null)
+    expect(wrapper.find('[data-test="panel-servers"]').exists()).toBe(true)
+  })
+})

--- a/frontend/tests/unit/onboarding-wizard-servers-step.spec.ts
+++ b/frontend/tests/unit/onboarding-wizard-servers-step.spec.ts
@@ -350,6 +350,52 @@ describe('OnboardingWizard mounted already-open', () => {
     expect(wrapper.find('[data-test="panel-clients"]').exists()).toBe(true)
   })
 
+  it('a superseded config read does not flip the security toggles back', async () => {
+    // These checkboxes are the one thing the open sequence writes that the user
+    // can also edit — and the panel is expanded by default, so editing one
+    // immediately is the expected path. A config read from a superseded open
+    // landing afterwards must not silently revert the user's choice.
+    let releaseConfig: (v: unknown) => void = () => {}
+    ;(api.getConfig as any).mockReturnValueOnce(
+      new Promise((resolve) => { releaseConfig = resolve })
+    )
+
+    const router = makeRouter()
+    router.push('/')
+    await router.isReady()
+    const wrapper = mount(OnboardingWizard, {
+      props: { show: true },
+      global: {
+        plugins: [router],
+        stubs: {
+          RouterLink: { template: '<a><slot /></a>' },
+          AddServerModal: { name: 'AddServerModal', props: ['show'], template: '<div />' },
+        },
+      },
+    })
+    await flushPromises()
+
+    // Supersede the first open: close, then reopen with quarantine off.
+    await wrapper.setProps({ show: false })
+    ;(api.getConfig as any).mockResolvedValue({
+      success: true,
+      data: { config: { quarantine_enabled: false } },
+    })
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+    await wrapper.find('[data-test="tab-servers"]').trigger('click')
+    await flushPromises()
+
+    const toggle = () => wrapper.find('[data-test="toggle-quarantine"]')
+    expect((toggle().element as HTMLInputElement).checked).toBe(false)
+
+    // The abandoned read finally returns, claiming quarantine is ON.
+    releaseConfig({ success: true, data: { config: { quarantine_enabled: true } } })
+    await flushPromises()
+
+    expect((toggle().element as HTMLInputElement).checked).toBe(false)
+  })
+
   it('still initialises (fetches its state) with no request pending', async () => {
     const store = useOnboardingStore()
     store.openWizard()

--- a/frontend/tests/unit/servers-first-run-empty.spec.ts
+++ b/frontend/tests/unit/servers-first-run-empty.spec.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ref } from 'vue'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createRouter, createMemoryHistory } from 'vue-router'
+
+// UX audit F3: the Servers page is where a new user lands after closing the
+// setup wizard, and with zero servers it used to render "No servers found /
+// No servers available" — a restatement with no way forward — above four
+// zero-valued stat tiles and four zero-count filter pills.
+//
+// These tests pin the two halves of the fix:
+//   1. Zero servers => a real empty state (add / registry / import), and none
+//      of the chrome that describes a list which does not exist.
+//   2. Servers exist but none match the filter or search => the *other* empty
+//      state. "You have nothing yet" and "nothing matched" are different
+//      problems and must not collapse into one message.
+
+vi.mock('@/services/api', () => {
+  const ok = (data: unknown = null) => vi.fn().mockResolvedValue({ success: true, data })
+  const base: Record<string, unknown> = {
+    getServers: ok({ servers: [] }),
+    hasAPIKey: vi.fn(() => true),
+    onAuthError: vi.fn(() => () => {}),
+  }
+  return {
+    default: new Proxy(base, {
+      get(target: Record<string, unknown>, prop: string) {
+        if (prop in target) return target[prop]
+        target[prop] = ok()
+        return target[prop]
+      },
+    }),
+  }
+})
+
+vi.mock('@/composables/useSecurityScannerStatus', () => ({
+  useSecurityScannerStatus: () => ({
+    hasEnabledScanners: () => false,
+    totalFindings: ref(0),
+    totalScans: ref(0),
+    loaded: ref(true),
+  }),
+}))
+
+import Servers from '@/views/Servers.vue'
+import { useServersStore } from '@/stores/servers'
+import { useOnboardingStore } from '@/stores/onboarding'
+import type { Server } from '@/types'
+
+function makeRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', name: 'dashboard', component: { template: '<div />' } },
+      { path: '/servers', name: 'servers', component: Servers },
+      { path: '/repositories', name: 'repositories', component: { template: '<div />' } },
+      { path: '/:pathMatch(.*)*', name: 'other', component: { template: '<div />' } },
+    ],
+  })
+}
+
+async function mountServers() {
+  const router = makeRouter()
+  router.push('/servers')
+  await router.isReady()
+  const wrapper = mount(Servers, {
+    global: {
+      plugins: [createPinia(), router],
+      stubs: {
+        ServerCard: { template: '<div class="server-card" />' },
+        AddServerModal: {
+          name: 'AddServerModal',
+          props: ['show'],
+          template: '<div class="add-server-modal" :data-show="String(show)" />',
+        },
+        CollapsibleHintsPanel: true,
+      },
+    },
+  })
+  await flushPromises()
+  return { wrapper, router }
+}
+
+function server(name: string, overrides: Partial<Server> = {}): Server {
+  return {
+    name,
+    enabled: true,
+    connected: true,
+    quarantined: false,
+    tool_count: 1,
+    ...overrides,
+  } as Server
+}
+
+describe('Servers first-run empty state (F3)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('offers add-server, registry and import actions when no servers are configured', async () => {
+    const { wrapper } = await mountServers()
+    const store = useServersStore()
+    store.servers = []
+    store.loaded = true
+    await flushPromises()
+
+    const empty = wrapper.find('[data-test="servers-first-run-empty"]')
+    expect(empty.exists()).toBe(true)
+    expect(empty.text()).toContain('No servers yet')
+    expect(wrapper.find('[data-test="servers-empty-add"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="servers-empty-registry"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="servers-empty-import"]').exists()).toBe(true)
+    // The generic "nothing matched" state must not also be on screen.
+    expect(wrapper.find('[data-test="servers-filter-empty"]').exists()).toBe(false)
+  })
+
+  it('hides the stat tiles, filter pills and search box while there are no servers', async () => {
+    const { wrapper } = await mountServers()
+    const store = useServersStore()
+    store.servers = []
+    store.loaded = true
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="kpi-card-total"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="kpi-card-connected"]').exists()).toBe(false)
+    expect(wrapper.find('input[placeholder="Search servers..."]').exists()).toBe(false)
+  })
+
+  it('does not claim "no servers" before a list has actually arrived', async () => {
+    const { wrapper } = await mountServers()
+    const store = useServersStore()
+    // `servers` is empty at rest too — only `loaded` separates "none
+    // configured" from "we have not been told yet".
+    store.servers = []
+    store.loaded = false
+    store.loading = { loading: false, error: null }
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="servers-first-run-empty"]').exists()).toBe(false)
+  })
+
+  it('opening the add-server modal shows it', async () => {
+    const { wrapper } = await mountServers()
+    const store = useServersStore()
+    store.servers = []
+    store.loaded = true
+    await flushPromises()
+
+    expect(wrapper.find('.add-server-modal').attributes('data-show')).toBe('false')
+    await wrapper.find('[data-test="servers-empty-add"]').trigger('click')
+    expect(wrapper.find('.add-server-modal').attributes('data-show')).toBe('true')
+  })
+
+  it('the import link routes to the dashboard with the wizard queued on the servers step', async () => {
+    const { wrapper, router } = await mountServers()
+    const store = useServersStore()
+    store.servers = []
+    store.loaded = true
+    await flushPromises()
+
+    await wrapper.find('[data-test="servers-empty-import"]').trigger('click')
+    await flushPromises()
+
+    const onboarding = useOnboardingStore()
+    expect(onboarding.wizardOpen).toBe(true)
+    expect(onboarding.wizardInitialTab).toBe('servers')
+    // The wizard is mounted by Dashboard.vue, so the Servers page has to hand
+    // over to it rather than try to render it in place.
+    expect(router.currentRoute.value.path).toBe('/')
+  })
+
+  it('falls back to the filter/search empty state once servers exist', async () => {
+    const { wrapper } = await mountServers()
+    const store = useServersStore()
+    store.servers = [server('alpha')]
+    store.loaded = true
+    await flushPromises()
+
+    await wrapper.find('input[placeholder="Search servers..."]').setValue('nothing-matches-this')
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="servers-filter-empty"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="servers-first-run-empty"]').exists()).toBe(false)
+    // Chrome stays: the user has servers, they are just filtered out.
+    expect(wrapper.find('[data-test="kpi-card-total"]').exists()).toBe(true)
+  })
+})

--- a/frontend/tests/unit/servers-first-run-empty.spec.ts
+++ b/frontend/tests/unit/servers-first-run-empty.spec.ts
@@ -140,6 +140,34 @@ describe('Servers first-run empty state (F3)', () => {
     expect(wrapper.find('[data-test="servers-first-run-empty"]').exists()).toBe(false)
   })
 
+  it('does not claim "nothing matched" either, before a list has arrived', async () => {
+    // This view does not fetch on mount, so `loading` can be false while the
+    // list is still unknown. Neither empty state is true then; showing one
+    // would tell the user something false about their own setup.
+    const { wrapper } = await mountServers()
+    const store = useServersStore()
+    store.servers = []
+    store.loaded = false
+    store.loading = { loading: false, error: null }
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="servers-filter-empty"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="servers-pending"]').exists()).toBe(true)
+  })
+
+  it('renders servers it already holds even if the load flag was never set', async () => {
+    // Servers in hand are a list by definition — the pending state must never
+    // stand between the user and a grid we can already draw.
+    const { wrapper } = await mountServers()
+    const store = useServersStore()
+    store.servers = [server('alpha'), server('beta')]
+    store.loaded = false
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="servers-pending"]').exists()).toBe(false)
+    expect(wrapper.findAll('.server-card')).toHaveLength(2)
+  })
+
   it('opening the add-server modal shows it', async () => {
     const { wrapper } = await mountServers()
     const store = useServersStore()

--- a/frontend/tests/unit/servers-first-run-empty.spec.ts
+++ b/frontend/tests/unit/servers-first-run-empty.spec.ts
@@ -198,6 +198,33 @@ describe('Servers first-run empty state (F3)', () => {
     expect(router.currentRoute.value.path).toBe('/')
   })
 
+  it('keeps showing the grid when a refresh fails, with a non-blocking notice', async () => {
+    // A background refresh failure is about freshness, not about the servers.
+    // Replacing a usable grid with a full-page error loses more than it says.
+    const { wrapper } = await mountServers()
+    const store = useServersStore()
+    store.servers = [server('alpha')]
+    store.loaded = true
+    store.loading = { loading: false, error: 'network down' }
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="servers-refresh-error"]').exists()).toBe(true)
+    expect(wrapper.findAll('.server-card')).toHaveLength(1)
+    expect(wrapper.find('.alert-error').exists()).toBe(false)
+  })
+
+  it('still blocks with the full error when the load failed and there is no fallback', async () => {
+    const { wrapper } = await mountServers()
+    const store = useServersStore()
+    store.servers = []
+    store.loaded = false
+    store.loading = { loading: false, error: 'network down' }
+    await flushPromises()
+
+    expect(wrapper.find('.alert-error').text()).toContain('Failed to load servers')
+    expect(wrapper.find('[data-test="servers-refresh-error"]').exists()).toBe(false)
+  })
+
   it('falls back to the filter/search empty state once servers exist', async () => {
     const { wrapper } = await mountServers()
     const store = useServersStore()

--- a/frontend/tests/unit/servers-store.spec.ts
+++ b/frontend/tests/unit/servers-store.spec.ts
@@ -188,3 +188,46 @@ describe('useServersStore — securityApproveServer (F-04)', () => {
     expect(api.unquarantineServer).not.toHaveBeenCalled()
   })
 })
+
+describe('useServersStore — a successful list clears a stale error', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  const srv = { name: 'srv', protocol: 'http' as const, enabled: true, connected: true, tool_count: 1 }
+
+  it('clears loading.error once a list arrives', async () => {
+    // `loading.error` was write-only: a silent background refresh sets it and
+    // nothing ever cleared it, so one transient blip pinned an error on the
+    // Servers page for the rest of the session.
+    const store = useServersStore()
+
+    ;(api.getServers as any).mockResolvedValue({ success: false, error: 'network down' })
+    await store.fetchServers(true)
+    expect(store.loading.error).toBe('network down')
+
+    ;(api.getServers as any).mockResolvedValue({ success: true, data: { servers: [srv] } })
+    await store.fetchServers(true)
+
+    expect(store.loading.error).toBeNull()
+    expect(store.servers).toHaveLength(1)
+    expect(store.loaded).toBe(true)
+  })
+
+  it('still records a failure that happens after a successful load', async () => {
+    // Clearing on success must not make errors unreportable afterwards.
+    const store = useServersStore()
+
+    ;(api.getServers as any).mockResolvedValue({ success: true, data: { servers: [srv] } })
+    await store.fetchServers(true)
+    expect(store.loading.error).toBeNull()
+
+    ;(api.getServers as any).mockResolvedValue({ success: false, error: 'network down' })
+    await store.fetchServers(true)
+
+    expect(store.loading.error).toBe('network down')
+    // …and the servers we already hold are still there to fall back on.
+    expect(store.servers).toHaveLength(1)
+  })
+})

--- a/frontend/tests/unit/servers-store.spec.ts
+++ b/frontend/tests/unit/servers-store.spec.ts
@@ -215,6 +215,30 @@ describe('useServersStore — a successful list clears a stale error', () => {
     expect(store.loaded).toBe(true)
   })
 
+  it('drops a failure from a request the newer list already superseded', async () => {
+    // Failures are sequenced like successes: an older request failing after a
+    // newer one delivered a list must not raise a stale error over fresh data.
+    const store = useServersStore()
+
+    let failOld: (v: unknown) => void = () => {}
+    ;(api.getServers as any).mockReturnValueOnce(
+      new Promise((resolve) => { failOld = resolve })
+    )
+    const oldFetch = store.fetchServers(true)
+
+    // A newer request completes first, with a real list.
+    ;(api.getServers as any).mockResolvedValueOnce({ success: true, data: { servers: [srv] } })
+    await store.fetchServers(true)
+    expect(store.loading.error).toBeNull()
+
+    // Only now does the older one come back, failing.
+    failOld({ success: false, error: 'stale failure' })
+    await oldFetch
+
+    expect(store.loading.error).toBeNull()
+    expect(store.servers).toHaveLength(1)
+  })
+
   it('still records a failure that happens after a successful load', async () => {
     // Clearing on success must not make errors unreportable afterwards.
     const store = useServersStore()

--- a/frontend/tests/unit/servers-store.spec.ts
+++ b/frontend/tests/unit/servers-store.spec.ts
@@ -239,6 +239,32 @@ describe('useServersStore — a successful list clears a stale error', () => {
     expect(store.servers).toHaveLength(1)
   })
 
+  it('does not let an older list land on top of a newer failure', async () => {
+    // A failure is news about the list too, so it advances the sequencing mark.
+    // Otherwise a newer request failing leaves the mark behind and an older
+    // list arriving afterwards is still accepted — overwriting the newer
+    // outcome with stale servers and silently clearing its error.
+    const store = useServersStore()
+
+    let finishOld: (v: unknown) => void = () => {}
+    ;(api.getServers as any).mockReturnValueOnce(
+      new Promise((resolve) => { finishOld = resolve })
+    )
+    const oldFetch = store.fetchServers(true)
+
+    // A newer request settles first — with a failure.
+    ;(api.getServers as any).mockResolvedValueOnce({ success: false, error: 'network down' })
+    await store.fetchServers(true)
+    expect(store.loading.error).toBe('network down')
+
+    // The older request now succeeds. It is stale: it must not apply.
+    finishOld({ success: true, data: { servers: [srv] } })
+    await oldFetch
+
+    expect(store.servers).toHaveLength(0)
+    expect(store.loading.error).toBe('network down')
+  })
+
   it('still records a failure that happens after a successful load', async () => {
     // Clearing on success must not make errors unreportable afterwards.
     const store = useServersStore()


### PR DESCRIPTION
Fixes three findings from the [Web UI UX audit](https://github.com/smart-mcp-proxy/mcpproxy-go/blob/audit/ux-webui-sweep/docs/qa/ux-audit-webui-2026-08.md) that sit on the first-run path — the one the ~48% one-and-done cohort walks.

## F3 (P0) — first-run Servers page had no call to action

`Servers.vue` with zero servers rendered *"No servers found / No servers available"* — a restatement, no button, no link — above four zero-valued stat tiles, four zero-count filter pills and a "Search servers…" box with nothing to search. This is the page a new user lands on after closing the setup wizard.

It now follows the `AgentTokens.vue` pattern the audit named as the model: a headline, one line of *why* upstream servers matter, and **Add Server** (primary) / **Browse Registry**, plus a quiet *Import from your AI client configs* link that opens the setup wizard on its Servers step.

Two further changes fall out of it:

- The stat tiles, filter pills and search box are hidden until a server exists — they describe a list that does not exist yet. Gated on `servers.length > 0` rather than the load flag, so a fresh install never flashes a row of zeroes first.
- *"You have nothing yet"* and *"nothing matched your filter"* are now separate states. They are different problems and need different answers; the filter state also gained a **Show all servers** escape for the non-search case.

The first-run claim is gated on `serversStore.loaded` (from #1044) — telling the user they have no servers is a claim, and only a list that actually arrived supports it.

## F4 (P0), residual after #1044

#1044 shipped most of this finding: `/usage` is a real route, the analytics panel is the default landing page, and the hub diagram is demoted. What it did not carry across is the other half the finding asked for — the landing page answers *"what happened"* but not *"what needs me"*.

Both attention banners (**servers needing attention**, **tools pending approval**) were inside the Overview panel. Once Overview stopped being the default panel they went down with it, so a fresh landing could render charts while a server was down and an unreviewed tool was waiting, and say neither.

They move above the panel switcher: rendered on whichever panel is active, and silent when there is nothing to act on. `serversNeedingAttention` and `loadPendingTools` were already driven on mount and on the 30s refresh regardless of panel, so this is a pure relocation.

> The finding also suggested a separate sidebar entry for Usage. Deliberately skipped: after #1044 the Dashboard entry *is* the analytics page and highlights on all three of its routes, so a second entry would be the duplicate-surface problem F20 complains about, in a sidebar F36 already calls hard to disambiguate.

## F19 (P2) — wizard had no path for a user with no existing MCP setup, and hid the security choice

Step 2 was entirely *"pick which servers from your existing AI clients to import"*, so a user with no prior MCP config saw an empty list and no alternative — a dead end on the step that decides whether the product gets used.

- **Nothing-to-import branch**: *Browse the registry* / *Add a server manually*, replacing the bare "No client configs with importable servers detected on this machine." line. The now-redundant collapsed *"Add a single server manually instead"* disclosure is hidden in that branch.
- **One primary, and it is the safe one**: **Import & quarantine** keeps `btn-primary`; *Import as active* becomes a link labelled **Import without review** with a tooltip saying what it skips. Previously two equally-weighted primaries with the safer one rendered as the weaker of the pair.
- **The security choice is expanded, not hidden**: the Docker-isolation / quarantine `<details>` opens by default and moved out of the sticky footer into the scrollable step body. Expanded in the footer it ate the modal and squeezed the import list back down to the single clipped row the finding complains about; in the body it simply scrolls.
- **The import list is capped and scrolls in place** (`max-h-[32vh]`) instead of running off the bottom of the modal with no scrollbar affordance — and the cap leaves the security panel partly on screen, so the choice is visible rather than something to go looking for.
- **Back** on every step.

`stores/onboarding.ts` gains a one-shot `wizardInitialTab` so the Servers page's import link can open the wizard on the right step; it is consumed on open, so a later plain `openWizard()` is never silently redirected.

## Cross-model review (opencode / gpt-sol)

Four rounds, verdict **CLEAN** on the fifth. Every finding was reproduced before being fixed, and each fix ships with a test that fails against the pre-fix code.

**Round 1**
- *P1* — the import link sets the store flag and then routes to the Dashboard, which is the component that mounts the wizard. The wizard therefore came into existence with `show` already true and never saw a transition to watch; the `onMounted` fallback for that case started the fetches but never picked a tab or consumed the request, so it opened on Clients and leaked the request into the next open. One `{ immediate: true }` watcher now owns opening and the fallback is gone.
- *P2* — `goToRegistry` did not await `dismiss()`, which awaits its mark-skipped calls before emitting `close`; routing first tore down the Dashboard that owns the flag.
- *P2* — the Servers page fetches on neither mount nor route, leaving a window where the filter empty state claimed "no servers match your search criteria" about a list nobody had fetched. Added an explicit pending state.
- The live run then caught a fourth: removing **Close** from the import action footer stranded the step *and* broke the committed sweep's dismiss helper, which uses exactly that control. Restored.

**Round 2**
- *P1* — nothing cancelled the wizard's open sequence, so a close (or close-then-reopen) mid-flight let the abandoned run stamp its tab and start a 5s poll on a closed wizard. Each run now takes a generation token.
- *P2* — `loading.error` was write-only: silent refreshes set it, nothing cleared it, so one transient blip replaced the Servers page with a full-page error for the rest of the session while a usable list sat behind it.

**Round 3**
- The open sequence's config read drives the quarantine and Docker-isolation checkboxes — the one thing it writes that the user can also edit, and this PR expands that panel by default. A superseded read now cannot commit over a toggle the user just changed.
- Server-list failures now take the same ticket as successes.

**Round 4**
- Only a delivered list advanced the sequencing mark, so a newer failure left it behind and an older list could still land on top of it.

## Not fixed here

F36's *"`MCPPROXY active / just started` reads as a stuck state"* is left alone deliberately. The diagnosis: `uptime` in `Dashboard.vue` is derived from `serverFirstSeen`, which is when **this browser tab** first saw the server running — so it resets to "just started" on every page load no matter how long the core has been up — and the computed reads `Date.now()` with no reactive time source, so it does not tick. Fixing it properly means adding a real start time to `GET /api/v1/status` (the value exists only as a Prometheus `mcpproxy_uptime_seconds` metric today), which pulls in a Go change, both-edition builds, swagger and generated-contracts regen. That does not belong in a frontend-only PR, and the panel it sits on is no longer the landing page after #1044.

## Verification

- `vitest` — **733 passed / 72 files**, including 37 new assertions across three new specs (`servers-first-run-empty`, `onboarding-wizard-servers-step`, `dashboard-attention-banners`) plus additions to `servers-store`.
- `vue-tsc --noEmit` clean.
- Playwright live-verify against two isolated real instances built with `make build` (embedded frontend): a **first-run** core on an empty scratch config (the state under test) and a **populated** one (3 servers, one unreachable, one disabled) for regressions — **14/14**, plus a 390px pass and a no-horizontal-scroll assertion.
- The committed `e2e/web-ui-sweep` suite green against the populated instance.
- No Go files touched.

