### PR TITLE
fix(release): stop generating a redundant `version` stanza in the brew formula

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1852,11 +1852,17 @@ jobs:
           cd tap
           mkdir -p Formula
 
+          # NOTE: deliberately NO `version` stanza. Every url below embeds the
+          # version, so Homebrew scans it from the URL, and since ~2026-08-05
+          # `brew audit --formula --online` FAILS an explicit stanza with
+          # "Stable: `version X` is redundant with version scanned from URL".
+          # That kept the tap's audit workflow red on every release from v0.53.0
+          # to v0.62.0. `version` is still available to the test block below —
+          # it is derived, not absent. Do not re-add it.
           cat > Formula/mcpproxy.rb << 'FORMULA_EOF'
           class Mcpproxy < Formula
             desc "Smart MCP Proxy - Intelligent tool discovery and proxying for MCP servers"
             homepage "https://github.com/smart-mcp-proxy/mcpproxy-go"
-            version "${VERSION}"
             license "MIT"
 
             on_macos do


### PR DESCRIPTION
The Homebrew tap's `brew style + audit` workflow has failed on **every release since v0.53.0** (2026-08-05) — eleven consecutive, most recently on [v0.62.0](https://github.com/smart-mcp-proxy/homebrew-mcpproxy/actions/runs/33188538080):

```
smart-mcp-proxy/mcpproxy/mcpproxy
  * Stable: `version 0.62.0` is redundant with version scanned from URL
```

## Cause

Every `url` in the generated formula already embeds the version, so Homebrew scans it from the URL and rejects the explicit `version` stanza as redundant. Brew turned this into a hard audit error somewhere between 2026-07-24 (v0.52.1, the last green run) and 2026-08-05 — exactly where the streak begins. I confirmed the cause is byte-identical across v0.62.0, v0.61.0, v0.60.0 and v0.59.0, so it is one persistent issue, not a series.

## Impact

**Installs were never affected.** The audit is a lint gate in the tap repo that runs *after* the formula is committed and pushed, so it never gated publication — the tap has had correct URLs and sha256s throughout.

What it did do is leave the tap permanently red, which is the condition under which a genuine formula regression would go unnoticed.

## Fix

Drop the `version` stanza from the generator, with a comment explaining why it must not come back. `version` stays available to the formula's own `test do assert_match version.to_s` — it is *derived* from the URL, not absent.

## Verification

Reproduced the failure locally by symlinking the checked-out tap into Homebrew's Taps dir (the same thing the tap workflow does), then re-ran the three commands that workflow uses:

| command | before | after |
|---|---|---|
| `brew style smart-mcp-proxy/mcpproxy` | pass | pass — no offenses |
| `brew audit --tap … --cask --online mcpproxy` | pass | pass — exit 0 |
| `brew audit --tap … --formula --online mcpproxy` | **fail** | **pass — exit 0** |
| `brew info --json=v2 …` version | 0.62.0 | **0.62.0** (scanned from URL) |

I also diffed this generator's rendered output — heredoc extracted and run through the same `sed` substitutions with the real v0.62.0 shas — against the formula I audited green: **identical**.

Local Homebrew state was restored afterwards (the tap was not previously installed, and the symlink was removed).

## Companion change

The tap's checked-in v0.62.0 formula is already fixed in smart-mcp-proxy/homebrew-mcpproxy@162cf39, so the **current** release is clean too, not just the next one. This PR stops the generator reintroducing the stanza at v0.63.0.