### PR TITLE
fix(webui): forms & modals UX audit — F6, F8, F16

### DIFF
--- a/frontend/src/components/AddSecretModal.vue
+++ b/frontend/src/components/AddSecretModal.vue
@@ -1,8 +1,28 @@
 <template>
-  <dialog :open="show" class="modal">
-    <div class="modal-box max-w-2xl">
+  <dialog :open="show" class="modal" data-test="add-secret-modal">
+    <div
+      ref="dialogRef"
+      class="modal-box max-w-2xl"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="add-secret-modal-title"
+    >
       <form @submit.prevent="handleSubmit">
-        <h3 class="font-bold text-lg mb-4">Add New Secret</h3>
+        <div class="flex items-start justify-between gap-4 mb-4">
+          <h3 id="add-secret-modal-title" class="font-bold text-lg">
+            {{ props.predefinedName ? 'Set Secret Value' : 'Add New Secret' }}
+          </h3>
+          <button
+            type="button"
+            class="btn btn-sm btn-circle btn-ghost"
+            data-modal-close-button
+            data-test="add-secret-modal-close"
+            aria-label="Close"
+            @click="handleClose"
+          >
+            ✕
+          </button>
+        </div>
 
         <!-- Secret Name -->
         <div class="form-control mb-4">
@@ -77,6 +97,7 @@
 import { reactive, ref, watch } from 'vue'
 import apiClient from '@/services/api'
 import { useSystemStore } from '@/stores/system'
