### PR TITLE
fix(oauth): keep the loopback callback port stable for static clients

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -540,9 +540,37 @@ explicitly to one of `http`, `sse`, or `streamable-http`.
 |-------|------|----------|-------------|
 | `client_id` | string | No | OAuth client ID (uses Dynamic Client Registration if empty) |
 | `client_secret` | string | No | OAuth client secret (can reference secure storage) |
-| `redirect_uri` | string | No | OAuth redirect URI (auto-generated if not provided) |
+| `redirect_uri` | string | No | Pins the loopback callback URL (auto-allocated if not provided) |
 | `scopes` | array | No | OAuth scopes to request |
 | `pkce_enabled` | boolean | No | PKCE is always enabled for security; this flag is currently ignored |
+
+#### Pinning the callback port with `redirect_uri`
+
+By default mcpproxy allocates a fresh loopback port for the OAuth callback on
+every login. Some providers — notably GitHub OAuth Apps — require the callback
+URL to match the registered one **exactly** and reject wildcards, so the port
+must not move.
+
+Set `redirect_uri` to pin it. mcpproxy then binds that exact port and sends that
+exact string to the provider as `redirect_uri`:
+
+```json
+{
+  "oauth": {
+    "client_id": "Iv1.abc123",
+    "redirect_uri": "http://127.0.0.1:54108/oauth/callback"
+  }
+}
+```
+
+The value must be an RFC 8252 loopback redirect: `http` scheme, a loopback host
+(`127.0.0.1`, `localhost` or `::1`), an explicit port, and the
+`/oauth/callback` path. A malformed value, or a pinned port that is already in
+use, fails the login with an explicit error in the logs rather than silently
+falling back to a random port. Register the same URL with the provider.
+
+When `redirect_uri` is not set, mcpproxy persists the port used by the first
+successful login and reuses it for subsequent logins.
 
 See [OAuth Documentation](mcp-go-oauth.md) for complete details.
 

--- a/internal/oauth/config.go
+++ b/internal/oauth/config.go
@@ -33,6 +33,62 @@ const (
 	resourceDetectRequestTimeout = 5 * time.Second  // Timeout for preflight requests
 )
 
+// ParsePinnedRedirectURI validates an operator-pinned OAuth redirect URI (the
+// per-server `oauth.redirect_uri` config field) and returns the loopback port it
+// pins.
+//
+// Providers such as GitHub OAuth Apps require the callback URL to match the
+// registered one exactly and reject wildcards, so operators need a way to nail
+// the loopback port down instead of letting mcpproxy allocate a fresh one per
+// login. The URI must therefore be an RFC 8252 loopback redirect with an
+// explicit port and mcpproxy's callback path, e.g.
+//
+//	http://127.0.0.1:54108/oauth/callback
+//
+// Anything else is rejected with an actionable error rather than silently
+// downgraded to dynamic allocation.
+func ParsePinnedRedirectURI(rawURI string) (int, error) {
+	trimmed := strings.TrimSpace(rawURI)
+	if trimmed == "" {
+		return 0, fmt.Errorf("oauth.redirect_uri is empty")
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return 0, fmt.Errorf("oauth.redirect_uri %q is not a valid URL: %w", trimmed, err)
+	}
+
+	if parsed.Scheme != "http" {
+		return 0, fmt.Errorf("oauth.redirect_uri %q must use the http scheme for a loopback redirect (RFC 8252), got %q", trimmed, parsed.Scheme)
+	}
+
+	switch parsed.Hostname() {
+	case "127.0.0.1", "localhost", "::1":
+	default:
+		return 0, fmt.Errorf("oauth.redirect_uri %q must use a loopback host (127.0.0.1, localhost or ::1), got %q", trimmed, parsed.Hostname())
+	}
+
+	if parsed.Path != DefaultRedirectPath {
+		return 0, fmt.Errorf("oauth.redirect_uri %q must use the callback path %q, got %q", trimmed, DefaultRedirectPath, parsed.Path)
+	}
+
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return 0, fmt.Errorf("oauth.redirect_uri %q must not contain a query string or fragment", trimmed)
+	}
+
+	portStr := parsed.Port()
+	if portStr == "" {
+		return 0, fmt.Errorf("oauth.redirect_uri %q must include an explicit port to pin (e.g. %s:54108%s)", trimmed, DefaultRedirectURIBase, DefaultRedirectPath)
+	}
+
+	port, err := strconv.Atoi(portStr)
+	if err != nil || port < 1 || port > 65535 {
+		return 0, fmt.Errorf("oauth.redirect_uri %q has an invalid port %q (expected 1-65535)", trimmed, portStr)
+	}
+
+	return port, nil
+}
+
 // CallbackServerManager manages OAuth callback servers for dynamic port allocation
 type CallbackServerManager struct {
 	servers map[string]*CallbackServer
@@ -750,18 +806,60 @@ func createOAuthConfigInternal(serverConfig *config.ServerConfig, storage *stora
 			zap.String("hint", "Set oauth.scopes in server config or ensure PRM/AS metadata advertises scopes_supported"))
 	}
 
