### PR TITLE
fix(security): redact custom credential header names

### DIFF
--- a/internal/oauth/logging.go
+++ b/internal/oauth/logging.go
@@ -580,7 +580,7 @@ func UnmaskHeaders(incoming, stored map[string]string) map[string]string {
 // renders one (key, value) pair; reused by UnmaskHeaders to recognise echoed
 // masks.
 func maskedHeaderValue(key, value string) string {
-	if sensitiveHeaders[strings.ToLower(key)] {
+	if isSensitiveHeaderKey(key) {
 		return MaskValue(value)
 	}
 	return RedactSensitiveData(value)

--- a/internal/oauth/logging.go
+++ b/internal/oauth/logging.go
@@ -25,6 +25,42 @@ var sensitiveHeaders = map[string]bool{
 	"proxy-authorization": true,
 }
 
+// sensitiveHeaderSegments catch credential-bearing custom header names that
+// cannot be enumerated exhaustively (for example access_token or
+// X-Client-Credential). Matching complete delimiter-separated segments avoids
+// false positives such as X-Author-ID and X-Monkey-ID.
+var sensitiveHeaderSegments = map[string]bool{
+	"auth":          true,
+	"authorization": true,
+	"bearer":        true,
+	"cookie":        true,
+	"token":         true,
+	"secret":        true,
+	"key":           true,
+	"apikey":        true,
+	"password":      true,
+	"passwd":        true,
+	"credential":    true,
+	"private":       true,
+	"session":       true,
+}
+
+var headerNameSegmentPattern = regexp.MustCompile(`[a-z0-9]+`)
+
+func isSensitiveHeaderKey(name string) bool {
+	if sensitiveHeaders[strings.ToLower(name)] {
+		return true
+	}
+
+	for _, segment := range headerNameSegmentPattern.FindAllString(strings.ToLower(name), -1) {
+		if sensitiveHeaderSegments[segment] {
+			return true
+		}
+	}
+
+	return false
+}
+
 // Sensitive parameter names in request bodies or URLs.
 var sensitiveParams = []string{
 	"access_token",
@@ -92,8 +128,7 @@ func RedactHeaders(headers http.Header) map[string]string {
 	redacted := make(map[string]string)
 
 	for key, values := range headers {
-		lowerKey := strings.ToLower(key)
-		if sensitiveHeaders[lowerKey] {
+		if isSensitiveHeaderKey(key) {
 			redacted[key] = "***REDACTED***"
 		} else {
 			// Join multiple values and redact any sensitive data within
@@ -129,8 +164,7 @@ func RedactStringHeaders(headers map[string]string) map[string]string {
 	}
 	redacted := make(map[string]string, len(headers))
 	for key, value := range headers {
-		lowerKey := strings.ToLower(key)
-		if sensitiveHeaders[lowerKey] {
+		if isSensitiveHeaderKey(key) {
 			redacted[key] = MaskValue(value)
 		} else {
 			redacted[key] = RedactSensitiveData(value)

--- a/internal/oauth/logging_test.go
+++ b/internal/oauth/logging_test.go
@@ -62,6 +62,14 @@ func TestRedactSensitiveData(t *testing.T) {
 }
 
 func TestRedactHeaders(t *testing.T) {
+	t.Run("redacts custom credential header names", func(t *testing.T) {
+		const plaintext = "fixture-access-token-value"
+		got := RedactHeaders(http.Header{"access_token": []string{plaintext}})
+
+		assert.NotEqual(t, plaintext, got["access_token"])
+		assert.NotContains(t, got["access_token"], plaintext)
+	})
+
 	t.Run("redacts authorization header", func(t *testing.T) {
 		headers := http.Header{
 			"Authorization": []string{"Bearer secret-token"},
@@ -90,10 +98,14 @@ func TestRedactHeaders(t *testing.T) {
 		headers := http.Header{
 			"Content-Type": []string{"application/json"},
 			"Accept":       []string{"*/*"},
+			"X-Author-ID":  []string{"42"},
+			"X-Monkey-ID":  []string{"capuchin"},
 		}
 		result := RedactHeaders(headers)
 		assert.Equal(t, "application/json", result["Content-Type"])
 		assert.Equal(t, "*/*", result["Accept"])
+		assert.Equal(t, "42", result["X-Author-ID"])
+		assert.Equal(t, "capuchin", result["X-Monkey-ID"])
 	})
 
 	t.Run("handles multiple values", func(t *testing.T) {
@@ -115,6 +127,21 @@ func TestRedactHeaders(t *testing.T) {
 }
 
 func TestRedactStringHeaders(t *testing.T) {
+	t.Run("redacts custom credential header names", func(t *testing.T) {
+		headerValues := map[string]string{
+			"access_token":        "fixture-access-token-value",
+			"X-Custom-Secret":     "fixture-custom-secret-value",
+			"X-Client-Credential": "fixture-client-credential-value",
+		}
+
+		got := RedactStringHeaders(headerValues)
+
+		for name, plaintext := range headerValues {
+			assert.NotEqual(t, plaintext, got[name], "header %q must be masked", name)
+			assert.NotContains(t, got[name], plaintext, "header %q leaked plaintext", name)
+		}
+	})
+
 	// The mask format mirrors the Web UI / macOS tray client-side
 	// display: `••••<last2> (<N> chars)`. Keeping length + the last
 	// two characters helps operators identify which token is in use
@@ -131,6 +158,16 @@ func TestRedactStringHeaders(t *testing.T) {
 		assert.NotContains(t, got["Authorization"], "fake-test-token",
 			"plaintext must not survive the mask")
 		assert.Equal(t, "pull_requests", got["X-MCP-Toolsets"])
+	})
+
+	t.Run("preserves words that only contain sensitive substrings", func(t *testing.T) {
+		got := RedactStringHeaders(map[string]string{
+			"X-Author-ID": "42",
+			"X-Monkey-ID": "capuchin",
+		})
+
+		assert.Equal(t, "42", got["X-Author-ID"])
+		assert.Equal(t, "capuchin", got["X-Monkey-ID"])
 	})
 
 	t.Run("redacts x-api-key", func(t *testing.T) {

--- a/internal/oauth/redact_hardening_test.go
+++ b/internal/oauth/redact_hardening_test.go
@@ -188,6 +188,32 @@ func TestUnmaskHeaders_RestoresEchoedMask(t *testing.T) {
 	assert.Equal(t, "Bearer realtokenvalue123", got["Authorization"])
 }
 
+// The read path (RedactStringHeaders) and the write path (UnmaskHeaders via
+// maskedHeaderValue) must agree on which header names are sensitive. When the
+// read path masks a custom credential header but the write path does not
+// recognise its own mask, an unedited echo persists `••••ue (16 chars)` OVER the
+// real credential (PATCH /api/v1/servers/{id}, upstream_servers patch).
+func TestUnmaskHeaders_RestoresEchoedMask_CustomCredentialHeaders(t *testing.T) {
+	stored := map[string]string{
+		"X-Custom-Secret":     "supersecretvalue",
+		"X-Client-Credential": "clientcredvalue",
+		"access_token":        "accesstokenvalue",
+	}
+	masked := RedactStringHeaders(stored)
+	incoming := make(map[string]string, len(masked))
+	for k, v := range masked {
+		require.NotContains(t, v, stored[k], "read path must mask %q", k)
+		incoming[k] = v
+	}
+
+	got := UnmaskHeaders(incoming, stored)
+
+	for k, plaintext := range stored {
+		assert.Equal(t, plaintext, got[k],
+			"echoed mask for %q must round-trip back to the stored credential", k)
+	}
+}
+
 // --- Codex round 2 ---
 
 // FINDING 1 (round 2) — UnmaskURL must NOT move a stored secret onto a different


### PR DESCRIPTION
# Pull Request

## Description

Known credential headers such as `Authorization` and `X-API-Key` are redacted in server listings and logs, but custom names such as `access_token`, `X-Custom-Secret`, and `X-Client-Credential` can currently expose an opaque value unchanged. The fallback value scanner cannot identify a secret when the value itself has no recognizable `token=` or `secret=` prefix.

This change centralizes header-name classification in `isSensitiveHeaderKey`, preserves the existing exact-name list, and additionally recognizes delimiter-separated credential segments. The same classifier is used by both `RedactHeaders` and `RedactStringHeaders`.

Negative regression coverage keeps non-sensitive names such as `X-Author-ID` and `X-Monkey-ID` readable, avoiding the false positives introduced by raw substring matching.

Related context: #872 and #875.

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests that prove my fix is effective or my feature works
- [x] All existing tests pass

Behavioral verification:

- The new regression tests fail before the fix because custom credential values remain in plaintext.
- Positive cases cover `access_token`, `X-Custom-Secret`, and `X-Client-Credential`.
- Negative cases cover `X-Author-ID` and `X-Monkey-ID`.
- API E2E completed with 65 passed, 0 failed, and 0 skipped.
