### PR TITLE
fix: quarantined servers over-report available tools (#1064) + three Web UI presentation defects (#1065)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -17,7 +17,14 @@
            its track and the footer ended up overlapping the last row at 390px
            (UX audit F14). -->
       <main class="overflow-y-auto min-h-0 min-w-0 p-4 sm:p-6">
-        <router-view />
+        <!-- #1065: keyed on authEpoch so repairing a failed auth remounts the
+             current view. Views hold their load errors in component-local refs
+             that nothing outside can reach, so a successful sign-in used to
+             leave a stale red error panel and zero rows behind the recovered
+             header. Key on authEpoch ONLY -- folding in the route path would
+             remount ServerDetail on every :serverName change and break the
+             Dashboard's single instance across /, /usage and /overview. -->
+        <router-view :key="systemStore.authEpoch" />
       </main>
 
       <!-- Persistent footer with project links (discussion #948) -->
@@ -79,24 +86,44 @@ function handleAuthModalClose() {
   systemStore.setAuthRequired(false)
 }
 
+// Re-prime everything that only loads at mount. The <router-view> key covers
+// the routed view, but these surfaces live outside it and would otherwise keep
+// their failed state until a full page reload (#1065).
+async function reloadAfterAuth() {
+  systemStore.connectEventSource()
+  serversStore.fetchServers()
+  systemStore.fetchInfo() // TopHeader version / update state
+  systemStore.fetchRouting() // TopHeader routing chip
+  // Server-edition role-based nav. The router guard does not run for a
+  // key-driven remount, so re-check here.
+  await authStore.checkAuth()
+}
+
 function handleAuthModalAuthenticated() {
   authModal.show = false
   authModal.lastError = ''
-  systemStore.setAuthRequired(false)
+  // markAuthRecovered, not setAuthRequired(false): this path validated the key,
+  // so it is safe to invalidate every view that failed while auth was broken.
+  systemStore.markAuthRecovered()
 
-  // Refresh data now that we're authenticated
-  systemStore.connectEventSource()
-  serversStore.fetchServers()
+  void reloadAfterAuth()
 }
 
-function handleAuthModalRefresh() {
+function handleAuthModalRefresh(verified: boolean) {
+  if (!verified) {
+    // The reloaded key did not authenticate. Leave the modal and the
+    // auth-required flag in place rather than remounting every view onto a
+    // key that is still 401.
+    return
+  }
+
   authModal.show = false
   authModal.lastError = ''
-  systemStore.setAuthRequired(false)
+  // The modal verified the reloaded key, so this is a real recovery and the
+  // views holding stale auth errors must be invalidated too (#1065).
+  systemStore.markAuthRecovered()
 
-  // Reconnect with potentially new API key
-  systemStore.connectEventSource()
-  serversStore.fetchServers()
+  void reloadAfterAuth()
 }
 
 // Handle API authentication errors

--- a/frontend/src/components/ActivityWidget.vue
+++ b/frontend/src/components/ActivityWidget.vue
@@ -105,6 +105,7 @@ import api from '@/services/api'
 import type { ActivityRecord, ActivitySummaryResponse } from '@/types/api'
 import {
   formatPreflightSummary,
+  getTypeIcon,
   isChildCall,
   isPreflightActivity,
   statusPresentation,
@@ -159,18 +160,6 @@ const formatRelativeTime = (timestamp: string): string => {
   if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`
   if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`
   return `${Math.floor(diff / 86400000)}d ago`
-}
-
-const getTypeIcon = (type: string): string => {
-  const typeIcons: Record<string, string> = {
-    'tool_call': '🔧',
-    'policy_decision': '🛡️',
-    'quarantine_change': '⚠️',
-    'server_change': '🔄',
-    // Spec 098: required-tools preflight
-    'preflight': '🛫'
-  }
-  return typeIcons[type] || '📋'
 }
 
 // Lifecycle

--- a/frontend/src/components/AuthErrorModal.vue
+++ b/frontend/src/components/AuthErrorModal.vue
@@ -109,7 +109,9 @@ interface Props {
 interface Emits {
   (e: 'close'): void
   (e: 'authenticated'): void
-  (e: 'refresh'): void
+  // `verified` says whether the reloaded key actually authenticated. App.vue
+  // only invalidates views when it did (#1065).
+  (e: 'refresh', verified: boolean): void
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -175,10 +177,27 @@ async function handleSetAPIKey() {
   }
 }
 
-function handleRefresh() {
-  // Reinitialize API key from URL/localStorage
-  api.reinitializeAPIKey()
-  emit('refresh')
+async function handleRefresh() {
+  // Reinitialize API key from URL/localStorage, then VERIFY it before telling
+  // the app auth is repaired. Without the verification this path could only
+  // assert recovery, so it could not safely invalidate the views holding stale
+  // auth errors -- and #1065's stale red panel survived on this path.
+  isValidating.value = true
+  inputError.value = ''
+  try {
+    api.reinitializeAPIKey()
+    const isValid = await api.validateAPIKey()
+    emit('refresh', isValid)
+    if (!isValid) {
+      inputError.value = 'No valid API key found — enter one above'
+    }
+  } catch (error) {
+    console.error('API key refresh error:', error)
+    inputError.value = error instanceof Error ? error.message : 'Refresh failed'
+    emit('refresh', false)
+  } finally {
+    isValidating.value = false
+  }
 }
 
 function handleClose() {

--- a/frontend/src/components/ServerCard.vue
+++ b/frontend/src/components/ServerCard.vue
@@ -85,7 +85,14 @@
       <!-- Security scan badge (Spec 039)
            Wrapped in a DaisyUI tooltip that explains the state and carries a
            disclaimer that the risk score is an experimental heuristic. -->
-      <div v-if="server.security_scan" class="flex items-center gap-2 mb-4">
+      <!-- #1065: hidden while the server is quarantined. A scan verdict is
+           about CONTENT; quarantine is about REVIEW STATE. Stacked as siblings
+           they read as contradictory claims about the same server ("Clean"
+           directly above "needs security review"). While quarantined the
+           verdict is folded into the banner below as a subordinate clause, so
+           the card carries exactly one security headline -- the subordination
+           ServerDetail's spec-088 banner already does. -->
+      <div v-if="server.security_scan && !server.quarantined" class="flex items-center gap-2 mb-4">
         <div
           class="flex items-center gap-1.5 text-sm tooltip tooltip-right tooltip-bottom max-w-xs"
           :data-tip="securityBadgeTooltip"
@@ -147,11 +154,18 @@
            ("needs security review") so it must also afford it — Review opens the
            server's Security tab, where the spec-088 banner carries the verdict
            and the approve/scan actions. -->
-      <div v-if="server.quarantined" class="alert alert-warning alert-sm mb-4" data-test="server-card-quarantine">
-        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <div v-if="server.quarantined" class="alert alert-warning alert-sm mb-4 items-start" data-test="server-card-quarantine">
+        <svg class="w-4 h-4 mt-0.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.732-.833-2.5 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z" />
         </svg>
-        <span class="text-xs flex-1">Quarantined — needs security review</span>
+        <div class="min-w-0 flex-1">
+          <div class="text-xs">Quarantined — needs security review</div>
+          <div
+            v-if="quarantineScanNote"
+            class="text-[11px] opacity-80 mt-0.5"
+            data-test="server-card-quarantine-scan-note"
+          >{{ quarantineScanNote }}</div>
+        </div>
         <router-link
           :to="serverDetailPath(server.name, 'security')"
           class="btn btn-xs btn-warning"
@@ -693,6 +707,36 @@ const securityBadgeTooltip = computed(() => {
       return 'Security scan in progress…'
     default:
       return disclaimer
+  }
+})
+
+// #1065: the subordinate half of the quarantine banner. Same reasoning as the
+// #938 held-tools downgrade above, one level up -- a reassuring statement must
+// never sit as a peer of a warning one. While quarantined the standalone badge
+// is suppressed and its verdict is restated here as a clause of the quarantine
+// headline: the verdict informs the review, it does not settle it. Returns ''
+// when there is nothing worth saying, keeping the banner a one-liner.
+const quarantineScanNote = computed(() => {
+  const scan = props.server.security_scan
+  const status = scan?.status
+  if (!scan || !status || status === 'not_scanned') return ''
+  switch (status) {
+    case 'scanning':
+      return 'Security scan in progress…'
+    case 'failed':
+      // A failed scan is an INCOMPLETE scan, never a threat verdict -- mirrors
+      // the scan-failed precaution branch in utils/quarantineBanner.ts.
+      return 'Last scan could not complete — still needs review'
+    case 'clean':
+      return 'Last scan: clean — still needs review'
+    case 'warnings': {
+      const n = scan.finding_counts?.warning ?? 0
+      return `Last scan: ${n} warning${n !== 1 ? 's' : ''} — needs review`
+    }
+    case 'dangerous':
+      return 'Last scan: dangerous findings — needs review'
+    default:
+      return ''
   }
 })
 

--- a/frontend/src/components/SidebarNav.vue
+++ b/frontend/src/components/SidebarNav.vue
@@ -475,7 +475,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, h, onMounted, ref, type FunctionalComponent } from 'vue'
+import { computed, h, onMounted, ref, watch, type FunctionalComponent } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useSystemStore } from '@/stores/system'
 import { formatDateTime } from '@/utils/datetime'
@@ -518,15 +518,24 @@ function onClickSetup() {
   }
 }
 
-onMounted(() => {
-  // Pull initial state so the badge is correct on first render. Personal-
-  // edition only — the surrounding template gates this for personal users.
+function loadBadgeCounts() {
+  // Personal-edition only — the surrounding template gates this for personal users.
   if (!authStore.isTeamsEdition) {
     void onboardingStore.fetchState()
     void fetchToolCount()
     void fetchSecretCount()
   }
+}
+
+onMounted(() => {
+  // Pull initial state so the badge is correct on first render.
+  loadBadgeCounts()
 })
+
+// #1065: the sidebar sits outside <router-view>, so App.vue's authEpoch key
+// cannot remount it. Without this, badge counts that failed while auth was
+// broken keep their stale values until a full page reload.
+watch(() => systemStore.authEpoch, loadBadgeCounts)
 
 const collapsed = computed(() => systemStore.sidebarCollapsed)
 

--- a/frontend/src/stores/servers.ts
+++ b/frontend/src/stores/servers.ts
@@ -44,10 +44,13 @@ export const useServersStore = defineStore('servers', () => {
     servers.value.filter(s => s.quarantined)
   )
 
-  // Only count tools from enabled servers (Issue #285 fix)
+  // Only count tools that are actually available: enabled servers (Issue #285)
+  // that are not quarantined (Issue #1064 -- a quarantined server's tools are
+  // refused at dispatch and purged from the search index, so counting them
+  // tells the operator N tools are available when none of them are callable).
   const totalTools = computed(() =>
     servers.value
-      .filter(s => s.enabled)
+      .filter(s => s.enabled && !s.quarantined)
       .reduce((sum, server) => sum + server.tool_count, 0)
   )
 

--- a/frontend/src/stores/system.ts
+++ b/frontend/src/stores/system.ts
@@ -57,8 +57,28 @@ export const useSystemStore = defineStore('system', () => {
   // owns the message too; the downstream surfaces read this flag and stay quiet.
   const authRequired = ref(false)
 
+  // Bumped when a failed auth is repaired with a VALIDATED key (#1065). Views
+  // keep their load errors in component-local refs that nothing outside the
+  // component can reach, so signing in left the header re-authenticated while
+  // the view body kept a red "Invalid or missing API key" panel and zero rows
+  // until the user clicked Retry by hand. App.vue keys <router-view> on this,
+  // so a repaired auth remounts the current view: its error, loading state and
+  // data reset to their declared initial values and onMounted re-runs.
+  const authEpoch = ref(0)
+
   function setAuthRequired(value: boolean) {
     authRequired.value = value
+  }
+
+  // Clear the auth-required flag AND invalidate the views that failed while it
+  // was set. Only for paths that actually verified the new key -- a path that
+  // merely re-reads the key from disk must use setAuthRequired(false), or every
+  // view remounts onto a possibly-still-401 epoch.
+  function markAuthRecovered() {
+    if (authRequired.value) {
+      authEpoch.value++
+    }
+    authRequired.value = false
   }
 
   // Available themes. `system` leads the list and is the default: a user on a
@@ -584,6 +604,7 @@ export const useSystemStore = defineStore('system', () => {
     checkingForUpdates,
     updateCheckedAt,
     authRequired,
+    authEpoch,
 
     // Computed
     isRunning,
@@ -612,5 +633,6 @@ export const useSystemStore = defineStore('system', () => {
     fetchRouting,
     checkForUpdates,
     setAuthRequired,
+    markAuthRecovered,
   }
 })

--- a/frontend/src/utils/activity.ts
+++ b/frontend/src/utils/activity.ts
@@ -5,21 +5,39 @@
 
 import { formatDateTime } from './datetime'
 
-// Activity type labels
-const typeLabels: Record<string, string> = {
+// Activity type labels.
+//
+// Keyed by every constant in internal/storage/activity_models.go — a backend
+// type with no entry here used to fall through the old `|| type` passthrough
+// and paint the raw storage enum into the Activity table's Type column, beside
+// title-cased prose (#1065). internal/storage/activity_label_parity_test.go
+// fails if a new backend type is added without a label here. Declaration order
+// is the filter-dropdown order.
+export const ACTIVITY_TYPE_LABELS: Record<string, string> = {
   'tool_call': 'Tool Call',
   'system_start': 'System Start',
   'system_stop': 'System Stop',
   'internal_tool_call': 'Internal Tool Call',
   'config_change': 'Config Change',
   'policy_decision': 'Policy Decision',
+  // Server-level quarantine. Deliberately NOT the same label as
+  // tool_quarantine_change below: collapsing the two is a real defect in the
+  // macOS tray's copy of this table.
   'quarantine_change': 'Quarantine Change',
   'server_change': 'Server Change',
   // Spec 098: one executed required-tools preflight.
-  'preflight': 'Preflight'
+  'preflight': 'Preflight',
+  // --- #1065: these four were emitted by the backend with no label ---
+  'tool_quarantine_change': 'Tool Quarantine Change', // Spec 032, tool-level
+  'security_scan': 'Security Scan', // Spec 077
+  'credential_broker': 'Credential Broker', // Spec 074, server edition only
+  'prompt_get': 'Prompt Fetch'
 }
 
-// Activity type icons
+const typeLabels = ACTIVITY_TYPE_LABELS
+
+// Activity type icons. Same keys as ACTIVITY_TYPE_LABELS; each distinct, so a
+// glyph identifies the type on its own.
 const typeIcons: Record<string, string> = {
   'tool_call': '🔧',
   'system_start': '🚀',
@@ -29,7 +47,11 @@ const typeIcons: Record<string, string> = {
   'policy_decision': '🛡️',
   'quarantine_change': '⚠️',
   'server_change': '🔄',
-  'preflight': '🛫'
+  'preflight': '🛫',
+  'tool_quarantine_change': '🧪',
+  'security_scan': '🔎',
+  'credential_broker': '🔑',
+  'prompt_get': '💬'
 }
 
 // Status labels
@@ -65,10 +87,23 @@ const intentClasses: Record<string, string> = {
 }
 
 /**
+ * snake_case -> Title Case. The last-resort fallback for formatType, so a
+ * backend value that has not been given a label yet still reads as prose
+ * instead of leaking the raw storage enum (#1065).
+ */
+export const humaniseType = (type: string): string => {
+  return type
+    .split('_')
+    .filter(Boolean)
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+/**
  * Format activity type for display
  */
 export const formatType = (type: string): string => {
-  return typeLabels[type] || type
+  return typeLabels[type] ?? humaniseType(type)
 }
 
 /**

--- a/frontend/src/views/Activity.vue
+++ b/frontend/src/views/Activity.vue
@@ -1287,6 +1287,7 @@ import {
 // Spec 098: preflight records carry their verdict in metadata; the renderers
 // are shared (and unit-tested) rather than re-derived in the template.
 import {
+  ACTIVITY_TYPE_LABELS,
   activeFilterChips,
   compactSummaryParts,
   formatPreflightSummary,
@@ -1351,19 +1352,14 @@ const filterEndDate = ref('')
 // query param (so sub-calls beyond the 200 loaded rows are included).
 const filterParentId = ref('')
 
-// Activity types configuration (Spec 024: includes new types)
-const activityTypes = [
-  { value: 'tool_call', label: 'Tool Call', icon: '🔧' },
-  { value: 'system_start', label: 'System Start', icon: '🚀' },
-  { value: 'system_stop', label: 'System Stop', icon: '🛑' },
-  { value: 'internal_tool_call', label: 'Internal Tool Call', icon: '⚙️' },
-  { value: 'config_change', label: 'Config Change', icon: '⚡' },
-  { value: 'policy_decision', label: 'Policy Decision', icon: '🛡️' },
-  { value: 'quarantine_change', label: 'Quarantine Change', icon: '⚠️' },
-  { value: 'server_change', label: 'Server Change', icon: '🔄' },
-  // Spec 098: required-tools preflight (set-scoped record).
-  { value: 'preflight', label: 'Preflight', icon: '🛫' },
-]
+// Activity types configuration. Derived from the single label map in
+// utils/activity so the filter dropdown cannot drift from the Type column
+// (#1065 — this list used to be hand-copied and was three types short).
+const activityTypes = Object.keys(ACTIVITY_TYPE_LABELS).map(value => ({
+  value,
+  label: formatType(value),
+  icon: getTypeIcon(value),
+}))
 
 // Pagination
 const currentPage = ref(1)

--- a/frontend/src/views/Servers.vue
+++ b/frontend/src/views/Servers.vue
@@ -275,7 +275,14 @@
           server.authenticated,
           server.trust_mode,
           server.quarantine?.pending_count,
-          server.quarantine?.changed_count
+          server.quarantine?.changed_count,
+          // #1065: the store updates server objects IN PLACE to preserve
+          // identity, so without these keys a scan settling on an already-
+          // quarantined server leaves the card's verdict stale. The warning
+          // count is tracked too -- the quarantine note renders it, so a rescan
+          // that stays `warnings` but changes the count must still re-render.
+          server.security_scan?.status,
+          server.security_scan?.finding_counts?.warning
         ]"
       />
     </TransitionGroup>

--- a/frontend/tests/unit/activity-type-labels.spec.ts
+++ b/frontend/tests/unit/activity-type-labels.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { ACTIVITY_TYPE_LABELS, formatType, getTypeIcon, humaniseType } from '../../src/utils/activity'
+
+// Issue #1065 defect 2: the Activity "Type" column mixed humanised labels with
+// raw snake_case, because the label map was hand-maintained and fell through
+// `|| type` for anything it did not know.
+describe('activity type labels', () => {
+  it('never renders a raw snake_case value, mapped or not', () => {
+    for (const type of [...Object.keys(ACTIVITY_TYPE_LABELS), 'a_type_from_the_future']) {
+      expect(formatType(type), `formatType(${type}) leaked the raw enum`).not.toMatch(/_/)
+    }
+  })
+
+  it('labels the four types issue #1065 was filed for', () => {
+    expect(formatType('tool_quarantine_change')).toBe('Tool Quarantine Change')
+    expect(formatType('security_scan')).toBe('Security Scan')
+    expect(formatType('credential_broker')).toBe('Credential Broker')
+    expect(formatType('prompt_get')).toBe('Prompt Fetch')
+  })
+
+  it('keeps server-level and tool-level quarantine distinct', () => {
+    expect(formatType('quarantine_change')).toBe('Quarantine Change')
+    expect(formatType('tool_quarantine_change')).toBe('Tool Quarantine Change')
+    const labels = Object.values(ACTIVITY_TYPE_LABELS)
+    expect(new Set(labels).size, 'two activity types share a label').toBe(labels.length)
+  })
+
+  it('gives every labelled type its own icon, not the fallback', () => {
+    const types = Object.keys(ACTIVITY_TYPE_LABELS)
+    const icons = types.map(getTypeIcon)
+    types.forEach((type, i) => {
+      expect(icons[i], `${type} falls back to the generic glyph`).not.toBe('📋')
+    })
+    expect(new Set(icons).size, 'two activity types share an icon').toBe(icons.length)
+  })
+
+  it('humanises snake_case', () => {
+    expect(humaniseType('tool_quarantine_change')).toBe('Tool Quarantine Change')
+    expect(humaniseType('preflight')).toBe('Preflight')
+    expect(humaniseType('')).toBe('')
+  })
+})

--- a/frontend/tests/unit/activity.spec.ts
+++ b/frontend/tests/unit/activity.spec.ts
@@ -42,8 +42,8 @@ describe('Activity Type Rendering', () => {
       expect(formatType('server_change')).toBe('Server Change')
     })
 
-    it('returns unknown type as-is', () => {
-      expect(formatType('unknown_type')).toBe('unknown_type')
+    it('humanises an unknown type rather than leaking the raw enum (#1065)', () => {
+      expect(formatType('unknown_type')).toBe('Unknown Type')
     })
   })
 

--- a/frontend/tests/unit/auth-recovery-epoch.spec.ts
+++ b/frontend/tests/unit/auth-recovery-epoch.spec.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { defineComponent, h, ref, onMounted } from 'vue'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { useSystemStore } from '@/stores/system'
+
+vi.mock('@/services/api', () => ({
+  default: {
+    createEventSource: vi.fn(),
+  },
+}))
+
+/**
+ * Issue #1065 defect 3: with no stored API key, entering a valid key and
+ * pressing "Set Key" re-authenticated the header — server counts, tool count
+ * and the Live badge all came back — while the view BODY kept its red
+ * "Invalid or missing API key" panel and rendered zero rows until the user
+ * clicked Retry by hand. The app knew it was authenticated and still showed the
+ * failure that was no longer true.
+ *
+ * Cause: every view keeps its load error in a component-local ref that nothing
+ * outside the component can reach. The fix is a monotonic `authEpoch` in the
+ * system store that App.vue keys <router-view> on, so a repaired auth remounts
+ * the current view and its error/loading/data reset with it.
+ */
+describe('auth recovery invalidates views (#1065)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('bumps authEpoch when a failed auth is repaired', () => {
+    const store = useSystemStore()
+    expect(store.authEpoch).toBe(0)
+
+    store.setAuthRequired(true)
+    store.markAuthRecovered()
+
+    expect(store.authRequired).toBe(false)
+    expect(store.authEpoch).toBe(1)
+  })
+
+  it('does not bump the epoch when auth never failed', () => {
+    // Otherwise every incidental call would remount healthy views and throw
+    // away their filters, pagination and scroll position.
+    const store = useSystemStore()
+    store.markAuthRecovered()
+    expect(store.authEpoch).toBe(0)
+  })
+
+  it('recovers on the Refresh path too, but only once the key is verified', () => {
+    // The modal's "Refresh & Retry" re-reads the key from disk. It now
+    // validates before reporting success, so App.vue can treat a verified
+    // refresh as a real recovery -- previously this path cleared the flag
+    // without invalidating views, and #1065's stale red panel survived it.
+    const store = useSystemStore()
+
+    store.setAuthRequired(true)
+    // Unverified refresh: nothing changes, the modal stays up.
+    expect(store.authEpoch).toBe(0)
+    expect(store.authRequired).toBe(true)
+
+    // Verified refresh: same treatment as Set Key.
+    store.markAuthRecovered()
+    expect(store.authRequired).toBe(false)
+    expect(store.authEpoch).toBe(1)
+  })
+
+  it('leaves the epoch alone for setAuthRequired(false)', () => {
+    // The modal's "Refresh" path only re-reads the key from disk and never
+    // validates it, so it must clear the flag without asserting recovery.
+    const store = useSystemStore()
+    store.setAuthRequired(true)
+    store.setAuthRequired(false)
+
+    expect(store.authRequired).toBe(false)
+    expect(store.authEpoch).toBe(0)
+  })
+
+  it('remounts a keyed view, clearing its local error and re-running its loader', async () => {
+    // Stands in for Activity.vue: a component-local `error` ref that only its
+    // own loader ever writes, exactly the shape that stayed stale.
+    let mounts = 0
+    const FailingView = defineComponent({
+      setup() {
+        const error = ref<string | null>(null)
+        onMounted(() => {
+          mounts++
+          // First mount lands while auth is broken; later mounts succeed.
+          error.value = mounts === 1 ? 'Invalid or missing API key' : null
+        })
+        return () => h('div', { 'data-test': 'body' }, error.value ?? 'rows')
+      },
+    })
+
+    const store = useSystemStore()
+    const Host = defineComponent({
+      setup() {
+        return () => h(FailingView, { key: store.authEpoch })
+      },
+    })
+
+    const wrapper = mount(Host, { global: { plugins: [createPinia()] } })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('[data-test="body"]').text()).toBe('Invalid or missing API key')
+
+    store.setAuthRequired(true)
+    store.markAuthRecovered()
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
+
+    expect(mounts).toBe(2)
+    expect(wrapper.find('[data-test="body"]').text()).toBe('rows')
+  })
+})

--- a/frontend/tests/unit/server-card-quarantine-scan-headline.spec.ts
+++ b/frontend/tests/unit/server-card-quarantine-scan-headline.spec.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import ServerCard from '@/components/ServerCard.vue'
+import type { Server } from '@/types'
+
+vi.mock('@/services/api', () => ({
+  default: {
+    getServers: vi.fn().mockResolvedValue({ success: true, data: { servers: [] } }),
+  },
+}))
+
+vi.mock('@/composables/useSecurityScannerStatus', () => ({
+  useSecurityScannerStatus: () => ({ hasEnabledScanners: () => true }),
+}))
+
+const RouterLinkStub = {
+  props: ['to'],
+  template: '<a :href="typeof to === \'string\' ? to : \'#\'"><slot /></a>',
+}
+
+function makeServer(overrides: Partial<Server> = {}): Server {
+  return {
+    name: 'memory',
+    protocol: 'stdio',
+    enabled: true,
+    quarantined: false,
+    connected: true,
+    connecting: false,
+    tool_count: 9,
+    ...overrides,
+  } as Server
+}
+
+function mountCard(server: Server) {
+  return mount(ServerCard, {
+    props: { server },
+    global: {
+      plugins: [createPinia()],
+      stubs: { RouterLink: RouterLinkStub, 'router-link': RouterLinkStub },
+    },
+  })
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
+
+// Issue #1065 defect 1: the card rendered a green "✓ Clean" scan verdict
+// directly above a yellow "Quarantined — needs security review" banner. Both
+// statements are individually true, but stacked as peers they tell the operator
+// opposite things about whether the server is safe. The scan verdict is about
+// CONTENT; quarantine is about REVIEW STATE.
+describe('ServerCard — one security headline per card (#1065)', () => {
+  const cleanScan = { status: 'clean' as const }
+
+  it('shows the standalone scan verdict when the server is NOT quarantined', () => {
+    const wrapper = mountCard(makeServer({ security_scan: cleanScan } as Partial<Server>))
+
+    expect(wrapper.find('[data-test="security-scan-badge"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="server-card-quarantine"]').exists()).toBe(false)
+  })
+
+  it('suppresses the standalone verdict while quarantined', () => {
+    const wrapper = mountCard(
+      makeServer({ quarantined: true, security_scan: cleanScan } as Partial<Server>)
+    )
+
+    expect(wrapper.find('[data-test="security-scan-badge"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="server-card-quarantine"]').exists()).toBe(true)
+  })
+
+  it('restates a clean verdict inside the banner, subordinate to the review ask', () => {
+    const wrapper = mountCard(
+      makeServer({ quarantined: true, security_scan: cleanScan } as Partial<Server>)
+    )
+
+    const banner = wrapper.find('[data-test="server-card-quarantine"]')
+    expect(banner.text()).toContain('Quarantined — needs security review')
+
+    const note = wrapper.find('[data-test="server-card-quarantine-scan-note"]')
+    expect(note.exists()).toBe(true)
+    expect(note.text()).toBe('Last scan: clean — still needs review')
+    // The note lives inside the banner, not beside it.
+    expect(banner.element.contains(note.element)).toBe(true)
+  })
+
+  it('never says a quarantined server is settled — every verdict still asks for review', () => {
+    const cases: Array<[Record<string, unknown>, string]> = [
+      [{ status: 'clean' }, 'Last scan: clean — still needs review'],
+      [{ status: 'failed' }, 'Last scan could not complete — still needs review'],
+      [{ status: 'warnings', finding_counts: { warning: 1 } }, 'Last scan: 1 warning — needs review'],
+      [{ status: 'warnings', finding_counts: { warning: 3 } }, 'Last scan: 3 warnings — needs review'],
+      [{ status: 'dangerous' }, 'Last scan: dangerous findings — needs review'],
+    ]
+
+    for (const [scan, expected] of cases) {
+      const wrapper = mountCard(
+        makeServer({ quarantined: true, security_scan: scan } as unknown as Partial<Server>)
+      )
+      const note = wrapper.find('[data-test="server-card-quarantine-scan-note"]')
+      expect(note.exists(), `status ${String(scan.status)} produced no note`).toBe(true)
+      expect(note.text()).toBe(expected)
+      expect(note.text(), `status ${String(scan.status)} reads as settled`).toMatch(/review/)
+    }
+  })
+
+  it('keeps the banner a one-liner when there is nothing to report', () => {
+    for (const scan of [undefined, { status: 'not_scanned' as const }]) {
+      const wrapper = mountCard(
+        makeServer({ quarantined: true, security_scan: scan } as unknown as Partial<Server>)
+      )
+      expect(wrapper.find('[data-test="server-card-quarantine"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="server-card-quarantine-scan-note"]').exists()).toBe(false)
+    }
+  })
+
+  it('still offers Review from the banner', () => {
+    const wrapper = mountCard(
+      makeServer({ quarantined: true, security_scan: cleanScan } as Partial<Server>)
+    )
+    const review = wrapper.find('[data-test="server-card-quarantine-review"]')
+    expect(review.exists()).toBe(true)
+    expect(review.attributes('href')).toContain('tab=security')
+  })
+})

--- a/frontend/tests/unit/servers-store.spec.ts
+++ b/frontend/tests/unit/servers-store.spec.ts
@@ -281,3 +281,56 @@ describe('useServersStore — a successful list clears a stale error', () => {
     expect(store.servers).toHaveLength(1)
   })
 })
+
+// Issue #1064: a quarantined server's tools are refused at dispatch and purged
+// from the search index, so counting them under "Available across all servers"
+// tells the operator N tools are available when none of them are callable.
+describe('useServersStore — totalTools counts only available tools (#1064)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  function srv(overrides: Record<string, unknown> = {}) {
+    return {
+      name: 'srv',
+      protocol: 'http' as const,
+      enabled: true,
+      quarantined: false,
+      connected: true,
+      connecting: false,
+      tool_count: 0,
+      ...overrides,
+    }
+  }
+
+  async function load(servers: Record<string, unknown>[]) {
+    const store = useServersStore()
+    ;(api.getServers as any).mockResolvedValue({ success: true, data: { servers } })
+    await store.fetchServers(true)
+    return store
+  }
+
+  it('excludes a quarantined server', async () => {
+    const store = await load([
+      srv({ name: 'clean', tool_count: 5 }),
+      srv({ name: 'held', quarantined: true, tool_count: 7 }),
+    ])
+    expect(store.totalTools).toBe(5)
+  })
+
+  it('still excludes a disabled server (issue #285)', async () => {
+    const store = await load([
+      srv({ name: 'clean', tool_count: 5 }),
+      srv({ name: 'off', enabled: false, tool_count: 3 }),
+    ])
+    expect(store.totalTools).toBe(5)
+  })
+
+  it('counts nothing when every server is quarantined', async () => {
+    const store = await load([srv({ name: 'held', quarantined: true, tool_count: 9 })])
+    expect(store.totalTools).toBe(0)
+    // ...while the server itself is still listed for review.
+    expect(store.quarantinedServers).toHaveLength(1)
+  })
+})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2036,6 +2036,23 @@ func (sc *ServerConfig) IsQuarantineSkipped() bool {
 	return sc.EffectiveTrustMode() == TrustModeAuto
 }
 
+// ServerContributesTools reports whether a server's tools count as AVAILABLE to
+// an agent. A quarantined server's tools are refused by every dispatch path
+// (the SECURITY BLOCK in internal/server/mcp.go) and are withheld from the
+// search index (#1061), so it contributes zero — the same answer the index
+// writer's serverEligibleForIndexing and preflight.ClassifyTool already give.
+// Takes plain bools because most callers hold a stateview server status rather
+// than a *ServerConfig. Issue #1064.
+func ServerContributesTools(enabled, quarantined bool) bool {
+	return enabled && !quarantined
+}
+
+// ContributesTools is the *ServerConfig form of ServerContributesTools. A nil
+// receiver contributes nothing.
+func (sc *ServerConfig) ContributesTools() bool {
+	return sc != nil && ServerContributesTools(sc.Enabled, sc.Quarantined)
+}
+
 // IsAutoApproveToolChanges reports the configured per-server intent to auto-approve
 // tool changes/additions (disabling per-server rug-pull protection). It is provided
 // for the runtime consumers that adopt it in MCP-2931 and is NOT yet consulted at

--- a/internal/config/server_contributes_tools_test.go
+++ b/internal/config/server_contributes_tools_test.go
@@ -1,0 +1,49 @@
+package config
+
+import "testing"
+
+// Issue #1064: "available tools" had three independent enabled-only predicates
+// and three surfaces with no predicate at all, so a quarantined server -- which
+// deliberately stays connected and ready so the tray and Web UI can inspect it
+// for review -- kept reporting its tools as available while every call to them
+// was refused and the search index correctly held nothing.
+//
+// This truth table is the mirror of runtime.serverEligibleForIndexing's
+// (TestServerEligibleForIndexing in internal/runtime): the security predicate
+// that decides what may be INDEXED and the availability predicate that decides
+// what is COUNTED must give the same answer for the same server, or the two
+// surfaces disagree again.
+func TestServerContributesTools(t *testing.T) {
+	cases := []struct {
+		name        string
+		enabled     bool
+		quarantined bool
+		want        bool
+	}{
+		{"enabled and trusted", true, false, true},
+		{"enabled but quarantined", true, true, false},
+		{"disabled", false, false, false},
+		{"disabled and quarantined", false, true, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ServerContributesTools(tc.enabled, tc.quarantined); got != tc.want {
+				t.Fatalf("ServerContributesTools(enabled=%v, quarantined=%v) = %v, want %v",
+					tc.enabled, tc.quarantined, got, tc.want)
+			}
+
+			sc := &ServerConfig{Name: tc.name, Enabled: tc.enabled, Quarantined: tc.quarantined}
+			if got := sc.ContributesTools(); got != tc.want {
+				t.Fatalf("(%+v).ContributesTools() = %v, want %v", sc, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestServerContributesToolsNilReceiver(t *testing.T) {
+	var sc *ServerConfig
+	if sc.ContributesTools() {
+		t.Fatal("a nil server config must contribute no tools")
+	}
+}

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -3199,11 +3199,14 @@ func (s *Server) handleGetGlobalTools(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Use the same management-service path as the per-server tools endpoint so
-	// behaviour is consistent: a disabled / not-connected server returns an
-	// empty tool set (NOT an error), so it contributes zero tools without
-	// being mislabelled as a failed server. Fall back to the controller path
-	// when the management service is unavailable (keeps unit tests + minimal
-	// deployments working).
+	// behaviour is consistent. A disabled / not-connected server reaches us as
+	// an empty tool set (NOT an error) because disabling disconnects it, so it
+	// contributes zero tools without being mislabelled as a failed server.
+	// Quarantine is neither of those things -- a quarantined server stays
+	// dialed for security inspection and status stays ready -- so it needs the
+	// explicit guard in the loop below (#1064). Fall back to the controller
+	// path when the management service is unavailable (keeps unit tests +
+	// minimal deployments working).
 	mgmtSvc, hasMgmt := s.controller.GetManagementService().(interface {
 		GetServerTools(ctx context.Context, name string) ([]map[string]interface{}, error)
 	})
@@ -3225,6 +3228,15 @@ func (s *Server) handleGetGlobalTools(w http.ResponseWriter, r *http.Request) {
 	for _, srv := range allServers {
 		name, _ := srv["name"].(string)
 		if name == "" {
+			continue
+		}
+		// #1064: a quarantined server contributes nothing here -- its tools are
+		// unreachable (SECURITY BLOCK at dispatch) and its descriptions are the
+		// TPA payload #1061 removed from the index. Skipping is not a failure,
+		// so it must not set Partial / FailedServers. Disabled servers still
+		// appear, per the GlobalToolsResponse contract; the review surface
+		// GET /api/v1/servers/{id}/tools is likewise untouched.
+		if quarantined, _ := srv["quarantined"].(bool); quarantined {
 			continue
 		}
 
@@ -5784,6 +5796,11 @@ func (s *Server) handleAnnotationCoverage(w http.ResponseWriter, r *http.Request
 	for _, srv := range allServers {
 		name, _ := srv["name"].(string)
 		if name == "" {
+			continue
+		}
+		// #1064: a quarantined server's tools are not available, so they are
+		// not part of the annotation-coverage denominator either.
+		if quarantined, _ := srv["quarantined"].(bool); quarantined {
 			continue
 		}
 

--- a/internal/httpapi/server_global_tools_test.go
+++ b/internal/httpapi/server_global_tools_test.go
@@ -214,3 +214,65 @@ func TestGlobalTools_ScanHoldEvidenceSurfaced(t *testing.T) {
 	assert.NotContains(t, legacy, "held_reason", "records without hold evidence must stay unchanged")
 	assert.NotContains(t, legacy, "held_signals")
 }
+
+// Issue #1064: a quarantined server kept reporting its tools as available.
+// Unlike the DISABLED case — which reaches this handler as an empty tool set
+// only because disabling disconnects the server — quarantine leaves the server
+// dialed for security inspection with status ready, so the tools came straight
+// through while every call to them was refused and the search index correctly
+// held nothing.
+func TestGlobalTools_QuarantinedServerContributesNothing(t *testing.T) {
+	ctrl := &globalToolsController{
+		allServers: []map[string]interface{}{
+			{"name": "github", "quarantined": false},
+			{"name": "memory", "quarantined": true},
+			// A disabled server must STILL contribute its tools: the
+			// GlobalToolsResponse contract lists them as disabled rather than
+			// hiding them.
+			{"name": "notes", "quarantined": false},
+		},
+		serverTools: map[string][]map[string]interface{}{
+			"github": {
+				{"name": "create_issue", "description": "Create issue"},
+				{"name": "delete_repo", "description": "Delete repo"},
+			},
+			"memory": {
+				{"name": "store", "description": "Store memory"},
+				{"name": "recall", "description": "Recall memory"},
+				{"name": "forget", "description": "Forget memory"},
+			},
+			"notes": {
+				{"name": "append", "description": "Append note"},
+			},
+		},
+		configDenied: map[string]bool{"notes\x00append": true},
+	}
+
+	data := doGlobalTools(t, ctrl)
+
+	tools := data["tools"].([]interface{})
+	byName := map[string]string{}
+	for _, x := range tools {
+		tm := x.(map[string]interface{})
+		byName[tm["name"].(string)] = tm["server_name"].(string)
+	}
+
+	assert.Contains(t, byName, "create_issue")
+	assert.Contains(t, byName, "delete_repo")
+	assert.Contains(t, byName, "append", "a disabled server's tools must still be listed")
+
+	for _, quarantined := range []string{"store", "recall", "forget"} {
+		assert.NotContains(t, byName, quarantined,
+			"quarantined server's tools must not be reported as available")
+	}
+
+	stats := data["stats"].(map[string]interface{})
+	assert.Equal(t, float64(3), stats["total"])
+
+	// Skipping a quarantined server is a deliberate exclusion, not a fetch
+	// failure — it must not be reported as a degraded response.
+	assert.NotEqual(t, true, data["partial"])
+	if failed, ok := data["failed_servers"]; ok {
+		assert.Empty(t, failed, "a quarantined server is not a failed server")
+	}
+}

--- a/internal/management/service.go
+++ b/internal/management/service.go
@@ -457,8 +457,10 @@ func (s *service) ListServers(ctx context.Context) ([]*contracts.Server, *contra
 		// Extract numeric fields
 		if toolCount, ok := srvRaw["tool_count"].(int); ok {
 			srv.ToolCount = toolCount
-			// Only count tools from enabled servers in the total
-			if srv.Enabled {
+			// Only count tools from servers that actually contribute available
+			// tools: enabled, and not quarantined (#1064 -- a quarantined
+			// server's tools are refused at dispatch and purged from the index).
+			if config.ServerContributesTools(srv.Enabled, srv.Quarantined) {
 				stats.TotalTools += toolCount
 			}
 		}

--- a/internal/management/service_test.go
+++ b/internal/management/service_test.go
@@ -324,6 +324,59 @@ func TestListServers(t *testing.T) {
 		}
 	})
 
+	// Issue #1064: a quarantined server stays connected and status ready -- that
+	// is deliberate, the tray and Web UI must inspect it for review -- so the
+	// enabled-only guard above never fired for it and its tools were still
+	// summed as "Available across all servers" while every call to them was
+	// refused.
+	t.Run("TotalTools excludes quarantined servers", func(t *testing.T) {
+		runtime := newMockRuntime()
+		runtime.servers = []map[string]interface{}{
+			{
+				"id":          "server1",
+				"name":        "clean-server",
+				"enabled":     true,
+				"connected":   true,
+				"quarantined": false,
+				"tool_count":  5,
+			},
+			{
+				"id":          "server2",
+				"name":        "quarantined-server",
+				"enabled":     true,
+				"connected":   true, // still dialed, for security inspection
+				"quarantined": true,
+				"tool_count":  7, // must NOT be counted
+			},
+			{
+				"id":          "server3",
+				"name":        "disabled-server",
+				"enabled":     false,
+				"connected":   false,
+				"quarantined": false,
+				"tool_count":  3, // must NOT be counted (issue #285)
+			},
+		}
+
+		svc := NewService(runtime, cfg, "", emitter, nil, logger)
+		servers, stats, err := svc.ListServers(context.Background())
+
+		require.NoError(t, err)
+		assert.Len(t, servers, 3)
+		assert.Equal(t, 5, stats.TotalTools,
+			"TotalTools must exclude both quarantined and disabled servers")
+
+		// The quarantined server is still listed and still flagged: the review
+		// surface must not go dark just because the count went to zero.
+		byName := map[string]*contracts.Server{}
+		for i := range servers {
+			byName[servers[i].Name] = servers[i]
+		}
+		require.Contains(t, byName, "quarantined-server")
+		assert.True(t, byName["quarantined-server"].Quarantined)
+		assert.Equal(t, 1, stats.QuarantinedServers)
+	})
+
 	t.Run("runtime error", func(t *testing.T) {
 		runtime := newMockRuntime()
 		runtime.getAllError = fmt.Errorf("runtime error")

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -2169,6 +2169,17 @@ func (r *Runtime) GetAllServers() ([]map[string]interface{}, error) {
 		// once, here, so every consumer (Web UI, tray, CLI) gets the clean chain.
 		lastError := stringutil.CollapseRepeatedErrorWrappers(serverStatus.LastError)
 
+		// #1064: a quarantined server's tools are not available to an agent --
+		// every dispatch is refused and the search index is purged (#1061) --
+		// but the stale pre-quarantine count survives in the StateView because
+		// the supervisor re-sticks it on reconcile and AddServer re-dials the
+		// server for inspection. Zero it here, at the wire boundary, so every
+		// consumer of this projection agrees with the index.
+		availableToolCount := serverStatus.ToolCount
+		if serverStatus.Quarantined {
+			availableToolCount = 0
+		}
+
 		serverMap := map[string]interface{}{
 			"id":              serverStatus.Name,
 			"name":            serverStatus.Name,
@@ -2180,7 +2191,7 @@ func (r *Runtime) GetAllServers() ([]map[string]interface{}, error) {
 			"created":         created,
 			"connected":       connected,
 			"connecting":      connecting,
-			"tool_count":      serverStatus.ToolCount,
+			"tool_count":      availableToolCount,
 			"last_error":      lastError,
 			"status":          status,
 			"should_retry":    false,
@@ -2353,7 +2364,7 @@ func (r *Runtime) GetAllServers() ([]map[string]interface{}, error) {
 			HasRefreshToken:       hasRefreshToken,
 			UserLoggedOut:         userLoggedOut,
 			CallTimeOAuthRequired: callTimeOAuthRequired,
-			ToolCount:             serverStatus.ToolCount,
+			ToolCount:             availableToolCount,
 			MissingSecret:         health.ExtractMissingSecret(lastError),
 			OAuthConfigErr:        health.ExtractOAuthConfigError(lastError),
 		}

--- a/internal/runtime/tool_quarantine_reindex_test.go
+++ b/internal/runtime/tool_quarantine_reindex_test.go
@@ -237,6 +237,15 @@ func TestServerEligibleForIndexing(t *testing.T) {
 	assert.False(t, rt.serverEligibleForIndexing("quarantined"), "quarantined server is ineligible")
 	assert.False(t, rt.serverEligibleForIndexing("disabled"), "disabled server is ineligible")
 	assert.False(t, rt.serverEligibleForIndexing("absent"), "server absent from config is ineligible")
+
+	// #1064: the availability predicate (what gets COUNTED) must agree with this
+	// security predicate (what gets INDEXED) for every enabled/quarantined pair.
+	// They diverged once already -- the index was purged on quarantine while the
+	// counting surfaces went on reporting the pre-quarantine number.
+	for _, srv := range rt.Config().Servers {
+		assert.Equalf(t, rt.serverEligibleForIndexing(srv.Name), srv.ContributesTools(),
+			"serverEligibleForIndexing and ContributesTools disagree about %q", srv.Name)
+	}
 }
 
 // TestReindexAfterApproval_QuarantinedServerNotIndexed guards the TOCTOU

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -5941,6 +5941,16 @@ func (p *MCPProxyServer) getVisibleToolCount(serverName string) int {
 		return 0
 	}
 
+	// #1064: a quarantined server contributes no AVAILABLE tools -- every
+	// dispatch to them is refused with a SECURITY BLOCK. Gated here rather than
+	// in isToolCallable, which is the search filter and must stay
+	// quarantine-blind to preserve merge-base retrieve_tools semantics
+	// (Spec 085 FR-006/FR-011). The tools themselves stay in the StateView so
+	// the review surface can still list them.
+	if cfg, err := p.storage.GetUpstreamServer(serverName); err == nil && cfg != nil && cfg.Quarantined {
+		return 0
+	}
+
 	supervisor := p.mainServer.runtime.Supervisor()
 	if supervisor == nil {
 		return 0
@@ -6093,6 +6103,13 @@ func (p *MCPProxyServer) isToolCallable(serverName, toolName string) bool {
 	if !serverConfig.Enabled {
 		return false
 	}
+
+	// NOTE: quarantine is deliberately NOT gated here. isToolCallable is the
+	// SEARCH filter and must reproduce merge-base semantics exactly (Spec 085
+	// FR-006/FR-011) -- retrieve_tools still surfaces a quarantined server's
+	// lingering indexed tools; the stricter p.toolVisibleToSession is what
+	// applies the quarantine gate. The #1064 counting fix lives in
+	// getVisibleToolCount instead.
 
 	// Config-layer filter — evaluated at call time, never written to BBolt.
 	// A tool absent from enabled_tools or present in disabled_tools is hard off.

--- a/internal/server/mcp_disabled_discovery_test.go
+++ b/internal/server/mcp_disabled_discovery_test.go
@@ -238,3 +238,30 @@ func TestServerToolCounts_Conditional(t *testing.T) {
 	assert.NotContains(t, js, "pending_approval")
 	assert.NotContains(t, js, "server_disabled")
 }
+
+// Issue #1064: the visible tool count reported for a quarantined server must be
+// zero -- every dispatch to its tools is refused with a SECURITY BLOCK.
+//
+// The gate lives in getVisibleToolCount, NOT in isToolCallable: isToolCallable
+// is the SEARCH filter and must stay quarantine-blind so retrieve_tools keeps
+// its merge-base semantics (Spec 085 FR-006/FR-011, pinned by
+// TestToolVisibility_RetrieveParity_Admin, which requires a quarantined
+// server's lingering indexed tool to still be returned by search). This test
+// pins both halves so a future "fix" cannot collapse them again.
+func TestVisibleToolCount_QuarantinedServer(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+	require.NoError(t, proxy.storage.SaveUpstreamServer(&config.ServerConfig{
+		Name: "held", Enabled: true, Quarantined: true,
+	}))
+	require.NoError(t, proxy.storage.SaveUpstreamServer(&config.ServerConfig{
+		Name: "clean", Enabled: true,
+	}))
+
+	assert.Equal(t, 0, proxy.getVisibleToolCount("held"),
+		"a quarantined server contributes no available tools")
+
+	// ...but the search filter still ignores quarantine, on purpose.
+	assert.True(t, proxy.isToolCallable("held", "store"),
+		"isToolCallable is the search filter and must stay quarantine-blind (Spec 085)")
+	assert.True(t, proxy.isToolCallable("clean", "store"))
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1139,6 +1139,15 @@ func (s *Server) GetUpstreamStats() map[string]interface{} {
 
 				connecting := strings.EqualFold(state, "connecting")
 
+				// #1064: a quarantined server contributes no available tools.
+				// This entry map carries no enabled/quarantined key, so
+				// downstream consumers (contracts.ConvertUpstreamStatsToServerStats)
+				// cannot gate on it -- the value has to be zeroed here.
+				availableToolCount := status.ToolCount
+				if status.Quarantined {
+					availableToolCount = 0
+				}
+
 				entry := map[string]interface{}{
 					"state":        state,
 					"connected":    status.Connected,
@@ -1146,7 +1155,7 @@ func (s *Server) GetUpstreamStats() map[string]interface{} {
 					"retry_count":  status.RetryCount,
 					"should_retry": false,
 					"name":         status.Name,
-					"tool_count":   status.ToolCount,
+					"tool_count":   availableToolCount,
 				}
 
 				if entry["name"] == "" {
@@ -1194,7 +1203,9 @@ func (s *Server) GetUpstreamStats() map[string]interface{} {
 				if status.Quarantined {
 					quarantinedCount++
 				}
-				totalTools += status.ToolCount
+				if config.ServerContributesTools(status.Enabled, status.Quarantined) {
+					totalTools += status.ToolCount
+				}
 
 				serverStats[name] = entry
 			}
@@ -1214,8 +1225,16 @@ func (s *Server) GetUpstreamStats() map[string]interface{} {
 
 	// Enhance stats with tool counts per server when falling back
 	if servers, ok := stats["servers"].(map[string]interface{}); ok {
+		quarantined := s.quarantinedServerNames()
 		for id, serverInfo := range servers {
 			if serverMap, ok := serverInfo.(map[string]interface{}); ok {
+				// #1064: getServerToolCount reads the managed client's tool-count
+				// cache, which no quarantine path invalidates, so it would hand
+				// back the pre-quarantine number. Gate it on the config instead.
+				if quarantined[id] {
+					serverMap["tool_count"] = 0
+					continue
+				}
 				serverMap["tool_count"] = s.getServerToolCount(id)
 			}
 		}
@@ -1328,6 +1347,15 @@ func (s *Server) GetAllServers() ([]map[string]interface{}, error) {
 
 		healthStatus := health.CalculateHealth(healthInput, health.DefaultHealthConfig())
 
+		// #1064: quarantined tools are not available -- see the same guard in
+		// Runtime.GetAllServers. GetQuarantinedServers below deliberately keeps
+		// the real count: that view exists to tell a reviewer how many tools
+		// await approval.
+		availableToolCount := serverStatus.ToolCount
+		if serverStatus.Quarantined {
+			availableToolCount = 0
+		}
+
 		serverMap := map[string]interface{}{
 			"name":            serverStatus.Name,
 			"url":             url,
@@ -1340,7 +1368,7 @@ func (s *Server) GetAllServers() ([]map[string]interface{}, error) {
 			"created":         created,
 			"connected":       connected,
 			"connecting":      connecting,
-			"tool_count":      serverStatus.ToolCount,
+			"tool_count":      availableToolCount,
 			"last_error":      serverStatus.LastError,
 			"status":          status,
 			"should_retry":    false, // Managed by Actor internally now
@@ -1833,6 +1861,24 @@ func (s *Server) QuarantineServer(serverName string, quarantined bool) error {
 
 // getServerToolCount returns the number of tools for a specific server
 // Returns cached tool count only (non-blocking) to avoid stalling SSE/API responses
+// quarantinedServerNames returns the set of configured server names currently in
+// quarantine. Used to gate cached tool counts on the GetUpstreamStats fallback
+// path, where neither the manager stats entry nor getServerToolCount has access
+// to the server config. Issue #1064.
+func (s *Server) quarantinedServerNames() map[string]bool {
+	out := make(map[string]bool)
+	cfg := s.runtime.Config()
+	if cfg == nil {
+		return out
+	}
+	for _, srv := range cfg.Servers {
+		if srv != nil && srv.Quarantined {
+			out[srv.Name] = true
+		}
+	}
+	return out
+}
+
 func (s *Server) getServerToolCount(serverID string) int {
 	client, exists := s.runtime.UpstreamManager().GetClient(serverID)
 	if !exists {

--- a/internal/storage/activity_label_parity_test.go
+++ b/internal/storage/activity_label_parity_test.go
@@ -1,0 +1,60 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A backend activity type with no Web-UI label used to fall through the label
+// map's `|| type` passthrough and paint the raw storage enum into the Activity
+// table's Type column, beside title-cased prose (#1065). Four types had escaped
+// that way.
+//
+// This guard lives in Go, not vitest, on purpose: .github/workflows/frontend.yml
+// is path-filtered to frontend/**, so a Go-only change that adds an activity
+// type would never run a frontend test. unit-tests.yml runs `go test ./...`
+// with no path filter, so this one fires on exactly the change it exists to
+// catch. Same shape as cmd/generate-types/main_test.go, which reads a frontend
+// file from Go for the same reason.
+func TestEveryActivityTypeHasAWebUILabel(t *testing.T) {
+	src, err := os.ReadFile(filepath.Join("..", "..", "frontend", "src", "utils", "activity.ts"))
+	require.NoError(t, err, "frontend/src/utils/activity.ts must be readable")
+
+	block := regexp.MustCompile(`ACTIVITY_TYPE_LABELS[^=]*=\s*\{([\s\S]*?)\n\}`).FindSubmatch(src)
+	require.NotNil(t, block, "ACTIVITY_TYPE_LABELS not found in frontend/src/utils/activity.ts")
+
+	labelled := map[string]bool{}
+	for _, m := range regexp.MustCompile(`(?m)^\s*'?([a-z_]+)'?\s*:`).FindAllSubmatch(block[1], -1) {
+		labelled[string(m[1])] = true
+	}
+	require.GreaterOrEqualf(t, len(labelled), len(ValidActivityTypes),
+		"parsed only %d labels — the regex has drifted from the file's shape", len(labelled))
+
+	for _, typ := range ValidActivityTypes {
+		assert.Truef(t, labelled[typ],
+			"activity type %q has no label: add it to ACTIVITY_TYPE_LABELS in frontend/src/utils/activity.ts, "+
+				"or the Activity table renders it as raw snake_case", typ)
+	}
+}
+
+// ValidActivityTypes has no production consumer, so nothing stops a new
+// constant from being declared and forgotten here — which would make the test
+// above vacuously green. Close that hole by reading the const block itself.
+func TestValidActivityTypesCoversEveryConstant(t *testing.T) {
+	src, err := os.ReadFile("activity_models.go")
+	require.NoError(t, err)
+
+	var declared []string
+	for _, m := range regexp.MustCompile(`ActivityType\w+\s+ActivityType\s*=\s*"([a-z_]+)"`).FindAllStringSubmatch(string(src), -1) {
+		declared = append(declared, m[1])
+	}
+	require.GreaterOrEqual(t, len(declared), 13, "parsed too few ActivityType constants — the regex has drifted")
+
+	assert.ElementsMatch(t, declared, ValidActivityTypes,
+		"ValidActivityTypes must list exactly the declared ActivityType constants")
+}

--- a/internal/upstream/manager.go
+++ b/internal/upstream/manager.go
@@ -1772,7 +1772,10 @@ func (m *Manager) GetTotalToolCount() int {
 		}
 		// Read config through the thread-safe accessor (MCP-770).
 		cfg := client.GetConfig()
-		if cfg == nil || !cfg.Enabled || !client.IsConnected() {
+		// #1064: a quarantined server stays dialed for security inspection, so
+		// IsConnected() is true and its cached count is still the pre-quarantine
+		// number -- exclude it explicitly.
+		if cfg == nil || !cfg.ContributesTools() || !client.IsConnected() {
 			continue
 		}
 


### PR DESCRIPTION
# Pull Request

## Description

Fixes [#1064](https://github.com/smart-mcp-proxy/mcpproxy-go/issues/1064) and [#1065](https://github.com/smart-mcp-proxy/mcpproxy-go/issues/1065) — one backend counting defect and three Web UI presentation defects. Two commits, independently reviewable.

### #1064 — a quarantined server's tools were still counted as "available"

`tool_count` stayed at its pre-quarantine value, `GET /api/v1/tools` returned every one of them, and the Servers page rendered the total under *"Available across all servers"* — while the search index correctly excluded them (#1061) and every call to those tools was refused with a SECURITY BLOCK. Two surfaces describing the same catalog disagreed, and the one an operator reads was the wrong one.

Quarantine is neither *disabled* nor *disconnected*: a quarantined server stays dialed with `status: ready` on purpose, so the tray and Web UI can inspect it for review. It therefore passed the existing disabled/not-connected guard untouched. The stale count also survives the supervisor's disconnect-zeroing, because `LoadConfiguredServers` re-dials the server and the next reconcile re-sticks the retained snapshot — which is why this is fixed at the projections rather than at the source.

Adds one shared predicate, `config.ServerContributesTools(enabled, quarantined)`, mirroring the answers `runtime.serverEligibleForIndexing` already gives the index writer and `preflight.ClassifyTool` gives dispatch, and adopts it at the surfaces that were each re-deriving "available" from a different field. `GET /api/v1/annotations/coverage` had the same bug and is not mentioned in the issue.

**Deliberately unchanged, and the main thing to check at review:**

- `GET /api/v1/servers/{id}/tools` still returns the full list. That is the **review surface** — it is how an operator inspects and approves a quarantined server, and after #1061 the StateView is its only source. Same for `Server.GetQuarantinedServers`, which exists to say how many tools await review.
- `isToolCallable` stays quarantine-blind. It is the *search* filter and must reproduce merge-base semantics exactly (Spec 085 FR-006/FR-011), which require `retrieve_tools` to keep surfacing a quarantined server's lingering indexed tools; the stricter `toolVisibleToSession` applies the quarantine gate. My first attempt gated here and broke three pinned tests. `TestVisibleToolCount_QuarantinedServer` now pins both halves so the two cannot be collapsed again.
- `stats.quarantined_servers` and health `admin_state=quarantined` are untouched — they are the counterpart that must still show a non-zero number.

**Behaviour change worth calling out:** users with quarantined servers will now report lower tool counts in `/api/v1/status`, the SSE `servers.changed` embed, `/api/v1/profiles`, the Prometheus tools-total gauge, the telemetry heartbeat, and the TOOLS column of `mcpproxy upstream list`.

### #1065 — three Web UI presentation defects

**1. A card asserted two contradictory security states.** Green `Clean` sat directly above yellow `Quarantined — needs security review`. Both true; stacked as peers they say opposite things, because the verdict is about CONTENT and quarantine is about REVIEW STATE. While quarantined the standalone badge is suppressed and the verdict becomes a subordinate clause inside the banner (`Last scan: clean — still needs review`), so there is one security headline per card — the subordination ServerDetail's spec-088 banner already does. Every verdict still ends in a request to review, including `failed`, which is an *incomplete* scan and never a threat verdict.

**2. The Activity Type column mixed two vocabularies.** `formatType` fell through `|| type`, so raw snake_case landed in a column otherwise full of title-cased prose. **Four** backend types had no label, not the one reported — `security_scan` is already rendering raw today, since it gained a findings drawer in #1046. The map is completed and exported, and the passthrough is replaced with a `snake_case -> Title Case` fallback so an unmapped value can never leak raw again. The filter dropdown is now derived from the same map instead of being hand-copied (it was three types short).

The recurrence guard lives in **Go**, not vitest: `.github/workflows/frontend.yml` is path-filtered to `frontend/**`, so a vitest-only guard would never run on the Go-only change that adds an activity type.

**3. A stale auth error survived a successful sign-in.** Entering a valid key re-authenticated the header while the view body kept its red panel and zero rows until the user clicked Retry. Every view holds its load error in a component-local ref nothing outside can reach. Adds a monotonic `authEpoch` bumped only on a genuine failed→ok transition; `App.vue` keys `<router-view>` on it so a repaired auth remounts the current view. `AuthErrorModal`'s "Refresh & Retry" now validates the reloaded key before reporting success — it previously cleared the auth flag without verifying anything, which is why it could not safely invalidate views.

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests that prove my fix is effective or my feature works
- [x] All existing tests pass

Every new test was confirmed to **fail** before the corresponding fix, not just pass after it.

| Check | Result |
|---|---|
| `go test -race ./...` (CI skip regex) | green |
| `golangci-lint run --config .github/.golangci.yml ./...` | **0 issues** |
| `vitest run` | **954 passed** (95 files) |
| Server edition (`-tags server`) build + tests | green |
| Generated files (`contracts.ts`, `web/`) | no drift |

**Live verification** against an isolated instance with a real `server-memory` upstream, quarantining and un-quarantining it:

| surface | before | quarantined | after unquarantine |
|---|---|---|---|
| `tool_count` | 9 | **0** | 9 |
| `stats.total_tools` | 9 | **0** | 9 |
| `GET /api/v1/tools` | 9 | **0** | 9 |
| `/api/v1/status` total | 9 | **0** | 9 |
| `annotations/coverage` | 9 | **0** | — |
| `index/search` | 0 | 0 | — |
| **`servers/{id}/tools`** (review surface) | 9 | **9** | 9 |

Disabled-server behaviour re-checked and unchanged. All three #1065 defects were confirmed in the running Web UI: no bare "Clean" anywhere on the Servers page, the Type column renders `Tool Quarantine Change` / `Security Scan`, and signing in drops the red panel and renders rows with no manual Retry.

**Not run:** `./scripts/test-api-e2e.sh` — it blanket-pkills other running cores and another local instance was live. Worth running before merge.

## Notes for the reviewer

Cross-reviewed with an independent model, which found two real defects that are fixed here: the `isToolCallable` over-reach described above, and a `v-memo` key that tracked `security_scan.status` but not the warning count the new note renders. It also flagged that `handleAuthModalRefresh` left defect 3 unfixed on the Refresh path — hence the validation change to `AuthErrorModal`.