+	// A static client_id in the server config is an operator-supplied credential.
+	// It is never obtained from — nor refreshable by — Dynamic Client Registration,
+	// so the DCR "clear and re-register" recovery paths below must never wipe it.
+	hasStaticClientID := serverConfig.OAuth != nil && serverConfig.OAuth.ClientID != ""
+
+	// An explicit `oauth.redirect_uri` pins the loopback callback port. Providers
+	// such as GitHub OAuth Apps match the callback URL exactly and reject
+	// wildcards, so an operator must be able to nail the port down (issue #975).
+	var pinnedRedirectURI string
+	var pinnedPort int
+	if serverConfig.OAuth != nil && strings.TrimSpace(serverConfig.OAuth.RedirectURI) != "" {
+		port, err := ParsePinnedRedirectURI(serverConfig.OAuth.RedirectURI)
+		if err != nil {
+			// Fail loudly: silently falling back to a random port would leave the
+			// operator believing they pinned the callback URL when they had not.
+			logger.Error("❌ Invalid oauth.redirect_uri in server config - refusing to fall back to a random callback port",
+				zap.String("server", serverConfig.Name),
+				zap.String("redirect_uri", serverConfig.OAuth.RedirectURI),
+				zap.Error(err),
+				zap.String("expected_format", "http://127.0.0.1:<port>"+DefaultRedirectPath))
+			return nil
+		}
+		pinnedRedirectURI = strings.TrimSpace(serverConfig.OAuth.RedirectURI)
+		pinnedPort = port
+	}
+
 	// Check for stored callback port from previous DCR (Spec 022: OAuth Redirect URI Port Persistence)
 	var preferredPort int
 	var serverKey string
 	if storage != nil {
 		serverKey = GenerateServerKey(serverConfig.Name, serverConfig.URL)
+	}
+
+	switch {
+	case pinnedPort > 0:
+		preferredPort = pinnedPort
+		logger.Info("📌 Using operator-pinned OAuth callback port from oauth.redirect_uri",
+			zap.String("server", serverConfig.Name),
+			zap.String("redirect_uri", pinnedRedirectURI),
+			zap.Int("preferred_port", preferredPort))
+	case storage != nil:
 		storedClientID, _, storedPort, err := storage.GetOAuthClientCredentials(serverKey)
-		if err == nil && storedPort > 0 {
+		switch {
+		case err == nil && storedPort > 0:
 			preferredPort = storedPort
-			logger.Info("🔄 Found stored callback port from previous DCR",
+			logger.Info("🔄 Found stored callback port from previous OAuth login",
 				zap.String("server", serverConfig.Name),
 				zap.Int("preferred_port", preferredPort))
-		} else if err == nil && storedClientID != "" && storedPort == 0 {
+		case err == nil && storedClientID != "" && storedPort == 0 && hasStaticClientID:
+			// Static credentials are configured by hand; there is nothing to
+			// re-register, so keep the record and let this login persist its port.
+			logger.Debug("Static OAuth client has no stored callback port yet; keeping credentials",
+				zap.String("server", serverConfig.Name))
+		case err == nil && storedClientID != "" && storedPort == 0:
 			// Spec 022: Legacy DCR credentials exist but port is unknown
 			// Clear them to force fresh registration with port tracking
 			logger.Warn("⚠️ Legacy DCR credentials found without stored port, clearing for re-registration",
@@ -793,27 +891,60 @@ func createOAuthConfigInternal(serverConfig *config.ServerConfig, storage *stora
 	// Spec 022: Detect port conflict and clear DCR credentials if port changed
 	// This forces fresh DCR with the new port
 	if preferredPort > 0 && callbackServer.Port != preferredPort {
-		logger.Warn("⚠️ Callback port changed, clearing DCR credentials for re-registration",
-			zap.String("server", serverConfig.Name),
-			zap.Int("stored_port", preferredPort),
-			zap.Int("new_port", callbackServer.Port))
-		if storage != nil {
-			if err := storage.ClearOAuthClientCredentials(serverKey); err != nil {
-				logger.Warn("Failed to clear DCR credentials after port change",
+		switch {
+		case pinnedPort > 0:
+			// The operator pinned this port; any other port produces a
+			// redirect_uri the provider will reject. Abort instead of pretending.
+			logger.Error("❌ Pinned OAuth callback port is unavailable - cannot honor oauth.redirect_uri",
+				zap.String("server", serverConfig.Name),
+				zap.String("redirect_uri", pinnedRedirectURI),
+				zap.Int("pinned_port", pinnedPort),
+				zap.Int("bound_port", callbackServer.Port),
+				zap.String("hint", "free the pinned port, or change oauth.redirect_uri (and the provider's callback URL) to a free one"))
+			if stopErr := globalCallbackManager.StopCallbackServer(serverConfig.Name); stopErr != nil {
+				logger.Warn("Failed to stop callback server bound to the wrong port",
 					zap.String("server", serverConfig.Name),
-					zap.Error(err))
+					zap.Error(stopErr))
+			}
+			return nil
+		case hasStaticClientID:
+			// Static credentials are not re-registerable, so clearing them would
+			// only destroy the operator's configuration for no benefit.
+			logger.Warn("⚠️ Callback port changed for a statically configured OAuth client; keeping credentials",
+				zap.String("server", serverConfig.Name),
+				zap.Int("stored_port", preferredPort),
+				zap.Int("new_port", callbackServer.Port),
+				zap.String("hint", "pin the port with oauth.redirect_uri if the provider requires an exact callback URL"))
+		default:
+			logger.Warn("⚠️ Callback port changed, clearing DCR credentials for re-registration",
+				zap.String("server", serverConfig.Name),
+				zap.Int("stored_port", preferredPort),
+				zap.Int("new_port", callbackServer.Port))
+			if storage != nil {
+				if err := storage.ClearOAuthClientCredentials(serverKey); err != nil {
+					logger.Warn("Failed to clear DCR credentials after port change",
+						zap.String("server", serverConfig.Name),
+						zap.Error(err))
+				}
 			}
 		}
 	}
 
+	// The pinned URI is sent to the provider verbatim so the string matches the
+	// one registered there (host spelling included: localhost vs 127.0.0.1).
+	redirectURI := callbackServer.RedirectURI
+	if pinnedRedirectURI != "" {
+		redirectURI = pinnedRedirectURI
+	}
+
 	logger.Info("Using exact redirect URI from allocated callback server",
 		zap.String("server", serverConfig.Name),
-		zap.String("redirect_uri", callbackServer.RedirectURI),
+		zap.String("redirect_uri", redirectURI),
 		zap.Int("port", callbackServer.Port))
 
 	logger.Info("OAuth callback server started successfully",
 		zap.String("server", serverConfig.Name),
-		zap.String("redirect_uri", callbackServer.RedirectURI),
+		zap.String("redirect_uri", redirectURI),
 		zap.Int("port", callbackServer.Port))
 
 	// Try to find a working metadata URL by validating multiple URL patterns
@@ -945,7 +1076,7 @@ func createOAuthConfigInternal(serverConfig *config.ServerConfig, storage *stora
 	oauthConfig := &client.OAuthConfig{
 		ClientID:              clientID,
 		ClientSecret:          clientSecret,
-		RedirectURI:           callbackServer.RedirectURI, // Exact redirect URI with allocated port
+		RedirectURI:           redirectURI, // Exact redirect URI: operator-pinned, or the allocated port
 		Scopes:                scopes,
 		TokenStore:            tokenStore,            // Shared token store for this server
 		PKCEEnabled:           true,                  // Always enable PKCE for security
@@ -957,7 +1088,7 @@ func createOAuthConfigInternal(serverConfig *config.ServerConfig, storage *stora
 		zap.String("server", serverConfig.Name),
 		zap.Strings("scopes", scopes),
 		zap.Bool("pkce_enabled", true),
-		zap.String("redirect_uri", callbackServer.RedirectURI),
+		zap.String("redirect_uri", redirectURI),
 		zap.String("auth_server_metadata_url", authServerMetadataURL),
 		zap.String("registration_mode", registrationMode),
 		zap.String("discovery_mode", "explicit metadata URL"), // Using explicit metadata URL to avoid discovery timeouts

--- a/internal/oauth/redirect_uri_pin_test.go
+++ b/internal/oauth/redirect_uri_pin_test.go
@@ -1,0 +1,206 @@
+package oauth
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newUnreachableUpstream returns an httptest server that answers 404 to every
+// request. OAuth metadata discovery degrades gracefully against it, which keeps
+// these tests hermetic and fast while still exercising the real
+// createOAuthConfigInternal() code path.
+func newUnreachableUpstream(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// reserveLoopbackPort picks a currently-free loopback port and releases it, so a
+// pinned redirect_uri in the test can name a port the callback server can bind.
+func reserveLoopbackPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+	return port
+}
+
+func stopCallbackServer(t *testing.T, serverName string) {
+	t.Helper()
+	t.Cleanup(func() {
+		if mgr := GetGlobalCallbackManager(); mgr != nil {
+			_ = mgr.StopCallbackServer(serverName)
+		}
+	})
+}
+
+func TestParsePinnedRedirectURI(t *testing.T) {
+	tests := []struct {
+		name     string
+		uri      string
+		wantPort int
+		wantErr  string
+	}{
+		{name: "loopback ipv4", uri: "http://127.0.0.1:54108/oauth/callback", wantPort: 54108},
+		{name: "localhost", uri: "http://localhost:8123/oauth/callback", wantPort: 8123},
+		{name: "ipv6 loopback", uri: "http://[::1]:8123/oauth/callback", wantPort: 8123},
+		{name: "surrounding whitespace tolerated", uri: "  http://127.0.0.1:54108/oauth/callback  ", wantPort: 54108},
+		{name: "empty", uri: "", wantErr: "empty"},
+		{name: "not a url", uri: "://nope", wantErr: "not a valid URL"},
+		{name: "https scheme", uri: "https://127.0.0.1:54108/oauth/callback", wantErr: "http scheme"},
+		{name: "non-loopback host", uri: "http://example.com:54108/oauth/callback", wantErr: "loopback host"},
+		{name: "wrong path", uri: "http://127.0.0.1:54108/callback", wantErr: "callback path"},
+		{name: "no port", uri: "http://127.0.0.1/oauth/callback", wantErr: "explicit port"},
+		{name: "port zero", uri: "http://127.0.0.1:0/oauth/callback", wantErr: "invalid port"},
+		{name: "query string", uri: "http://127.0.0.1:54108/oauth/callback?x=1", wantErr: "query string or fragment"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			port, err := ParsePinnedRedirectURI(tt.uri)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPort, port)
+		})
+	}
+}
+
+// TestCreateOAuthConfig_HonorsPinnedRedirectURI verifies part (c) of the fix:
+// a configured oauth.redirect_uri pins the loopback callback port AND is sent to
+// the provider verbatim (GitHub OAuth Apps match the callback URL exactly).
+func TestCreateOAuthConfig_HonorsPinnedRedirectURI(t *testing.T) {
+	upstream := newUnreachableUpstream(t)
+	store := setupTestStorage(t)
+
+	port := reserveLoopbackPort(t)
+	pinned := fmt.Sprintf("http://127.0.0.1:%d/oauth/callback", port)
+
+	serverName := "pinned-redirect-server"
+	stopCallbackServer(t, serverName)
+
+	serverConfig := &config.ServerConfig{
+		Name: serverName,
+		URL:  upstream.URL + "/mcp",
+		OAuth: &config.OAuthConfig{
+			ClientID:    "static-client",
+			RedirectURI: pinned,
+		},
+	}
+
+	oauthConfig := CreateOAuthConfig(serverConfig, store)
+	require.NotNil(t, oauthConfig, "pinned redirect_uri should produce a usable OAuth config")
+
+	assert.Equal(t, pinned, oauthConfig.RedirectURI,
+		"the configured redirect_uri must be sent to the provider verbatim")
+
+	callbackServer, ok := GetCallbackServer(serverName)
+	require.True(t, ok, "callback server should be running")
+	assert.Equal(t, port, callbackServer.Port,
+		"callback server must listen on the pinned port")
+}
+
+// TestCreateOAuthConfig_MalformedPinnedRedirectURI verifies that a malformed
+// oauth.redirect_uri fails loudly instead of silently falling back to a random
+// port (which the operator would never discover until the provider rejects it).
+func TestCreateOAuthConfig_MalformedPinnedRedirectURI(t *testing.T) {
+	upstream := newUnreachableUpstream(t)
+	store := setupTestStorage(t)
+
+	serverName := "malformed-redirect-server"
+	stopCallbackServer(t, serverName)
+
+	serverConfig := &config.ServerConfig{
+		Name: serverName,
+		URL:  upstream.URL + "/mcp",
+		OAuth: &config.OAuthConfig{
+			ClientID:    "static-client",
+			RedirectURI: "https://example.com/oauth/callback",
+		},
+	}
+
+	oauthConfig := CreateOAuthConfig(serverConfig, store)
+	assert.Nil(t, oauthConfig, "malformed redirect_uri must abort OAuth config creation")
+
+	_, ok := GetCallbackServer(serverName)
+	assert.False(t, ok, "no callback server should be started for a malformed pin")
+}
+
+// TestCreateOAuthConfig_StaticClientCredentialsSurviveMissingPort verifies part
+// (b) of the fix: a statically configured client is never "re-registered", so
+// the legacy-DCR clearing branch must not wipe its stored record.
+func TestCreateOAuthConfig_StaticClientCredentialsSurviveMissingPort(t *testing.T) {
+	upstream := newUnreachableUpstream(t)
+	store := setupTestStorage(t)
+
+	serverName := "static-client-server"
+	stopCallbackServer(t, serverName)
+
+	serverURL := upstream.URL + "/mcp"
+	serverKey := GenerateServerKey(serverName, serverURL)
+
+	// Simulate the state left behind by a login that persisted the static
+	// client_id but no callback port.
+	require.NoError(t, store.UpdateOAuthClientCredentials(serverKey, "static-client", "static-secret", 0))
+
+	serverConfig := &config.ServerConfig{
+		Name: serverName,
+		URL:  serverURL,
+		OAuth: &config.OAuthConfig{
+			ClientID:     "static-client",
+			ClientSecret: "static-secret",
+		},
+	}
+
+	oauthConfig := CreateOAuthConfig(serverConfig, store)
+	require.NotNil(t, oauthConfig)
+
+	storedClientID, storedSecret, _, err := store.GetOAuthClientCredentials(serverKey)
+	require.NoError(t, err)
+	assert.Equal(t, "static-client", storedClientID,
+		"static OAuth credentials must never be cleared for re-registration")
+	assert.Equal(t, "static-secret", storedSecret)
+}
+
+// TestCreateOAuthConfig_LegacyDCRCredentialsStillCleared guards the original
+// Spec 022 behavior for genuine DCR clients (no static client_id in config).
+func TestCreateOAuthConfig_LegacyDCRCredentialsStillCleared(t *testing.T) {
+	upstream := newUnreachableUpstream(t)
+	store := setupTestStorage(t)
+
+	serverName := "legacy-dcr-server"
+	stopCallbackServer(t, serverName)
+
+	serverURL := upstream.URL + "/mcp"
+	serverKey := GenerateServerKey(serverName, serverURL)
+
+	require.NoError(t, store.UpdateOAuthClientCredentials(serverKey, "dcr-client", "dcr-secret", 0))
+
+	serverConfig := &config.ServerConfig{
+		Name: serverName,
+		URL:  serverURL,
+	}
+
+	oauthConfig := CreateOAuthConfig(serverConfig, store)
+	require.NotNil(t, oauthConfig)
+
+	storedClientID, _, _, err := store.GetOAuthClientCredentials(serverKey)
+	require.NoError(t, err)
+	assert.Empty(t, storedClientID,
+		"legacy DCR credentials without a stored port should still be cleared")
+}

--- a/internal/upstream/core/connection_oauth.go
+++ b/internal/upstream/core/connection_oauth.go
@@ -14,6 +14,7 @@ import (
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/contracts"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/diagnostics"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/oauth"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/transport"
 
 	"github.com/mark3labs/mcp-go/client"
@@ -1666,11 +1667,11 @@ func (c *Client) persistDCRCredentials() {
 
 	serverKey := oauth.GenerateServerKey(c.config.Name, c.config.URL)
 
-	// Preserve existing callbackPort from the record (set during the DCR flow)
-	callbackPort := 0
-	if record, err := c.storage.GetOAuthToken(serverKey); err == nil {
-		callbackPort = record.CallbackPort
-	}
+	// Persist the port this login actually used. Only DCR-succeeded flows used
+	// to record a port, so a static-client login persisted port 0 and the next
+	// login allocated a fresh loopback port — breaking providers that require an
+	// exact, unchanging callback URL (issue #975).
+	callbackPort := resolveCallbackPortForPersistence(c.config.Name, serverKey, c.storage)
 
 	if err := c.storage.UpdateOAuthClientCredentials(serverKey, clientID, clientSecret, callbackPort); err != nil {
 		c.logger.Error("Failed to persist DCR credentials",
@@ -1682,7 +1683,30 @@ func (c *Client) persistDCRCredentials() {
 	c.logger.Info("DCR credentials persisted for proactive token refresh",
 		zap.String("server", c.config.Name),
 		zap.String("client_id_prefix", clientID[:min(8, len(clientID))]+"..."),
-		zap.Bool("has_client_secret", clientSecret != ""))
+		zap.Bool("has_client_secret", clientSecret != ""),
+		zap.Int("callback_port", callbackPort))
+}
+
+// resolveCallbackPortForPersistence returns the loopback callback port to store
+// alongside the OAuth client credentials for serverName.
+//
+// The live callback server wins: it is the port the redirect_uri of the login
+// that just completed actually pointed at, so persisting it lets the next login
+// bind the same port and reuse the identical redirect_uri. Only when no callback
+// server is running do we fall back to whatever was stored previously, so a
+// refresh-only code path never downgrades a known port to 0.
+func resolveCallbackPortForPersistence(serverName, serverKey string, store *storage.BoltDB) int {
+	if callbackServer, exists := oauth.GetCallbackServer(serverName); exists && callbackServer.Port > 0 {
+		return callbackServer.Port
+	}
+
+	if store == nil {
+		return 0
+	}
+	if record, err := store.GetOAuthToken(serverKey); err == nil && record != nil {
+		return record.CallbackPort
+	}
+	return 0
 }
 
 // wasOAuthRecentlyCompleted checks if OAuth was completed recently to prevent retry loops

--- a/internal/upstream/core/oauth_callback_port_test.go
+++ b/internal/upstream/core/oauth_callback_port_test.go
@@ -1,0 +1,190 @@
+package core
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/oauth"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
+	"github.com/smart-mcp-proxy/mcpproxy-go/tests/oauthserver"
+
+	mcpclient "github.com/mark3labs/mcp-go/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func newCallbackPortTestStorage(t *testing.T) *storage.BoltDB {
+	t.Helper()
+	db, err := storage.NewBoltDB(t.TempDir(), zap.NewNop().Sugar())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func stopCallbackServerAfterTest(t *testing.T, serverName string) {
+	t.Helper()
+	t.Cleanup(func() {
+		if mgr := oauth.GetGlobalCallbackManager(); mgr != nil {
+			_ = mgr.StopCallbackServer(serverName)
+		}
+	})
+}
+
+// TestResolveCallbackPortForPersistence_UsesLiveCallbackServer covers part (a)
+// of the fix: the port we persist must be the one the callback server is
+// actually listening on, not merely whatever happened to be stored already.
+func TestResolveCallbackPortForPersistence_UsesLiveCallbackServer(t *testing.T) {
+	db := newCallbackPortTestStorage(t)
+	serverName := "live-callback-port"
+	serverKey := oauth.GenerateServerKey(serverName, "https://example.test/mcp")
+
+	// A record exists with no port — the pre-fix code would keep persisting 0.
+	require.NoError(t, db.UpdateOAuthClientCredentials(serverKey, "static-client", "", 0))
+
+	stopCallbackServerAfterTest(t, serverName)
+	callbackServer, err := oauth.GetGlobalCallbackManager().StartCallbackServer(serverName, 0)
+	require.NoError(t, err)
+	require.Positive(t, callbackServer.Port)
+
+	got := resolveCallbackPortForPersistence(serverName, serverKey, db)
+	assert.Equal(t, callbackServer.Port, got,
+		"the live callback server port must win over the stored value")
+}
+
+// TestResolveCallbackPortForPersistence_FallsBackToStoredPort verifies we do not
+// regress the original behavior when no callback server is running.
+func TestResolveCallbackPortForPersistence_FallsBackToStoredPort(t *testing.T) {
+	db := newCallbackPortTestStorage(t)
+	serverName := "no-live-callback-port"
+	serverKey := oauth.GenerateServerKey(serverName, "https://example.test/mcp")
+
+	require.NoError(t, db.UpdateOAuthClientCredentials(serverKey, "static-client", "", 43117))
+
+	got := resolveCallbackPortForPersistence(serverName, serverKey, db)
+	assert.Equal(t, 43117, got)
+}
+
+// loginCycle runs one complete OAuth login for serverConfig against a real test
+// OAuth provider using production code only:
+//
+//	oauth.CreateOAuthConfig()  -> allocates/binds the loopback callback server
+//	client.markOAuthComplete() -> persists credentials, then frees the port
+//
+// It returns the loopback port the callback server bound for this login and the
+// redirect_uri that would have been sent to the provider.
+func loginCycle(t *testing.T, serverConfig *config.ServerConfig, db *storage.BoltDB) (port int, redirectURI string) {
+	t.Helper()
+
+	oauthConfig := oauth.CreateOAuthConfig(serverConfig, db)
+	require.NotNil(t, oauthConfig, "OAuth config creation must succeed")
+
+	callbackServer, ok := oauth.GetCallbackServer(serverConfig.Name)
+	require.True(t, ok, "callback server must be running during the flow")
+	port = callbackServer.Port
+	redirectURI = oauthConfig.RedirectURI
+
+	mcpClient, err := mcpclient.NewOAuthStreamableHttpClient(serverConfig.URL, *oauthConfig)
+	require.NoError(t, err)
+
+	c := &Client{
+		config:  serverConfig,
+		storage: db,
+		logger:  zap.NewNop(),
+		client:  mcpClient,
+	}
+
+	// This is what the real connection does when the browser callback lands:
+	// persist the credentials, then shut the callback server down.
+	c.markOAuthComplete()
+
+	return port, redirectURI
+}
+
+// TestOAuthCallbackPort_StableAcrossLogins_StaticClient is the regression test
+// for issue #975. With a static oauth.client_id, the loopback callback port used
+// to change on every login, so providers that require an exact callback URL
+// (GitHub OAuth Apps reject wildcards) could never be made to work.
+func TestOAuthCallbackPort_StableAcrossLogins_StaticClient(t *testing.T) {
+	provider := oauthserver.Start(t, oauthserver.Options{
+		Clients: []oauthserver.ClientConfig{{
+			ClientID:     "static-client",
+			ClientName:   "Static Client",
+			RedirectURIs: []string{"http://127.0.0.1/oauth/callback"},
+		}},
+	})
+	t.Cleanup(func() { _ = provider.Shutdown() })
+
+	db := newCallbackPortTestStorage(t)
+	serverName := "static-client-port-stability"
+	stopCallbackServerAfterTest(t, serverName)
+
+	serverConfig := &config.ServerConfig{
+		Name:     serverName,
+		URL:      provider.MCPURL,
+		Protocol: "http",
+		OAuth: &config.OAuthConfig{
+			ClientID: "static-client",
+		},
+	}
+
+	firstPort, firstURI := loginCycle(t, serverConfig, db)
+	secondPort, secondURI := loginCycle(t, serverConfig, db)
+
+	assert.Equal(t, firstPort, secondPort,
+		"a statically configured OAuth client must reuse the same loopback callback port (issue #975): got %d then %d",
+		firstPort, secondPort)
+	assert.Equal(t, firstURI, secondURI,
+		"the redirect_uri sent to the provider must be identical across logins")
+
+	// And the record must survive: the static client is never re-registered.
+	serverKey := oauth.GenerateServerKey(serverName, serverConfig.URL)
+	storedClientID, _, storedPort, err := db.GetOAuthClientCredentials(serverKey)
+	require.NoError(t, err)
+	assert.Equal(t, "static-client", storedClientID)
+	assert.Equal(t, firstPort, storedPort, "the live callback port must be persisted")
+}
+
+// TestOAuthCallbackPort_PinnedRedirectURI_StableAcrossLogins covers part (c):
+// an operator who pins oauth.redirect_uri gets exactly that port and URI, on
+// every login, with no reliance on stored state at all.
+func TestOAuthCallbackPort_PinnedRedirectURI_StableAcrossLogins(t *testing.T) {
+	provider := oauthserver.Start(t, oauthserver.Options{
+		Clients: []oauthserver.ClientConfig{{
+			ClientID:     "pinned-client",
+			ClientName:   "Pinned Client",
+			RedirectURIs: []string{"http://127.0.0.1/oauth/callback"},
+		}},
+	})
+	t.Cleanup(func() { _ = provider.Shutdown() })
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	pinnedPort := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+	pinnedURI := fmt.Sprintf("http://127.0.0.1:%d/oauth/callback", pinnedPort)
+
+	db := newCallbackPortTestStorage(t)
+	serverName := "pinned-client-port-stability"
+	stopCallbackServerAfterTest(t, serverName)
+
+	serverConfig := &config.ServerConfig{
+		Name:     serverName,
+		URL:      provider.MCPURL,
+		Protocol: "http",
+		OAuth: &config.OAuthConfig{
+			ClientID:    "pinned-client",
+			RedirectURI: pinnedURI,
+		},
+	}
+
+	firstPort, firstURI := loginCycle(t, serverConfig, db)
+	secondPort, secondURI := loginCycle(t, serverConfig, db)
+
+	assert.Equal(t, pinnedPort, firstPort)
+	assert.Equal(t, pinnedPort, secondPort)
+	assert.Equal(t, pinnedURI, firstURI)
+	assert.Equal(t, pinnedURI, secondURI)
+}

--- a/tests/oauthserver/cmd/server/main.go
+++ b/tests/oauthserver/cmd/server/main.go
@@ -126,12 +126,17 @@ func main() {
 		// Pre-register test-client for Playwright tests
 		Clients: []oauthserver.ClientConfig{
 			{
-				ClientID:     "test-client",
-				ClientName:   "Test Client",
+				ClientID:   "test-client",
+				ClientName: "Test Client",
 				RedirectURIs: []string{
 					"http://127.0.0.1/callback",
 					"http://localhost/callback",
 					"http://127.0.0.1:9000/callback", // Allow callback on same port as OAuth server
+					// mcpproxy's own loopback callback path (internal/oauth
+					// DefaultRedirectPath) — needed to drive a real login
+					// against this server.
+					"http://127.0.0.1/oauth/callback",
+					"http://localhost/oauth/callback",
 				},
 			},
 		},


### PR DESCRIPTION
Related #975

## The bug

With a static `oauth.client_id` configured, mcpproxy allocated a **fresh loopback callback port on every login**, so the `redirect_uri` sent to the provider changed each time. GitHub OAuth Apps (and other providers) require the callback URL to match the registered one exactly and reject wildcards, so such an integration could never be made to work — there is no single URL you can register.

**Before / after**, same isolated instance, same script, two consecutive login cycles with `oauth.client_id: test-client`:

```
# origin/main (310386f19)
### login 1
PORT=53568
connected: True
### login 2
PORT=53641          <-- port moved; redirect_uri changed
connected: True

# this branch
### login 1
PORT=53734
connected: True
### login 2
PORT=53734          <-- same port, identical redirect_uri
connected: True
```

## The three parts of the fix

**(a) `persistDCRCredentials()` persists the live callback port.**
It previously only *preserved* an already-stored port (`callbackPort := 0` then read the record), and only the DCR-succeeded branches ever wrote one. A static-credential login therefore persisted `client_id` with port `0`. It now resolves the port from the callback server that is actually running for that upstream (`resolveCallbackPortForPersistence`), falling back to the stored value when no callback server is up, so a refresh-only path never downgrades a known port to 0.

**(b) The clearing branches skip static clients.**
With a non-empty `client_id` and port `0`, the next login hit the "Legacy DCR credentials found without stored port, clearing for re-registration" branch and wiped the record — after which `preferredPort` stayed `0` and `net.Listen("tcp", "127.0.0.1:0")` handed out a new port. A statically configured client is never re-registered, so clearing it is always wrong. Both clearing branches (legacy-no-port and port-changed) now skip when `serverConfig.OAuth.ClientID != ""`. Genuine DCR clients keep the original Spec 022 behavior, guarded by its own test.

**(c) `oauth.redirect_uri` is honored as an explicit operator pin.**
The field existed at `internal/config/config.go:707`, was diffed in `DetectConfigChanges`, was documented in `specs/006-oauth-extra-params/quickstart.md` — and was never read: `internal/oauth/config.go` unconditionally used `callbackServer.RedirectURI`. Operators believed they had pinned a port and had not. It now pins the preferred callback port, and the configured URI is sent to the provider verbatim (so `localhost` vs `127.0.0.1` spelling is preserved). New `ParsePinnedRedirectURI` validates it — `http` scheme, loopback host, explicit port, `/oauth/callback` path, no query/fragment — and a malformed value **aborts the flow with an actionable error** rather than silently falling back to a random port. An unavailable pinned port fails the same way, since any other port produces a redirect the provider will reject.

Pinning verified end to end as well (`"redirect_uri": "http://127.0.0.1:18987/oauth/callback"`):

```
### login 1
PORT=18987
connected: True
### login 2
PORT=18987
connected: True
```

## Tests

Written first, watched fail against unmodified production code, then implemented. The regression test drives real production code (`oauth.CreateOAuthConfig` → `markOAuthComplete`) against the existing `tests/oauthserver` provider — no new fake provider.

Red before the fix:

```
--- FAIL: TestOAuthCallbackPort_StableAcrossLogins_StaticClient
    Error: Not equal: expected: 49679  actual: 49681
    Messages: a statically configured OAuth client must reuse the same loopback
              callback port (issue #975): got 49679 then 49681
    Error: Not equal: expected: 49679  actual: 0
    Messages: the live callback port must be persisted
--- FAIL: TestCreateOAuthConfig_StaticClientCredentialsSurviveMissingPort
    Error: Not equal: expected: "static-client"  actual: ""
    Messages: static OAuth credentials must never be cleared for re-registration
--- FAIL: TestCreateOAuthConfig_MalformedPinnedRedirectURI
```

Green after:

```
--- PASS: TestResolveCallbackPortForPersistence_UsesLiveCallbackServer (0.03s)
--- PASS: TestResolveCallbackPortForPersistence_FallsBackToStoredPort (0.03s)
--- PASS: TestOAuthCallbackPort_StableAcrossLogins_StaticClient (0.12s)
--- PASS: TestOAuthCallbackPort_PinnedRedirectURI_StableAcrossLogins (0.18s)
```

New coverage: `internal/upstream/core/oauth_callback_port_test.go`, `internal/oauth/redirect_uri_pin_test.go` (including a `ParsePinnedRedirectURI` validation table and a guard that legacy DCR credentials are *still* cleared).

## How the local verification was run

Isolated instance only — high port, scratch `--data-dir` and `--config`, `HEADLESS=1`; `~/.mcpproxy/` untouched and `scripts/test-api-e2e.sh` never invoked. The upstream was `tests/oauthserver` (`go run ./tests/oauthserver/cmd/server -port 18951`), configured with a static `client_id`. Each login cycle: `POST /api/v1/servers/oauthtest/login` → complete the provider's login form → deliver the callback to the loopback URI. The second login was forced the way a real provider rotation does — restart the provider (new signing keys), then restart the upstream, which lands in `Authentication required`. No `logout` between cycles, since a full logout deletes the whole token record (including the port) by design.

The standalone test-provider `main.go` gained mcpproxy's own `/oauth/callback` path in the pre-registered client's redirect URIs; without it the provider rejects a real mcpproxy login with `invalid_request`.

## Gates

- `go test -race ./internal/oauth/... ./internal/upstream/...` — ok
- `go test ./internal/config/... ./internal/storage/... ./tests/...` — ok
- `go build ./...` and `go build -tags server -o /dev/null ./cmd/mcpproxy` — ok
- `golangci-lint run --config .github/.golangci.yml ./internal/oauth/... ./internal/upstream/... ./tests/...` — 0 issues

## Not touched

The callback-channel / state-dispatch region (`handleCallback`, the shared `CallbackChan`, `StartCallbackServer`'s reuse path, `waitForOAuthCallbackAsync`) is untouched — a separate bug lives there.
