### PR TITLE
fix(web-ui): quarantine is not a fault (#1076) + unblock Windows E2E (#1034)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -95,8 +95,17 @@ jobs:
       - name: Run unit tests
         # -short skips the heavy property/timing tests (TestRapidQuarantine* etc.);
         # they run unguarded in the main-only stress-tests job below so coverage
-        # is preserved. Bumped to 4m for headroom under -race on slow runners.
-        run: go test -v -short -race -timeout 4m -skip "Binary|MCP|E2E|TestInfoEndpoint|TestGracefulShutdownNoPanic|TestSocketInfoEndpoint" ./internal/...
+        # is preserved.
+        #
+        # Timeout is 10m to match the equivalent sweep in unit-tests.yml. It was
+        # 4m, which the windows-latest runner could not meet: internal/server
+        # took 240s and died at `panic: test timed out after 4m0s` — with a
+        # single test only 2s in, so cumulative slowness (Bleve index creation
+        # on the Windows filesystem), never a hang. That kept this job red on
+        # main from 2026-08-13 (issue #1034). Keep the two workflows' budgets in
+        # step; the same code timing out in one and passing in the other is the
+        # signature of this bug returning.
+        run: go test -v -short -race -timeout 10m -skip "Binary|MCP|E2E|TestInfoEndpoint|TestGracefulShutdownNoPanic|TestSocketInfoEndpoint" ./internal/...
 
       # Binary tests are too flaky in CI due to server startup timing issues
       # All Binary tests consistently timeout waiting for server to be ready

--- a/frontend/src/views/ServerDetail.vue
+++ b/frontend/src/views/ServerDetail.vue
@@ -198,7 +198,15 @@
           @fixed="handleDiagnosticFixed"
         />
 
-        <div v-else-if="server.last_error" class="alert alert-error">
+        <!-- Issue #1076 — carries the same quarantine guard as the ErrorPanel
+             above it. Without it, suppressing the diagnostic panel would just
+             fall through to here and print the identical fault in a different
+             red box, directly above the calm quarantine banner. -->
+        <div
+          v-else-if="server.last_error && !quarantineSuppressesFaultAlerts"
+          data-test="server-detail-generic-error"
+          class="alert alert-error"
+        >
           <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
@@ -1803,12 +1811,23 @@ const healthLevelTone = computed(() => {
   }
 })
 
+// Issue #1076 — quarantine is an intentional admin state, not a fault. mcpproxy
+// still attempts a connection to a quarantined server so the scanner can export
+// its tool definitions; that attempt fails and leaves an error-severity
+// diagnostic (often the unclassified "file a bug report" one) behind, while the
+// health calculator short-circuits the server to healthy/quarantined. Both
+// facts arrive in one payload. The quarantine banner below already states the
+// situation and the action, so every red fault alert is suppressed here — the
+// same rule the tray applies via ServerStatus.isBadgeExempt.
+const quarantineSuppressesFaultAlerts = computed(() => !!server.value?.quarantined)
+
 // Spec 044 — render the structured diagnostic panel whenever a warn/error
 // diagnostic is attached. Info-level diagnostics are ignored (shown only in
 // verbose/admin views, per spec).
 const showDiagnosticPanel = computed(() => {
   const d = server.value?.diagnostic
   if (!d || !d.code) return false
+  if (quarantineSuppressesFaultAlerts.value) return false
   return d.severity === 'warn' || d.severity === 'error'
 })
 