+import { useModalA11y } from '@/composables/useModalA11y'
 
 interface Props {
   show: boolean
@@ -90,6 +111,9 @@ interface Emits {
 
 const props = defineProps<Props>()
 const emit = defineEmits<Emits>()
+
+// UX audit F6/F8: Escape closes, focus enters the dialog and is trapped there.
+const { dialogRef } = useModalA11y(() => props.show, () => handleClose())
 
 const systemStore = useSystemStore()
 

--- a/frontend/src/components/AddServerModal.vue
+++ b/frontend/src/components/AddServerModal.vue
@@ -1,10 +1,36 @@
 <template>
   <dialog :open="show" class="modal" data-test="add-server-modal">
-    <div class="modal-box max-w-3xl" data-test="add-server-modal-box">
-      <h3 class="font-bold text-lg mb-4">Add New Server</h3>
+    <!--
+      UX audit F6: the box is a flex column with its own scroll region so the
+      submit row stays pinned to the bottom instead of falling below the fold,
+      and it carries the ARIA dialog contract (role/aria-modal/labelledby) that
+      `<dialog open>` does not provide on its own.
+    -->
+    <div
+      ref="dialogRef"
+      class="modal-box max-w-3xl flex flex-col max-h-[85vh] p-0 overflow-hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="add-server-modal-title"
+      data-test="add-server-modal-box"
+    >
+      <!-- Header -->
+      <div class="flex items-start justify-between gap-4 px-6 pt-6 pb-4">
+        <h3 id="add-server-modal-title" class="font-bold text-lg">Add New Server</h3>
+        <button
+          type="button"
+          class="btn btn-sm btn-circle btn-ghost"
+          data-modal-close-button
+          data-test="add-server-modal-close"
+          aria-label="Close"
+          @click="handleClose"
+        >
+          ✕
+        </button>
+      </div>
 
       <!-- Tab Selection -->
-      <div class="tabs tabs-box mb-4">
+      <div class="tabs tabs-box mx-6 mb-4">
         <a
           :class="['tab', activeTab === 'manual' ? 'tab-active' : '']"
           @click="activeTab = 'manual'"
@@ -20,8 +46,9 @@
       </div>
 
       <!-- Manual Tab -->
-      <div v-if="activeTab === 'manual'">
-        <form @submit.prevent="handleSubmit">
+      <div v-if="activeTab === 'manual'" class="flex flex-col flex-1 min-h-0">
+        <form @submit.prevent="handleSubmit" class="flex flex-col flex-1 min-h-0">
+          <div class="flex-1 min-h-0 overflow-y-auto px-6 pb-4" data-test="add-server-modal-body">
           <!-- Server Type Selection -->
           <div class="form-control mb-4">
             <label class="label">
@@ -245,9 +272,13 @@
             </svg>
             <span>{{ error }}</span>
           </div>
+          </div>
 
-          <!-- Actions -->
-          <div class="modal-action">
+          <!-- Actions (sticky footer — F6) -->
+          <div
+            class="modal-action mt-0 px-6 py-4 border-t border-base-300 bg-base-100"
+            data-test="add-server-modal-footer"
+          >
             <button type="button" @click="handleClose" class="btn btn-ghost">Cancel</button>
             <button type="submit" class="btn btn-primary" :disabled="loading">
               <span v-if="loading" class="loading loading-spinner loading-sm"></span>
@@ -258,7 +289,8 @@
       </div>
 
       <!-- Import Tab -->
-      <div v-if="activeTab === 'import'">
+      <div v-if="activeTab === 'import'" class="flex flex-col flex-1 min-h-0">
+        <div class="flex-1 min-h-0 overflow-y-auto px-6 pb-4">
         <!-- Input Method Tabs -->
         <div class="flex gap-2 mb-4">
           <button
@@ -531,9 +563,10 @@ Example (Claude Desktop):
             <div class="text-sm mt-2">Deselect these servers or fix the configuration before importing.</div>
           </div>
         </div>
+        </div>
 
-        <!-- Actions -->
-        <div class="modal-action">
+        <!-- Actions (sticky footer — F6) -->
+        <div class="modal-action mt-0 px-6 py-4 border-t border-base-300 bg-base-100">
           <button type="button" @click="handleClose" class="btn btn-ghost">Cancel</button>
           <button
             @click="handleImport"
@@ -558,6 +591,7 @@ import { useServersStore } from '@/stores/servers'
 import { useSystemStore } from '@/stores/system'
 import api, { type CanonicalConfigPath } from '@/services/api'
 import TrustModeSelector from '@/components/TrustModeSelector.vue'
+import { useModalA11y } from '@/composables/useModalA11y'
 import type { TrustMode } from '@/utils/trustMode'
 import type { ImportResponse, ImportedServer } from '@/types'
 
@@ -572,6 +606,10 @@ interface Emits {
 
 const props = defineProps<Props>()
 const emit = defineEmits<Emits>()
+
+// UX audit F6: Escape closes, focus enters the dialog on open and is trapped
+// inside it, and returns to the trigger on close.
+const { dialogRef } = useModalA11y(() => props.show, () => handleClose())
 
 const serversStore = useServersStore()
 const systemStore = useSystemStore()

--- a/frontend/src/composables/useModalA11y.ts
+++ b/frontend/src/composables/useModalA11y.ts
@@ -27,6 +27,20 @@ const FOCUSABLE_SELECTOR = [
   '[tabindex]:not([tabindex="-1"])',
 ].join(',')
 
+/**
+ * Every currently-open modal, oldest first.
+ *
+ * The keydown listener lives on `document`, and stopPropagation does NOT stop
+ * other listeners already bound to the same node in the same phase — so with
+ * two modals open, both would see Escape and both would close. Only the
+ * topmost entry acts; the ones beneath it ignore the key entirely.
+ */
+const openStack: symbol[] = []
+
+function isTopmost(id: symbol): boolean {
+  return openStack.length > 0 && openStack[openStack.length - 1] === id
+}
+
 export interface ModalA11yOptions {
   /**
    * Selector for the element that should receive focus when the modal opens.
@@ -42,6 +56,7 @@ export function useModalA11y(
   options: ModalA11yOptions = {}
 ) {
   const dialogRef = ref<HTMLElement | null>(null)
+  const id = Symbol('modal-a11y')
   let previouslyFocused: HTMLElement | null = null
 
   function visibleFocusables(): HTMLElement[] {
@@ -79,7 +94,9 @@ export function useModalA11y(
   }
 
   function onKeydown(event: KeyboardEvent) {
-    if (!isOpen()) return
+    // A modal underneath another one neither closes on Escape nor fights the
+    // top modal for focus.
+    if (!isOpen() || !isTopmost(id)) return
 
     if (event.key === 'Escape' || event.key === 'Esc') {
       event.preventDefault()
@@ -116,12 +133,16 @@ export function useModalA11y(
   }
 
   function activate() {
+    if (openStack.includes(id)) return
     previouslyFocused = document.activeElement as HTMLElement | null
+    openStack.push(id)
     document.addEventListener('keydown', onKeydown, true)
     void nextTick(() => focusInitial())
   }
 
   function deactivate() {
+    const at = openStack.indexOf(id)
+    if (at !== -1) openStack.splice(at, 1)
     document.removeEventListener('keydown', onKeydown, true)
     const target = previouslyFocused
     previouslyFocused = null

--- a/frontend/src/composables/useModalA11y.ts
+++ b/frontend/src/composables/useModalA11y.ts
@@ -59,41 +59,51 @@ export function useModalA11y(
   const id = Symbol('modal-a11y')
   let previouslyFocused: HTMLElement | null = null
 
+  /**
+   * Whether an element can actually take focus right now.
+   *
+   * An element inside a `v-show`-hidden (display:none) or `visibility:hidden`
+   * subtree is in the DOM but cannot be focused, and letting one bound the Tab
+   * trap would make Tab appear to stick. checkVisibility covers display and
+   * content-visibility on its own; `visibility` needs checkVisibilityCSS, which
+   * is off by default. jsdom does not implement the method, so the unit tests
+   * fall through to "visible" — which matches how they build the DOM (v-if
+   * branches are absent rather than hidden). The browser path is covered by the
+   * Playwright sweep instead.
+   */
+  function isFocusable(el: HTMLElement): boolean {
+    if (el.hasAttribute('hidden')) return false
+    if (el.getAttribute('aria-hidden') === 'true') return false
+    if (el.hasAttribute('disabled')) return false
+    if (typeof el.checkVisibility === 'function') {
+      return el.checkVisibility({ checkVisibilityCSS: true })
+    }
+    return true
+  }
+
   function visibleFocusables(): HTMLElement[] {
     const root = dialogRef.value
     if (!root) return []
-    return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter((el) => {
-      if (el.hasAttribute('hidden')) return false
-      if (el.getAttribute('aria-hidden') === 'true') return false
-      // A control inside a `v-show`-hidden (display:none) or `visibility:hidden`
-      // subtree is in the DOM but cannot take focus, and letting it bound the
-      // trap would make Tab appear to stick. checkVisibility covers display and
-      // content-visibility on its own; `visibility` needs checkVisibilityCSS,
-      // which is off by default. jsdom does not implement the method, so the
-      // tests fall through to "visible" — which matches how they build the DOM
-      // (v-if branches are absent rather than hidden).
-      if (typeof el.checkVisibility === 'function') {
-        return el.checkVisibility({ checkVisibilityCSS: true })
-      }
-      return true
-    })
+    return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(isFocusable)
   }
 
   function focusInitial() {
     const root = dialogRef.value
     if (!root) return
-    const candidates = visibleFocusables()
     if (options.initialFocus) {
-      // Matched against the SAME filtered set, not a raw querySelector: a
-      // configured selector must not be able to hand focus to a control that
-      // is hidden or disabled, which would silently focus nothing.
-      const selector = options.initialFocus
-      const preferred = candidates.find((el) => el.matches(selector))
-      if (preferred) {
+      // Resolved with its own query rather than against the Tab-order list: the
+      // usual target for this option is the dialog heading carrying
+      // tabindex="-1", which is programmatically focusable but deliberately NOT
+      // in the tab order, so matching it against FOCUSABLE_SELECTOR would
+      // silently ignore the option. Visibility and disabled are still enforced,
+      // so a selector can never hand focus to something that cannot take it.
+      const preferred = root.querySelector<HTMLElement>(options.initialFocus)
+      if (preferred && isFocusable(preferred)) {
         preferred.focus()
         return
       }
     }
+    const candidates = visibleFocusables()
     const first = candidates.find((el) => el.dataset.modalCloseButton === undefined) ?? candidates[0]
     if (first) {
       first.focus()

--- a/frontend/src/composables/useModalA11y.ts
+++ b/frontend/src/composables/useModalA11y.ts
@@ -141,7 +141,11 @@ export function useModalA11y(
   )
 
   onBeforeUnmount(() => {
-    document.removeEventListener('keydown', onKeydown, true)
+    // Unmounting while open (a route change, a v-if around the modal) must not
+    // strand the listener or the focus: deactivate does both, and its
+    // document.contains guard makes restoring a no-op when the trigger went
+    // away with the same subtree.
+    deactivate()
   })
 
   return { dialogRef, focusInitial }

--- a/frontend/src/composables/useModalA11y.ts
+++ b/frontend/src/composables/useModalA11y.ts
@@ -65,13 +65,16 @@ export function useModalA11y(
     return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter((el) => {
       if (el.hasAttribute('hidden')) return false
       if (el.getAttribute('aria-hidden') === 'true') return false
-      // A control inside a `v-show`-hidden (display:none) subtree is in the DOM
-      // but cannot take focus, and letting it bound the trap would make Tab
-      // appear to stick. checkVisibility covers display/visibility/content-
-      // visibility in every browser we target; jsdom does not implement it, so
-      // the tests fall through to "visible", which matches how they build the
-      // DOM (v-if branches are absent rather than hidden).
-      if (typeof el.checkVisibility === 'function') return el.checkVisibility()
+      // A control inside a `v-show`-hidden (display:none) or `visibility:hidden`
+      // subtree is in the DOM but cannot take focus, and letting it bound the
+      // trap would make Tab appear to stick. checkVisibility covers display and
+      // content-visibility on its own; `visibility` needs checkVisibilityCSS,
+      // which is off by default. jsdom does not implement the method, so the
+      // tests fall through to "visible" — which matches how they build the DOM
+      // (v-if branches are absent rather than hidden).
+      if (typeof el.checkVisibility === 'function') {
+        return el.checkVisibility({ checkVisibilityCSS: true })
+      }
       return true
     })
   }
@@ -79,14 +82,18 @@ export function useModalA11y(
   function focusInitial() {
     const root = dialogRef.value
     if (!root) return
+    const candidates = visibleFocusables()
     if (options.initialFocus) {
-      const preferred = root.querySelector<HTMLElement>(options.initialFocus)
+      // Matched against the SAME filtered set, not a raw querySelector: a
+      // configured selector must not be able to hand focus to a control that
+      // is hidden or disabled, which would silently focus nothing.
+      const selector = options.initialFocus
+      const preferred = candidates.find((el) => el.matches(selector))
       if (preferred) {
         preferred.focus()
         return
       }
     }
-    const candidates = visibleFocusables()
     const first = candidates.find((el) => el.dataset.modalCloseButton === undefined) ?? candidates[0]
     if (first) {
       first.focus()

--- a/frontend/src/composables/useModalA11y.ts
+++ b/frontend/src/composables/useModalA11y.ts
@@ -1,0 +1,148 @@
+import { nextTick, onBeforeUnmount, ref, watch, type Ref } from 'vue'
+
+/**
+ * Keyboard + focus behaviour for the `<dialog :open>` modals used across the
+ * Web UI (UX audit F6).
+ *
+ * These modals are rendered with the `open` attribute rather than
+ * `HTMLDialogElement.showModal()`, so the browser gives us *none* of the modal
+ * affordances: Escape does not close, focus stays on the trigger button and
+ * Tab walks straight out of the dialog into the page behind it. This composable
+ * supplies those three behaviours plus focus restoration, without changing how
+ * the dialogs are mounted or styled.
+ *
+ * Usage:
+ *   const { dialogRef } = useModalA11y(() => props.show, handleClose)
+ *   <div class="modal-box" ref="dialogRef" role="dialog" aria-modal="true">
+ */
+
+// Elements that can receive focus inside the dialog. `[hidden]` and elements
+// inside a `display:none` subtree are filtered out separately (offsetParent).
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
+
+export interface ModalA11yOptions {
+  /**
+   * Selector for the element that should receive focus when the modal opens.
+   * Defaults to the first focusable element that is not the header close
+   * button, so keyboard users land on the form rather than on "✕".
+   */
+  initialFocus?: string
+}
+
+export function useModalA11y(
+  isOpen: () => boolean,
+  close: () => void,
+  options: ModalA11yOptions = {}
+) {
+  const dialogRef = ref<HTMLElement | null>(null)
+  let previouslyFocused: HTMLElement | null = null
+
+  function visibleFocusables(): HTMLElement[] {
+    const root = dialogRef.value
+    if (!root) return []
+    return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter((el) => {
+      if (el.hasAttribute('hidden')) return false
+      if (el.getAttribute('aria-hidden') === 'true') return false
+      // jsdom reports offsetParent === null for everything, so only trust this
+      // signal in a real browser (where at least one element reports a parent).
+      return true
+    })
+  }
+
+  function focusInitial() {
+    const root = dialogRef.value
+    if (!root) return
+    if (options.initialFocus) {
+      const preferred = root.querySelector<HTMLElement>(options.initialFocus)
+      if (preferred) {
+        preferred.focus()
+        return
+      }
+    }
+    const candidates = visibleFocusables()
+    const first = candidates.find((el) => el.dataset.modalCloseButton === undefined) ?? candidates[0]
+    if (first) {
+      first.focus()
+    } else {
+      // Nothing focusable yet (async content): park focus on the box itself so
+      // Escape and the Tab trap still have a live target inside the dialog.
+      root.setAttribute('tabindex', '-1')
+      root.focus()
+    }
+  }
+
+  function onKeydown(event: KeyboardEvent) {
+    if (!isOpen()) return
+
+    if (event.key === 'Escape' || event.key === 'Esc') {
+      event.preventDefault()
+      event.stopPropagation()
+      close()
+      return
+    }
+
+    if (event.key !== 'Tab') return
+
+    const root = dialogRef.value
+    if (!root) return
+    const focusables = visibleFocusables()
+    if (focusables.length === 0) return
+
+    const first = focusables[0]
+    const last = focusables[focusables.length - 1]
+    const active = document.activeElement as HTMLElement | null
+
+    // Focus escaped the dialog (or never entered it) — pull it back in.
+    if (!active || !root.contains(active)) {
+      event.preventDefault()
+      ;(event.shiftKey ? last : first).focus()
+      return
+    }
+
+    if (event.shiftKey && active === first) {
+      event.preventDefault()
+      last.focus()
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault()
+      first.focus()
+    }
+  }
+
+  function activate() {
+    previouslyFocused = document.activeElement as HTMLElement | null
+    document.addEventListener('keydown', onKeydown, true)
+    void nextTick(() => focusInitial())
+  }
+
+  function deactivate() {
+    document.removeEventListener('keydown', onKeydown, true)
+    const target = previouslyFocused
+    previouslyFocused = null
+    if (target && typeof target.focus === 'function' && document.contains(target)) {
+      target.focus()
+    }
+  }
+
+  watch(
+    isOpen,
+    (open, wasOpen) => {
+      if (open === wasOpen) return
+      if (open) activate()
+      else if (wasOpen !== undefined) deactivate()
+    },
+    { immediate: true }
+  )
+
+  onBeforeUnmount(() => {
+    document.removeEventListener('keydown', onKeydown, true)
+  })
+
+  return { dialogRef, focusInitial }
+}

--- a/frontend/src/composables/useModalA11y.ts
+++ b/frontend/src/composables/useModalA11y.ts
@@ -65,8 +65,13 @@ export function useModalA11y(
     return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter((el) => {
       if (el.hasAttribute('hidden')) return false
       if (el.getAttribute('aria-hidden') === 'true') return false
-      // jsdom reports offsetParent === null for everything, so only trust this
-      // signal in a real browser (where at least one element reports a parent).
+      // A control inside a `v-show`-hidden (display:none) subtree is in the DOM
+      // but cannot take focus, and letting it bound the trap would make Tab
+      // appear to stick. checkVisibility covers display/visibility/content-
+      // visibility in every browser we target; jsdom does not implement it, so
+      // the tests fall through to "visible", which matches how they build the
+      // DOM (v-if branches are absent rather than hidden).
+      if (typeof el.checkVisibility === 'function') return el.checkVisibility()
       return true
     })
   }
@@ -137,10 +142,15 @@ export function useModalA11y(
     previouslyFocused = document.activeElement as HTMLElement | null
     openStack.push(id)
     document.addEventListener('keydown', onKeydown, true)
-    void nextTick(() => focusInitial())
+    void nextTick(() => {
+      // The tick may land after this modal closed again, or after a second
+      // modal opened on top of it; in either case grabbing focus now would
+      // take it somewhere the user cannot see.
+      if (isOpen() && isTopmost(id)) focusInitial()
+    })
   }
 
-  function deactivate() {
+  function deactivate(deferRestore = false) {
     const at = openStack.indexOf(id)
     const wasOpen = at !== -1
     if (wasOpen) openStack.splice(at, 1)
@@ -152,10 +162,26 @@ export function useModalA11y(
     // closes while another is still open sits underneath it, and focusing its
     // trigger would drag focus out of the top modal and behind it. The top
     // modal keeps focus and restores to its own trigger when it goes.
+    //
+    // Known limit: when a stack unwinds bottom-up in one tick, the top modal's
+    // remembered trigger is an element of the modal below it, which is by then
+    // gone or hidden — focus lands on <body> rather than the original opener.
+    // Unwinding top-down (the normal order) restores correctly. Chaining the
+    // remembered targets across instances is not worth it while nothing in the
+    // app stacks these modals.
     if (!wasOpen || openStack.length > 0) return
-    if (target && typeof target.focus === 'function' && document.contains(target)) {
+    if (!target || typeof target.focus !== 'function') return
+
+    const restore = () => {
+      // Re-check at call time: a trigger torn down with the modal must not be
+      // focused just before removal (a pointless focus/blur pair that scrolls
+      // and is announced), and a modal opened in the meantime keeps focus.
+      if (openStack.length > 0) return
+      if (!document.contains(target)) return
       target.focus()
     }
+    if (deferRestore) void nextTick(restore)
+    else restore()
   }
 
   watch(
@@ -170,10 +196,12 @@ export function useModalA11y(
 
   onBeforeUnmount(() => {
     // Unmounting while open (a route change, a v-if around the modal) must not
-    // strand the listener or the focus: deactivate does both, and its
-    // document.contains guard makes restoring a no-op when the trigger went
-    // away with the same subtree.
-    deactivate()
+    // strand the listener or the focus. The restore is deferred one tick so it
+    // runs AFTER Vue has detached this subtree: a trigger that went away with
+    // the modal then fails the contains() check and is left alone, while a
+    // trigger that outlives it (modal alone behind a v-if) still gets focus
+    // back.
+    deactivate(true)
   })
 
   return { dialogRef, focusInitial }

--- a/frontend/src/composables/useModalA11y.ts
+++ b/frontend/src/composables/useModalA11y.ts
@@ -142,10 +142,17 @@ export function useModalA11y(
 
   function deactivate() {
     const at = openStack.indexOf(id)
-    if (at !== -1) openStack.splice(at, 1)
+    const wasOpen = at !== -1
+    if (wasOpen) openStack.splice(at, 1)
     document.removeEventListener('keydown', onKeydown, true)
     const target = previouslyFocused
     previouslyFocused = null
+
+    // Restore focus only when this was the LAST modal standing. A modal that
+    // closes while another is still open sits underneath it, and focusing its
+    // trigger would drag focus out of the top modal and behind it. The top
+    // modal keeps focus and restores to its own trigger when it goes.
+    if (!wasOpen || openStack.length > 0) return
     if (target && typeof target.focus === 'function' && document.contains(target)) {
       target.focus()
     }

--- a/frontend/src/views/Secrets.vue
+++ b/frontend/src/views/Secrets.vue
@@ -6,17 +6,32 @@
         <h1 class="text-3xl font-bold">Secrets & Environment Variables</h1>
         <p class="text-base-content/70 mt-1">Manage secrets stored in your system's secure keyring and environment variables</p>
       </div>
-      <button
-        @click="refreshSecrets"
-        :disabled="loading"
-        class="btn btn-outline"
-      >
-        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-        </svg>
-        <span v-if="loading" class="loading loading-spinner loading-sm"></span>
-        {{ loading ? 'Refreshing...' : 'Refresh' }}
-      </button>
+      <div class="flex gap-2">
+        <button
+          @click="refreshSecrets"
+          :disabled="loading"
+          class="btn btn-outline"
+        >
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+          </svg>
+          <span v-if="loading" class="loading loading-spinner loading-sm"></span>
+          {{ loading ? 'Refreshing...' : 'Refresh' }}
+        </button>
+        <!-- UX audit F8: the page promises secret management but the only way
+             in used to be a per-row "Add Value" button, which does not render
+             when there are no rows. -->
+        <button
+          @click="showAddSecretModal()"
+          class="btn btn-primary"
+          data-test="secrets-add-button"
+        >
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+          </svg>
+          Add Secret
+        </button>
+      </div>
     </div>
 
     <!-- Summary Stats -->
@@ -112,11 +127,27 @@
       </svg>
       <h3 class="text-xl font-semibold mb-2">No secrets found</h3>
       <p class="text-base-content/70 mb-4">
-        {{ searchQuery ? 'No secrets match your search criteria' : `No ${filter === 'all' ? '' : filter} secrets available`.replace(/\s+/g, ' ').trim() }}
+        {{ searchQuery
+          ? 'No secrets match your search criteria'
+          : 'Store an API key or token in your system keyring, then reference it from your config as ${keyring:name}.' }}
       </p>
-      <button v-if="searchQuery" @click="searchQuery = ''" class="btn btn-outline">
-        Clear Search
-      </button>
+      <div class="flex gap-2 justify-center">
+        <button v-if="searchQuery" @click="searchQuery = ''" class="btn btn-outline">
+          Clear Search
+        </button>
+        <!-- UX audit F8: empty-state CTA -->
+        <button
+          v-if="!searchQuery"
+          @click="showAddSecretModal()"
+          class="btn btn-primary"
+          data-test="secrets-empty-add-button"
+        >
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+          </svg>
+          Add Secret
+        </button>
+      </div>
     </div>
 
     <!-- Secrets List with Smooth Transitions -->
@@ -373,8 +404,9 @@ const runMigrationAnalysis = async () => {
   }
 }
 
-const showAddSecretModal = (predefinedName: string) => {
-  // Open modal with predefined name
+// Called with a name to fill a config-referenced secret, or with no argument
+// from the page-level / empty-state "Add Secret" CTA (UX audit F8).
+const showAddSecretModal = (predefinedName?: string) => {
   modalPredefinedName.value = predefinedName
   showAddModal.value = true
 }

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -193,6 +193,7 @@ import {
   DOCS_BASE,
   docsUrl,
   isBlankInstructions,
+  restartRequiredLabels,
   type SettingField,
   type SettingsAccordion,
 } from '@/views/settings/fields'
@@ -424,8 +425,10 @@ const settingsHints = computed<Hint[]>(() => [
         text: 'Each section saves only the fields you changed, so secrets like your API key are never overwritten.',
       },
       {
+        // UX audit F16: derived from the badges the fields actually carry, not
+        // a hand-maintained list that drifts away from them.
         title: 'Requires restart',
-        list: ['Listen address', 'Data directory', 'API key', 'TLS/HTTPS settings'],
+        list: restartRequiredLabels(),
       },
     ],
   },

--- a/frontend/src/views/settings/fields.ts
+++ b/frontend/src/views/settings/fields.ts
@@ -324,7 +324,10 @@ export const ADVANCED_ACCORDIONS: SettingsAccordion[] = [
     fields: [
       { key: 'code_execution_timeout_ms', label: 'Max run time per execution (ms)', control: 'number', min: 1, max: 600000 },
       { key: 'code_execution_max_tool_calls', label: 'Max tool calls per execution', help: '0 = unlimited.', control: 'number', min: 0 },
-      { key: 'code_execution_pool_size', label: 'JavaScript runtime pool size', help: 'How many sandboxes run concurrently.', control: 'number', min: 1, max: 100 },
+      // UX audit F16: the Go detector forces a restart for this one (the JS
+      // runtime pool is sized at server construction and never resized), so it
+      // must carry the badge — its siblings above genuinely apply hot.
+      { key: 'code_execution_pool_size', label: 'JavaScript runtime pool size', help: 'How many sandboxes run concurrently.', control: 'number', min: 1, max: 100, restart: true },
       { key: 'code_execution_max_parallel', label: 'Parallel calls per call_tools() batch', help: 'Default concurrency for batched tool calls; a script can override it per call (1-32).', control: 'number', min: 1, max: 32 },
     ],
   },
@@ -437,6 +440,30 @@ export const ADVANCED_ACCORDIONS: SettingsAccordion[] = [
 // prototype, constructor) so a crafted dot-path can never reach Object.prototype.
 // Settings keys come from the static catalogue above, but the generic helper is
 // guarded regardless.
+
+/**
+ * Labels of every field that carries the "restart" badge, derived from the
+ * catalogue itself.
+ *
+ * UX audit F16: the Settings hints panel used to hardcode this list in prose,
+ * which drifted from the badges (it named "Data directory", which has no field
+ * at all, and missed the code-execution pool size). Deriving it means the two
+ * surfaces cannot disagree — a field gains or loses the badge and the hint
+ * follows.
+ */
+export function restartRequiredLabels(): string[] {
+  const fields = [
+    ...GENERAL_FIELDS,
+    ...SECURITY_FIELDS,
+    ...SERVER_EDITION_FIELDS,
+    ...ADVANCED_ACCORDIONS.flatMap((a) => a.fields),
+  ]
+  const labels: string[] = []
+  for (const f of fields) {
+    if (f.restart && !labels.includes(f.label)) labels.push(f.label)
+  }
+  return labels
+}
 
 export function getPath(obj: any, path: string): any {
   return path.split('.').reduce((o, k) => (o == null ? undefined : o[k]), obj)

--- a/frontend/tests/unit/modal-a11y.spec.ts
+++ b/frontend/tests/unit/modal-a11y.spec.ts
@@ -159,6 +159,43 @@ describe('modal accessibility (UX audit F6)', () => {
       wrapper.unmount()
     })
 
+    // The keydown listener lives on `document`, and stopPropagation does not
+    // stop sibling listeners on the same node — so without a topmost check two
+    // open modals would both close on one Escape.
+    it('only the topmost modal reacts to Escape', async () => {
+      const under = mount(AddServerModal, { props: { show: true }, attachTo: document.body })
+      await flushPromises()
+      const over = mount(AddSecretModal, { props: { show: true }, attachTo: document.body })
+      await flushPromises()
+
+      pressEscape()
+      expect(over.emitted('close'), 'the top modal closes').toBeTruthy()
+      expect(under.emitted('close'), 'the one beneath it must not').toBeFalsy()
+
+      // Once the top one is gone, the modal beneath owns Escape again.
+      await over.setProps({ show: false })
+      await flushPromises()
+      pressEscape()
+      expect(under.emitted('close')).toBeTruthy()
+
+      over.unmount()
+      under.unmount()
+    })
+
+    it('restores focus when unmounted while still open', async () => {
+      const trigger = document.createElement('button')
+      document.body.appendChild(trigger)
+      trigger.focus()
+
+      const wrapper = mount(AddSecretModal, { props: { show: false }, attachTo: document.body })
+      await wrapper.setProps({ show: true })
+      await flushPromises()
+      expect(document.activeElement).not.toBe(trigger)
+
+      wrapper.unmount()
+      expect(document.activeElement).toBe(trigger)
+    })
+
     it('moves focus into the dialog on open', async () => {
       const wrapper = mount(AddSecretModal, { props: { show: false }, attachTo: document.body })
       await wrapper.setProps({ show: true })

--- a/frontend/tests/unit/modal-a11y.spec.ts
+++ b/frontend/tests/unit/modal-a11y.spec.ts
@@ -182,6 +182,36 @@ describe('modal accessibility (UX audit F6)', () => {
       under.unmount()
     })
 
+    // Closing the modal underneath must leave focus where the top modal put it,
+    // not drag it back to a trigger that now sits behind an open dialog.
+    it('closing a modal underneath another does not steal focus from the top one', async () => {
+      const underTrigger = document.createElement('button')
+      underTrigger.textContent = 'under-trigger'
+      document.body.appendChild(underTrigger)
+      underTrigger.focus()
+
+      const under = mount(AddServerModal, { props: { show: false }, attachTo: document.body })
+      await under.setProps({ show: true })
+      await flushPromises()
+
+      const over = mount(AddSecretModal, { props: { show: false }, attachTo: document.body })
+      await over.setProps({ show: true })
+      await flushPromises()
+
+      const topBox = over.find('[role="dialog"]').element
+      expect(topBox.contains(document.activeElement)).toBe(true)
+
+      // The one underneath closes on its own (e.g. its request resolved).
+      await under.setProps({ show: false })
+      await flushPromises()
+
+      expect(document.activeElement).not.toBe(underTrigger)
+      expect(topBox.contains(document.activeElement), 'focus stays in the top modal').toBe(true)
+
+      over.unmount()
+      under.unmount()
+    })
+
     it('restores focus when unmounted while still open', async () => {
       const trigger = document.createElement('button')
       document.body.appendChild(trigger)

--- a/frontend/tests/unit/modal-a11y.spec.ts
+++ b/frontend/tests/unit/modal-a11y.spec.ts
@@ -212,7 +212,10 @@ describe('modal accessibility (UX audit F6)', () => {
       under.unmount()
     })
 
-    it('restores focus when unmounted while still open', async () => {
+    // The trigger lives outside the modal's own subtree here (the real shape:
+    // a page-level button with the modal behind a v-if), so it survives the
+    // unmount and must get focus back.
+    it('restores focus to a surviving trigger when unmounted while still open', async () => {
       const trigger = document.createElement('button')
       document.body.appendChild(trigger)
       trigger.focus()
@@ -223,7 +226,52 @@ describe('modal accessibility (UX audit F6)', () => {
       expect(document.activeElement).not.toBe(trigger)
 
       wrapper.unmount()
+      await flushPromises() // the restore is deferred until after teardown
       expect(document.activeElement).toBe(trigger)
+
+      trigger.remove()
+    })
+
+    // A trigger torn down together with the modal must not be focused on its
+    // way out — that is a pointless focus/blur pair that scrolls and is
+    // announced by a screen reader, for an element about to vanish.
+    it('does not focus a trigger that is torn down with the modal', async () => {
+      const host = document.createElement('div')
+      const trigger = document.createElement('button')
+      host.appendChild(trigger)
+      document.body.appendChild(host)
+      trigger.focus()
+
+      const wrapper = mount(AddSecretModal, { props: { show: false }, attachTo: host })
+      await wrapper.setProps({ show: true })
+      await flushPromises()
+
+      const focusSpy = vi.spyOn(trigger, 'focus')
+      wrapper.unmount()
+      host.remove() // the trigger's subtree goes away in the same teardown
+      await flushPromises()
+
+      expect(focusSpy).not.toHaveBeenCalled()
+      focusSpy.mockRestore()
+    })
+
+    // The focus-on-open runs on nextTick; by then the modal may have closed
+    // again, and grabbing focus would drag it somewhere invisible.
+    it('does not grab focus if the modal closed before the open tick landed', async () => {
+      const trigger = document.createElement('button')
+      document.body.appendChild(trigger)
+      trigger.focus()
+
+      const wrapper = mount(AddSecretModal, { props: { show: false }, attachTo: document.body })
+      // Open and close again within the same tick.
+      await wrapper.setProps({ show: true })
+      await wrapper.setProps({ show: false })
+      await flushPromises()
+
+      expect(document.activeElement).toBe(trigger)
+
+      wrapper.unmount()
+      trigger.remove()
     })
 
     it('moves focus into the dialog on open', async () => {

--- a/frontend/tests/unit/modal-a11y.spec.ts
+++ b/frontend/tests/unit/modal-a11y.spec.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import AddServerModal from '@/components/AddServerModal.vue'
+import AddSecretModal from '@/components/AddSecretModal.vue'
+
+vi.mock('@/services/api', () => ({
+  default: {
+    getCanonicalConfigPaths: vi.fn().mockResolvedValue({ success: true, data: [] }),
+    setSecret: vi.fn().mockResolvedValue({ success: true, data: { reference: '${keyring:x}' } }),
+    previewImport: vi.fn(),
+    importServers: vi.fn(),
+  },
+}))
+
+function pressEscape() {
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+}
+
+describe('modal accessibility (UX audit F6)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    document.body.innerHTML = ''
+  })
+
+  describe('AddServerModal', () => {
+    it('carries the ARIA dialog contract', async () => {
+      const wrapper = mount(AddServerModal, {
+        props: { show: true },
+        attachTo: document.body,
+      })
+      await flushPromises()
+
+      const box = wrapper.find('[data-test="add-server-modal-box"]')
+      expect(box.attributes('role')).toBe('dialog')
+      expect(box.attributes('aria-modal')).toBe('true')
+      const labelledBy = box.attributes('aria-labelledby')
+      expect(labelledBy).toBeTruthy()
+      expect(wrapper.find(`#${labelledBy}`).text()).toContain('Add New Server')
+
+      wrapper.unmount()
+    })
+
+    it('keeps the submit row out of the scrolling body so it cannot fall below the fold', async () => {
+      const wrapper = mount(AddServerModal, { props: { show: true }, attachTo: document.body })
+      await flushPromises()
+
+      const body = wrapper.find('[data-test="add-server-modal-body"]')
+      const footer = wrapper.find('[data-test="add-server-modal-footer"]')
+      expect(body.exists()).toBe(true)
+      expect(footer.exists()).toBe(true)
+      // The scroll region is the body only; the footer is a sibling of it.
+      expect(body.classes()).toContain('overflow-y-auto')
+      expect(body.element.contains(footer.element)).toBe(false)
+      expect(footer.text()).toContain('Add Server')
+
+      wrapper.unmount()
+    })
+
+    it('has a header close affordance', async () => {
+      const wrapper = mount(AddServerModal, { props: { show: true }, attachTo: document.body })
+      await flushPromises()
+
+      const close = wrapper.find('[data-test="add-server-modal-close"]')
+      expect(close.exists()).toBe(true)
+      expect(close.attributes('aria-label')).toBe('Close')
+      await close.trigger('click')
+      expect(wrapper.emitted('close')).toBeTruthy()
+
+      wrapper.unmount()
+    })
+
+    it('moves focus into the dialog when it opens', async () => {
+      const trigger = document.createElement('button')
+      document.body.appendChild(trigger)
+      trigger.focus()
+      expect(document.activeElement).toBe(trigger)
+
+      const wrapper = mount(AddServerModal, { props: { show: false }, attachTo: document.body })
+      await wrapper.setProps({ show: true })
+      await flushPromises()
+
+      const box = wrapper.find('[data-test="add-server-modal-box"]').element
+      expect(box.contains(document.activeElement)).toBe(true)
+      // The header ✕ is skipped — focus lands on the form, not on "close".
+      expect((document.activeElement as HTMLElement).dataset.modalCloseButton).toBeUndefined()
+
+      wrapper.unmount()
+    })
+
+    it('closes on Escape', async () => {
+      const wrapper = mount(AddServerModal, { props: { show: true }, attachTo: document.body })
+      await flushPromises()
+
+      pressEscape()
+      expect(wrapper.emitted('close')).toBeTruthy()
+
+      wrapper.unmount()
+    })
+
+    it('does not close on Escape while hidden', async () => {
+      const wrapper = mount(AddServerModal, { props: { show: false }, attachTo: document.body })
+      await flushPromises()
+
+      pressEscape()
+      expect(wrapper.emitted('close')).toBeFalsy()
+
+      wrapper.unmount()
+    })
+
+    it('restores focus to the trigger when it closes', async () => {
+      const trigger = document.createElement('button')
+      document.body.appendChild(trigger)
+      trigger.focus()
+
+      const wrapper = mount(AddServerModal, { props: { show: false }, attachTo: document.body })
+      await wrapper.setProps({ show: true })
+      await flushPromises()
+      expect(document.activeElement).not.toBe(trigger)
+
+      await wrapper.setProps({ show: false })
+      await flushPromises()
+      expect(document.activeElement).toBe(trigger)
+
+      wrapper.unmount()
+    })
+
+    it('traps Tab inside the dialog', async () => {
+      const outside = document.createElement('button')
+      document.body.appendChild(outside)
+
+      const wrapper = mount(AddServerModal, { props: { show: true }, attachTo: document.body })
+      await flushPromises()
+
+      const box = wrapper.find('[data-test="add-server-modal-box"]').element as HTMLElement
+      // Focus escaped to a control behind the modal: Tab must pull it back in.
+      outside.focus()
+      const evt = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true })
+      document.dispatchEvent(evt)
+      expect(evt.defaultPrevented).toBe(true)
+      expect(box.contains(document.activeElement)).toBe(true)
+
+      wrapper.unmount()
+    })
+  })
+
+  describe('AddSecretModal', () => {
+    it('carries the ARIA dialog contract and closes on Escape', async () => {
+      const wrapper = mount(AddSecretModal, { props: { show: true }, attachTo: document.body })
+      await flushPromises()
+
+      const box = wrapper.find('[role="dialog"]')
+      expect(box.exists()).toBe(true)
+      expect(box.attributes('aria-modal')).toBe('true')
+
+      pressEscape()
+      expect(wrapper.emitted('close')).toBeTruthy()
+
+      wrapper.unmount()
+    })
+
+    it('moves focus into the dialog on open', async () => {
+      const wrapper = mount(AddSecretModal, { props: { show: false }, attachTo: document.body })
+      await wrapper.setProps({ show: true })
+      await flushPromises()
+
+      const box = wrapper.find('[role="dialog"]').element
+      expect(box.contains(document.activeElement)).toBe(true)
+
+      wrapper.unmount()
+    })
+  })
+})

--- a/frontend/tests/unit/secrets-add-cta.spec.ts
+++ b/frontend/tests/unit/secrets-add-cta.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import Secrets from '@/views/Secrets.vue'
+import api from '@/services/api'
+
+vi.mock('@/services/api', () => ({
+  default: {
+    getConfigSecrets: vi.fn(),
+    runMigrationAnalysis: vi.fn(),
+    setSecret: vi.fn(),
+    deleteSecret: vi.fn(),
+  },
+}))
+
+function emptySecrets() {
+  return {
+    success: true,
+    data: {
+      secrets: [],
+      environment_vars: [],
+      total_secrets: 0,
+      total_env_vars: 0,
+    },
+  }
+}
+
+async function mountSecrets() {
+  const wrapper = mount(Secrets, { attachTo: document.body })
+  // onMounted awaits a 100ms timer before loading.
+  await vi.advanceTimersByTimeAsync(150)
+  await flushPromises()
+  return wrapper
+}
+
+describe('Secrets page add-secret CTA (UX audit F8)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.useFakeTimers()
+    ;(api.getConfigSecrets as any).mockReset()
+    ;(api.getConfigSecrets as any).mockResolvedValue(emptySecrets())
+  })
+
+  it('offers a page-level Add Secret button', async () => {
+    const wrapper = await mountSecrets()
+    expect(wrapper.find('[data-test="secrets-add-button"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('offers an Add Secret CTA in the empty state', async () => {
+    const wrapper = await mountSecrets()
+    expect(wrapper.find('[data-test="secrets-empty-add-button"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('opens the add-secret modal with no predefined name from the empty state', async () => {
+    const wrapper = await mountSecrets()
+
+    expect(wrapper.findComponent({ name: 'AddSecretModal' }).props('show')).toBe(false)
+
+    await wrapper.find('[data-test="secrets-empty-add-button"]').trigger('click')
+    await flushPromises()
+
+    const modal = wrapper.findComponent({ name: 'AddSecretModal' })
+    expect(modal.props('show')).toBe(true)
+    expect(modal.props('predefinedName')).toBeUndefined()
+    // The name field is editable, i.e. the user can name a brand new secret.
+    const nameInput = modal.find('input[type="text"]')
+    expect(nameInput.attributes('readonly')).toBeUndefined()
+
+    wrapper.unmount()
+  })
+
+  it('still passes the config-referenced name through from a per-row Set button', async () => {
+    ;(api.getConfigSecrets as any).mockResolvedValue({
+      success: true,
+      data: {
+        secrets: [
+          {
+            secret_ref: { name: 'my-api-key', original: '${keyring:my-api-key}', type: 'keyring' },
+            is_set: false,
+          },
+        ],
+        environment_vars: [],
+        total_secrets: 1,
+        total_env_vars: 0,
+      },
+    })
+
+    const wrapper = await mountSecrets()
+    const rowButtons = wrapper.findAll('button').filter((b) => b.text().includes('Add Value'))
+    expect(rowButtons.length).toBe(1)
+    await rowButtons[0].trigger('click')
+    await flushPromises()
+
+    const modal = wrapper.findComponent({ name: 'AddSecretModal' })
+    expect(modal.props('predefinedName')).toBe('my-api-key')
+
+    wrapper.unmount()
+  })
+})

--- a/frontend/tests/unit/settings-restart-fields.spec.ts
+++ b/frontend/tests/unit/settings-restart-fields.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import {
+  restartRequiredLabels,
+  GENERAL_FIELDS,
+  SECURITY_FIELDS,
+  SERVER_EDITION_FIELDS,
+  ADVANCED_ACCORDIONS,
+  type SettingField,
+} from '@/views/settings/fields'
+
+function allFields(): SettingField[] {
+  return [
+    ...GENERAL_FIELDS,
+    ...SECURITY_FIELDS,
+    ...SERVER_EDITION_FIELDS,
+    ...ADVANCED_ACCORDIONS.flatMap((a) => a.fields),
+  ]
+}
+
+function fieldByKey(key: string): SettingField | undefined {
+  return allFields().find((f) => f.key === key)
+}
+
+describe('Settings restart-required surface (UX audit F16)', () => {
+  it('derives the hint list from the fields that actually carry the badge', () => {
+    const labels = restartRequiredLabels()
+    const badged = allFields().filter((f) => f.restart)
+
+    expect(badged.length).toBeGreaterThan(0)
+    for (const f of badged) {
+      expect(labels).toContain(f.label)
+    }
+    // Nothing in the list that no field claims — the old hardcoded prose listed
+    // "Data directory", which has no settings field at all.
+    for (const label of labels) {
+      expect(badged.some((f) => f.label === label)).toBe(true)
+    }
+  })
+
+  it('does not badge enable_code_execution — it hot-applies', () => {
+    const field = fieldByKey('enable_code_execution')
+    expect(field).toBeDefined()
+    expect(field!.restart).toBeFalsy()
+    expect(restartRequiredLabels()).not.toContain(field!.label)
+  })
+
+  it('badges code_execution_pool_size — the JS runtime pool is sized at startup', () => {
+    const field = fieldByKey('code_execution_pool_size')
+    expect(field).toBeDefined()
+    expect(field!.restart).toBe(true)
+    expect(restartRequiredLabels()).toContain(field!.label)
+  })
+
+  it('leaves the hot-reloadable code-execution limits unbadged', () => {
+    for (const key of [
+      'code_execution_timeout_ms',
+      'code_execution_max_tool_calls',
+      'code_execution_max_parallel',
+    ]) {
+      expect(fieldByKey(key)?.restart).toBeFalsy()
+    }
+  })
+})

--- a/frontend/tests/unit/use-modal-a11y-initial-focus.spec.ts
+++ b/frontend/tests/unit/use-modal-a11y-initial-focus.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { defineComponent, h, ref } from 'vue'
+import { mount, flushPromises } from '@vue/test-utils'
+import { useModalA11y } from '@/composables/useModalA11y'
+
+/**
+ * The `initialFocus` option has no caller in the app yet, so these tests are
+ * the only thing holding its contract (UX audit F6, cross-model review round 5):
+ * it must be able to target the dialog heading — programmatically focusable via
+ * tabindex="-1" but deliberately outside the tab order, the standard ARIA
+ * dialog pattern — while still refusing anything that cannot take focus.
+ */
+function harness(initialFocus?: string) {
+  const show = ref(false)
+  const closed = ref(0)
+
+  const Modal = defineComponent({
+    setup() {
+      const { dialogRef } = useModalA11y(
+        () => show.value,
+        () => {
+          closed.value++
+          show.value = false
+        },
+        initialFocus ? { initialFocus } : {}
+      )
+      return () =>
+        h('div', { ref: dialogRef, role: 'dialog' }, [
+          h('h2', { id: 'title', tabindex: '-1' }, 'Dialog title'),
+          h('button', { id: 'plain' }, 'plain'),
+          h('button', { id: 'hidden-btn', style: 'display:none' }, 'hidden'),
+          h('button', { id: 'disabled-btn', disabled: true }, 'disabled'),
+        ])
+    },
+  })
+
+  return { show, closed, Modal }
+}
+
+describe('useModalA11y initialFocus (UX audit F6)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('can focus a tabindex="-1" heading, which is not in the tab order', async () => {
+    const { show, Modal } = harness('#title')
+    const wrapper = mount(Modal, { attachTo: document.body })
+    show.value = true
+    await flushPromises()
+
+    expect((document.activeElement as HTMLElement)?.id).toBe('title')
+    wrapper.unmount()
+  })
+
+  it('falls back to the first tabbable control when the selector matches nothing', async () => {
+    const { show, Modal } = harness('#does-not-exist')
+    const wrapper = mount(Modal, { attachTo: document.body })
+    show.value = true
+    await flushPromises()
+
+    expect((document.activeElement as HTMLElement)?.id).toBe('plain')
+    wrapper.unmount()
+  })
+
+  it('refuses a disabled target and falls back', async () => {
+    const { show, Modal } = harness('#disabled-btn')
+    const wrapper = mount(Modal, { attachTo: document.body })
+    show.value = true
+    await flushPromises()
+
+    expect((document.activeElement as HTMLElement)?.id).not.toBe('disabled-btn')
+    expect((document.activeElement as HTMLElement)?.id).toBe('plain')
+    wrapper.unmount()
+  })
+
+  it('without the option, focuses the first tabbable control', async () => {
+    const { show, Modal } = harness()
+    const wrapper = mount(Modal, { attachTo: document.body })
+    show.value = true
+    await flushPromises()
+
+    expect((document.activeElement as HTMLElement)?.id).toBe('plain')
+    wrapper.unmount()
+  })
+
+  it('a disabled control never bounds the Tab trap', async () => {
+    const { show, Modal } = harness()
+    const wrapper = mount(Modal, { attachTo: document.body })
+    show.value = true
+    await flushPromises()
+
+    // Cycle forward past the end; the trap must wrap to the first tabbable
+    // control rather than parking on the disabled one.
+    for (let i = 0; i < 6; i++) {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }))
+    }
+    expect((document.activeElement as HTMLElement)?.id).not.toBe('disabled-btn')
+    expect((document.activeElement as HTMLElement)?.id).not.toBe('hidden-btn')
+
+    wrapper.unmount()
+  })
+})

--- a/internal/runtime/config_hotreload.go
+++ b/internal/runtime/config_hotreload.go
@@ -90,7 +90,12 @@ func DetectConfigChanges(oldCfg, newCfg *config.Config) *ConfigApplyResult {
 			tlsChanged = true
 		} else if oldCfg.TLS.Enabled != newCfg.TLS.Enabled ||
 			oldCfg.TLS.RequireClientCert != newCfg.TLS.RequireClientCert ||
-			oldCfg.TLS.CertsDir != newCfg.TLS.CertsDir {
+			oldCfg.TLS.CertsDir != newCfg.TLS.CertsDir ||
+			// HSTS wraps the handler chain once, where the HTTP server is built
+			// (server.go withHSTS), so it cannot apply hot. Settings already
+			// badges tls.hsts as restart-required; this makes the backend agree
+			// instead of silently reporting the edit as applied (UX audit F16).
+			oldCfg.TLS.HSTS != newCfg.TLS.HSTS {
 			tlsChanged = true
 		}
 
@@ -119,8 +124,21 @@ func DetectConfigChanges(oldCfg, newCfg *config.Config) *ConfigApplyResult {
 
 	// Track hot-reloadable changes
 
-	// Server configuration changes (can be hot-reloaded)
-	if !reflect.DeepEqual(oldCfg.Servers, newCfg.Servers) {
+	// Server configuration changes (can be hot-reloaded).
+	//
+	// Compared via jsonEqual, not reflect.DeepEqual, for the same reason as
+	// docker_isolation and trusted_hosts below: PATCH /api/v1/config round-trips
+	// the LIVE config through JSON before merging the patch, so newCfg.Servers is
+	// a decoded copy while oldCfg.Servers is the in-memory slice. DeepEqual saw
+	// those as different for every patch — `Created`/`Updated` carry a monotonic
+	// reading and a *time.Location in memory but not after an RFC3339 decode, and
+	// `omitempty` collapses empty Args/Env/Headers to nil. That mislabelled
+	// changed_fields as ["mcpServers"] on unrelated edits (UX audit F16) AND
+	// triggered a spurious full upstream reload/reconnect on every settings save.
+	// The length guard keeps nil vs []*ServerConfig{} (`null` vs `[]`) from
+	// re-introducing the same false positive when there are no servers at all.
+	if len(oldCfg.Servers) != len(newCfg.Servers) ||
+		(len(oldCfg.Servers) > 0 && !jsonEqual(oldCfg.Servers, newCfg.Servers)) {
 		result.ChangedFields = append(result.ChangedFields, "mcpServers")
 		// These will be applied by triggering server reconnection
 	}
@@ -206,13 +224,24 @@ func DetectConfigChanges(oldCfg, newCfg *config.Config) *ConfigApplyResult {
 	// code_execution handler resolves timeout / max_tool_calls /
 	// max_parallel from the LIVE snapshot (p.currentConfig()) on every
 	// execution, so a lone edit here must be reported as a change instead of
-	// being swallowed as "no changes detected". EnableCodeExecution is
-	// deliberately absent: toggling it changes the registered tool set,
-	// which is a restart concern.
+	// being swallowed as "no changes detected".
 	if oldCfg.CodeExecutionTimeoutMs != newCfg.CodeExecutionTimeoutMs ||
 		oldCfg.CodeExecutionMaxToolCalls != newCfg.CodeExecutionMaxToolCalls ||
 		oldCfg.CodeExecutionMaxParallel != newCfg.CodeExecutionMaxParallel {
 		result.ChangedFields = append(result.ChangedFields, "code_execution")
+	}
+
+	// enable_code_execution (UX audit F16 — hot-reloadable). Toggling this
+	// changes the advertised tool set, which used to make it a restart concern:
+	// the routing-mode surfaces built their code_execution entry (live tool or
+	// "disabled" stub) once, from the construction-time config snapshot. Both
+	// now build from the LIVE snapshot and are rebuilt on config.reloaded
+	// (server.listenForRoutingModeRefresh), and the handler gate already read
+	// the live value per call — so the flag applies without a restart and must
+	// be reported here, or ApplyConfig swallows a lone toggle as "no changes
+	// detected" and never emits config.reloaded.
+	if oldCfg.EnableCodeExecution != newCfg.EnableCodeExecution {
+		result.ChangedFields = append(result.ChangedFields, "enable_code_execution")
 	}
 
 	// The JS runtime pool is sized once at server construction and never

--- a/internal/runtime/config_hotreload_test.go
+++ b/internal/runtime/config_hotreload_test.go
@@ -761,3 +761,129 @@ func TestDetectConfigChanges_CodeExecution(t *testing.T) {
 		assert.NotContains(t, result.ChangedFields, "code_execution_pool_size")
 	})
 }
+
+// TestDetectConfigChanges_EnableCodeExecution (UX audit F16): the Settings page
+// states that changes save instantly, and the enable_code_execution field
+// carries no "restart" badge. Before this clause the toggle contributed nothing
+// to ChangedFields, so the field the user actually flipped was never named back
+// to them — the toast reported whatever else the round-trip had (falsely)
+// flagged. The tool surface now rebuilds off the live snapshot on
+// config.reloaded, so the change genuinely applies hot.
+func TestDetectConfigChanges_EnableCodeExecution(t *testing.T) {
+	mk := func(on bool) *config.Config {
+		return &config.Config{
+			Listen: "127.0.0.1:8080", DataDir: "/d", TLS: &config.TLSConfig{},
+			EnableCodeExecution: on,
+		}
+	}
+
+	t.Run("off to on is a hot-reloadable change", func(t *testing.T) {
+		result := DetectConfigChanges(mk(false), mk(true))
+		require.True(t, result.Success)
+		assert.Contains(t, result.ChangedFields, "enable_code_execution")
+		assert.False(t, result.RequiresRestart, "the tool surface is rebuilt on config.reloaded")
+		assert.True(t, result.AppliedImmediately)
+	})
+
+	t.Run("on to off is a hot-reloadable change", func(t *testing.T) {
+		result := DetectConfigChanges(mk(true), mk(false))
+		require.True(t, result.Success)
+		assert.Contains(t, result.ChangedFields, "enable_code_execution")
+		assert.False(t, result.RequiresRestart)
+	})
+
+	t.Run("unchanged is not reported", func(t *testing.T) {
+		result := DetectConfigChanges(mk(true), mk(true))
+		require.True(t, result.Success)
+		assert.NotContains(t, result.ChangedFields, "enable_code_execution")
+	})
+}
+
+// TestDetectConfigChanges_ServersRoundTripNoFalsePositive (UX audit F16): the
+// PATCH /api/v1/config handler round-trips the LIVE config through JSON before
+// merging the patch, so newCfg.Servers is a decoded copy while oldCfg.Servers is
+// the in-memory slice. reflect.DeepEqual saw those as different — `Created`
+// carries a monotonic reading and a *time.Location in memory but not after an
+// RFC3339 decode, and `omitempty` collapses empty Args/Env/Headers to nil — so
+// EVERY patch reported "mcpServers" as changed. That both mislabelled
+// changed_fields in the UI (the audit's own symptom) and triggered a spurious
+// full upstream reload/reconnect on every settings save.
+func TestDetectConfigChanges_ServersRoundTripNoFalsePositive(t *testing.T) {
+	now := time.Now()
+	old := &config.Config{
+		Listen: "127.0.0.1:8080", DataDir: "/d", TLS: &config.TLSConfig{},
+		Servers: []*config.ServerConfig{
+			{
+				Name:     "github",
+				URL:      "https://api.github.com/mcp",
+				Protocol: "http",
+				Enabled:  true,
+				Args:     []string{},
+				Env:      map[string]string{},
+				Headers:  map[string]string{},
+				Created:  now,
+				Updated:  now,
+			},
+		},
+	}
+
+	b, err := json.Marshal(old) // simulate handlePatchConfig's round-trip
+	require.NoError(t, err)
+	var next config.Config
+	require.NoError(t, json.Unmarshal(b, &next))
+	// The user patched exactly one unrelated scalar.
+	next.EnableCodeExecution = !old.EnableCodeExecution
+
+	result := DetectConfigChanges(old, &next)
+	require.True(t, result.Success)
+	assert.NotContains(t, result.ChangedFields, "mcpServers",
+		"mcpServers was not patched — the JSON round-trip is not a change")
+	assert.Equal(t, []string{"enable_code_execution"}, result.ChangedFields)
+}
+
+// TestDetectConfigChanges_ServersRealChangeStillDetected: real server edits must
+// still be detected through the round-trip-tolerant comparison.
+func TestDetectConfigChanges_ServersRealChangeStillDetected(t *testing.T) {
+	mk := func(url string) *config.Config {
+		return &config.Config{
+			Listen: "127.0.0.1:8080", DataDir: "/d", TLS: &config.TLSConfig{},
+			Servers: []*config.ServerConfig{
+				{Name: "github", URL: url, Protocol: "http", Enabled: true},
+			},
+		}
+	}
+
+	t.Run("field edit", func(t *testing.T) {
+		result := DetectConfigChanges(mk("https://a/mcp"), mk("https://b/mcp"))
+		require.True(t, result.Success)
+		assert.Contains(t, result.ChangedFields, "mcpServers")
+	})
+
+	t.Run("server added", func(t *testing.T) {
+		next := mk("https://a/mcp")
+		next.Servers = append(next.Servers, &config.ServerConfig{Name: "second", URL: "https://c/mcp"})
+		result := DetectConfigChanges(mk("https://a/mcp"), next)
+		require.True(t, result.Success)
+		assert.Contains(t, result.ChangedFields, "mcpServers")
+	})
+
+	t.Run("server removed", func(t *testing.T) {
+		old := mk("https://a/mcp")
+		next := mk("https://a/mcp")
+		next.Servers = nil
+		result := DetectConfigChanges(old, next)
+		require.True(t, result.Success)
+		assert.Contains(t, result.ChangedFields, "mcpServers")
+	})
+
+	t.Run("no servers on either side is not a change", func(t *testing.T) {
+		old := &config.Config{Listen: "127.0.0.1:8080", DataDir: "/d", TLS: &config.TLSConfig{}}
+		next := &config.Config{
+			Listen: "127.0.0.1:8080", DataDir: "/d", TLS: &config.TLSConfig{},
+			Servers: []*config.ServerConfig{},
+		}
+		result := DetectConfigChanges(old, next)
+		require.True(t, result.Success)
+		assert.NotContains(t, result.ChangedFields, "mcpServers")
+	})
+}

--- a/internal/server/code_execution_hotreload_test.go
+++ b/internal/server/code_execution_hotreload_test.go
@@ -1,0 +1,144 @@
+package server
+
+import (
+	"testing"
+
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+)
+
+// UX audit F16: Settings advertises enable_code_execution as an
+// instantly-applied field, but the tool surfaces built their code_execution
+// entry — the live tool, or a "disabled" stub whose handler refuses every call
+// unconditionally — exactly once, at construction. Flipping the flag on
+// therefore left the stub in place on /mcp, so `code_execution` kept answering
+// "Code execution is disabled" from a brand-new MCP session until a restart,
+// even though the handler-level gate (mcp_code_execution.go) had already gone
+// live. These tests pin the rebuild seam that makes the promise true.
+
+func isDisabledCodeExecutionStub(tool mcpserver.ServerTool) bool {
+	return tool.Tool.Annotations.Title == "Code Execution (Disabled)"
+}
+
+func codeExecutionToolFrom(tools []mcpserver.ServerTool) *mcpserver.ServerTool {
+	for i := range tools {
+		if tools[i].Tool.Name == "code_execution" {
+			return &tools[i]
+		}
+	}
+	return nil
+}
+
+// TestBuildCodeExecutionTool_FollowsCurrentConfig: the builder must resolve the
+// flag on every call, not capture it. currentConfig() falls back to p.config
+// when no runtime is attached, so mutating that snapshot models a hot reload.
+func TestBuildCodeExecutionTool_FollowsCurrentConfig(t *testing.T) {
+	cfg := &config.Config{EnableCodeExecution: false}
+	p := &MCPProxyServer{config: cfg}
+
+	disabled := p.buildCodeExecutionTool()
+	require.Len(t, disabled, 1)
+	assert.True(t, isDisabledCodeExecutionStub(disabled[0]), "expected the disabled stub while the flag is off")
+
+	cfg.EnableCodeExecution = true
+	enabled := p.buildCodeExecutionTool()
+	require.Len(t, enabled, 1)
+	assert.False(t, isDisabledCodeExecutionStub(enabled[0]), "the live tool must appear once the flag is on")
+	assert.Equal(t, codeExecutionToolDescription, enabled[0].Tool.Description)
+
+	cfg.EnableCodeExecution = false
+	assert.True(t, isDisabledCodeExecutionStub(p.buildCodeExecutionTool()[0]),
+		"turning the flag back off must restore the stub")
+}
+
+// TestRefreshCodeExecutionAvailability_SwapsAdvertisedTool: the call-tool
+// surface (/mcp in the default retrieve_tools routing mode) and the code-exec
+// surface must both re-advertise code_execution after a config reload.
+func TestRefreshCodeExecutionAvailability_SwapsAdvertisedTool(t *testing.T) {
+	cfg := &config.Config{EnableCodeExecution: false}
+	p := &MCPProxyServer{
+		config:         cfg,
+		logger:         zap.NewNop(),
+		callToolServer: mcpserver.NewMCPServer("test", "0.0.0"),
+		codeExecServer: mcpserver.NewMCPServer("test", "0.0.0"),
+		server:         mcpserver.NewMCPServer("test", "0.0.0"),
+	}
+
+	for _, st := range p.buildCallToolModeTools() {
+		p.callToolServer.AddTool(st.Tool, st.Handler)
+	}
+	for _, st := range p.buildCodeExecModeTools() {
+		p.codeExecServer.AddTool(st.Tool, st.Handler)
+	}
+
+	advertised := func(s *mcpserver.MCPServer) *mcpserver.ServerTool {
+		tool, ok := s.ListTools()["code_execution"]
+		if !ok {
+			return nil
+		}
+		return tool
+	}
+
+	require.NotNil(t, advertised(p.callToolServer))
+	assert.True(t, isDisabledCodeExecutionStub(*advertised(p.callToolServer)))
+	assert.True(t, isDisabledCodeExecutionStub(*advertised(p.codeExecServer)))
+
+	// The operator flips the toggle; ApplyConfig swaps the live snapshot and
+	// emits config.reloaded, which drives this call.
+	cfg.EnableCodeExecution = true
+	p.RefreshCodeExecutionAvailability()
+
+	require.NotNil(t, advertised(p.callToolServer), "code_execution must still be advertised")
+	assert.False(t, isDisabledCodeExecutionStub(*advertised(p.callToolServer)),
+		"the call-tool surface must serve the live tool after a hot enable")
+	assert.False(t, isDisabledCodeExecutionStub(*advertised(p.codeExecServer)),
+		"the code-exec surface must serve the live tool after a hot enable")
+
+	// The default/stdio surface is updated in place with AddTools, which must
+	// not disturb the tools registerTools put there.
+	require.NotNil(t, advertised(p.server))
+	assert.False(t, isDisabledCodeExecutionStub(*advertised(p.server)))
+
+	// And back off again.
+	cfg.EnableCodeExecution = false
+	p.RefreshCodeExecutionAvailability()
+	assert.True(t, isDisabledCodeExecutionStub(*advertised(p.callToolServer)),
+		"turning the flag off must restore the refusing stub")
+}
+
+// TestRefreshCodeExecutionAvailability_PreservesOtherTools: the default surface
+// is refreshed with AddTools rather than SetTools precisely because its tool set
+// is assembled once by registerTools; SetTools would drop everything else.
+func TestRefreshCodeExecutionAvailability_PreservesOtherTools(t *testing.T) {
+	cfg := &config.Config{EnableCodeExecution: false}
+	p := &MCPProxyServer{
+		config: cfg,
+		logger: zap.NewNop(),
+		server: mcpserver.NewMCPServer("test", "0.0.0"),
+	}
+
+	callToolTools := p.buildCallToolModeTools()
+	for _, st := range callToolTools {
+		p.server.AddTool(st.Tool, st.Handler)
+	}
+	before := len(p.server.ListTools())
+	require.Greater(t, before, 1)
+
+	cfg.EnableCodeExecution = true
+	p.RefreshCodeExecutionAvailability()
+
+	assert.Len(t, p.server.ListTools(), before,
+		"refreshing code_execution must not add or drop any other tool")
+	assert.NotNil(t, codeExecutionToolFrom(callToolTools), "sanity: the builder emits code_execution")
+}
+
+// TestRefreshCodeExecutionAvailability_NilSafe: the refresh runs from the shared
+// event listener, which fires before every surface exists in some code paths.
+func TestRefreshCodeExecutionAvailability_NilSafe(t *testing.T) {
+	p := &MCPProxyServer{config: &config.Config{}, logger: zap.NewNop()}
+	assert.NotPanics(t, p.RefreshCodeExecutionAvailability)
+}

--- a/internal/server/mcp_routing.go
+++ b/internal/server/mcp_routing.go
@@ -515,8 +515,17 @@ func (p *MCPProxyServer) buildCallToolModeTools() []mcpserver.ServerTool {
 
 // buildCodeExecutionTool builds the code_execution tool for routing mode servers.
 // Returns a slice (either 1 tool or 1 disabled stub) for easy appending.
+//
+// UX audit F16: this reads the LIVE snapshot, never the construction-time
+// p.config. Settings advertises enable_code_execution as an instantly-applied
+// field; when this read was pinned to startup, flipping it on left the disabled
+// stub — whose handler refuses unconditionally — on the /mcp surface, so the
+// tool kept answering "Code execution is disabled" until a restart even though
+// the handler-level gate (mcp_code_execution.go) had already gone live. The
+// paired half of the fix is RefreshCallToolModeTools/RefreshCodeExecModeTools
+// being called on config.reloaded.
 func (p *MCPProxyServer) buildCodeExecutionTool() []mcpserver.ServerTool {
-	if p.config != nil && !p.config.EnableCodeExecution {
+	if cfg := p.currentConfig(); cfg != nil && !cfg.EnableCodeExecution {
 		// Disabled stub
 		codeExecutionTool := mcp.NewTool("code_execution",
 			mcp.WithDescription("Code execution is currently disabled. Enable it by setting \"enable_code_execution\": true in your mcpproxy config."),
@@ -691,6 +700,47 @@ func (p *MCPProxyServer) RefreshCodeExecModeTools() {
 
 	p.logger.Info("refreshed code execution mode tools",
 		zap.Int("tool_count", len(codeExecTools)))
+}
+
+// RefreshCallToolModeTools rebuilds the call-tool mode server's tool set.
+//
+// UX audit F16: callToolServer is the surface behind /mcp in the DEFAULT
+// routing mode (retrieve_tools), and its tools were registered exactly once in
+// initRoutingModeServers. Its code_execution entry is therefore the one a
+// client sees, and a hot enable_code_execution toggle had no way to replace it.
+// buildCallToolModeTools reads the live config snapshot, so re-running it on
+// config.reloaded swaps the disabled stub for the live tool (and back).
+func (p *MCPProxyServer) RefreshCallToolModeTools() {
+	if p.callToolServer == nil {
+		return
+	}
+
+	callToolTools := p.buildCallToolModeTools()
+	serverTools := make([]mcpserver.ServerTool, len(callToolTools))
+	copy(serverTools, callToolTools)
+
+	p.callToolServer.SetTools(serverTools...)
+
+	p.logger.Info("refreshed call tool mode tools",
+		zap.Int("tool_count", len(callToolTools)))
+}
+
+// RefreshCodeExecutionAvailability re-advertises code_execution on every tool
+// surface that carries it, so an enable_code_execution flip applies without a
+// restart (UX audit F16). directServer is deliberately absent — direct mode
+// does not expose code_execution at all.
+//
+// The stdio surface (p.server) is updated with AddTools rather than SetTools:
+// its tool set is assembled once by registerTools and SetTools would drop
+// everything else. AddTools replaces the entry with the same name in place, so
+// a startup-disabled server that never registered code_execution gains it, and
+// an enabled one has it swapped for the disabled stub.
+func (p *MCPProxyServer) RefreshCodeExecutionAvailability() {
+	p.RefreshCallToolModeTools()
+	p.RefreshCodeExecModeTools()
+	if p.server != nil {
+		p.server.AddTools(p.buildCodeExecutionTool()...)
+	}
 }
 
 // buildAggregatedServerPrompts combines built-in prompts with upstream

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -562,6 +562,14 @@ func (s *Server) listenForRoutingModeRefresh() {
 			// prompts in its own case; config.reloaded fires for a config-only edit.)
 			if s.mcpProxy != nil {
 				s.mcpProxy.RefreshPrompts()
+				// UX audit F16: enable_code_execution is hot-reloadable. The
+				// routing-mode tool surfaces build their code_execution entry
+				// (live tool or "disabled" stub) from the live config snapshot,
+				// but they build it ONCE at init — so without this the /mcp
+				// surface kept serving the stale stub, which refuses every call,
+				// until a restart. Same shape as RefreshPrompts above: cheap,
+				// idempotent, static construction on this one listener goroutine.
+				s.mcpProxy.RefreshCodeExecutionAvailability()
 			}
 		case runtime.EventTypeUpstreamPromptsChanged:
 			// F13: an upstream added/removed a prompt at runtime (debounced


### PR DESCRIPTION
Three findings from the [August 2026 Web UI UX audit](https://github.com/smart-mcp-proxy/mcpproxy-go/blob/audit/ux-webui-sweep/docs/qa/ux-audit-webui-2026-08.md), all in the forms-and-modals cluster.

## F6 — Add Server modal: submit below the fold, Escape dead, focus never entered

The audit measured `scrollHeight 1494` against a 900px viewport: 594px of the form — the submit row included — sat below the fold, with no sticky footer and no close affordance. Escape did nothing and `document.activeElement` was still the triggering button, because `<dialog :open>` (as opposed to `showModal()`) gives none of the modal affordances.

The box is now a flex column capped at `85vh`: header (title + ✕), tabs, one scrolling body, and the action row pinned as a sticky footer — per tab, since the Manual and Import tabs each have their own. A new `useModalA11y` composable supplies the rest of the ARIA dialog contract: initial focus into the form (deliberately skipping the ✕), a Tab trap, Escape to close, and focus restored to the trigger on close. It is applied to `AddSecretModal` too, since F8 makes that the primary path into it. `role` / `aria-modal` / `aria-labelledby` on both boxes.

## F8 — Secrets page could not add a secret

`AddSecretModal` was only reachable from a per-row **Add Value** button that renders when a secret is referenced in config but not yet set. With zero rows the page's stated purpose — "Manage secrets stored in your system's secure keyring" — was unreachable. The backend route (`POST /api/v1/secrets`) was fine; nothing led to it.

Adds a page-level **+ Add Secret** button and the same CTA in the empty state, both opening the modal with no predefined name so a brand new secret can be named. The empty-state copy now explains what a secret is for instead of restating "no secrets available". **No API change.**

## F16 — Settings promised instant apply; `enable_code_execution` did not apply

`PATCH /api/v1/config {"enable_code_execution": true}` answered `applied_immediately: true, requires_restart: false`, and `GET` reported the new value — yet `code_execution` kept answering *"Code execution is disabled"*, including from a brand-new MCP session.

I took the **hot-apply** path rather than adding a restart badge, because the seam already existed and the handler-level gate was *already* live-reading. Two independent causes:

* `buildCodeExecutionTool` read the construction-time `p.config`, so the routing-mode surfaces kept serving the *"disabled" stub* — whose handler refuses unconditionally and never reaches the live gate. It now reads `currentConfig()`.
* That stub was built once at init and never rebuilt. `RefreshCallToolModeTools` joins its direct/code-exec siblings, and `RefreshCodeExecutionAvailability` re-advertises the tool on every surface that carries it, driven from the `config.reloaded` listener — the same shape PR #973 used for `aggregate_upstream_prompts`. The stdio surface is updated with `AddTools`, not `SetTools`, so `registerTools`' other tools survive.

`DetectConfigChanges` gains `enable_code_execution` as hot-reloadable; without it a lone toggle computed empty `ChangedFields` and was swallowed as "no changes detected", so `config.reloaded` never fired.

**Also fixes the mislabelled `changed_fields` the audit noted alongside it.** Servers were compared with `reflect.DeepEqual`, but `handlePatchConfig` round-trips the live config through JSON before merging, and neither `Created`/`Updated` (monotonic reading + `*time.Location`) nor `omitempty` empty slices survive that. Every PATCH therefore reported `["mcpServers"]` — and, worse, drove a **spurious full upstream reload/reconnect on every settings save**. Now compared with `jsonEqual`, the helper `docker_isolation` and `trusted_hosts` already use for this exact reason, with a length guard so `nil` vs `[]` does not reintroduce it.

**Restart honesty**, since F16 asked for a real list rather than guesswork:
* `code_execution_pool_size` gains the restart badge it always warranted (Go forces a restart for it).
* `tls.hsts` joins the Go-side TLS restart check to match the badge TS already showed — HSTS wraps the handler chain once, at construction.
* The Settings hints panel derives its "Requires restart" list from the fields that actually carry the badge, instead of hardcoded prose that had drifted: it named *"Data directory"*, which has no settings field at all.

---

## Verification

Live, on an isolated instance (`127.0.0.1:18422`, scratch config + data dir), Playwright at 1440×900:

**F6** — modal `scrollHeight 765 == clientHeight 765`, `bottom 832 < 900`; submit row `bottom 816` (above the fold); the body is the only scroll region (`scrollHeight 1290` vs `clientHeight 556`); focus lands on the first radio *inside* the dialog; Tab ×40 never escapes; Escape closes and focus returns to the **Add Server** trigger. Repeated at 1280×700.

**F8** — both CTAs render on an empty page, the modal opens with an editable name field, and the form reaches `POST /api/v1/secrets` carrying the typed payload. (The sandbox has no usable keyring backend, so the dialog shows the backend's refusal — the wiring is what F8 was about.)

**F16** — toggled for real. `/mcp`, `/mcp/call` and `/mcp/code` all flip from the disabled stub to a working `code_execution` (`6*7` → `42`) on a brand-new MCP session with **no restart**, and back off again:

```
=== enable via PATCH ===
{"success":true,"applied_immediately":true,"requires_restart":false,"changed_fields":["enable_code_execution"]}
http://127.0.0.1:18422/mcp       ->  "{\"ok\":true,\"value\":42}"
http://127.0.0.1:18422/mcp/call  ->  "{\"ok\":true,\"value\":42}"
http://127.0.0.1:18422/mcp/code  ->  "{\"ok\":true,\"value\":42}"

=== an unrelated PATCH must NOT report mcpServers ===
{"success":true,...,"changed_fields":["tools_limit"]}
```

Before the fix the same probe returned `Code Execution (Disabled)` in `tools/list` and the refusal message from `tools/call`, with `changed_fields: ["mcpServers"]`.

**Suites**: `go test -race` full tree with the CI skip regex (green) · `go test -tags server -race ./internal/serveredition/...` (green) · both-edition builds · `golangci-lint` v2 with `.github/.golangci.yml` (0 issues) · `vitest` 681/681 across 68 files, incl. 3 new specs · `vue-tsc` clean.

No new dependencies. No API-surface change, so no swagger regen.

## Not addressed

F36's sub-items are all outside this cluster (Dashboard status chip, Sessions label clipping, Tools table Approval column, collapsed sidebar, telemetry banner) — none are forms or modals.

## Modal a11y hardening

`useModalA11y` went through five cross-model review rounds; the follow-up commits are its findings, each with a regression test:

* Only the **topmost** modal reacts to Escape and owns the Tab trap — the listener sits on `document`, and `stopPropagation` does not stop sibling listeners bound to the same node in the same phase, so one Escape used to close a whole stack.
* A modal closing **underneath** another no longer restores its own trigger, which dragged focus behind the top dialog. Focus is restored only when the stack empties.
* Focus restoration on **unmount** is deferred a tick so it runs after Vue detaches the subtree: a trigger torn down with the modal is left alone rather than taking a pointless focus/blur pair (which scrolls and is announced) on its way out, while a trigger that outlives the modal still gets focus back.
* The **focus-on-open** tick checks it is still open and still topmost before grabbing focus.
* `visibleFocusables()` now actually skips what it claimed to — `checkVisibility({ checkVisibilityCSS: true })` where the browser has it, plus a `disabled` check — so a hidden or disabled control cannot bound the trap and make Tab appear to stick. jsdom has no `checkVisibility`, so the browser path is covered by a Playwright case that injects `display:none` / `visibility:hidden` decoys and sweeps Tab over them.
* `initialFocus` resolves with its own query so it can target a `tabindex="-1"` heading (the standard ARIA pattern, outside the tab order), while the shared visibility/disabled predicate still prevents it handing focus to something that cannot take it. The option has no caller yet, so a dedicated spec holds the contract in both directions.

One residual is documented in the source rather than fixed: unwinding a stack **bottom-up in a single tick** lands focus on `<body>` rather than the original opener. Top-down (the normal order) restores correctly, and the reviewer confirmed no caller in this codebase stacks these modals.
