### PR TITLE
test(runtime): fix racy config-watcher reload assertions

### DIFF
--- a/internal/runtime/config_watcher_test.go
+++ b/internal/runtime/config_watcher_test.go
@@ -273,9 +273,13 @@ func TestConfigWatcher_ReloadSyncsLegacyGetConfig(t *testing.T) {
 		return rt.ConfigSnapshot().Config.ToolResponseLimit == 77777
 	}, 5*time.Second, 25*time.Millisecond, "snapshot must pick up the external edit")
 
-	legacyCfg, err := rt.GetConfig()
-	require.NoError(t, err)
-	assert.Equal(t, 77777, legacyCfg.ToolResponseLimit,
+	// The reload publishes the configsvc snapshot BEFORE syncing the legacy
+	// r.cfg, so poll here too — a bare assert right after the snapshot wait
+	// races with that window.
+	require.Eventually(t, func() bool {
+		legacyCfg, err := rt.GetConfig()
+		return err == nil && legacyCfg != nil && legacyCfg.ToolResponseLimit == 77777
+	}, 5*time.Second, 25*time.Millisecond,
 		"legacy GetConfig (backing GET/PATCH /api/v1/config) must see the reloaded config")
 }
 
@@ -293,9 +297,13 @@ func TestConfigWatcher_ReloadPropagatesGlobalConfigToUpstream(t *testing.T) {
 		return rt.ConfigSnapshot().Config.ToolResponseLimit == 99999
 	}, 5*time.Second, 25*time.Millisecond, "snapshot must pick up the external edit")
 
-	gc := rt.upstreamManager.GlobalConfig()
-	require.NotNil(t, gc)
-	assert.Equal(t, 99999, gc.ToolResponseLimit,
+	// SetGlobalConfig runs AFTER the configsvc snapshot is published, so the
+	// snapshot wait above does not imply the upstream manager has caught up —
+	// poll instead of asserting once (flaky CI run 33043282299).
+	require.Eventually(t, func() bool {
+		gc := rt.upstreamManager.GlobalConfig()
+		return gc != nil && gc.ToolResponseLimit == 99999
+	}, 5*time.Second, 25*time.Millisecond,
 		"watcher reload must propagate the new global config to the upstream manager")
 }
 


### PR DESCRIPTION
## Problem

`TestConfigWatcher_ReloadPropagatesGlobalConfigToUpstream` failed the "End-to-End Tests (ubuntu-latest, 1.25)" job on 2026-08-27 ([run 33043282299](https://github.com/smart-mcp-proxy/mcpproxy-go/actions/runs/33043282299), job 98421741995) with `expected: 99999, actual: 20000` (20000 = the initial fixture value).

## Root cause

`Runtime.ReloadConfiguration` (`internal/runtime/lifecycle.go`) commits the reload to three surfaces in sequence:

1. `configSvc.ReloadFromFile()` — publishes the configsvc snapshot
2. legacy `r.cfg` sync
3. `r.upstreamManager.SetGlobalConfig(...)`

Both affected tests gated on **surface 1** with `require.Eventually`, then asserted **surface 2 or 3** exactly once. The snapshot wait can be satisfied while the later surfaces still hold the old value — a real window, not a fixture problem.

`TestConfigWatcher_ReloadSyncsLegacyGetConfig` had the identical pattern against `rt.GetConfig()` and would flake the same way; it is fixed alongside.

## Fix

Turn both downstream assertions into `require.Eventually` on the same 5s/25ms cadence as the snapshot wait.

The other tests in the file don't share the pattern — their post-wait assertions are negative checks after a fixed sleep, or reload counting.

Test-only change; no production behaviour altered.

## Verification

```
go test -race -count=20 -run TestConfigWatcher ./internal/runtime
ok  github.com/smart-mcp-proxy/mcpproxy-go/internal/runtime  396.148s
```

Unrelated to the OAuth work in #1068/#1069 — it only surfaced in their CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