--- a/frontend/tests/unit/server-detail-quarantine-error-panel.spec.ts
+++ b/frontend/tests/unit/server-detail-quarantine-error-panel.spec.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createRouter, createWebHistory } from 'vue-router'
+
+// Issue #1076 — a quarantined server rendered the red ErrorPanel AND the calm
+// Security-Quarantine banner off ONE payload that says healthy/quarantined.
+//
+// mcpproxy still attempts a connection to a quarantined server so the scanner
+// can export its tool definitions. That attempt fails and leaves an
+// error-severity diagnostic behind, while internal/health/calculator.go
+// short-circuits quarantined servers to level:healthy, admin_state:quarantined.
+// Both facts are true in one response; the UI must read the admin state first.
+//
+// The precedent is SignInPanel (MCP-1821): a server that needs sign-in is a
+// calm state, not a fault. Quarantine is the second such state. The tray
+// equivalent is ServerStatus.isBadgeExempt (isOAuthLoginRequired ||
+// isQuarantineReview) — `admin_state` is the cross-surface contract.
+
+let serverExtra: Record<string, unknown>
+
+vi.mock('@/services/api', () => {
+  const ok = (data: unknown = {}) => Promise.resolve({ success: true, data })
+  return {
+    default: {
+      getServers: vi.fn(() =>
+        ok({
+          servers: [
+            {
+              name: 'everything',
+              protocol: 'stdio',
+              enabled: true,
+              connected: false,
+              quarantined: true,
+              tool_count: 0,
+              ...serverExtra,
+            },
+          ],
+        })
+      ),
+      getToolApprovals: vi.fn(() => ok({ tools: [], count: 0 })),
+      getToolDiff: vi.fn(() => ok({})),
+      getServerTools: vi.fn(() => ok({ tools: [] })),
+      getSecurityOverview: vi.fn(() => ok({ scanners_enabled: 0, docker_available: true })),
+      listScanners: vi.fn(() => ok([])),
+      getScanReport: vi.fn(() => Promise.resolve({ success: false, error: 'no report' })),
+      getScanStatus: vi.fn(() => ok({ id: 'scan-1', status: 'completed', scan_pass: 1 })),
+      startScan: vi.fn(() => ok({ id: 'scan-2' })),
+      getServerLogs: vi.fn(() => ok({ logs: [] })),
+      discoverServerTools: vi.fn(() => ok({})),
+      approveTools: vi.fn(() => ok({ approved: 1 })),
+      blockTools: vi.fn(() => ok({ blocked: 1 })),
+      patchServer: vi.fn(() => ok({ message: 'ok' })),
+    },
+  }
+})
+
+async function mountDetail() {
+  const ServerDetail = (await import('@/views/ServerDetail.vue')).default
+  const router = createRouter({
+    history: createWebHistory(),
+    routes: [
+      { path: '/servers/:serverName', component: { template: '<div/>' } },
+      { path: '/security/scans/:jobId', component: { template: '<div/>' } },
+    ],
+  })
+  await router.push('/servers/everything?tab=tools')
+  await router.isReady()
+  const wrapper = mount(ServerDetail, {
+    props: { serverName: 'everything' },
+    global: { plugins: [createPinia(), router] },
+  })
+  await flushPromises()
+  await flushPromises()
+  return wrapper
+}
+
+// The real payload from the issue: an unclassified error diagnostic riding
+// along with a healthy/quarantined health block.
+const unclassifiedDiagnostic = {
+  code: 'MCPX_UNKNOWN_UNCLASSIFIED',
+  severity: 'error',
+  user_message:
+    'mcpproxy could not classify this failure. Please file a bug report so we can add a specific code.',
+}
+
+const quarantinedHealth = {
+  level: 'healthy',
+  admin_state: 'quarantined',
+  summary: 'Quarantined for review',
+  action: 'approve',
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.clearAllMocks()
+  serverExtra = {}
+})
+
+describe('ServerDetail — quarantine suppresses the fault alerts (issue #1076)', () => {
+  it('renders the quarantine banner alone, not the red ErrorPanel', async () => {
+    serverExtra = {
+      trust_mode: 'manual',
+      diagnostic: unclassifiedDiagnostic,
+      health: quarantinedHealth,
+    }
+    const wrapper = await mountDetail()
+
+    expect(wrapper.find('[data-test="security-quarantine-banner"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="error-panel-code"]').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('file a bug report')
+  })
+
+  it('does not let the generic last_error alert through in the ErrorPanel’s place', async () => {
+    // Suppressing the diagnostic panel must not simply fall through to the
+    // `v-else-if="server.last_error"` branch — that prints the same fault in a
+    // different red box.
+    serverExtra = {
+      trust_mode: 'manual',
+      last_error: 'failed to connect: stdio transport: transport error: transport closed',
+      diagnostic: unclassifiedDiagnostic,
+      health: quarantinedHealth,
+    }
+    const wrapper = await mountDetail()
+
+    expect(wrapper.find('[data-test="security-quarantine-banner"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="server-detail-generic-error"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="error-panel-code"]').exists()).toBe(false)
+  })
+
+  it('still shows the ErrorPanel for the same diagnostic when NOT quarantined', async () => {
+    // The guard is narrow: quarantine is the exemption, not the diagnostic.
+    serverExtra = {
+      quarantined: false,
+      diagnostic: unclassifiedDiagnostic,
+      health: { level: 'unhealthy', admin_state: 'enabled', summary: 'Connection failed', action: 'retry' },
+    }
+    const wrapper = await mountDetail()
+
+    expect(wrapper.find('[data-test="security-quarantine-banner"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="error-panel-code"]').text()).toBe('MCPX_UNKNOWN_UNCLASSIFIED')
+  })
+
+  it('still shows the generic last_error alert when NOT quarantined and no diagnostic', async () => {
+    serverExtra = {
+      quarantined: false,
+      last_error: 'dial tcp: lookup example.invalid: no such host',
+      health: { level: 'unhealthy', admin_state: 'enabled', summary: 'Host not found', action: 'edit_url' },
+    }
+    const wrapper = await mountDetail()
+
+    expect(wrapper.find('[data-test="server-detail-generic-error"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="server-detail-generic-error"]').text()).toContain('no such host')
+  })
+
+  it('keeps SignInPanel precedence for a quarantined server that needs sign-in', async () => {
+    // MCP-1821's calm panel already handles quarantine (it takes a
+    // `quarantined` prop); the new guard must not swallow it.
+    serverExtra = {
+      trust_mode: 'manual',
+      diagnostic: {
+        code: 'MCPX_OAUTH_LOGIN_REQUIRED',
+        severity: 'error',
+        user_message: 'Sign in to continue.',
+      },
+      health: { ...quarantinedHealth, action: 'login' },
+    }
+    const wrapper = await mountDetail()
+
+    expect(wrapper.find('[data-test="oauth-signin-panel"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="error-panel-code"]').exists()).toBe(false)
+  })
+})


### PR DESCRIPTION
Two independent fixes, both clearing red state ahead of the v0.62.0 cut.

Closes #1076
Closes #1034

## #1076 — quarantined server told to file a bug report

Server Detail rendered the red `ErrorPanel` **and** the calm Security Quarantine banner off one payload that says `healthy` / `quarantined`.

mcpproxy still attempts a connection to a quarantined server so the scanner can export its tool definitions. That attempt fails and leaves an error-severity diagnostic behind — usually `MCPX_UNKNOWN_UNCLASSIFIED`, whose copy asks the user to file a bug report — while `internal/health/calculator.go` short-circuits the server to `level: healthy`, `admin_state: quarantined`, `action: approve`. Both facts are true in one response; the UI read only the first.

Quarantine now suppresses every fault alert on the page, following the `SignInPanel` precedent one block up (MCP-1821): an intentional admin state is not a fault, and the quarantine banner already states the situation and the action.

The guard deliberately covers **both** red surfaces — the diagnostic panel and the generic `v-else-if="server.last_error"` alert below it. The issue flagged this: suppressing only the first falls straight through to the second and prints the same fault in a different red box.

This is the rule [#1075](https://github.com/smart-mcp-proxy/mcpproxy-go/pull/1075) applied to the tray badge (`ServerStatus.isBadgeExempt`), now on the surface that PR deliberately did not touch. `admin_state` stays the cross-surface contract.

Scope is unchanged elsewhere: a non-quarantined server with the same diagnostic still gets the full `ErrorPanel`, and `SignInPanel` keeps its precedence for a quarantined server that needs sign-in.

## #1034 — E2E Tests / windows-latest, red on main since 2026-08-13

A timeout-budget mismatch between two workflows running the same sweep: `e2e-tests.yml` used `-timeout 4m` where `unit-tests.yml` uses `10m`. `internal/server` took 240s on the Windows runner and died at `panic: test timed out after 4m0s`.

Nothing hangs — the panic's `running tests:` line named a single test only 2s in (`TestProfile_UnauthFilteredByProfile`), so this is cumulative slowness (Bleve index creation on the Windows filesystem), and raising the budget to match the sibling workflow is the whole fix. A comment on the step records that, so the two budgets are kept in step.

The nil-deref panics visible in the same job log are unrelated and **not** a production bug: `agent_token_gating_test.go` drives every mutating route through `baseController`, whose `EditRegistrySourceRef` returns `(nil, nil, nil)`; chi's Recoverer catches it and the auth-gate assertion still passes.

## Verification

- **New spec** `frontend/tests/unit/server-detail-quarantine-error-panel.spec.ts` — 5 cases, written first and watched fail for the right reasons (ErrorPanel present on a quarantined server, with and without `last_error`). Two of the five passed from the start as deliberate regression guards on the narrowness of the fix.
- **959/959** frontend unit tests pass (96 files); `vue-tsc --noEmit` clean.
- **Playwright web-UI sweep** (`scripts/run-web-smoke.sh`, required for `frontend/src/` changes) run four ways: with and without `MCPPROXY_FIXTURE_PATH`, on this branch and on a rebuilt `origin/main` baseline. Each pairing produced identical results, so the sweep's remaining failures are pre-existing on main and untouched here. The `web-ui-sweep.spec.ts` suite — including server detail — passes.

The pre-existing sweep failures are worth their own issue and are not addressed here: a 4.23:1 contrast on the dashboard empty-state paragraph (`opacity-60`, below AA), and three data-dependent `visual-a11y-sweep` checks that only fail once a fixture upstream is registered.