### PR TITLE
feat(bench): measure code execution's response-side saving

### DIFF
--- a/bench/cmd/breakevencurve/main.go
+++ b/bench/cmd/breakevencurve/main.go
@@ -1,0 +1,220 @@
+// Command breakevencurve computes the fleet-size break-even curve: at how many
+// upstream tools (and servers) does the proxy stop costing more than it saves?
+//
+// Net(n) = B(n) - M - sum(r), where B(n) is the cumulative cost of n upstream
+// tool definitions, M is mcpproxy's own advertised menu (fixed), and sum(r) is
+// the measured cost of the session's discovery responses.
+//
+// B(n) depends on WHICH n tools: definition sizes span 145..6485 bytes on the
+// reference snapshot, so a single ordering yields one arbitrary curve. This
+// bootstraps over many random orderings and reports the median and a p10..p90
+// band, so the answer is a distribution and reads as one.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"sort"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/bench"
+	"github.com/smart-mcp-proxy/mcpproxy-go/bench/corpusio"
+)
+
+func main() {
+	corpusPath := flag.String("corpus", "specs/083-discovery-profiler/datasets/livemcptool_snapshot/tools.json", "livemcptool snapshot")
+	trials := flag.Int("trials", 400, "bootstrap orderings")
+	meanResp := flag.Float64("mean-response", 1704.3, "mean discovery response tokens")
+	calls := flag.Int("calls", 3, "discovery calls per session")
+	jsonOut := flag.String("json", "", "write curve data to this path")
+	seed := flag.Int64("seed", 20260901, "rng seed (pinned for reproducibility)")
+	flag.Parse()
+
+	corpus, _, _, err := corpusio.LoadLiveMCPTool(*corpusPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "load:", err)
+		os.Exit(1)
+	}
+	tk, err := bench.NewTokenizer("cl100k_base")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "tokenizer:", err)
+		os.Exit(1)
+	}
+
+	// Per-tool cost, computed once. BPE is not additive across concatenation,
+	// so this is an approximation of B(n) by summation -- stated, not hidden.
+	cost := make([]int, len(corpus.Tools))
+	servers := make([]string, len(corpus.Tools))
+	for i, tl := range corpus.Tools {
+		cost[i] = tk.CountToolWithSchema(tl)
+		servers[i] = tl.Server
+	}
+	total := 0
+	for _, c := range cost {
+		total += c
+	}
+
+	spend := *meanResp * float64(*calls)
+	fmt.Printf("corpus            : %s (%d tools)\n", corpus.Version, len(corpus.Tools))
+	fmt.Printf("B(all)            : %d tokens   mean %.1f/tool\n", total, float64(total)/float64(len(cost)))
+	fmt.Printf("session spend     : %d calls x %.1f = %.0f tokens\n\n", *calls, *meanResp, spend)
+
+	for _, mode := range []string{bench.ModeRetrieveTools, bench.ModeCodeExecution} {
+		m := 0
+		for _, tl := range bench.ProxyToolsForMode(mode) {
+			m += tk.CountToolWithSchema(tl)
+		}
+		threshold := float64(m) + spend
+		rng := rand.New(rand.NewSource(*seed))
+		crossings := make([]int, 0, *trials)
+		never := 0
+		for t := 0; t < *trials; t++ {
+			perm := rng.Perm(len(cost))
+			run, hit := 0.0, -1
+			for k, idx := range perm {
+				run += float64(cost[idx])
+				if run >= threshold {
+					hit = k + 1
+					break
+				}
+			}
+			if hit < 0 {
+				never++
+				continue
+			}
+			crossings = append(crossings, hit)
+		}
+		sort.Ints(crossings)
+		fmt.Printf("mode %-15s menu M = %d tokens\n", mode, m)
+		fmt.Printf("  break-even threshold : %.0f tokens (M + session spend)\n", threshold)
+		if never > 0 {
+			fmt.Printf("  NEVER breaks even in %d/%d orderings (whole fleet is cheaper than the proxy)\n", never, *trials)
+		}
+		if len(crossings) > 0 {
+			fmt.Printf("  break-even tools     : p10=%d  median=%d  p90=%d\n",
+				crossings[len(crossings)/10], crossings[len(crossings)/2], crossings[len(crossings)*9/10])
+		}
+		fmt.Println()
+	}
+
+	if *jsonOut != "" {
+		emitCurve(*jsonOut, tk, cost, servers, spend, *trials, *seed, corpus.Version)
+	}
+
+	// Servers are what a user actually adds or removes.
+	byServer := map[string]int{}
+	for i := range cost {
+		byServer[servers[i]] += cost[i]
+	}
+	sizes := make([]int, 0, len(byServer))
+	for _, v := range byServer {
+		sizes = append(sizes, v)
+	}
+	sort.Ints(sizes)
+	fmt.Printf("servers           : %d, median %d tokens each (p10=%d p90=%d)\n",
+		len(sizes), sizes[len(sizes)/2], sizes[len(sizes)/10], sizes[len(sizes)*9/10])
+}
+
+type curvePoint struct {
+	N   int     `json:"n"`
+	P10 float64 `json:"p10"`
+	Med float64 `json:"median"`
+	P90 float64 `json:"p90"`
+}
+
+// emitCurve writes net-token curves (B(n) - M - spend) per mode. Menus are
+// listed with the value bench computes AND the deployed default, which differ
+// because ProxyModeToolDefs pins EnableCodeExecution:true while the shipped
+// default serves a disabled stub.
+func emitCurve(path string, tk *bench.Tokenizer, cost []int, servers []string, spend float64, trials int, seed int64, version string) {
+	rng := rand.New(rand.NewSource(seed))
+	perms := make([][]int, trials)
+	for t := range perms {
+		perms[t] = rng.Perm(len(cost))
+	}
+	// Cumulative B(n) per ordering.
+	cum := make([][]float64, trials)
+	for t, perm := range perms {
+		row := make([]float64, len(cost)+1)
+		for k, idx := range perm {
+			row[k+1] = row[k] + float64(cost[idx])
+		}
+		cum[t] = row
+	}
+	menus := map[string]int{}
+	for _, mode := range []string{bench.ModeRetrieveTools, bench.ModeCodeExecution} {
+		m := 0
+		for _, tl := range bench.ProxyToolsForMode(mode) {
+			m += tk.CountToolWithSchema(tl)
+		}
+		menus[mode] = m
+	}
+	out := map[string]interface{}{
+		"corpus": version, "tools": len(cost), "spend": spend,
+		"menus": menus, "trials": trials,
+	}
+	catalog := []curvePoint{}
+	for n := 0; n <= len(cost); n++ {
+		vals := make([]float64, trials)
+		for t := range cum {
+			vals[t] = cum[t][n]
+		}
+		sort.Float64s(vals)
+		catalog = append(catalog, curvePoint{N: n, P10: vals[trials/10], Med: vals[trials/2], P90: vals[trials*9/10]})
+	}
+	out["tool_catalog_curve"] = catalog
+	curves := map[string][]curvePoint{}
+	step := 1
+	for mode, m := range menus {
+		pts := []curvePoint{}
+		thr := float64(m) + spend
+		for n := 0; n <= len(cost); n += step {
+			vals := make([]float64, trials)
+			for t := range cum {
+				vals[t] = cum[t][n] - thr
+			}
+			sort.Float64s(vals)
+			pts = append(pts, curvePoint{N: n,
+				P10: vals[trials/10], Med: vals[trials/2], P90: vals[trials*9/10]})
+		}
+		curves[mode] = pts
+	}
+	out["curves"] = curves
+	byServer := map[string]int{}
+	for i := range cost {
+		byServer[servers[i]] += cost[i]
+	}
+	// Bootstrap over SERVER orderings too: a user adds and removes servers,
+	// not individual tools, and server sizes are far more skewed than tool
+	// sizes (p10=152, p90=3184 on this snapshot).
+	svcCost := make([]int, 0, len(byServer))
+	for _, v := range byServer {
+		svcCost = append(svcCost, v)
+	}
+	srng := rand.New(rand.NewSource(seed))
+	scum := make([][]float64, trials)
+	for t := range scum {
+		perm := srng.Perm(len(svcCost))
+		row := make([]float64, len(svcCost)+1)
+		for k, idx := range perm {
+			row[k+1] = row[k] + float64(svcCost[idx])
+		}
+		scum[t] = row
+	}
+	scurve := []curvePoint{}
+	for n := 0; n <= len(svcCost); n++ {
+		vals := make([]float64, trials)
+		for t := range scum {
+			vals[t] = scum[t][n]
+		}
+		sort.Float64s(vals)
+		scurve = append(scurve, curvePoint{N: n, P10: vals[trials/10], Med: vals[trials/2], P90: vals[trials*9/10]})
+	}
+	out["server_catalog_curve"] = scurve
+	out["servers"] = len(byServer)
+	b, _ := json.MarshalIndent(out, "", " ")
+	_ = os.WriteFile(path, b, 0o644)
+	fmt.Println("curve written:", path)
+}

--- a/bench/cmd/codeexecsaving/main.go
+++ b/bench/cmd/codeexecsaving/main.go
@@ -16,6 +16,9 @@ import (
 
 func main() {
 	in := flag.String("in", "", "activity export JSONL (must live outside the repository)")
+	inPrice := flag.Float64("in-price", 3.0, "USD per Mtok, input")
+	outPrice := flag.Float64("out-price", 15.0, "USD per Mtok, output")
+	cacheMult := flag.Float64("cache-mult", 0.1, "input multiplier for a cached prefix (1.0 = uncached)")
 	// Default OFF, matching replaycorpus's zero value: bodies-on reads recorded
 	// request and response CONTENT unmasked. With the sub-call byte counts now
 	// emitted, bodies-off still yields a byte-basis figure.
@@ -64,6 +67,31 @@ func main() {
 		}
 		fmt.Println()
 	}
+	// Money, not just tokens: a call's ARGUMENTS are output (billed ~5x) and its
+	// RESPONSE is input, so the token total is not proportional to cost. Priced
+	// per-call and summed, since only measured calls can be priced at all.
+	pricedTotal, priced, unpriceable := 0.0, 0, 0
+	for _, sv := range rep.Savings {
+		if usd, ok := sv.PricedSavingUSD(*inPrice, *outPrice, *cacheMult); ok {
+			pricedTotal += usd
+			priced++
+		} else {
+			unpriceable++
+		}
+	}
+	if priced > 0 {
+		fmt.Printf("\npriced over %d measured call(s) at $%.2f/$%.2f per Mtok, input x%.2f:\n",
+			priced, *inPrice, *outPrice, *cacheMult)
+		fmt.Printf("  net saving: %+.6f USD\n", pricedTotal)
+		if pricedTotal < 0 {
+			fmt.Println("  NOTE: negative in money. Code execution trades cheap input for expensive")
+			fmt.Println("        output — the script is a fixed cost however few calls it replaces.")
+		}
+	}
+	if unpriceable > 0 {
+		fmt.Printf("  %d call(s) could not be priced (withheld, or byte estimates rather than tokens)\n", unpriceable)
+	}
+
 	for reason, n := range rep.Withheld {
 		fmt.Printf("\nwithheld: %d call(s) — %s\n", n, reason)
 	}

--- a/bench/cmd/codeexecsaving/main.go
+++ b/bench/cmd/codeexecsaving/main.go
@@ -1,0 +1,74 @@
+// Command codeexecsaving reports the RESPONSE-SIDE saving of code execution
+// from a recorded activity export: what the sandbox's sub-call responses would
+// have cost an agent that made those calls itself, against the script it sent
+// and the single result it got back.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/bench/replaycorpus"
+)
+
+func main() {
+	in := flag.String("in", "", "activity export JSONL (must live outside the repository)")
+	// Default OFF, matching replaycorpus's zero value: bodies-on reads recorded
+	// request and response CONTENT unmasked. With the sub-call byte counts now
+	// emitted, bodies-off still yields a byte-basis figure.
+	bodies := flag.Bool("bodies-unmasked", false, "read recorded bodies and count real TOKENS (reads unmasked content)")
+	flag.Parse()
+	if *in == "" {
+		fmt.Fprintln(os.Stderr, "-in is required")
+		os.Exit(2)
+	}
+
+	policy := replaycorpus.BodiesOff
+	if *bodies {
+		policy = replaycorpus.BodiesOnUnmasked
+	}
+	corpus, err := replaycorpus.LoadFile(*in, replaycorpus.Options{Bodies: policy})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "load:", err)
+		os.Exit(1)
+	}
+	rep := replaycorpus.CodeExecSavingsFor(corpus.Sessions)
+
+	fmt.Printf("sessions %d  bodies=%v\n", len(corpus.Sessions), policy)
+	for _, w := range corpus.Warnings {
+		fmt.Println("  warning:", w)
+	}
+	bases := make([]string, 0, len(rep.Buckets))
+	for b := range rep.Buckets {
+		bases = append(bases, string(b))
+	}
+	sort.Strings(bases)
+	if len(bases) == 0 {
+		fmt.Println("\nno code_execution call produced a figure")
+	}
+	for _, b := range bases {
+		k := rep.Buckets[replaycorpus.CostBasis(b)]
+		unit := "bytes"
+		if b == string(replaycorpus.CostMeasured) {
+			unit = "tokens"
+		}
+		fmt.Printf("\n[%s] %d call(s), %d sub-call(s) — unit: %s\n", b, k.Calls, k.SubCalls, unit)
+		fmt.Printf("  baseline (agent makes the sub-calls itself) : %d\n", k.Baseline)
+		fmt.Printf("  proxy    (script sent + result returned)    : %d\n", k.Proxy)
+		fmt.Printf("  saving                                      : %+d", k.Saving)
+		if k.Baseline > 0 {
+			fmt.Printf("  (%.1f%% of baseline)", 100*float64(k.Saving)/float64(k.Baseline))
+		}
+		fmt.Println()
+	}
+	for reason, n := range rep.Withheld {
+		fmt.Printf("\nwithheld: %d call(s) — %s\n", n, reason)
+	}
+	if b, err := json.MarshalIndent(rep.Savings, "", " "); err == nil && len(rep.Savings) > 0 {
+		fmt.Println("\nper-call detail:")
+		fmt.Println(string(b))
+	}
+}

--- a/bench/cmd/iosplit/main.go
+++ b/bench/cmd/iosplit/main.go
@@ -1,0 +1,112 @@
+// Command iosplit reports code execution's cost split by BILLING DIRECTION.
+//
+// Every other figure in this harness sums a tool call's arguments and its
+// response into one number. They are not the same kind of token: the arguments
+// are text the MODEL GENERATED (output, billed ~5x input) and the response is
+// text it reads (input, billed 1x, or 0.1x cached). Summing them prices a 5x
+// asymmetry at 1x.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/bench"
+)
+
+type row struct {
+	ToolName  string          `json:"tool_name"`
+	RequestID string          `json:"request_id"`
+	ParentID  string          `json:"parent_id"`
+	Arguments json.RawMessage `json:"arguments"`
+	Response  json.RawMessage `json:"response"`
+}
+
+func text(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	return string(raw)
+}
+
+func main() {
+	in := flag.String("in", "", "activity export JSONL")
+	inPrice := flag.Float64("in-price", 3.0, "USD per Mtok, input")
+	outPrice := flag.Float64("out-price", 15.0, "USD per Mtok, output")
+	cacheMult := flag.Float64("cache-mult", 0.1, "cached-input multiplier")
+	flag.Parse()
+
+	f, err := os.Open(*in)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer f.Close()
+	tk, err := bench.NewTokenizer("cl100k_base")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	var rows []row
+	dec := json.NewDecoder(f)
+	for dec.More() {
+		var r row
+		if err := dec.Decode(&r); err != nil {
+			break
+		}
+		rows = append(rows, r)
+	}
+
+	kids := map[string][]row{}
+	for _, r := range rows {
+		if r.ParentID != "" {
+			kids[r.ParentID] = append(kids[r.ParentID], r)
+		}
+	}
+	type out struct{ subs, bOut, bIn, cOut, cIn int }
+	var results []out
+	for _, p := range rows {
+		if p.ToolName != "code_execution" {
+			continue
+		}
+		subs := kids[p.RequestID]
+		if len(subs) == 0 {
+			continue
+		}
+		o := out{subs: len(subs), cOut: tk.Count(text(p.Arguments)), cIn: tk.Count(text(p.Response))}
+		for _, s := range subs {
+			o.bOut += tk.Count(text(s.Arguments))
+			o.bIn += tk.Count(text(s.Response))
+		}
+		results = append(results, o)
+	}
+	sort.Slice(results, func(i, j int) bool { return results[i].subs < results[j].subs })
+
+	usd := func(in, outTok int, cached bool) float64 {
+		m := 1.0
+		if cached {
+			m = *cacheMult
+		}
+		return (float64(in)*(*inPrice)*m + float64(outTok)*(*outPrice)) / 1e6
+	}
+
+	fmt.Printf("%-5s | %-17s | %-17s | %-9s | %s\n",
+		"subs", "OUTPUT (generated)", "INPUT (read)", "tok saved", "USD saved (uncached / cached input)")
+	fmt.Printf("%-5s | %-8s %-8s | %-8s %-8s |           |\n", "", "base", "codeex", "base", "codeex")
+	fmt.Println("---------------------------------------------------------------------------------------------")
+	for _, r := range results {
+		tokSaved := (r.bOut + r.bIn) - (r.cOut + r.cIn)
+		u := usd(r.bIn, r.bOut, false) - usd(r.cIn, r.cOut, false)
+		c := usd(r.bIn, r.bOut, true) - usd(r.cIn, r.cOut, true)
+		fmt.Printf("%-5d | %-8d %-8d | %-8d %-8d | %+9d | %+.6f / %+.6f\n",
+			r.subs, r.bOut, r.cOut, r.bIn, r.cIn, tokSaved, u, c)
+	}
+}

--- a/bench/replaycorpus/codeexec.go
+++ b/bench/replaycorpus/codeexec.go
@@ -1,0 +1,213 @@
+// codeexec.go — the response-side saving of code execution.
+//
+// Every other savings figure in this harness is about the MENU: how many tokens
+// of tool definitions an agent carries. Code execution's menu is already
+// measured and it is the smallest of the three surfaces, but the menu is not
+// where code execution actually pays.
+//
+// It pays on the RESPONSE side. A script issues several upstream calls inside
+// the sandbox and only the value it returns enters the model's context; the
+// intermediate responses — which an agent driving those tools itself would have
+// paid for in full, request and response both — never appear. That difference
+// is what this file computes, and nothing else in bench measures it.
+package replaycorpus
+
+// CodeExecToolName is the built-in whose activity records parent a sandbox's
+// sub-calls. Sub-calls join to it by parent_id (see group.go).
+const CodeExecToolName = "code_execution"
+
+// CodeExecSaving is the response-side saving of ONE code_execution call.
+//
+// Baseline is what an agent would have paid making the sub-calls itself; Proxy
+// is what it actually paid — the script it sent plus the single result it got
+// back. The difference can be NEGATIVE, and that is a real outcome rather than
+// an error: a script that dispatches nothing, or whose sub-calls return less
+// than the script's own source costs, genuinely loses tokens.
+type CodeExecSaving struct {
+	// ParentID is the code_execution call's own request id.
+	ParentID string `json:"parent_id"`
+
+	SubCalls int `json:"sub_calls"`
+
+	// Basis names both the provenance AND the unit: measured figures are
+	// TOKENS, estimated figures are BYTES. They are never mixed — see
+	// ReasonMixedCostBasis.
+	Basis CostBasis `json:"basis"`
+
+	// Reason explains a CostUnavailable saving. Empty otherwise.
+	Reason ExclusionReason `json:"reason,omitempty"`
+
+	// Baseline, Proxy and Saving are populated only when Basis is not
+	// CostUnavailable. An unavailable saving carries no numbers at all, because
+	// a zero here would read as "code execution saved nothing" — a measurement
+	// — when the truth is that no measurement was possible.
+	Baseline int `json:"baseline,omitempty"`
+	Proxy    int `json:"proxy,omitempty"`
+	Saving   int `json:"saving,omitempty"`
+}
+
+// amount returns the cost in the unit its basis implies, and whether a figure
+// exists at all.
+func (c Cost) amount() (int, bool) {
+	switch c.Basis {
+	case CostMeasured:
+		return c.Tokens, true
+	case CostEstimated:
+		return c.Bytes, true
+	default:
+		return 0, false
+	}
+}
+
+// CodeExecSavingFor computes the response-side saving of one code_execution
+// call. parent must be the code_execution record itself; its SubCalls are the
+// sandbox dispatches joined by parent_id.
+//
+// The accounting refuses three things rather than producing a plausible number:
+//
+//   - a component with no honest figure (CostUnavailable) makes the whole
+//     saving unavailable, because a missing sub-call understates the baseline
+//     and so quietly flatters code execution;
+//   - components on DIFFERENT bases are never summed, since measured figures
+//     are tokens and estimated ones are bytes, and adding them produces a
+//     number in no unit at all;
+//   - a parent that is not a code_execution call, which is a caller error
+//     rather than a measurement.
+func CodeExecSavingFor(parent *ReplayCall) CodeExecSaving {
+	out := CodeExecSaving{}
+	if parent == nil {
+		return CodeExecSaving{Basis: CostUnavailable, Reason: ReasonNotACall}
+	}
+	out.ParentID = parent.RequestID
+	out.SubCalls = len(parent.SubCalls)
+	if parent.ToolName != CodeExecToolName {
+		return CodeExecSaving{ParentID: out.ParentID, Basis: CostUnavailable, Reason: ReasonNotACall}
+	}
+
+	// Collect every component first so a single pass can decide the basis.
+	// The parent's own request is the script source and its response is the
+	// value the model received; both are costs code execution really incurred.
+	type component struct {
+		cost  Cost
+		child bool
+	}
+	comps := []component{{parent.RequestCost, false}, {parent.ResponseCost, false}}
+	for _, sub := range parent.SubCalls {
+		comps = append(comps, component{sub.RequestCost, true}, component{sub.ResponseCost, true})
+	}
+
+	basis := CostBasis("")
+	baseline, proxy := 0, 0
+	// Any truncation anywhere in the call withholds it — see
+	// ReasonTruncatedSubCallOverstates. Checked before the components are
+	// summed so no partial total is ever built.
+	truncatedAnywhere := parent.Flags.Truncated
+	for _, sub := range parent.SubCalls {
+		if sub != nil && sub.Flags.Truncated {
+			truncatedAnywhere = true
+		}
+	}
+	if truncatedAnywhere {
+		return CodeExecSaving{ParentID: out.ParentID, SubCalls: out.SubCalls,
+			Basis: CostUnavailable, Reason: ReasonTruncatedSubCallOverstates}
+	}
+	for _, c := range comps {
+		amount, ok := c.cost.amount()
+		if !ok {
+			reason := c.cost.Reason
+			if reason == "" {
+				reason = ReasonNoByteCounts
+			}
+			return CodeExecSaving{ParentID: out.ParentID, SubCalls: out.SubCalls,
+				Basis: CostUnavailable, Reason: reason}
+		}
+		if basis == "" {
+			basis = c.cost.Basis
+		} else if basis != c.cost.Basis {
+			return CodeExecSaving{ParentID: out.ParentID, SubCalls: out.SubCalls,
+				Basis: CostUnavailable, Reason: ReasonMixedCostBasis}
+		}
+		// A truncated component's byte length is the FULL pre-truncation size,
+		// but the baseline means "what an agent would have paid making this
+		// call itself" and that agent receives a cut response. Counting the
+		// full size overstates the baseline, and an overstated baseline
+		// inflates the saving — so withhold rather than annotate. Annotating
+		// leaves the wrong number in the headline with a footnote beside it.
+		if c.cost.Truncated {
+			return CodeExecSaving{ParentID: out.ParentID, SubCalls: out.SubCalls,
+				Basis: CostUnavailable, Reason: ReasonTruncatedSubCallOverstates}
+		}
+		if c.child {
+			baseline += amount
+		} else {
+			proxy += amount
+		}
+	}
+
+	out.Basis = basis
+	out.Baseline = baseline
+	out.Proxy = proxy
+	out.Saving = baseline - proxy
+	return out
+}
+
+// CodeExecReport aggregates response-side savings, bucketed BY BASIS so a
+// measured total and an estimated one are never added together.
+type CodeExecReport struct {
+	// Buckets is keyed by basis: "measured" totals are tokens, "estimated"
+	// totals are bytes.
+	Buckets map[CostBasis]*CodeExecBucket `json:"buckets"`
+
+	// Withheld counts the calls that produced no figure, by reason.
+	Withheld map[ExclusionReason]int `json:"withheld,omitempty"`
+
+	// Savings is the per-call detail, in input order.
+	Savings []CodeExecSaving `json:"savings,omitempty"`
+}
+
+// CodeExecBucket is the total for one accounting basis.
+type CodeExecBucket struct {
+	Calls    int `json:"calls"`
+	SubCalls int `json:"sub_calls"`
+	Baseline int `json:"baseline"`
+	Proxy    int `json:"proxy"`
+	Saving   int `json:"saving"`
+}
+
+// CodeExecSavingsFor walks sessions and reports the response-side saving of
+// every code_execution call in them.
+func CodeExecSavingsFor(sessions []*ReplaySession) *CodeExecReport {
+	rep := &CodeExecReport{Buckets: map[CostBasis]*CodeExecBucket{}}
+	for _, session := range sessions {
+		if session == nil {
+			continue
+		}
+		// Only top-level calls: a code_execution never nests inside another
+		// sandbox, and walking AllCalls would revisit sub-calls as parents.
+		for _, call := range session.Calls {
+			if call == nil || call.ToolName != CodeExecToolName {
+				continue
+			}
+			saving := CodeExecSavingFor(call)
+			rep.Savings = append(rep.Savings, saving)
+			if saving.Basis == CostUnavailable {
+				if rep.Withheld == nil {
+					rep.Withheld = map[ExclusionReason]int{}
+				}
+				rep.Withheld[saving.Reason]++
+				continue
+			}
+			bucket := rep.Buckets[saving.Basis]
+			if bucket == nil {
+				bucket = &CodeExecBucket{}
+				rep.Buckets[saving.Basis] = bucket
+			}
+			bucket.Calls++
+			bucket.SubCalls += saving.SubCalls
+			bucket.Baseline += saving.Baseline
+			bucket.Proxy += saving.Proxy
+			bucket.Saving += saving.Saving
+		}
+	}
+	return rep
+}

--- a/bench/replaycorpus/codeexec.go
+++ b/bench/replaycorpus/codeexec.go
@@ -12,6 +12,8 @@
 // is what this file computes, and nothing else in bench measures it.
 package replaycorpus
 
+import "math"
+
 // CodeExecToolName is the built-in whose activity records parent a sandbox's
 // sub-calls. Sub-calls join to it by parent_id (see group.go).
 const CodeExecToolName = "code_execution"
@@ -256,6 +258,15 @@ func CodeExecSavingsFor(sessions []*ReplaySession) *CodeExecReport {
 func (s CodeExecSaving) PricedSavingUSD(inPerMTok, outPerMTok, cacheMult float64) (float64, bool) {
 	if s.Basis != CostMeasured {
 		return 0, false
+	}
+	// Reject prices that cannot produce a meaningful figure. NaN and +/-Inf
+	// propagate silently through the arithmetic and would be reported as a
+	// confident dollar amount; a negative price is not a price. ok=false is the
+	// same answer this function gives for anything it cannot honestly compute.
+	for _, v := range []float64{inPerMTok, outPerMTok, cacheMult} {
+		if math.IsNaN(v) || math.IsInf(v, 0) || v < 0 {
+			return 0, false
+		}
 	}
 	cost := func(outTok, inTok int) float64 {
 		return (float64(outTok)*outPerMTok + float64(inTok)*inPerMTok*cacheMult) / 1e6

--- a/bench/replaycorpus/codeexec.go
+++ b/bench/replaycorpus/codeexec.go
@@ -44,6 +44,21 @@ type CodeExecSaving struct {
 	Baseline int `json:"baseline,omitempty"`
 	Proxy    int `json:"proxy,omitempty"`
 	Saving   int `json:"saving,omitempty"`
+
+	// Split by BILLING DIRECTION, because Saving above is not proportional to
+	// cost. A tool call's ARGUMENTS are tokens the model generated (output,
+	// billed around 5x input) and its RESPONSE is tokens it reads (input, billed
+	// 1x, or 0.1x when the prefix is cached). Code execution trades the cheap
+	// direction for the expensive one: it replaces N argument-writings with ONE
+	// script, whose cost is fixed regardless of N.
+	//
+	// Measured consequence, on real traffic at three sub-calls: +262 tokens
+	// "saved" and a NET LOSS in money. Anything that quotes the token figure as
+	// a saving has to carry this split beside it.
+	BaselineOutput int `json:"baseline_output,omitempty"`
+	BaselineInput  int `json:"baseline_input,omitempty"`
+	ProxyOutput    int `json:"proxy_output,omitempty"`
+	ProxyInput     int `json:"proxy_input,omitempty"`
 }
 
 // amount returns the cost in the unit its basis implies, and whether a figure
@@ -88,16 +103,23 @@ func CodeExecSavingFor(parent *ReplayCall) CodeExecSaving {
 	// The parent's own request is the script source and its response is the
 	// value the model received; both are costs code execution really incurred.
 	type component struct {
-		cost  Cost
-		child bool
+		cost      Cost
+		child     bool
+		generated bool
 	}
-	comps := []component{{parent.RequestCost, false}, {parent.ResponseCost, false}}
+	// generated marks a component the MODEL WROTE — a call's arguments — as
+	// opposed to one it read. The distinction is the billing direction.
+	comps := []component{
+		{parent.RequestCost, false, true},
+		{parent.ResponseCost, false, false},
+	}
 	for _, sub := range parent.SubCalls {
-		comps = append(comps, component{sub.RequestCost, true}, component{sub.ResponseCost, true})
+		comps = append(comps, component{sub.RequestCost, true, true},
+			component{sub.ResponseCost, true, false})
 	}
 
 	basis := CostBasis("")
-	baseline, proxy := 0, 0
+	baselineOut, baselineIn, proxyOut, proxyIn := 0, 0, 0, 0
 	// Any truncation anywhere in the call withholds it — see
 	// ReasonTruncatedSubCallOverstates. Checked before the components are
 	// summed so no partial total is ever built.
@@ -137,17 +159,24 @@ func CodeExecSavingFor(parent *ReplayCall) CodeExecSaving {
 			return CodeExecSaving{ParentID: out.ParentID, SubCalls: out.SubCalls,
 				Basis: CostUnavailable, Reason: ReasonTruncatedSubCallOverstates}
 		}
-		if c.child {
-			baseline += amount
-		} else {
-			proxy += amount
+		switch {
+		case c.child && c.generated:
+			baselineOut += amount
+		case c.child:
+			baselineIn += amount
+		case c.generated:
+			proxyOut += amount
+		default:
+			proxyIn += amount
 		}
 	}
 
 	out.Basis = basis
-	out.Baseline = baseline
-	out.Proxy = proxy
-	out.Saving = baseline - proxy
+	out.BaselineOutput, out.BaselineInput = baselineOut, baselineIn
+	out.ProxyOutput, out.ProxyInput = proxyOut, proxyIn
+	out.Baseline = baselineOut + baselineIn
+	out.Proxy = proxyOut + proxyIn
+	out.Saving = out.Baseline - out.Proxy
 	return out
 }
 
@@ -210,4 +239,26 @@ func CodeExecSavingsFor(sessions []*ReplaySession) *CodeExecReport {
 		}
 	}
 	return rep
+}
+
+// PricedSavingUSD converts the saving to money, which is the only form in which
+// the input/output asymmetry is visible.
+//
+// inPerMTok and outPerMTok are USD per million tokens; cacheMult scales the
+// INPUT side only (0.1 for a cached prefix, 1.0 for uncached). It returns
+// ok=false rather than a number whenever pricing would be dishonest:
+//
+//   - a withheld saving has no figures at all, and 0.0 would read as "code
+//     execution was free" instead of "nothing was measurable";
+//   - an ESTIMATED saving is BYTE lengths, not tokens, so pricing it per-token
+//     would be wrong by roughly the bytes-per-token ratio and would look
+//     entirely plausible.
+func (s CodeExecSaving) PricedSavingUSD(inPerMTok, outPerMTok, cacheMult float64) (float64, bool) {
+	if s.Basis != CostMeasured {
+		return 0, false
+	}
+	cost := func(outTok, inTok int) float64 {
+		return (float64(outTok)*outPerMTok + float64(inTok)*inPerMTok*cacheMult) / 1e6
+	}
+	return cost(s.BaselineOutput, s.BaselineInput) - cost(s.ProxyOutput, s.ProxyInput), true
 }

--- a/bench/replaycorpus/codeexec_test.go
+++ b/bench/replaycorpus/codeexec_test.go
@@ -292,3 +292,61 @@ func TestCodeExecSavingsFor_TruncatedSubCallNeverReachesTheTotal(t *testing.T) {
 		"only the clean call contributes; 250k must not appear in the total")
 	assert.Equal(t, 1, rep.Withheld[ReasonTruncatedSubCallOverstates])
 }
+
+// Tool-call ARGUMENTS are tokens the model generated (output, billed ~5x) and
+// RESPONSES are tokens it reads (input, billed 1x, or 0.1x cached). Summing them
+// into one "tokens saved" figure prices a 5x asymmetry at 1x.
+//
+// This is the case that proves it matters, taken from measured traffic: at three
+// sub-calls the token count says +262 saved while the money says LOSS, because
+// code execution trades cheap input for expensive output — the script is a fixed
+// cost regardless of how many calls it replaces.
+func TestCodeExecSaving_SplitsByBillingDirection(t *testing.T) {
+	parent := codeExecCall(measured(78), measured(11), // script out, result in
+		subCall(measured(12), measured(105)),
+		subCall(measured(12), measured(105)),
+		subCall(measured(12), measured(105)),
+	)
+
+	got := CodeExecSavingFor(parent)
+
+	require.Equal(t, CostMeasured, got.Basis)
+	assert.Equal(t, 36, got.BaselineOutput, "three calls of arguments the model would have written")
+	assert.Equal(t, 315, got.BaselineInput, "three responses it would have read")
+	assert.Equal(t, 78, got.ProxyOutput, "the script it wrote instead")
+	assert.Equal(t, 11, got.ProxyInput)
+
+	assert.Equal(t, got.BaselineOutput+got.BaselineInput, got.Baseline, "the totals must stay consistent")
+	assert.Equal(t, got.ProxyOutput+got.ProxyInput, got.Proxy)
+	assert.Equal(t, 262, got.Saving, "the raw token count is positive...")
+
+	// ...and the money is negative once output is priced at 5x and input is cached.
+	priced, ok := got.PricedSavingUSD(3.0, 15.0, 0.1)
+	require.True(t, ok)
+	assert.Negative(t, priced,
+		"+262 tokens is a LOSS in money: 42 extra output tokens outweigh 304 cached input tokens")
+
+	uncached, _ := got.PricedSavingUSD(3.0, 15.0, 1.0)
+	assert.Positive(t, uncached, "without caching the same call is a small win — caching moves break-even right")
+}
+
+// A withheld saving has no numbers to price, and must not return a confident 0.
+func TestCodeExecSaving_PricedSavingRefusesWithheldFigures(t *testing.T) {
+	parent := codeExecCall(measured(100), measured(50), subCall(measured(10), unavailable()))
+	got := CodeExecSavingFor(parent)
+	require.Equal(t, CostUnavailable, got.Basis)
+
+	_, ok := got.PricedSavingUSD(3.0, 15.0, 0.1)
+	assert.False(t, ok, "no measurement means no price, not a free call")
+}
+
+// An ESTIMATED saving is bytes, not tokens. Pricing bytes per-token would be
+// wrong by roughly the bytes-per-token ratio and would look entirely plausible.
+func TestCodeExecSaving_PricedSavingRefusesByteEstimates(t *testing.T) {
+	parent := codeExecCall(estimated(400), estimated(200), subCall(estimated(100), estimated(5000)))
+	got := CodeExecSavingFor(parent)
+	require.Equal(t, CostEstimated, got.Basis)
+
+	_, ok := got.PricedSavingUSD(3.0, 15.0, 0.1)
+	assert.False(t, ok, "byte lengths cannot be priced as tokens")
+}

--- a/bench/replaycorpus/codeexec_test.go
+++ b/bench/replaycorpus/codeexec_test.go
@@ -1,6 +1,7 @@
 package replaycorpus
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -349,4 +350,63 @@ func TestCodeExecSaving_PricedSavingRefusesByteEstimates(t *testing.T) {
 
 	_, ok := got.PricedSavingUSD(3.0, 15.0, 0.1)
 	assert.False(t, ok, "byte lengths cannot be priced as tokens")
+}
+
+// A stored-script invocation sends a NAME, not source. mcpproxy records the
+// resolved source under "code" too, so the audit trail shows what ran — but
+// billing that source as model-generated output charges ~5,200 tokens per run
+// for a request the model wrote in ~17. Found by cross-model review, and it hits
+// the exact configuration stored scripts exist to make cheap.
+func TestBillableArguments_DropsServerResolvedScriptSource(t *testing.T) {
+	stored := map[string]interface{}{
+		"script": "jira-triage",
+		"input":  map[string]interface{}{"board": "GCLOUD2"},
+		"code":   "const huge = 'twenty kilobytes of resolved source';",
+	}
+	billable, resolved := billableArguments(stored)
+	require.True(t, resolved, "the record carried content the model did not send")
+	assert.NotContains(t, billable, "code", "the model never generated the source")
+	assert.Equal(t, "jira-triage", billable["script"], "it did send the name")
+	assert.Contains(t, billable, "input")
+	assert.Contains(t, stored, "code", "the caller's map must not be mutated")
+
+	// An INLINE call genuinely sent its source and must keep it.
+	inline := map[string]interface{}{"code": "call_tool('a','b',{})", "language": "javascript"}
+	back, resolved2 := billableArguments(inline)
+	assert.False(t, resolved2)
+	assert.Contains(t, back, "code", "an inline call really did generate this")
+
+	// A script name with no resolved source recorded: nothing to strip.
+	nameOnly := map[string]interface{}{"script": "x"}
+	_, resolved3 := billableArguments(nameOnly)
+	assert.False(t, resolved3)
+
+	// An empty script name is an inline call.
+	_, resolved4 := billableArguments(map[string]interface{}{"script": "", "code": "x"})
+	assert.False(t, resolved4)
+}
+
+// NaN, infinity and negative prices propagate silently through the arithmetic
+// and would be reported as a confident dollar figure.
+func TestCodeExecSaving_PricedSavingRejectsNonsensePrices(t *testing.T) {
+	got := CodeExecSavingFor(codeExecCall(measured(78), measured(11),
+		subCall(measured(12), measured(105))))
+	require.Equal(t, CostMeasured, got.Basis)
+
+	_, ok := got.PricedSavingUSD(3.0, 15.0, 0.1)
+	require.True(t, ok, "the sane case must still price")
+
+	for _, bad := range []struct {
+		name              string
+		in, out, cacheMul float64
+	}{
+		{"NaN cache multiplier", 3, 15, math.NaN()},
+		{"infinite output price", 3, math.Inf(1), 0.1},
+		{"NaN input price", math.NaN(), 15, 0.1},
+		{"negative price", -3, 15, 0.1},
+		{"negative multiplier", 3, 15, -0.1},
+	} {
+		_, ok := got.PricedSavingUSD(bad.in, bad.out, bad.cacheMul)
+		assert.False(t, ok, "%s must be refused, not reported", bad.name)
+	}
 }

--- a/bench/replaycorpus/codeexec_test.go
+++ b/bench/replaycorpus/codeexec_test.go
@@ -1,0 +1,294 @@
+package replaycorpus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func measured(tokens int) Cost { return Cost{Basis: CostMeasured, Tokens: tokens, Bytes: tokens * 4} }
+func estimated(bytes int) Cost { return Cost{Basis: CostEstimated, Bytes: bytes} }
+func unavailable() Cost        { return Cost{Basis: CostUnavailable, Reason: ReasonSubCallZeroBytes} }
+
+func codeExecCall(req, resp Cost, subs ...*ReplayCall) *ReplayCall {
+	return &ReplayCall{
+		RequestID: "parent-1", ToolName: CodeExecToolName, Internal: true,
+		RequestCost: req, ResponseCost: resp, SubCalls: subs,
+	}
+}
+
+func subCall(req, resp Cost) *ReplayCall {
+	return &ReplayCall{RequestID: "sub", ParentID: "parent-1", RequestCost: req, ResponseCost: resp}
+}
+
+// The headline case: three sandbox sub-calls whose responses never reached the
+// model, against the script sent and the one result returned.
+func TestCodeExecSaving_MeasuresTheResponseSideDifference(t *testing.T) {
+	parent := codeExecCall(measured(120), measured(80),
+		subCall(measured(30), measured(900)),
+		subCall(measured(25), measured(1500)),
+		subCall(measured(40), measured(600)),
+	)
+
+	got := CodeExecSavingFor(parent)
+
+	require.Equal(t, CostMeasured, got.Basis)
+	assert.Equal(t, 3, got.SubCalls)
+	assert.Equal(t, 30+900+25+1500+40+600, got.Baseline, "what the agent would have paid itself")
+	assert.Equal(t, 120+80, got.Proxy, "the script it sent plus the result it got")
+	assert.Equal(t, 3095-200, got.Saving)
+}
+
+// A script that dispatches nothing costs tokens and returns none. That is a
+// real loss and must be reported as one rather than filtered out or floored.
+func TestCodeExecSaving_NoSubCallsIsARealNegative(t *testing.T) {
+	got := CodeExecSavingFor(codeExecCall(measured(500), measured(20)))
+
+	require.Equal(t, CostMeasured, got.Basis)
+	assert.Equal(t, 0, got.SubCalls)
+	assert.Equal(t, 0, got.Baseline)
+	assert.Equal(t, -520, got.Saving, "a script that dispatched nothing lost 520 tokens")
+}
+
+// Measured figures are tokens, estimated ones are bytes. Summing them would
+// produce a confident number in no unit at all.
+func TestCodeExecSaving_NeverSumsAcrossBases(t *testing.T) {
+	parent := codeExecCall(measured(100), measured(50),
+		subCall(measured(10), estimated(4000)),
+	)
+
+	got := CodeExecSavingFor(parent)
+
+	require.Equal(t, CostUnavailable, got.Basis)
+	assert.Equal(t, ReasonMixedCostBasis, got.Reason)
+	assert.Zero(t, got.Saving, "an unavailable saving carries no number")
+	assert.Zero(t, got.Baseline)
+}
+
+// A sub-call with no honest figure understates the baseline, which flatters
+// code execution. Withhold instead.
+func TestCodeExecSaving_UnavailableComponentWithholdsTheWhole(t *testing.T) {
+	parent := codeExecCall(measured(100), measured(50),
+		subCall(measured(10), measured(900)),
+		subCall(measured(10), unavailable()),
+	)
+
+	got := CodeExecSavingFor(parent)
+
+	require.Equal(t, CostUnavailable, got.Basis)
+	assert.Equal(t, ReasonSubCallZeroBytes, got.Reason, "the reason must survive to the caller")
+	assert.Zero(t, got.Saving)
+}
+
+// An all-estimated call is computable, in BYTES, and says so.
+func TestCodeExecSaving_EstimatedBasisIsBytes(t *testing.T) {
+	parent := codeExecCall(estimated(400), estimated(200),
+		subCall(estimated(100), estimated(5000)),
+	)
+
+	got := CodeExecSavingFor(parent)
+
+	require.Equal(t, CostEstimated, got.Basis)
+	assert.Equal(t, 5100-600, got.Saving)
+}
+
+// Superseded by TestCodeExecSaving_TruncatedSubCallWithholdsRatherThanInflates.
+// This previously asserted that truncation merely set an annotation flag while
+// the saving was still computed and published — which is exactly the defect
+// cross-model review caught, so the assertion is inverted rather than dropped.
+func TestCodeExecSaving_TruncationWithholds(t *testing.T) {
+	sub := subCall(measured(10), Cost{Basis: CostMeasured, Tokens: 900, Truncated: true})
+	got := CodeExecSavingFor(codeExecCall(measured(100), measured(50), sub))
+	require.Equal(t, CostUnavailable, got.Basis, "a truncated sub-call understates nothing — it OVERstates the baseline")
+	assert.Equal(t, ReasonTruncatedSubCallOverstates, got.Reason)
+
+	flagged := subCall(measured(10), measured(900))
+	flagged.Flags.Truncated = true
+	got2 := CodeExecSavingFor(codeExecCall(measured(100), measured(50), flagged))
+	assert.Equal(t, CostUnavailable, got2.Basis, "the call-level flag must withhold too")
+
+	parentCut := codeExecCall(measured(100), measured(50), subCall(measured(10), measured(900)))
+	parentCut.Flags.Truncated = true
+	assert.Equal(t, CostUnavailable, CodeExecSavingFor(parentCut).Basis,
+		"a truncated PARENT understates the proxy cost, which also inflates the saving")
+}
+
+func TestCodeExecSaving_RejectsNonCodeExecParents(t *testing.T) {
+	other := &ReplayCall{RequestID: "x", ToolName: "retrieve_tools", RequestCost: measured(1), ResponseCost: measured(1)}
+	got := CodeExecSavingFor(other)
+	require.Equal(t, CostUnavailable, got.Basis)
+	assert.Equal(t, ReasonNotACall, got.Reason)
+
+	assert.Equal(t, CostUnavailable, CodeExecSavingFor(nil).Basis)
+}
+
+// The aggregate must bucket by basis rather than producing one blended total,
+// and must never silently drop the calls it could not measure.
+func TestCodeExecSavingsFor_BucketsByBasisAndCountsWithheld(t *testing.T) {
+	sessions := []*ReplaySession{{
+		WorkSessionID: "w1",
+		Calls: []*ReplayCall{
+			codeExecCall(measured(100), measured(50), subCall(measured(10), measured(900))),
+			codeExecCall(estimated(400), estimated(200), subCall(estimated(100), estimated(5000))),
+			codeExecCall(measured(100), measured(50), subCall(measured(10), unavailable())),
+			{RequestID: "rt", ToolName: "retrieve_tools", RequestCost: measured(5), ResponseCost: measured(5)},
+		},
+	}}
+
+	rep := CodeExecSavingsFor(sessions)
+
+	require.Len(t, rep.Buckets, 2, "measured and estimated must stay separate")
+	assert.Equal(t, 760, rep.Buckets[CostMeasured].Saving)
+	assert.Equal(t, 4500, rep.Buckets[CostEstimated].Saving)
+	assert.Equal(t, 1, rep.Buckets[CostMeasured].Calls, "the unavailable call must not land in a bucket")
+	assert.Equal(t, 1, rep.Withheld[ReasonSubCallZeroBytes])
+	assert.Len(t, rep.Savings, 3, "retrieve_tools is not a code_execution call")
+}
+
+// Sub-calls hang off their parent, never in Calls. If the aggregate ever walked
+// AllCalls it would treat each sub-call as a parent of its own.
+func TestCodeExecSavingsFor_DoesNotRevisitSubCalls(t *testing.T) {
+	sub := subCall(measured(10), measured(900))
+	sub.ToolName = CodeExecToolName // adversarial: a sub-call that looks like a parent
+	sessions := []*ReplaySession{{
+		WorkSessionID: "w1",
+		Calls:         []*ReplayCall{codeExecCall(measured(100), measured(50), sub)},
+		CallCount:     1, SubCallCount: 1,
+	}}
+
+	rep := CodeExecSavingsFor(sessions)
+
+	assert.Len(t, rep.Savings, 1, "exactly one code_execution call was made")
+	assert.Equal(t, 760, rep.Buckets[CostMeasured].Saving)
+}
+
+// REGRESSION GUARD for the emission change that accompanies this file.
+//
+// Internal built-in records used to carry NO byte lengths at all, so a
+// truncated retrieve_tools was withheld simply because there was nothing to
+// count. Now that the internal emission populates request_bytes/response_bytes,
+// that accidental protection is gone and only the explicit truncation branch
+// remains. It must still fire: for a built-in the log stores the FULL response
+// while the agent consumed the CUT text, so the pre-truncation byte length
+// describes something LARGER than what was paid for, and counting it would
+// OVERSTATE mcpproxy's own cost.
+func TestResponseCost_TruncatedInternalStillWithheldNowThatBytesExist(t *testing.T) {
+	rep := &ExclusionReport{}
+	rec := &decodedRecord{
+		toolName: "retrieve_tools", internal: true, truncated: true,
+		responseBytes: 48_000, // present now, and deliberately large
+		response:      "full pre-truncation text the agent never saw",
+	}
+
+	got := responseCost(rec, false, &Options{Bodies: BodiesOff}, func(string) int { return 1 }, rep)
+
+	require.Equal(t, CostUnavailable, got.Basis,
+		"a truncated built-in must stay withheld even though it now has a byte length")
+	assert.Equal(t, ReasonTruncatedRetrieveOverstates, got.Reason)
+	assert.Zero(t, got.Bytes, "an unavailable cost carries no number")
+	assert.Equal(t, 1, rep.Withheld[ReasonTruncatedRetrieveOverstates])
+}
+
+// The other half: an UNtruncated built-in that now has byte lengths becomes
+// accountable, where before it was withheld as ReasonInternalNoByteCounts. That
+// is the intended gain, so pin it — otherwise a future revert is invisible.
+func TestResponseCost_UntruncatedInternalIsNowAccountable(t *testing.T) {
+	rep := &ExclusionReport{}
+	rec := &decodedRecord{toolName: "retrieve_tools", internal: true, responseBytes: 4096}
+
+	got := responseCost(rec, false, &Options{Bodies: BodiesOff}, func(string) int { return 1 }, rep)
+
+	require.Equal(t, CostEstimated, got.Basis)
+	assert.Equal(t, 4096, got.Bytes)
+	assert.Empty(t, rep.Withheld[ReasonInternalNoByteCounts],
+		"the byte-gap that motivated the emission change should no longer fire")
+}
+
+// A PARAMETERLESS tool call records no arguments at all. With bodies on that is
+// not a recording gap — the record exists and its byte length is the serialized
+// empty object — so the cost is KNOWN and must be measured like its siblings.
+//
+// Before this, such a call fell through to the byte-length estimate while every
+// tool that DID take arguments was measured, so the two bases collided and any
+// aggregate containing a parameterless tool was withheld entirely. Found on real
+// traffic: filesystem:list_allowed_directories and memory:read_graph poisoned a
+// whole code_execution whose third sub-call was measured normally.
+func TestRequestCost_ParameterlessCallIsMeasuredNotEstimated(t *testing.T) {
+	opts := &Options{Bodies: BodiesOnUnmasked}
+	count := func(s string) int { return len(s) }
+
+	parameterless := &decodedRecord{toolName: "read_graph", requestBytes: 2} // "{}"
+	got := requestCost(parameterless, true, opts, count)
+	require.Equal(t, CostMeasured, got.Basis,
+		"an empty argument set is known exactly, not estimated")
+	assert.Equal(t, 2, got.Bytes)
+
+	withArgs := requestCost(&decodedRecord{toolName: "list_directory",
+		arguments: `{"path":"/tmp"}`, requestBytes: 15}, true, opts, count)
+	require.Equal(t, CostMeasured, withArgs.Basis)
+
+	assert.Equal(t, got.Basis, withArgs.Basis,
+		"siblings in one script must share a basis or the aggregate is withheld")
+}
+
+// The rule must NOT swallow a genuine recording gap. Empty arguments beside a
+// LARGE byte length means content really is missing, and claiming a measured
+// figure there would invent one.
+func TestRequestCost_EmptyArgsWithLargePayloadStaysEstimated(t *testing.T) {
+	opts := &Options{Bodies: BodiesOnUnmasked}
+	count := func(s string) int { return len(s) }
+
+	got := requestCost(&decodedRecord{toolName: "x", requestBytes: 4096}, true, opts, count)
+	assert.Equal(t, CostEstimated, got.Basis,
+		"4096 bytes of arguments that are not present is a gap, not a parameterless call")
+
+	none := requestCost(&decodedRecord{toolName: "x"}, true, opts, count)
+	assert.Equal(t, CostUnavailable, none.Basis, "no bytes and no body is still unknown")
+}
+
+// A truncated SUB-CALL must withhold the whole saving, not merely annotate it.
+//
+// Found by cross-model review. The sandbox stores at most 8KB of a sub-call's
+// response (subCallActivityResponseLimit) while response_bytes records the FULL
+// pre-truncation size. Baseline means "what an agent would have paid making this
+// call itself", and an agent calling through call_tool_* receives a response cut
+// to ToolResponseLimit — so charging the baseline the full size overstates it,
+// and overstating the baseline INFLATES the claimed saving. That is the one
+// direction of error a savings figure must never make.
+//
+// With bodies on this was already caught indirectly: the truncated component
+// falls to an estimate while its siblings are measured, and the never-sum guard
+// withholds. With bodies OFF everything is estimated, the bases agree, and the
+// inflated number went straight into the total.
+func TestCodeExecSaving_TruncatedSubCallWithholdsRatherThanInflates(t *testing.T) {
+	huge := subCall(estimated(40), Cost{Basis: CostEstimated, Bytes: 250_000, Truncated: true})
+	parent := codeExecCall(estimated(400), estimated(200),
+		subCall(estimated(50), estimated(900)),
+		huge,
+	)
+
+	got := CodeExecSavingFor(parent)
+
+	require.Equal(t, CostUnavailable, got.Basis,
+		"the full pre-truncation size would inflate the baseline and so the saving")
+	assert.Equal(t, ReasonTruncatedSubCallOverstates, got.Reason)
+	assert.Zero(t, got.Saving)
+	assert.Zero(t, got.Baseline)
+}
+
+// The aggregate must not carry an inflated total either — the withheld call is
+// counted under its reason and contributes nothing to any bucket.
+func TestCodeExecSavingsFor_TruncatedSubCallNeverReachesTheTotal(t *testing.T) {
+	clean := codeExecCall(estimated(400), estimated(200), subCall(estimated(50), estimated(900)))
+	dirty := codeExecCall(estimated(400), estimated(200),
+		subCall(estimated(40), Cost{Basis: CostEstimated, Bytes: 250_000, Truncated: true}))
+
+	rep := CodeExecSavingsFor([]*ReplaySession{{WorkSessionID: "w", Calls: []*ReplayCall{clean, dirty}}})
+
+	require.NotNil(t, rep.Buckets[CostEstimated])
+	assert.Equal(t, 1, rep.Buckets[CostEstimated].Calls)
+	assert.Equal(t, 950-600, rep.Buckets[CostEstimated].Saving,
+		"only the clean call contributes; 250k must not appear in the total")
+	assert.Equal(t, 1, rep.Withheld[ReasonTruncatedSubCallOverstates])
+}

--- a/bench/replaycorpus/flags.go
+++ b/bench/replaycorpus/flags.go
@@ -95,6 +95,28 @@ const (
 	// counting; that needs a limit the export does not carry, so exclusion is
 	// what is implementable here.
 	ReasonTruncatedRetrieveOverstates ExclusionReason = "truncated_retrieve_tools_overstates"
+
+	// ReasonMixedCostBasis marks a figure withheld because its components did
+	// not share an accounting basis. A measured cost is a TOKEN count and an
+	// estimated one is a BYTE length; adding them yields a number in no unit at
+	// all, and it would look entirely plausible. This is the never-sum rule
+	// applied at the point of addition rather than at publication.
+	ReasonMixedCostBasis ExclusionReason = "mixed_cost_basis"
+
+	// ReasonTruncatedSubCallOverstates marks a code-execution saving withheld
+	// because one of the sandbox's sub-calls was truncated. response_bytes is
+	// the FULL pre-truncation size, but the baseline it feeds means "what an
+	// agent would have paid making this call itself" — and that agent receives
+	// a response cut to ToolResponseLimit. Charging the baseline the full size
+	// overstates it, and an overstated baseline INFLATES the saving, which is
+	// the one direction of error a savings figure must never make.
+	//
+	// Withholding, rather than substituting the cut length, follows the policy
+	// ReasonTruncatedRetrieveOverstates already sets. The alternative worth
+	// considering later is to count the truncated component at its STORED
+	// length and publish the result as a lower bound — more informative, and it
+	// needs a saving type that can express "at least".
+	ReasonTruncatedSubCallOverstates ExclusionReason = "truncated_sub_call_overstates_saving"
 )
 
 // ExclusionRow is one line of an exclusion report: a reason and how many times
@@ -378,11 +400,35 @@ func requestCost(rec *decodedRecord, isSubCall bool, opts *Options, count func(s
 	if bodiesOn && rec.arguments != "" {
 		return Cost{Basis: CostMeasured, Tokens: count(rec.arguments), Bytes: len(rec.arguments)}
 	}
+	// A PARAMETERLESS call records no arguments at all, and with bodies on that
+	// is not a recording gap: the record is present and its byte length is the
+	// serialized empty object, so the cost is known exactly rather than
+	// estimated. Falling through to the byte estimate gave such a call a
+	// different BASIS from its siblings, and since measured figures are tokens
+	// while estimated ones are bytes, any aggregate holding both is withheld —
+	// so a single parameterless tool poisoned a whole script. Most fleets have
+	// several (list_allowed_directories, read_graph, get_current_time).
+	//
+	// Bounded by emptyArgsMaxBytes so it cannot swallow a real gap: empty
+	// arguments beside a LARGE byte length means content genuinely is missing,
+	// and that must stay an estimate.
+	if bodiesOn && rec.arguments == "" && rec.requestBytes > 0 && rec.requestBytes <= emptyArgsMaxBytes {
+		return Cost{Basis: CostMeasured, Tokens: count(emptyArgsJSON), Bytes: rec.requestBytes}
+	}
 	if rec.requestBytes > 0 {
 		return Cost{Basis: CostEstimated, Bytes: rec.requestBytes}
 	}
 	return Cost{Basis: CostUnavailable, Reason: byteGapReason(rec, isSubCall)}
 }
+
+// emptyArgsJSON is what an argument-less call serializes to on the wire, and
+// emptyArgsMaxBytes is the largest request that can still BE one. "{}" is two
+// bytes and "null" is four; anything larger had content that is not in the
+// record, which is a gap rather than a parameterless call.
+const (
+	emptyArgsJSON     = "{}"
+	emptyArgsMaxBytes = 4
+)
 
 // byteGapReason names WHICH known gap left this record without a byte length.
 // The two systematic gaps get their own names so an operator reading the

--- a/bench/replaycorpus/load.go
+++ b/bench/replaycorpus/load.go
@@ -244,7 +244,12 @@ type decodedRecord struct {
 	// arguments and response are the only fields holding recorded content.
 	// Nothing copies them onward.
 	arguments string
-	response  string
+
+	// serverResolvedRequest marks a request whose RECORDED arguments contain
+	// content the server substituted rather than the model generating it — a
+	// stored code-execution script (spec 097). See billableArguments.
+	serverResolvedRequest bool
+	response              string
 }
 
 // admit decides whether a record is a call this loader can account for, and
@@ -283,9 +288,11 @@ func admit(rec *contracts.ActivityRecord, report *ExclusionReport) (*decodedReco
 		// Marshalled here, not carried as a map: a map would keep the recorded
 		// values alive on a struct, and Go's map marshalling sorts keys, so the
 		// counted text is also deterministic across runs (SC-002).
-		if encoded, err := json.Marshal(rec.Arguments); err == nil {
+		billable, resolved := billableArguments(rec.Arguments)
+		if encoded, err := json.Marshal(billable); err == nil {
 			decoded.arguments = string(encoded)
 		}
+		decoded.serverResolvedRequest = resolved
 	}
 	return decoded, true
 }
@@ -314,4 +321,36 @@ func newCall(rec *decodedRecord, opts *Options, counter tokenCounter, report *Ex
 	call.RequestCost = requestCost(rec, isSubCall, opts, counter.Count)
 	call.ResponseCost = responseCost(rec, isSubCall, opts, counter.Count, report)
 	return call
+}
+
+// billableArguments returns the arguments as the MODEL actually sent them, and
+// whether the record contained server-resolved content that had to be removed.
+//
+// A stored-script code_execution invocation is the case that matters. The model
+// sends `{"script": "<name>", "input": {...}}` — a few dozen tokens — but
+// mcpproxy records the RESOLVED source under "code" as well, so the audit trail
+// shows what actually ran. Counting that source as request cost charges the
+// model for output it never generated: a 20KB stored script bills as ~5,200
+// output tokens per invocation, at roughly 5x the input rate, on every run.
+// That is the exact configuration stored scripts exist to make cheap, so
+// getting it wrong understates code execution by the whole size of the script.
+//
+// Only the "code" key is dropped, and only when a non-empty "script" name is
+// present — an INLINE call genuinely did send its source and must keep it.
+func billableArguments(args map[string]interface{}) (map[string]interface{}, bool) {
+	name, ok := args["script"].(string)
+	if !ok || name == "" {
+		return args, false
+	}
+	if _, hasCode := args["code"]; !hasCode {
+		return args, false
+	}
+	billable := make(map[string]interface{}, len(args))
+	for k, v := range args {
+		if k == "code" {
+			continue
+		}
+		billable[k] = v
+	}
+	return billable, true
 }

--- a/internal/httpapi/diagnostics_per_server.go
+++ b/internal/httpapi/diagnostics_per_server.go
@@ -157,6 +157,19 @@ func viewString(view map[string]interface{}, key, fallback string) string {
 // than persisting it over the credential, which is the same bind-or-refuse
 // answer the server write path gives.
 func redactedRegistrySummary(entry *config.RegistryEntry) contracts.RegistrySummary {
+	// Nil-tolerant on purpose. This renders the SUCCESS payload for three
+	// registry handlers, each of which reaches it whenever the controller
+	// returned no error — and a controller may legitimately report success
+	// without an entry. Dereferencing there panicked inside the handler, which
+	// chi's recoverer turned into a bare 500 with an EMPTY body: the caller saw
+	// an unexplained server error on a request that had in fact succeeded, and
+	// the real cause only appeared as a stack in the log.
+	//
+	// The guard lives here rather than at the three call sites so a fourth
+	// caller cannot reintroduce it.
+	if entry == nil {
+		return contracts.RegistrySummary{}
+	}
 	return contracts.RegistrySummary{
 		ID:         entry.ID,
 		Name:       entry.Name,

--- a/internal/httpapi/registry_summary_nil_test.go
+++ b/internal/httpapi/registry_summary_nil_test.go
@@ -1,0 +1,64 @@
+package httpapi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// redactedRegistrySummary dereferences its argument, and all three registry
+// handlers called it on the SUCCESS path without checking the entry for nil.
+// A controller that reports success with no entry therefore panicked inside the
+// handler; chi's recoverer turned that into a bare 500 with an empty body, so
+// the failure looked like an unrelated server error rather than a nil deref.
+//
+// This is not hypothetical plumbing: MockServerController already returns
+// (nil, nil, nil) from these methods, so every caller exercising these routes
+// through it hit the panic — intermittently visible as a Windows CI failure
+// where the recovered panic escaped the test process.
+func TestRegistryHandlers_NilEntryOnSuccessDoesNotPanic(t *testing.T) {
+	const adminKey = "admin-secret"
+	body := `{"name":"n","url":"https://example.com","servers_url":"https://example.com/s"}`
+
+	for _, rt := range []struct {
+		name, method, path, body string
+	}{
+		{"add", http.MethodPost, "/api/v1/registries", body},
+		{"edit", http.MethodPut, "/api/v1/registries/reg1", body},
+		{"remove", http.MethodDelete, "/api/v1/registries/reg1", ""},
+	} {
+		t.Run(rt.name, func(t *testing.T) {
+			ctrl := &adminConfigController{ServerController: &MockServerController{}, apiKey: adminKey}
+			srv := NewServer(ctrl, zap.NewNop().Sugar(), nil)
+
+			req := httptest.NewRequest(rt.method, rt.path, strings.NewReader(rt.body))
+			req.Header.Set("X-API-Key", adminKey)
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			require.NotPanics(t, func() { srv.ServeHTTP(w, req) },
+				"a nil entry on the success path must not deref")
+
+			// A recovered panic renders as a 500 with an EMPTY body. Whatever
+			// this route decides to answer, it has to actually answer.
+			assert.NotEmpty(t, w.Body.String(),
+				"an empty 500 body is the signature of a recovered panic")
+		})
+	}
+}
+
+// The renderer itself must tolerate nil rather than relying on every caller to
+// remember — it is called from three places and dereferences seven fields.
+func TestRedactedRegistrySummary_NilEntryIsZeroValue(t *testing.T) {
+	require.NotPanics(t, func() {
+		got := redactedRegistrySummary(nil)
+		assert.Empty(t, got.ID, "a nil entry has no identity to report")
+		assert.Empty(t, got.URL)
+		assert.False(t, got.Trusted, "nothing unknown may be reported as trusted")
+	})
+}

--- a/internal/runtime/activity_service.go
+++ b/internal/runtime/activity_service.go
@@ -858,6 +858,11 @@ func (s *ActivityService) handleInternalToolCall(evt Event) {
 	// tokenizing text the agent never paid for.
 	responseTruncated := getBoolPayload(evt.Payload, "response_truncated")
 
+	// Spec 103: pre-truncation sizes, emitted for built-ins as well as upstream
+	// dispatches. 0 stays UNKNOWN rather than free.
+	internalRequestBytes := int(getInt64Payload(evt.Payload, "request_bytes"))
+	internalResponseBytes := int(getInt64Payload(evt.Payload, "response_bytes"))
+
 	metadata := map[string]interface{}{
 		"internal_tool_name": internalToolName,
 	}
@@ -898,6 +903,8 @@ func (s *ActivityService) handleInternalToolCall(evt Event) {
 		WorkSessionID:     s.resolveWorkSession(sessionID),
 		RequestID:         requestID,
 		ResponseTruncated: responseTruncated,
+		RequestBytes:      internalRequestBytes,
+		ResponseBytes:     internalResponseBytes,
 	}
 
 	// Extract user identity from auth metadata injected into arguments (server edition)

--- a/internal/runtime/event_bus.go
+++ b/internal/runtime/event_bus.go
@@ -2,6 +2,8 @@ package runtime
 
 import (
 	"context"
+	"encoding/json"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -635,6 +637,23 @@ func (r *Runtime) EmitActivityInternalToolCallTruncated(internalToolName, target
 	// the same wire state here, because a consumer reading "no key" as "not
 	// truncated" is exactly the silent understatement this flag prevents.
 	payload["response_truncated"] = responseTruncated
+	// Spec 103: pre-truncation byte lengths, the same measure the upstream
+	// tool-call path carries. Every built-in call was unaccountable without
+	// these — 0 means UNKNOWN in the activity log, not free, so a cost
+	// recomputation had to withhold every internal row (bench records the gap
+	// as ReasonInternalNoByteCounts).
+	//
+	// `response` here is the FULL pre-truncation value (see the doc on
+	// MCPProxyServer.emitActivityInternalToolCallTruncated), which is exactly
+	// what response_bytes is defined to mean. When responseTruncated is set the
+	// agent consumed LESS than this, and the flag travelling beside it is what
+	// lets a consumer exclude the row rather than overstate mcpproxy's cost.
+	if n := jsonByteLen(arguments); n > 0 {
+		payload["request_bytes"] = n
+	}
+	if n := jsonByteLen(response); n > 0 {
+		payload["response_bytes"] = n
+	}
 	r.publishEvent(newEvent(EventTypeActivityInternalToolCall, payload))
 }
 
@@ -794,4 +813,23 @@ func (r *Runtime) EmitSecurityScannerChanged(scannerID, status, errMsg string) {
 		payload["error"] = errMsg
 	}
 	r.publishEvent(newEvent(EventTypeSecurityScannerChanged, payload))
+}
+
+// jsonByteLen returns the JSON-serialized byte length of v, or 0 when there is
+// nothing to measure or it cannot be marshaled. A typed-nil pointer inside a
+// non-nil interface encodes as "null"; that is 4 bytes of nothing, so it is
+// reported as 0 rather than as a measured response.
+func jsonByteLen(v interface{}) int {
+	if v == nil {
+		return 0
+	}
+	if rv := reflect.ValueOf(v); (rv.Kind() == reflect.Ptr || rv.Kind() == reflect.Map ||
+		rv.Kind() == reflect.Slice || rv.Kind() == reflect.Interface) && rv.IsNil() {
+		return 0
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return 0
+	}
+	return len(b)
 }

--- a/internal/runtime/usage_aggregate.go
+++ b/internal/runtime/usage_aggregate.go
@@ -337,7 +337,7 @@ func (a *UsageAggregate) countInTimeBucket(rec *storage.ActivityRecord, isError 
 	if isError {
 		b.Errors++
 	}
-	if rec.ResponseBytes > 0 {
+	if rec.ResponseBytes > 0 && !truncatedBuiltinOverstatesDelivery(rec) {
 		b.RespBytesSum += int64(rec.ResponseBytes)
 	}
 	a.evictOldBuckets()
@@ -470,4 +470,24 @@ func (s *UsageStore) Snapshot() *UsageAggregate {
 	snap := s.snap.Load()
 	s.mu.Unlock()
 	return snap
+}
+
+// truncatedBuiltinOverstatesDelivery reports whether a record's ResponseBytes
+// describes MORE than the agent actually consumed, and so must not be added to
+// delivered traffic.
+//
+// The direction differs by record type, and that is the whole point:
+//
+//   - an upstream tool_call is truncated on the way into the LOG while the agent
+//     received the whole response, so the pre-truncation length is honest;
+//   - an internal built-in — retrieve_tools above all — is the reverse: the log
+//     keeps the FULL response and the agent consumed the CUT text, so the
+//     pre-truncation length describes something larger than was delivered.
+//
+// Counting the second case inflates the usage timeline in the flattering
+// direction, which is the one error a cost surface must not make. It became
+// reachable only when internal calls began carrying byte counts at all (spec
+// 103); before that they contributed zero and the question could not arise.
+func truncatedBuiltinOverstatesDelivery(rec *storage.ActivityRecord) bool {
+	return rec.ResponseTruncated && rec.Type == storage.ActivityTypeInternalToolCall
 }

--- a/internal/runtime/usage_aggregate_test.go
+++ b/internal/runtime/usage_aggregate_test.go
@@ -327,3 +327,58 @@ func BenchmarkUsageStore_Apply(b *testing.B) {
 		store.Apply(toolCall("s", "t", "success", 10, 0, 100, ts))
 	}
 }
+
+// A truncated BUILT-IN response must not contribute its pre-truncation size to
+// delivered traffic.
+//
+// The asymmetry (spec 103): for an ordinary upstream tool_call, truncation cuts
+// the STORED text while the agent consumed the whole thing, so the pre-truncation
+// length is honest. For an internal built-in — retrieve_tools above all — it is
+// the other way round: the log keeps the FULL response while the agent consumed
+// the CUT text, so counting the full length overstates what was delivered.
+//
+// This became reachable only when internal calls started carrying byte counts at
+// all; before that they contributed 0 and the question could not arise. Found by
+// cross-model review of that change.
+func TestUsageAggregate_TruncatedBuiltinDoesNotInflateDeliveredBytes(t *testing.T) {
+	base := time.Date(2026, 9, 1, 10, 0, 0, 0, time.UTC)
+	internal := func(truncated bool, respBytes int) *storage.ActivityRecord {
+		return &storage.ActivityRecord{
+			Type:              storage.ActivityTypeInternalToolCall,
+			ToolName:          "retrieve_tools",
+			Status:            "success",
+			ResponseBytes:     respBytes,
+			ResponseTruncated: truncated,
+			Timestamp:         base,
+		}
+	}
+
+	agg := newUsageAggregate()
+	agg.Apply(internal(false, 4_000))
+	var delivered int64
+	for _, b := range agg.Buckets {
+		delivered += b.RespBytesSum
+	}
+	require.EqualValues(t, 4_000, delivered, "an untruncated built-in is delivered in full")
+
+	agg2 := newUsageAggregate()
+	agg2.Apply(internal(true, 1_000_000)) // stored 1MB, agent consumed the cut text
+	var inflated int64
+	for _, b := range agg2.Buckets {
+		inflated += b.RespBytesSum
+	}
+	assert.Zero(t, inflated,
+		"the stored size describes more than the agent consumed; counting it overstates traffic")
+
+	// An upstream tool_call is the OPPOSITE case and must still count.
+	agg3 := newUsageAggregate()
+	up := toolCall("github", "search", "success", 10, 100, 50_000, base)
+	up.ResponseTruncated = true
+	agg3.Apply(up)
+	var upstream int64
+	for _, b := range agg3.Buckets {
+		upstream += b.RespBytesSum
+	}
+	assert.EqualValues(t, 50_000, upstream,
+		"an upstream response was consumed whole; only the STORED copy was cut")
+}

--- a/internal/server/code_exec_activity_test.go
+++ b/internal/server/code_exec_activity_test.go
@@ -147,3 +147,39 @@ func TestEmitSubCallActivity_SkipsOnlyObservedSheds(t *testing.T) {
 		"server_unavailable has NO canonical record — the sandbox emit is its only witness")
 	require.False(t, detect(errors.New("plain failure")))
 }
+
+// Sandbox sub-calls hardcoded 0/0 byte lengths, and 0 means UNKNOWN in the
+// activity log rather than free — so every sub-call was unaccountable with
+// bodies off, and the one population that shows what code execution saves (the
+// sub-call responses that never reach the model) could not be measured at all.
+func TestSubCallByteSizes_MeasuresBothSides(t *testing.T) {
+	args := map[string]interface{}{"path": "/tmp/x", "limit": 10}
+	result := mcp.NewToolResultText(strings.Repeat("payload ", 32))
+
+	reqBytes, respBytes := subCallByteSizes(args, result)
+
+	require.Greater(t, reqBytes, 0, "arguments were formed and must be measured")
+	require.Greater(t, respBytes, 0, "the sub-call response is the whole point of the measurement")
+	assert.Equal(t, rawByteSize(args), reqBytes, "must agree with the top-level dispatch's accounting")
+	assert.Equal(t, rawByteSize(result), respBytes)
+	assert.Greater(t, respBytes, len("payload ")*32,
+		"a JSON-serialized result is at least its own text")
+}
+
+// A nil result must report 0 response bytes rather than the 4 bytes of "null".
+// The dispatch result is an interface{}, so a typed-nil pointer arrives inside a
+// NON-nil interface and json.Marshal happily encodes it as "null" — which would
+// book 4 bytes of response for a call that never answered.
+func TestSubCallByteSizes_TypedNilResultIsZeroNotNull(t *testing.T) {
+	args := map[string]interface{}{"q": "x"}
+
+	var typedNil *mcp.CallToolResult
+	_, respBytes := subCallByteSizes(args, typedNil)
+	assert.Equal(t, 0, respBytes, "a typed-nil result answered nothing")
+
+	_, untypedNil := subCallByteSizes(args, nil)
+	assert.Equal(t, 0, untypedNil)
+
+	require.Equal(t, 4, rawByteSize(typedNil),
+		"guard the premise: rawByteSize alone would book \"null\" as 4 bytes")
+}

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -200,7 +200,23 @@ type MCPProxyServer struct {
 	// tools/list, describe_tool and dispatch, and it never mutates after
 	// publication. This is the same read-mostly trade Spec 085 accepted for the
 	// signature cache, and it reduces the read path's lock scope to zero.
-	directCatalogPtr        atomic.Pointer[directCatalog]
+	directCatalogPtr atomic.Pointer[directCatalog]
+
+	// Surface fingerprints: the content last actually registered on each tool
+	// surface, so a rebuild that would change nothing can be skipped instead of
+	// notifying every client. See mcp_surface_fingerprint.go.
+	//
+	// The direct pair is guarded by directRefreshMu, which every caller of
+	// refreshDirectModeToolsLocked already holds; the code-exec surface gets its
+	// own mutex because it has no such lock today.
+	directSurfaceToolsFP   string
+	directSurfaceRoutingFP string
+
+	codeExecRefreshMu sync.Mutex
+	codeExecSurfaceFP string
+	// codeExecPublishes counts rebuilds that actually re-registered, so the
+	// guard's effect is observable rather than only visible in the log.
+	codeExecPublishes       atomic.Uint64
 	directCatalogGeneration atomic.Uint64
 
 	// directRefreshMu serializes whole rebuilds so SetTools and the matching

--- a/internal/server/mcp_code_execution.go
+++ b/internal/server/mcp_code_execution.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"reflect"
 	"sync"
 	"time"
 
@@ -811,10 +812,40 @@ func (u *upstreamToolCaller) emitSubCallActivity(serverName, toolName string, ar
 	status, errMsg, responseText, truncated := subCallActivityOutcome(result, callErr)
 
 	requestID := mintCorrelationIDAt(startTime, serverName, toolName)
+	requestBytes, responseBytes := subCallByteSizes(args, result)
 	u.proxy.emitActivityToolCallCompleted(
 		serverName, toolName, u.sessionID, requestID, string(storage.ActivitySourceInternal),
 		status, errMsg, duration.Milliseconds(), args, responseText, truncated,
-		"", nil, "", "", 0, 0, "", nil, u.parentCallID)
+		"", nil, "", "", requestBytes, responseBytes, "", nil, u.parentCallID)
+}
+
+// subCallByteSizes returns the pre-truncation JSON byte lengths of a sandbox
+// sub-call's arguments and result, the same way the top-level dispatch computes
+// them (mcp.go, spec 069 A1).
+//
+// These were hardcoded to 0 until now, and that zero was not harmless: the
+// convention throughout the activity log is that 0 bytes means UNKNOWN, not
+// free. Every code-execution sub-call therefore had an unaccountable cost with
+// bodies off, which is the gap bench records as ReasonSubCallZeroBytes — and it
+// is exactly the population needed to measure what code execution actually
+// saves, since the sub-call responses are the ones that never reach the model's
+// context. Without these lengths that saving cannot be computed at all with
+// bodies off.
+//
+// A nil result yields 0 response bytes. That is a TRUE zero rather than an
+// unknown: the caller only reaches this with a nil result when the upstream
+// never answered, and a call that produced no response contributed no response
+// tokens.
+// result is the untyped dispatch result, so a typed-nil pointer can arrive
+// inside a non-nil interface; that marshals to "null" rather than nothing, and
+// reflect is what tells the two apart.
+func subCallByteSizes(args map[string]interface{}, result interface{}) (requestBytes, responseBytes int) {
+	if result != nil {
+		if rv := reflect.ValueOf(result); rv.Kind() == reflect.Ptr && rv.IsNil() {
+			result = nil
+		}
+	}
+	return rawByteSize(args), rawByteSize(result)
 }
 
 // emitSubCallRefused records a sandbox sub-call that the policy gate refused
@@ -831,7 +862,10 @@ func (u *upstreamToolCaller) emitSubCallRefused(serverName, toolName string, arg
 	u.proxy.emitActivityToolCallCompleted(
 		serverName, toolName, u.sessionID, requestID, string(storage.ActivitySourceInternal),
 		storage.ActivityStatusBlocked, refusal.Error(), duration.Milliseconds(), args, "", false,
-		"", nil, "", "", 0, 0, "", nil, u.parentCallID)
+		// The policy gate refused this before dispatch, so there IS no response
+		// and 0 response bytes is a true zero, not an unmeasured one. The
+		// request was still formed and is measured like any other.
+		"", nil, "", "", rawByteSize(args), 0, "", nil, u.parentCallID)
 }
 
 // shedHasCanonicalRecord reports whether callErr is a limiter shed the

--- a/internal/server/mcp_routing.go
+++ b/internal/server/mcp_routing.go
@@ -1127,11 +1127,30 @@ func (p *MCPProxyServer) refreshDirectModeToolsLocked() {
 	// Both close at the publish. The three accepted residuals (T002/T003) are
 	// the schema- and annotations-only changes, which are invisible in the
 	// listing by construction.
+	// Skip a rebuild that would change nothing. SetTools notifies every client
+	// unconditionally (see mcp_surface_fingerprint.go), and servers.changed fires
+	// on ordinary connection churn, so an unguarded rebuild re-notified everyone
+	// on every reconnect attempt.
+	//
+	// BOTH fingerprints must match. The listing alone is not enough: registry and
+	// catalog are published as a pair because a handler closes over its catalog
+	// entry, and routing can move — a collision resolving to a different upstream,
+	// a changed RequiredPermission — while the listing stays byte-identical.
+	toolsFP := toolSetFingerprint(serverTools)
+	routingFP := cat.routingFingerprint()
+	if directSurfaceUnchanged(p.directSurfaceToolsFP, p.directSurfaceRoutingFP, toolsFP, routingFP) {
+		p.logger.Debug("direct mode tools unchanged; skipping rebuild",
+			zap.Int("tool_count", len(directTools)))
+		return
+	}
+
 	p.directServer.SetTools(serverTools...)
 	if p.directRebuildPause != nil {
 		p.directRebuildPause()
 	}
 	p.publishDirectCatalog(cat)
+	p.directSurfaceToolsFP = toolsFP
+	p.directSurfaceRoutingFP = routingFP
 
 	p.logger.Info("refreshed direct mode tools",
 		zap.Int("tool_count", len(directTools)),
@@ -1149,7 +1168,25 @@ func (p *MCPProxyServer) RefreshCodeExecModeTools() {
 	serverTools := make([]mcpserver.ServerTool, len(codeExecTools))
 	copy(serverTools, codeExecTools)
 
+	// This surface carries BUILT-INS ONLY — buildCodeExecModeTools never
+	// iterates upstreams — yet it was rebuilt on every servers.changed, which
+	// made every reconnect tell every client its tool list had changed. Measured
+	// 9 of 9 spurious on one ordinary 4-server startup.
+	//
+	// Guarded on content rather than by dropping the servers.changed call, so
+	// this stays correct if the surface ever does gain fleet-dependent content.
+	fp := toolSetFingerprint(serverTools)
+	p.codeExecRefreshMu.Lock()
+	defer p.codeExecRefreshMu.Unlock()
+	if p.codeExecSurfaceFP == fp {
+		p.logger.Debug("code execution mode tools unchanged; skipping rebuild",
+			zap.Int("tool_count", len(codeExecTools)))
+		return
+	}
+
 	p.codeExecServer.SetTools(serverTools...)
+	p.codeExecSurfaceFP = fp
+	p.codeExecPublishes.Add(1)
 
 	p.logger.Info("refreshed code execution mode tools",
 		zap.Int("tool_count", len(codeExecTools)))

--- a/internal/server/mcp_surface_fingerprint.go
+++ b/internal/server/mcp_surface_fingerprint.go
@@ -1,0 +1,136 @@
+package server
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	mcpserver "github.com/mark3labs/mcp-go/server"
+)
+
+// Surface fingerprints exist to stop a tool surface re-registering itself when
+// nothing about it changed.
+//
+// mcp-go's SetTools notifies EVERY initialized client unconditionally — it
+// replaces the registry and then sends notifications/tools/list_changed without
+// comparing old and new content, despite its own comment saying "when the list
+// of available tools changes". So any caller that rebuilds speculatively tells
+// every client the tool set moved, whether or not it did.
+//
+// Measured on one ordinary 4-server startup before this guard: the
+// code-execution surface published 9 times with tool_count 7 every time (9 of 9
+// spurious), and the direct surface published 10 times across 4 distinct tool
+// sets (at least 6 spurious). Both are driven by servers.changed, which has 17
+// emitters including server_connected, server_disconnected and
+// server_state_changed — so a reconnecting upstream re-notified every client on
+// every attempt, and the 50ms coalescer does not collapse anything on that
+// timescale.
+//
+// The cost is a client round-trip per notification, not a lost provider cache:
+// mcp-go sorts tools/list, so a re-fetch of an unchanged set returns
+// byte-identical content and a cached prefix still hits. The direct surface is
+// the one where content genuinely moves, and there the rebuild must still
+// happen — guarding must not become muting.
+
+// toolSetFingerprint hashes the tool DEFINITIONS a surface would advertise.
+//
+// It covers exactly what a client can observe in tools/list — name, description,
+// schemas, annotations — because that is also precisely what invalidates a
+// provider's prompt cache. Sorted by name, since tools/list is sorted and
+// registration order is therefore not observable.
+func toolSetFingerprint(tools []mcpserver.ServerTool) string {
+	encoded := make([]string, 0, len(tools))
+	for i := range tools {
+		blob, err := json.Marshal(tools[i].Tool)
+		if err != nil {
+			// A tool that will not marshal cannot be compared. Return a value
+			// that never matches, so the caller rebuilds rather than skipping
+			// on the strength of a comparison that did not happen.
+			return fmt.Sprintf("unfingerprintable-%d-%v", i, err)
+		}
+		encoded = append(encoded, string(blob))
+	}
+	sort.Strings(encoded)
+
+	sum := sha256.New()
+	for _, e := range encoded {
+		// Length-prefixed so two adjacent definitions cannot be re-split into a
+		// different pair with the same concatenation.
+		fmt.Fprintf(sum, "%d:%s", len(e), e)
+	}
+	return hex.EncodeToString(sum.Sum(nil))
+}
+
+// routingFingerprint hashes the catalog state that DISPATCH depends on, which is
+// not the same as what the listing shows.
+//
+// The direct surface publishes registry and catalog as a pair — a handler closes
+// over its catalog entry — so a rebuild may only be skipped when routing is
+// unchanged as well. Routing can move while the listing stays byte-identical: a
+// display-name collision resolves to one upstream or the other without changing
+// what is listed, and RequiredPermission gates scoped tokens without appearing
+// in the tool definition at all.
+//
+// RenderedDescription is deliberately EXCLUDED. It is captured at render time
+// and the signature cache mutates independently of rebuilds, so including it
+// would report a cache warm or evict as a catalog change — the distinction D13
+// rule 5 exists to preserve. What the client sees is already covered by
+// toolSetFingerprint, which the caller pairs with this.
+func (c *directCatalog) routingFingerprint() string {
+	if c == nil {
+		return "nil-catalog"
+	}
+	sum := sha256.New()
+	fmt.Fprintf(sum, "mode:%s\n", c.mode)
+
+	names := make([]string, 0, len(c.byDisplayName))
+	for name := range c.byDisplayName {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		e := c.byDisplayName[name]
+		if e == nil {
+			fmt.Fprintf(sum, "entry:%s:nil\n", name)
+			continue
+		}
+		fmt.Fprintf(sum, "entry:%s\x00%s\x00%s\x00%s\x00%s\n",
+			e.DisplayName, e.ServerName, e.ToolName, e.Hash, e.RequiredPermission)
+	}
+
+	// Withheld collisions decide which names are absent AND why, so a change
+	// there is a routing change even when the surviving listing is identical.
+	withheld := make([]string, 0, len(c.withheld))
+	for _, w := range c.withheld {
+		origins := make([]string, 0, len(w.Origins))
+		for _, o := range w.Origins {
+			origins = append(origins, fmt.Sprintf("%v", o))
+		}
+		sort.Strings(origins)
+		withheld = append(withheld, fmt.Sprintf("%s=%v", w.DisplayName, origins))
+	}
+	sort.Strings(withheld)
+	for _, w := range withheld {
+		fmt.Fprintf(sum, "withheld:%s\n", w)
+	}
+
+	return hex.EncodeToString(sum.Sum(nil))
+}
+
+// directSurfaceUnchanged reports whether a rebuild would be a no-op.
+//
+// It is a named predicate rather than an inline `&&` because BOTH halves are
+// load-bearing and the second is the non-obvious one: the listing can be
+// byte-identical while dispatch has moved underneath it, and a guard that
+// compared only the listing would skip a rebuild that had to happen. Extracted
+// so that requirement is covered by a test rather than by a comment.
+func directSurfaceUnchanged(lastTools, lastRouting, toolsFP, routingFP string) bool {
+	if lastTools == "" && lastRouting == "" {
+		// Nothing has been published yet, so there is nothing to compare and a
+		// first rebuild must always proceed.
+		return false
+	}
+	return lastTools == toolsFP && lastRouting == routingFP
+}

--- a/internal/server/mcp_surface_fingerprint_test.go
+++ b/internal/server/mcp_surface_fingerprint_test.go
@@ -167,3 +167,36 @@ func TestDirectSurfaceUnchanged_RequiresBothHalves(t *testing.T) {
 	assert.False(t, directSurfaceUnchanged("", "", "t1", "r1"),
 		"nothing published yet: the first rebuild must always proceed")
 }
+
+// The code-exec guard is a bare `p.codeExecSurfaceFP == fp` comparison against a
+// zero value that starts as "". It is only safe because a fingerprint is NEVER
+// the empty string — otherwise the very first refresh after init, which
+// registers via AddTool and so leaves the stored fingerprint empty, would match
+// and skip, leaving the surface holding whatever AddTool put there.
+//
+// The direct guard states this explicitly via directSurfaceUnchanged; this one
+// relies on the property, so pin the property.
+func TestToolSetFingerprint_IsNeverEmpty(t *testing.T) {
+	assert.NotEmpty(t, toolSetFingerprint(nil),
+		"an empty surface must still fingerprint to something, or the first refresh silently skips")
+	assert.NotEmpty(t, toolSetFingerprint([]mcpserver.ServerTool{}))
+	assert.NotEqual(t, toolSetFingerprint(nil), toolSetFingerprint([]mcpserver.ServerTool{st("a", "x")}),
+		"empty and non-empty must not collide")
+}
+
+// A nil catalog is a real state — initRoutingModeServers publishes an empty one
+// before upstreams connect — and it must not fingerprint as equal to a populated
+// catalog.
+func TestDirectCatalogRoutingFingerprint_NilAndEmptyAreDistinct(t *testing.T) {
+	var nilCat *directCatalog
+	empty := &directCatalog{mode: config.DirectToolResponseModeFull}
+	populated := &directCatalog{
+		mode:          config.DirectToolResponseModeFull,
+		byDisplayName: map[string]*directCatalogEntry{"s__t": {DisplayName: "s__t", ServerName: "s", ToolName: "t"}},
+	}
+
+	assert.NotEmpty(t, nilCat.routingFingerprint(), "nil must be representable, not a panic")
+	assert.NotEqual(t, nilCat.routingFingerprint(), empty.routingFingerprint())
+	assert.NotEqual(t, empty.routingFingerprint(), populated.routingFingerprint(),
+		"an empty catalog must not look like a populated one")
+}

--- a/internal/server/mcp_surface_fingerprint_test.go
+++ b/internal/server/mcp_surface_fingerprint_test.go
@@ -1,0 +1,169 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+)
+
+func st(name, desc string, opts ...mcp.ToolOption) mcpserver.ServerTool {
+	all := append([]mcp.ToolOption{mcp.WithDescription(desc)}, opts...)
+	return mcpserver.ServerTool{Tool: mcp.NewTool(name, all...)}
+}
+
+// The fingerprint has to cover exactly what a client sees in tools/list, because
+// that is also precisely what invalidates a provider's prompt cache: Anthropic's
+// rule is that "modifying tool definitions (names, descriptions, parameters)
+// invalidates the entire cache".
+func TestToolSetFingerprint_CoversWhatAClientCanSee(t *testing.T) {
+	base := []mcpserver.ServerTool{st("a", "first"), st("b", "second")}
+	require.Equal(t, toolSetFingerprint(base), toolSetFingerprint(base),
+		"a fingerprint must be stable for identical input")
+
+	reordered := []mcpserver.ServerTool{st("b", "second"), st("a", "first")}
+	assert.Equal(t, toolSetFingerprint(base), toolSetFingerprint(reordered),
+		"tools/list is sorted by name, so registration order is not observable")
+
+	assert.NotEqual(t, toolSetFingerprint(base),
+		toolSetFingerprint([]mcpserver.ServerTool{st("a", "CHANGED"), st("b", "second")}),
+		"a description change invalidates the provider cache and must be detected")
+
+	assert.NotEqual(t, toolSetFingerprint(base),
+		toolSetFingerprint([]mcpserver.ServerTool{
+			st("a", "first", mcp.WithString("q", mcp.Description("query"))), st("b", "second")}),
+		"a parameter change invalidates the provider cache and must be detected")
+
+	assert.NotEqual(t, toolSetFingerprint(base),
+		toolSetFingerprint([]mcpserver.ServerTool{st("a", "first")}),
+		"a removed tool must be detected")
+}
+
+// The direct surface's handlers close over catalog entries, so registry and
+// catalog are published as a pair. Skipping a rebuild is only safe when ROUTING
+// is unchanged too — and routing can move while the listing stays byte-identical,
+// because a display-name collision resolves to one server or the other without
+// changing what is listed.
+func TestDirectCatalogRoutingFingerprint_CatchesRoutingMovesTheListingHides(t *testing.T) {
+	catA := &directCatalog{
+		mode:         config.DirectToolResponseModeFull,
+		displayNames: []string{"x__foo"},
+		byDisplayName: map[string]*directCatalogEntry{
+			"x__foo": {DisplayName: "x__foo", ServerName: "alpha", ToolName: "foo", Hash: "h1"},
+		},
+	}
+	same := &directCatalog{
+		mode:         config.DirectToolResponseModeFull,
+		displayNames: []string{"x__foo"},
+		byDisplayName: map[string]*directCatalogEntry{
+			"x__foo": {DisplayName: "x__foo", ServerName: "alpha", ToolName: "foo", Hash: "h1"},
+		},
+	}
+	require.Equal(t, catA.routingFingerprint(), same.routingFingerprint())
+
+	// Identical DisplayName, different upstream: the listing cannot show this.
+	rerouted := &directCatalog{
+		mode:         config.DirectToolResponseModeFull,
+		displayNames: []string{"x__foo"},
+		byDisplayName: map[string]*directCatalogEntry{
+			"x__foo": {DisplayName: "x__foo", ServerName: "BETA", ToolName: "foo", Hash: "h1"},
+		},
+	}
+	assert.NotEqual(t, catA.routingFingerprint(), rerouted.routingFingerprint(),
+		"same name, different server — skipping this rebuild would leave stale routing")
+
+	// Permission is derived from upstream annotations and gates scoped tokens.
+	reperm := &directCatalog{
+		mode:         config.DirectToolResponseModeFull,
+		displayNames: []string{"x__foo"},
+		byDisplayName: map[string]*directCatalogEntry{
+			"x__foo": {DisplayName: "x__foo", ServerName: "alpha", ToolName: "foo", Hash: "h1",
+				RequiredPermission: "write"},
+		},
+	}
+	assert.NotEqual(t, catA.routingFingerprint(), reperm.routingFingerprint(),
+		"a permission change must not be skipped")
+
+	modeFlip := &directCatalog{
+		mode:          config.DirectToolResponseModeDeferred,
+		displayNames:  catA.displayNames,
+		byDisplayName: catA.byDisplayName,
+	}
+	assert.NotEqual(t, catA.routingFingerprint(), modeFlip.routingFingerprint(),
+		"serialization mode changes what is rendered")
+}
+
+// The guard's whole purpose: an unchanged surface must not re-register, because
+// SetTools notifies every connected client unconditionally.
+func TestRefreshDirectModeTools_UnchangedContentDoesNotRepublish(t *testing.T) {
+	p := newReloadGuardProxy(t, config.DirectToolResponseModeFull)
+	first := p.loadDirectCatalog().Generation()
+
+	p.RefreshDirectModeTools()
+	p.RefreshDirectModeTools()
+	p.RefreshDirectModeTools()
+
+	assert.Equal(t, first, p.loadDirectCatalog().Generation(),
+		"nothing changed, so no rebuild was published and no client was notified")
+}
+
+// ...but a real change must still get through. Guarding must not become muting.
+func TestRefreshDirectModeTools_RealChangeStillRepublishes(t *testing.T) {
+	p := newReloadGuardProxy(t, config.DirectToolResponseModeFull)
+	before := p.loadDirectCatalog().Generation()
+
+	p.config.DirectToolResponseMode = config.DirectToolResponseModeDeferred
+	p.RefreshDirectModeTools()
+
+	assert.Equal(t, before+1, p.loadDirectCatalog().Generation())
+}
+
+// The code-execution surface is built from built-ins ONLY — buildCodeExecModeTools
+// never iterates upstreams — yet it was rebuilt on every servers.changed. Measured
+// on one ordinary 4-server startup: 9 refreshes, tool_count 7 every time, so 9 of 9
+// notifications told clients about a change that could not have happened.
+func TestRefreshCodeExecModeTools_UnchangedContentDoesNotRepublish(t *testing.T) {
+	p := newReloadGuardProxy(t, config.DirectToolResponseModeFull)
+	require.NotNil(t, p.codeExecServer)
+
+	p.RefreshCodeExecModeTools()
+	base := p.codeExecPublishes.Load()
+
+	p.RefreshCodeExecModeTools()
+	p.RefreshCodeExecModeTools()
+
+	assert.Equal(t, base, p.codeExecPublishes.Load(),
+		"the code-execution surface cannot change on server churn")
+}
+
+func TestRefreshCodeExecModeTools_RealChangeStillRepublishes(t *testing.T) {
+	p := newReloadGuardProxy(t, config.DirectToolResponseModeFull)
+	p.RefreshCodeExecModeTools()
+	base := p.codeExecPublishes.Load()
+
+	p.config.EnableCodeExecution = !p.config.EnableCodeExecution
+	p.RefreshCodeExecModeTools()
+
+	assert.Equal(t, base+1, p.codeExecPublishes.Load(),
+		"flipping enable_code_execution swaps the live tool for the disabled stub")
+}
+
+// Both halves of the guard are load-bearing, and the routing half is the one no
+// integration test can reach: the reload harness has no upstreams, so a
+// routing-only change cannot be staged there. Pinned here instead.
+func TestDirectSurfaceUnchanged_RequiresBothHalves(t *testing.T) {
+	assert.True(t, directSurfaceUnchanged("t1", "r1", "t1", "r1"),
+		"identical listing and identical routing is the skip case")
+
+	assert.False(t, directSurfaceUnchanged("t1", "r1", "t2", "r1"),
+		"the listing moved")
+	assert.False(t, directSurfaceUnchanged("t1", "r1", "t1", "r2"),
+		"the LISTING is identical but dispatch moved — skipping would leave stale routing")
+
+	assert.False(t, directSurfaceUnchanged("", "", "t1", "r1"),
+		"nothing published yet: the first rebuild must always proceed")
+}

--- a/specs/103-token-bench/findings/cache-prefix-stability-audit.md
+++ b/specs/103-token-bench/findings/cache-prefix-stability-audit.md
@@ -1,0 +1,154 @@
+# Step 1: prefix-stability audit — is mcpproxy cache-hostile by construction?
+
+**Date**: 2026-09-01. **Method**: static read of every tool-list mutation path, plus
+the refresh log of one ordinary 4-server startup on an isolated instance. No API spend.
+
+## Verdict
+
+**Mixed, and the headline hazard is NOT the one I predicted.**
+
+- The default `retrieve_tools` surface is **cache-stable**. Confirmed.
+- The `code_execution` surface broadcasts `notifications/tools/list_changed` on every
+  upstream state change for a tool list that provably cannot change. Gratuitous, but
+  **not** a cache invalidation on its own (see "The correction").
+- The `direct` surface genuinely re-writes its tool definitions on ordinary server
+  churn, and that IS a full cache invalidation — `tools` sits first in the prefix, so
+  it cascades through `system` and every message.
+- The largest effect on the break-even argument is not invalidation at all. It is that
+  **caching shrinks the absolute saving by ~10x while leaving the crossover fleet size
+  roughly where it is.**
+
+## Primary-source pricing (verified 2026-09-01, platform.claude.com)
+
+| Fact | Value |
+|---|---|
+| Cache prefix order | `tools` -> `system` -> `messages`, hierarchical |
+| 5-minute cache write | **1.25x** base input |
+| 1-hour cache write | **2x** base input |
+| Cache read | **0.1x** base input |
+| Tool-definition change | "Modifying tool definitions (names, descriptions, parameters) **invalidates the entire cache**" |
+| Minimum cacheable | 512 tok (Opus 5) / 1,024 (Sonnet 5, Opus 4.8) |
+
+mcpproxy's `retrieve_tools` menu is 4,712 tokens — comfortably above every floor, so it
+is cacheable on any current model.
+
+## Mutation paths
+
+`SetTools` in mark3labs/mcp-go sends `list_changed` to **every initialized client
+unconditionally** — there is no content comparison, despite the code comment saying
+"when the list of available tools changes":
+
+```go
+s.tools = newTools
+...
+if s.capabilities.tools.listChanged {
+    s.SendNotificationToAllClients(mcp.MethodNotificationToolsListChanged, nil)
+}
+```
+
+Three surfaces call it. What reaches each:
+
+| Surface | Carries | Rebuilt on | Guarded? | Tool set can actually change? |
+|---|---|---|---|---|
+| `callToolServer` (`/mcp`, **default**) | built-ins only | `config.reloaded` only | n/a | Only on `enable_code_execution` flip |
+| `codeExecServer` | built-ins only | **every `servers.changed`** | **NO** | **Never** — `buildCodeExecModeTools` does not iterate upstreams |
+| `directServer` (`/mcp/all`) | the whole fleet | **every `servers.changed`** | **NO** | **Yes** — this is the real one |
+
+`RefreshDirectModeToolsOnSerializationChange` IS guarded by a drift check, but that guard
+only covers the `config.reloaded` path. The `servers.changed` path calls the **unguarded**
+`RefreshDirectModeTools` (internal/server/server.go:554).
+
+### What emits `servers.changed` — 17 sites
+
+`config hot-reload`, `sync`, `restart` (x2), `enable_toggle`, `bulk_enable_toggle`,
+`quarantine_toggle`, `tools_approved`, `tools_blocked`, `tools_changed`, `tools_indexed`,
+`server_connected`, `server_disconnected`, `server_state_changed`, `oauth_logout`,
+`oauth_logout_all`.
+
+`server_connected` / `server_disconnected` / `server_state_changed` are the ones that
+matter: they fire on ordinary connection churn, including every reconnect. Coalescing is
+only a **50 ms** window (`newServersChangedCoalescer(rt, 50*time.Millisecond)`), which
+collapses simultaneous bursts and does nothing for a reconnect loop retrying on a seconds
+timescale.
+
+### Measured on one ordinary startup (4 servers, 26 tools)
+
+| Surface | Refreshes | Distinct tool_counts | No-op refreshes |
+|---|---|---|---|
+| `codeExecServer` | 9 | 1 (always 7) | **9 of 9** |
+| `directServer` | 10 | 4 (1, 3, 18, 27) | at least 6 of 10 |
+
+Nine broadcasts telling every client the code-execution tool list changed, on a list that
+is structurally incapable of changing.
+
+## The correction — and it undoes part of my own claim
+
+I asserted that gratuitous `list_changed` is itself a caching hazard. **It is not**, and
+the reason matters:
+
+1. `list_changed` prompts a compliant client to re-fetch `tools/list`.
+2. mcp-go sorts that listing (`sort.Strings(toolNames)`, server.go:1782), so an unchanged
+   tool set returns a **byte-identical** payload.
+3. The client re-sends an identical `tools` block, and the cache **still hits** — the
+   invalidation trigger is a changed tool *definition*, not a notification.
+
+So the code-exec surface's nine broadcasts are wasted client work and log noise, not lost
+cache. They remain worth fixing (a client that re-fetches on every upstream flap is paying
+round-trips for nothing) but they are a **correctness/efficiency** defect, not a cost one.
+
+The real invalidation is the `directServer` column: 1 -> 3 -> 18 -> 27 tools during one
+startup is three genuine tool-definition changes, each of which discards the entire cache
+including system and all prior messages. Any later connect, disconnect, enable toggle,
+quarantine change or `set_profile` does the same.
+
+## The bigger correction — caching's actual effect on break-even
+
+I previously said caching pushes the crossover "further right, possibly much further."
+**That was wrong, and the error was worth catching.**
+
+Both arms cache the same way. Over n turns with a stable menu:
+
+```
+cost(menu) = menu x (1.25 + 0.1 x (n-1))
+```
+
+The saving is `(B - M)` and BOTH terms carry that identical factor, so it divides out of
+the crossing condition. **The break-even fleet size is roughly invariant under caching.**
+The chart's 67-tool / 10-server crossover survives.
+
+What caching does instead is shrink the **absolute** saving. In a cached steady state a
+token is billed at 0.1x, so a headline "saves N tokens" is worth about a tenth of its face
+value in money. Every figure this spec publishes is a raw token count, and none of them
+say that.
+
+Two second-order effects that do move the line, both against the proxy:
+
+1. **Discovery responses are per-turn cache WRITES.** Each `retrieve_tools` result is new
+   content appended to `messages`: written at 1.25x, only read at 0.1x on later turns. The
+   baseline pays nothing extra per turn. So the proxy's marginal per-turn cost is higher,
+   and a session that re-discovers repeatedly erodes its own advantage.
+2. **Direct-mode invalidation is unbounded.** One tool-set change mid-session re-writes the
+   entire prefix at 1.25x — including the conversation, which by then may dwarf the menu.
+   This is the only mechanism found that can plausibly flip the sign, and it is confined to
+   direct mode with a churning fleet.
+
+## Recommendations
+
+1. **Guard `RefreshCodeExecModeTools`** — it cannot change on `servers.changed`, so do not
+   call it there, or compare content before `SetTools`. Removes 9 of 9 spurious broadcasts.
+2. **Give `RefreshDirectModeTools` the same drift check** its serialization sibling already
+   has. At least 6 of 10 startup rebuilds were no-ops; a content hash would drop them.
+3. **Publish savings in money as well as tokens**, or state the cache multiplier beside the
+   token figure. A raw token saving overstates value ~10x in a cached steady state.
+4. **Do not measure step 2 without fixing 1 and 2 first** — otherwise the experiment prices
+   avoidable churn as if it were inherent.
+
+## What this did NOT establish
+
+- No provider was called. The amortisation arithmetic above is a model, not a measurement.
+- OpenAI and Gemini cache automatically under different rules; only Anthropic's numbers are
+  pinned here.
+- Whether real clients (Claude Code, Cursor, VS Code) actually re-fetch on `list_changed`
+  and whether they re-serialize deterministically is **unverified** — step 3 above assumes
+  a compliant, deterministic client, and a client that reorders or re-formats would break
+  the byte-identity argument the correction rests on.

--- a/specs/103-token-bench/findings/honest-savings-design.md
+++ b/specs/103-token-bench/findings/honest-savings-design.md
@@ -1,0 +1,448 @@
+# Design: how mcpproxy should honestly measure and present token savings
+
+**Task**: follow-up to T061 (`webui-savings-vs-bench.md`).
+**Date**: 2026-09-01.
+**Status**: design proposal. No production code changed. All figures below were
+measured on an isolated instance (scratch data-dir + config, port 18744, killed
+after) over the committed 7-server reference fleet
+(`specs/065-evaluation-foundation/datasets/snapshot-servers.config.json`, 45 tools).
+
+---
+
+## 0. Summary
+
+The Web-UI savings figure is not merely optimistic. On the reference fleet it is:
+
+1. **Non-deterministic.** 25 consecutive requests to `GET /api/v1/stats/tokens`
+   over an unchanging fleet returned six distinct values spanning
+   **52.35 % – 78.80 %** (spread 26.45 points).
+2. **Opposite in sign to the measured truth.** A real three-discovery-call
+   session on that fleet cost **9 825 tokens** through mcpproxy versus **4 368**
+   without it — the proxy cost 2.25× the baseline, a net **−5 457 tokens**.
+3. **Contradicted by its own tooltip**, which tells the user the number "changes
+   when you add, remove or reconnect servers — not with each call"
+   (`frontend/src/views/Dashboard.vue:833-836`).
+4. **Mislabelled**: two surfaces claim the query-side number is a BM25 result
+   (`Dashboard.vue:486`, `Usage.vue:78`); the code takes an unranked prefix
+   (`internal/server/tokens/savings.go:139`).
+
+The bench headline is closer but **also wrong, in the other direction**: it
+prices a proxy menu with code execution force-enabled, which the shipped default
+is not.
+
+Recommendation: **stop simulating and start measuring.** Replace the single
+percentage with a three-row session ledger computed from the proxy's own
+activity log, which already carries everything required. Keep break-even, but as
+an explanation, not the headline — and add a second break-even (in fleet size)
+because the call-count one is undefined in exactly the regime the user needs an
+answer in.
+
+---
+
+## 1. The honest quantity, stated precisely
+
+For one **work session** `s` under fleet `F`:
+
+```
+C_baseline(s) = B                                  (no proxy)
+C_proxy(s)    = M + Σ_{c ∈ D(s)} r_c               (with proxy)
+
+Net(s) = C_baseline(s) − C_proxy(s) = (B − M) − Σ r_c
+```
+
+where
+
+| Term | Meaning | Measured on the reference fleet |
+|---|---|---|
+| `B` | every upstream tool definition, once, as the client's `tools/list` renders it | **4 368** tokens (45 tools) |
+| `M` | mcpproxy's own advertised menu, **as deployed**, carried for the whole session | **4 712** tokens (12 built-ins) |
+| `D(s)` | mcpproxy built-in calls whose responses are pure overhead relative to baseline: `retrieve_tools`, `describe_tool`, `read_cache` | 3 calls |
+| `r_c` | tokens of each such response | 681 / 1 794 / 2 638 |
+
+`call_tool_read|write|destructive` responses are **excluded** from `D(s)`: they
+carry the upstream tool result, which the baseline agent pays for too, so the
+term cancels. This is exactly the population split
+`storage.InternalCallToolPrefix` already encodes
+(`internal/storage/activity_call_population.go:79-91`).
+
+**Net on the reference fleet: 4 368 − (4 712 + 5 113) = −5 457 tokens.**
+
+### Four things this makes visible that the current formula cannot
+
+- **It is per-session, not per-request.** The current label — "smaller tool
+  context per request" (`Dashboard.vue:328`), "Tokens saved per request"
+  (`Usage.vue:67`) — describes a quantity that does not exist. There is no
+  per-request saving; there is a fixed menu cost and a per-call spend against it.
+- **`(B − M)` is a budget, not a saving.** Each discovery call spends from it.
+  Sign flips at `n* = (B − M)/r̄`.
+- **When `B ≤ M` the product costs more before a single call is made.** Here
+  `B − M = −344`. No amount of good retrieval recovers that.
+- **Response *size* is the lever, not call count.** Measured spread across three
+  ordinary queries at `tools_limit: 15` was 681–2 638 tokens (3.9×). `tools_limit`,
+  `tool_response_mode: compact` and schema deferral are all mcpproxy's own knobs.
+  Call count is the agent's; response size is ours.
+
+### Where the framing in the brief needs correcting
+
+1. **"Every upstream tool definition, once" understates the baseline's
+   billing.** In a multi-turn conversation the menu is re-sent every turn. So is
+   the proxy's. The proxy's cost is *back-loaded* (menu at turn 1, menu + r₁ after
+   the first discovery), so a per-turn integral favours the proxy slightly more
+   than the additive comparison above. **Not quantified — open question, §7.**
+2. **Prompt caching is unmodelled by every figure here.** A stable tool menu is a
+   maximally cacheable prefix, billed at a fraction of input rate on reads.
+   Appending discovery responses does not invalidate that prefix, so both sides
+   cache; I *reason* the sign is preserved but the dollar magnitudes are not
+   derivable from any of these token counts. **Unverified — open question, §7.**
+3. **`describe_tool` and `read_cache` belong in the ledger** and are absent from
+   the brief's framing. Under Spec 085/102 an agent that receives compact
+   signatures and then calls `describe_tool` pays for the same schema twice.
+4. **The baseline is partly counterfactual at large fleets.** A user who does not
+   run mcpproxy often *cannot* connect every server — Cursor's 40-tool limit and
+   OpenAI's 128-function cap (`README.md:41`). Above those caps the honest
+   comparison is not "500 tools in context" but "the user connected fewer
+   servers". That makes mcpproxy's value a **capability**, not a token saving —
+   which matters a great deal for §6.
+
+---
+
+## 2. Is break-even the right frame? Partly.
+
+`bench/breakeven.go:25-40` computes `n* = (naive_full_menu − proxy_menu) / mean_response`.
+The arithmetic is right and the guard rails are good: `bench/breakeven.go:31-34`
+returns `NoBreakEven` when the numerator is ≤ 0, and `:36-38` refuses to divide
+by an unmeasured mean rather than fabricating a verdict.
+
+**Three reasons it should not be the headline.**
+
+1. **It is silent exactly where it matters.** On the reference fleet
+   `B − M = −344`, so `ComputeBreakEven` returns `NoBreakEven` with
+   `BreakEvenCalls = 0`. The dashboard would have *nothing to say* in the one
+   regime where the user is being overcharged. A metric that goes quiet on bad
+   news is the same failure as the clamp, wearing a better hat.
+2. **It inverts the product message.** "You can afford 3 more discovery calls"
+   makes more usage read as worse. True, but it is a strange thing for a product
+   to put on its own dashboard as the primary number.
+3. **It is modelled when a measurement is available.** §3 shows the real data is
+   already recorded.
+
+**Recommended frame: measured session ledger as the headline, two break-evens as
+the explanation.**
+
+- **(a) Call break-even** `n* = (B − M)/r̄` — how many discovery calls the fleet
+  affords. Defined only when `B > M`.
+- **(b) Fleet break-even** — how many upstream tools before `B` exceeds
+  `M + Σr` at the user's measured call rate. Defined precisely when (a) is not,
+  and it is the actionable one: **fleet size is what the user controls**, and it
+  is the axis along which savings actually scale.
+
+Together they always leave something true to say. Neither alone does.
+
+---
+
+## 3. What to compute it from: the activity log already has it
+
+### Verified present today
+
+| Need | Where | Verified |
+|---|---|---|
+| Session grouping | `ActivityRecord.WorkSessionID` (`internal/storage/activity_models.go:230`) | Three probe calls grouped under one id `ws-79fc67cd0eca9c32` |
+| Discovery call count per session | filter `type=internal_tool_call`, `tool_name=retrieve_tools` (`internal/httpapi/activity.go:44` supports `work_session_id`) | 3 records returned |
+| Exact response text the agent paid for | `ActivityRecord.Response`, written pre-storage-truncation (`internal/server/mcp.go:2093`) | Stored lengths **2 884 / 11 410 / 8 271** matched the wire payloads **exactly** |
+| Truncation flag | `ResponseTruncated`, propagated via `emitActivityInternalToolCallTruncated` (`internal/server/mcp.go:2093` → `internal/runtime/activity_service.go:859,899`) and exported (`internal/httpapi/activity.go:464`) | present |
+| Retention window | 90 days / 100 k records / 256 MB (`internal/config/config.go:465-467`, defaults `:1768`) | ample |
+
+Note that `specs/103-token-bench/contracts/replay-input.md` lists the truncation
+flag and the export byte fields as *required backend changes*. **Both have since
+landed** — that section of the contract is stale.
+
+### Verified missing
+
+1. **`retrieve_tools` records carry no byte counts.** The internal-tool-call
+   record is built without `RequestBytes`/`ResponseBytes`
+   (`internal/runtime/activity_service.go:884-901`); the upstream `tool_call`
+   path does set them (`:607-630`). Confirmed live: `request_bytes` and
+   `response_bytes` were `null` on all three probe records.
+2. **No token count is persisted anywhere per record.** Tokenizing on read is a
+   full scan of the activity window per dashboard request.
+3. **The existing usage aggregate cannot help as-is.** `applyToolRollup`
+   deliberately drops `internal_tool_call` from the per-tool rollup
+   (`internal/runtime/usage_aggregate.go:264-267`) — and its reasoning is
+   *correct*: mixing mcpproxy's own latency and sizes into upstream percentiles
+   would invent tool rows no upstream owns. Discovery cost needs its **own**
+   rollup, not admission into that one.
+4. **No fleet snapshot per session.** Historical sessions can only be scored
+   against *today's* catalog. `bench/replay.go:47-57` already states this
+   constraint and `ReplayCounterfactualLabel` (`:92-101`) is the right wording to
+   reuse verbatim.
+
+### The privacy objection does not apply here
+
+`bench/replay.go:22-45` is right to default bodies-off: the **export** path is
+unmasked, so an export is raw user traffic leaving the machine. An **in-process**
+aggregate is a different posture entirely — the proxy already holds these
+records, tokenizes in memory, and emits only counts. That is the same boundary
+`replay-input.md` §Privacy rule 5 describes ("nothing crosses the loader boundary
+but counts"). This is the strongest argument for computing the figure **inside
+the server** rather than reusing the replay pipeline.
+
+---
+
+## 4. Replacing `estimateQueryResultSize`
+
+**Recommendation: delete the simulation.** Use the measured distribution of real
+discovery responses; report **median and p90**, never a bare mean, alongside the
+sample count.
+
+Why not "a real BM25 ranking over representative queries":
+
+- It fixes the smaller of the two errors. The dominant error is the missing `M`
+  term (4 712 tokens), not the ranking (which changed `average_query_result_size`
+  between 993 and 2 232 across my samples).
+- It replaces one invented number with another. You would have to author the
+  representative query set, and the headline becomes a property of a query set
+  nobody agreed to — the thing `bench/README.md:60-63` already warns against.
+- We can measure it. The measurement is exact (§3, byte-for-byte match).
+
+**But keep a labelled estimate for cold start.** A fresh install with no recorded
+discovery calls has no distribution. There, show the structural terms `B` and `M`
+— which *are* computable with no history — and say plainly that the session
+figure is not measured yet. Never silently substitute one for the other.
+
+### The prefix bug is separate and shippable now
+
+`estimateQueryResultSize` takes `allTools[:topK]` (`savings.go:139`), and
+`allTools` is a flatten of `servers` in the order given
+(`internal/server/tokens/savings.go:128-131`), and that order comes from
+`GetAllServerNames` (called at `internal/runtime/runtime.go:1924`; defined at
+`internal/upstream/manager.go:945-954`), which ranges over a Go map. Go
+randomises map iteration order per range, so **which 15 tools form the "typical
+query" is a fresh coin flip on every HTTP request**. That is what produced the
+52.35 – 78.80 % spread. Sorting the returned names is a two-line fix that makes
+the current figure at least *stable*, independent of everything else in this
+document, and it directly falsifies the shipped tooltip at
+`Dashboard.vue:833-836`.
+
+---
+
+## 5. The clamp, and what the UI should actually say
+
+`savings.go:87-89` clamps negatives to zero. **Removing it is necessary but not
+sufficient**: `Dashboard.vue:317` renders the chip only
+`v-if="tokenSavingsData.saved_tokens_percentage > 0"`, so an unclamped negative
+makes the chip *vanish*. That is the same dishonesty by omission, harder to
+notice. Both must go together.
+
+A bare "−125 %" is also not the answer. The honest message names the cause and
+the lever.
+
+### Regime A — measured, net positive
+
+> **61 % less tool-definition context**
+> Median 9 400 tokens saved per session, over your last 12 sessions.
+> 312 upstream tools · mcpproxy menu 4 712 · typical session: 3 discovery calls,
+> ~1 700 tokens each.
+
+### Regime B — measured, net negative (the reference fleet today)
+
+Lead with the ledger, not the percentage:
+
+> **mcpproxy is costing you context on this fleet.**
+>
+> | | tokens |
+> |---|---|
+> | Loading all 45 upstream tools directly | 4 368 |
+> | mcpproxy's own 12 tools (carried all session) | −4 712 |
+> | Typical session: 3 discovery calls | −5 113 |
+> | **Net per session** | **−5 457** |
+>
+> This flips as your fleet grows: at your current usage mcpproxy starts saving
+> above roughly **95 upstream tools**.
+> Cut discovery cost now: [use compact responses] · [lower tools_limit from 15]
+> You are still getting quarantine, TPA scanning, and no 40-tool client limit.
+
+### Regime C — not enough data
+
+> **Not measured yet.** mcpproxy needs a few sessions with discovery calls before
+> it can tell you. Structurally: your catalog is 4 368 tokens; the mcpproxy menu
+> is 4 712.
+
+**No percentage at all in Regime C.** A percentage with no denominator on screen
+is the failure mode `bench/README.md:60-63` already forbids for published
+numbers; it should be forbidden in the product too.
+
+### Three rules the widget must obey
+
+1. Every percentage carries its fleet size and session count on the same screen.
+2. The widget must be capable of rendering bad news, in every regime, without
+   disappearing.
+3. Labels must describe the computation. "BM25 result" (`Dashboard.vue:486`) and
+   "via BM25 discovery" (`Usage.vue:78`) are false today and must go regardless
+   of whether the rest of this design is adopted.
+
+---
+
+## 6. Concrete code changes
+
+### Tier 0 — outright bugs, shippable independently, no narrative risk
+
+| # | Change | Anchor |
+|---|---|---|
+| 0.1 | Sort server names so the figure stops changing per request | `internal/upstream/manager.go:949-953` |
+| 0.2 | Remove the false BM25 labels | `frontend/src/views/Dashboard.vue:486`, `frontend/src/views/Usage.vue:78` |
+| 0.3 | Fix the falsified tooltip ("not with each call") | `frontend/src/views/Dashboard.vue:833-836`, duplicated at `frontend/src/views/Usage.vue:225-229` |
+
+### Tier 1 — the ledger terms
+
+| # | Change | Anchor |
+|---|---|---|
+| 1.1 | Add the `M` term. `ProxyModeToolDefs` fabricates `&config.Config{EnableCodeExecution: true}` and a zero-value `DisableManagement`/`ReadOnlyMode`, so it returns the **maximal** menu, not the deployed one. Needs a variant that calls `p.buildCallToolModeTools()` on the **live** `p`. | `internal/server/bench_export.go:43-49`; builders at `internal/server/mcp_routing.go:636,689`; management set `internal/server/mcp.go:1147-1148` |
+| 1.2 | Unify the renderer. `savings.go` prices a `{"tools":[…]}` JSON envelope; bench prices `name\ndesc\ncanonical-schema`. Same fleet: **4 684** (API) vs **4 368** (bench) — a 316-token, 7.2 % gap purely from rendering. Promote `CanonicalToolText` to a package both import. | `internal/server/tokens/savings.go:97-123`; `bench/arms/baseline.go:41`; `bench/canonical.go:25`; `bench/tokens.go:154` |
+| 1.3 | Remove the clamp | `internal/server/tokens/savings.go:87-89` |
+| 1.4 | Delete `estimateQueryResultSize` | `internal/server/tokens/savings.go:126-168` |
+| 1.5 | Rewire the caller | `internal/runtime/runtime.go:1966-1988` |
+
+Tokenizer note: both sides use `pkoukk/tiktoken-go` and default to
+`cl100k_base` (`bench/tokens.go:37`, `internal/server/tokens/models.go:63`), so
+the BPE is not the problem — the *rendered string* is. But `internal`'s encoding
+is operator-overridable (`internal/config/config.go:583`) and its tokenizer can
+be disabled entirely, returning 0 (`internal/server/tokens/tokenizer.go:91-95`);
+a disabled tokenizer must render "not available", never "0 % saved".
+
+### Tier 2 — measurement from real sessions
+
+| # | Change | Anchor |
+|---|---|---|
+| 2.1 | Set `RequestBytes`/`ResponseBytes` on internal-tool-call records (emitter-side, mirroring `rawByteSize` at `internal/server/mcp.go:2647`) | `internal/runtime/activity_service.go:884-901` |
+| 2.2 | Add a **separate** discovery rollup — do not admit built-ins into `ToolUsage`; the existing exclusion is correct | `internal/runtime/usage_aggregate.go:264-267`, `:222-231` |
+| 2.3 | Persist a token count per discovery record, or fold tokens into the rollup at write time; tokenizing the window per dashboard request will not scale to the 100 k-record default | `internal/config/config.go:466` |
+| 2.4 | Exclude `ResponseTruncated` records from the response-cost mean and **count the exclusions**; the stored text overstates what the agent received | `internal/storage/activity_models.go:198`, `internal/server/mcp.go:2087-2093` |
+| 2.5 | Carry the counterfactual caveat ("scored against today's fleet") into the UI, reusing the existing wording | `bench/replay.go:92-101` |
+
+### Tier 3 — contract, surfaces, and the other savings numbers
+
+| # | Change | Anchor |
+|---|---|---|
+| 3.1 | New payload fields; `frontend/src/types/api.ts` is **generated** — edit the generator and `make swagger` | `internal/contracts/types.go:370-377`, `oas/swagger.yaml:2626-2645`, `frontend/src/types/api.ts:517-523` |
+| 3.2 | Second endpoint echoes the same figure | `internal/httpapi/activity.go:1022-1032` |
+| 3.3 | **Dead surface**: `ServerStats.TokenMetrics` is declared in Go, Swagger and Swift and read by the macOS dashboard, but no Go code ever populates it. Decide: wire or delete. | `internal/contracts/types.go:367`; `native/macos/.../CoreProcessManager.swift:2056-2064`; `DashboardView.swift:78-93,379-427` |
+| 3.4 | **Fourth, independent savings estimator**: `hidden × 150 tokens`, feeding telemetry activation. Only-positive by construction, unrelated to everything above. | `internal/server/mcp.go:1879-1892`; `internal/telemetry/activation.go:28,49` |
+| 3.5 | Release gate snapshots `tokens_saved` | `cmd/release-gate/invariants.go:172,198-199` |
+
+### Tests that will break (expected, not regressions)
+
+- `internal/server/tokens/savings_test.go:72-73,120-121` — assert non-negative.
+- `:178-180` — asserts `SavedTokens == Total − AvgQuery` **and** the ~60 % prefix
+  arithmetic. Both are pins on the behaviour being removed.
+- `:246-248` — asserts `> 70 %` savings.
+- `internal/httpapi/activity_usage_test.go:138-141,275,283` — echo assertions.
+- `tests/token-metrics.spec.ts:22-28,163-176` — **already stale**: asserts label
+  strings (`Full Tool List Size`, `Typical Query Result`,
+  `Per-Server Token Breakdown`) that no longer exist in `Dashboard.vue`. It is
+  passing vacuously; treat a failure here as a real find, not a break.
+- `internal/server/bench_export_test.go:16,41` pins `ProxyModeToolDefs` to the
+  builders — keep that pin, add a live-config variant beside it.
+
+---
+
+## 7. Verified vs open
+
+### Verified in this investigation
+
+- 25 samples of `GET /api/v1/stats/tokens`, unchanging fleet: six distinct
+  values, 52.35 – 78.80 %, spread 26.45 points. Root cause is map iteration in
+  `GetAllServerNames` feeding the `allTools[:topK]` prefix.
+- Live deployed menu = **4 712** tokens (12 tools, `code_execution` served as the
+  113-char *disabled stub* — the shipped default). bench's in-process derivation
+  reports 5 783 because it pins `EnableCodeExecution: true`; the ~1 071-token
+  overstatement matches bench's own note at `bench/mcptools.go:21-24` (1 049).
+  **Both published figures are wrong, in opposite directions.**
+- Upstream catalog: 4 368 tokens (bench renderer) / 4 684 (the API's own
+  renderer) — the renderer gap is real and 7.2 %.
+- `B − M = −344`: the proxy is behind before any call. `ComputeBreakEven` returns
+  `NoBreakEven` here.
+- Three real `retrieve_tools` calls: 681 / 1 794 / 2 638 tokens. Session net
+  **−5 457** tokens versus baseline, while the dashboard read +52 … +79 %.
+- Activity records: `work_session_id` populated; `request_bytes`/`response_bytes`
+  `null`; stored `Response` length identical to the wire payload.
+- Both backend changes `replay-input.md` demands (truncation flag on internal
+  records; byte fields in the export DTO) have landed.
+
+### Open — stated as unresolved, not guessed
+
+1. **Prompt caching.** Nothing here models cached-input pricing. I reason the
+   *sign* survives (appending does not invalidate a prefix, so both sides cache),
+   but I did not verify it and no dollar claim follows from these counts.
+2. **The per-turn integral.** The proxy's cost is back-loaded within a session, a
+   second-order effect favouring the proxy. Not quantified.
+3. **Sample size.** One fleet, one client, three queries. `r̄ = 1 704` with a 3.9×
+   spread; three points are not a distribution, and the median/p90 design in §5
+   is exactly why.
+4. **Real `describe_tool` / `read_cache` frequency is unknown.** I generated
+   none. If agents call `describe_tool` often, the ledger is worse than measured
+   here; if never, slightly better.
+5. **Neither renderer is what a model provider actually bills.** `B` and `M` are
+   both proxies for the client's own serialization. Unresolved, and it caps how
+   precise any of this can honestly claim to be.
+6. **A +1 discrepancy I did not chase**: startup logs report `built direct mode
+   tools tool_count: 45` then `refreshed direct mode tools tool_count: 46`
+   (`internal/server/mcp_routing.go:126,1097`). Whether the direct surface
+   carries one tool the catalog does not is unresolved.
+7. **Whether the telemetry activation counter should change with the definition.**
+   Leaving it produces two contradicting numbers; changing it breaks the
+   activation time series. A product decision, not a technical one.
+
+---
+
+## 8. Migration and communication risk
+
+### What breaks
+
+- **The dashboard chip on a small fleet goes from roughly +50…79 % to a negative
+  number.** For the reference fleet the honest reading is "−5 457 tokens per
+  session". Every existing user below the crossover sees the product tell them it
+  costs more than it saves.
+- **`README.md:43` claims "~99 % token reduction"** and `docs/social.html:50`
+  shows "−99 % tokens". Those are reachable only at very large fleets *and* only
+  if `M` is ignored. They cannot survive this change unqualified.
+  `bench/README.md:60-63` already says savings approach an asymptote with tool
+  count and that a percentage must be quoted with its corpus size — the repo's
+  own benchmark documentation already contradicts the marketing.
+- `docs/qa/ux-audit-webui-2026-08.md:75,389-396` records a user-visible symptom
+  of this ("hero metric … did not move after 16 further tool calls"); the fix
+  recorded at `:573-577` accepted the structural framing rather than questioning
+  it.
+
+### Sequencing
+
+- **Step 0 — now.** Tier 0. Sorted enumeration and the two false BM25 labels are
+  bugs; they need no narrative and no coordination.
+- **Step 1 — additive.** Show the ledger rows (`B`, `M`, measured discovery cost)
+  *beside* the existing percentage, unchanged. Users see the components one
+  release before the headline moves. This is also the cheapest way to find out
+  what real fleets look like before committing to a message.
+- **Step 2 — swap the headline** to the measured net. Keep the old figure in the
+  details panel for one release, relabelled honestly — "catalog reduction
+  (excludes mcpproxy's own tools)" — so the drop is explicable rather than
+  mysterious.
+- **Step 3 — remove the old figure**, and update `README.md`, `docs/social.html`
+  and the blog in the *same* release, stating the crossover explicitly.
+
+### The communication problem, and the honest answer
+
+The temptation is to frame this as "we were wrong by 100 points". That is both
+worse than necessary and less true than the alternative.
+
+The accurate story is: **savings scale with fleet size, and we now show you where
+you sit on that curve.** The product was measuring the right physics on the wrong
+axis. At 45 tools mcpproxy does not save context — and it was never mainly a
+context-saver at that size. What it gives a small-fleet user is quarantine and
+TPA detection, and freedom from the 40-tool client cap that `README.md:41`
+already leads with. Those are real, independent of tokens, and they are the thing
+to lead with in Regime B.
+
+The risk of *not* doing this is larger than the risk of doing it: a benchmark
+already exists in-repo that contradicts the shipped number, the QA audit already
+flagged the metric as unexplainable, and the figure is currently random within a
+26-point band. Someone will find this. It is much better as a changelog entry
+than as an issue.

--- a/specs/103-token-bench/findings/tool-count-limits-2026.md
+++ b/specs/103-token-bench/findings/tool-count-limits-2026.md
@@ -1,0 +1,290 @@
+# Research: is "40-128 tools" still a real constraint? (2026)
+
+**Date**: 2026-09-01. **Method**: 4 independent search angles, adversarial per-claim
+verification, synthesis, completeness critic. 30 agents, 89 claims.
+
+> **Read the critic in section C first.** It judges this research **"not thorough"** and
+> names three systematic holes, two of which it says INVERT conclusions the synthesis
+> states confidently. The synthesis is not settled fact; it is the best current reading
+> with its own gaps documented.
+
+## Why this exists
+
+Spec 103's break-even argument leaned on a claim inherited from 2025: that above roughly
+40-128 tools a user physically cannot connect everything, so mcpproxy's value is
+CAPABILITY rather than token saving. That claim is a year old. This checks it.
+
+---
+
+## A. Synthesis
+
+# Can a user still not connect more than 40–128 tools? (2026 synthesis)
+
+**Compiled 2026-09-01.** Every figure below carries a date. Claims that failed adversarial verification are marked ⚠️ **REFUTED** rather than dropped, because most of them are still in wide circulation.
+
+---
+
+## 1. Direct answer
+
+**No — the tool-count cap is no longer the binding constraint on fleet size, and for the median user it never was.** In 2026 the binding constraints are, in order: (a) *tool-selection quality*, which Anthropic documents as degrading past **30–50 available tools** with nothing erroring; (b) *context budget*, ~**55k tokens of definitions for a 5-server setup**; and only then (c) residual hard caps, which now bind on what a client **sends** in one request (OpenAI 128, VS Code 128, Antigravity 100) rather than on what a user **connects**. The 2026 industry answer to large tool surfaces was not a raised ceiling but **deferred loading** — Claude Code, Cursor, VS Code, Kiro and Amp all now put tool *names* in context and fetch definitions on demand — which means "you cannot connect more than N" has quietly become "you cannot usefully *expose* more than ~30–50 at once."
+
+---
+
+## 2. The dated table
+
+Columns: subject | limit kind | 2026 value | 2025 value if changed | source | confidence.
+
+### 2a. Provider APIs
+
+| Subject | Kind | 2026 value | 2025 value if changed | Source (date) | Conf. |
+|---|---|---|---|---|---|
+| OpenAI Chat Completions `tools` | **hard cap** | **128** — HTTP 400 `array_above_max_length`. Enforced but **undocumented** on the live param | unchanged | Error text reproduced in the wild through 2026-07; Azure quotas doc `ms.date 2026-08-20` states "Maximum number of /chat/completions tools \| 128" | High (value) / Med (docs) |
+| OpenAI Responses API `tools` | — | ⚠️ **REFUTED as a documented cap.** `openai-openapi` v2.3.0 (fetched 2026-09-01) puts **no `maxItems`** on `ToolsArray`. A ~128 server-side ceiling probably still applies by inference, not documentation | claimed 128 (2025-11-10, Zed #42393 — third-party, endpoint not isolated) | openai/openai-openapi master (2026-08-31) | Low |
+| OpenAI docs "documents no cap" | observation | Confirmed **for live surfaces**. But 128 *is* published as `maxItems` on the **deprecated** Chat `functions` param and the **Assistants API** (sunset 2026-08-26) | — | openapi.yaml, 2026-08-31 | High |
+| OpenAI function-calling guide | **recommended** | "Aim for fewer than 20 functions available at the start of a turn… **just a soft suggestion**" | unchanged (page undated; proven 2026-edited — documents `tool_search`, gpt-5.6) | developers.openai.com (verified 2026-09-01) | Med-High |
+| OpenAI Structured Outputs (applies to tool param schemas) | **hard cap**, only when `strict: true` | 5,000 properties · **10 levels of nesting** · 120,000 schema chars · 1,000 enum values · (+15,000-char budget for any enum >250 values) | 2025-07-11 raise from 100 props / 15,000 chars / 500 enums. ⚠️ The widely-quoted "**5 levels of nesting**" is **wrong** — it is 10; the raise was made silently, no changelog entry | developers.openai.com (2026-09-01); Azure's page still says 100/5 as of 2026-08-24 — **vendors disagree** | High |
+| Anthropic Messages `tools` (whole array) | none documented | No `maxItems` on `tools`. Meaningful silence: the same reference *does* cap `skills` at 20 and `messages` at 100,000 | — | platform.claude.com/docs/en/api/messages (2026-09-01) | High |
+| Anthropic tool search, deferred tools | **hard cap** | **10,000** tools with `defer_loading: true` per request; ≥1 tool must be non-deferred (400 otherwise) | GA'd 2026-02-05 (beta header dropped) | platform.claude.com tool-search-tool | High |
+| Anthropic tool selection | **degradation threshold** | "degrades once you exceed **30–50 available tools**" | — | same page (undated, actively maintained) | High for the quote / Med for the number's provenance |
+| Anthropic tool-def token budget | **recommended** | Use tool search at **10+ tools or >10k tokens** of definitions; ~**55k tokens** for a typical 5-server setup | — | same page | High |
+| Google Gemini 3 `functionDeclarations` | **hard cap** | **512** — "At most 512 function declarations can be specified" | supersedes the widely-cited **128** | gemini-cli #19083, observed on `gemini-3-pro-preview` (2026-02-14). **No Google page states 512** | Med (behaviour only) |
+| Google Vertex / Enterprise Agent Platform docs | **hard cap** (documented) | **128** — *contradicted by Google's own API.* Google's docs disagree with Google's runtime | — | docs.cloud.google.com (undated) | Low |
+| Google Gemini best practices | **recommended** | "Keep active set to **10–20 tools maximum**" | — | ai.google.dev (2026-08-26) | High |
+| Azure OpenAI `/chat/completions` tools & legacy functions | **hard cap** | **128** each | unchanged | MicrosoftDocs/azure-ai-docs (2026-08-20) | High |
+| AWS Bedrock Converse `toolConfig.tools` | none documented | "Minimum number of 1 item" and **no maximum** — unusual for AWS, which normally documents both bounds. Per-model caps may still apply underneath | — | AWS API reference (2026-09-01) | High (that docs are silent) |
+| Mistral function calling | none found | No cap published | — | docs.mistral.ai (2026-09-01) | Low (absence of evidence) |
+| Groq `tools` | **hard cap** | 128 claimed | — | single third-party GH issue, **no retrievable date** | Low |
+
+### 2b. Clients
+
+| Subject | Kind | 2026 value | 2025 value if changed | Source (date) | Conf. |
+|---|---|---|---|---|---|
+| VS Code + GitHub Copilot | **hard cap on tools *sent*** | **128 per request.** Above the threshold, VS Code auto-groups into "virtual tools" behind `activate_*` stubs, so >128 can be *enabled* while ≤128 are sent. When grouping is off it errors: `Tool limit exceeded (132/128)` | 128 unchanged; virtualization shipped v1.103 (2025-07) | code.visualstudio.com docs stamped **2026-08-26** (v1.135); microsoft/vscode #290356, #294055 | High |
+| VS Code `virtualTools.threshold` | **default setting** | Default 128; adjustable **downward only** — setting 256 "produces no effect" | — | microsoft/vscode #294055 (2026-02-10, unanswered by maintainers) | Med |
+| Cursor — "40-tool cap" | — | ⚠️ **REFUTED / STALE.** Not in Cursor's docs. Originates in forum posts dated **2025-06-23/24**. Cursor staff (2026-07-14) recharacterize the constraint as an upstream **per-model provider** capacity limit, not a Cursor cap | 40 was a 2025 soft warning that degraded, not a hard cap | cursor.com/docs/mcp (raw-HTML grep, 2026-09-01: zero hits for any tool-count number) | High that 40 is stale |
+| Cursor — deferred loading | **default behaviour** (no toggle found) | Tool definitions live as JSON in `.cursor`; agent gets **names only**, loads on demand; vendor-reported **46.9%** agent-token reduction | new in 2026 | Shipped in **Cursor 2.4, 2026-01-22** — *not* the blog's 2026-01-06, which was forward-looking ("coming weeks"); staff confirmed on 2026-01-14 it was not yet in stable | High |
+| Cursor CLI (`cursor-agent`) | **hard cap**, undocumented | Errors `Too many MCP tools are enabled for this model` — the CLI sends **all** tool definitions in one request while the IDE sends far fewer. Threshold is model-dependent; **no published number**. ⚠️ The framing "no Cursor-imposed cap" is wrong — the gate is client-side, only the threshold is upstream | new 2026 distinction | forum.cursor.com/t/cli-mcp-tool-limits/165642 (2026-07-13/14, staff reply) | Med |
+| Cursor IDE observed | anecdote | 80+ tools enabled, no warning — **n=1, no staff confirmation**. Do not quote 80 as a threshold | contradicts 40 | forum thread 153432 (2026-03-03) | Low |
+| Claude Code | none documented | No cap on MCP servers or tools; "work with hundreds of tools without context overhead" | 2025 advice to hand-prune is obsolete | code.claude.com/docs/en/mcp (2026-08) | High |
+| Claude Code tool search | **default setting** | **ON by default**; disable with `ENABLE_TOOL_SEARCH=false` | opt-in/absent in 2025 | same | High |
+| Claude Code MCP output | **default setting** | 25,000 tokens/result (`MAX_MCP_OUTPUT_TOKENS`), warning >10,000, per-tool override to 500,000 chars | — | same | High |
+| Google Antigravity IDE | **hard cap** | **100**, hardcoded; **rejects the whole server load** with "enabled tools would exceed max limit of 100" | new 2026 entrant | gemini-cli #26678 (2026-05-07) | Med |
+| Gemini CLI | contested | ~100 with silent drops **(#21823, 2026-03-10, no maintainer reply)** vs. "handles 300+ fine, only Antigravity has the 100" **(#26678, 2026-05-07)**. **These directly conflict** | — | GitHub issues | Low |
+| Windsurf / Cascade (now docs.devin.ai) | **hard cap** | **100 total tools.** Page **undated**, domain 307-redirects post-Cognition consolidation, may be unmaintained; does not say what happens on overflow | 100 unchanged | docs.devin.ai/desktop/cascade/mcp | Med |
+| Claude Desktop | observed | 206-tool server → only 100 tools visible, **silent client-side truncation**. One user's observation; **no Anthropic source documents any cap** | — | modelcontextprotocol discussion #537 (2026-07-20) | Low |
+| Kiro | **default setting** | **No tool cap.** Tool Search **disabled by default**; auto-activates at 5% of context or 50,000 tokens | new 2026 entrant | kiro.dev/docs/mcp/tool-search (2026-08-04) | High |
+| Amp (Sourcegraph) | observed | No cap; lazy-loads via skills (26 tools = 17k tokens → 4 tools = 1.5k) | — | ampcode.com (2026-01-08) | Med |
+| Cline | none documented | No cap; **also no per-tool enable/disable** — whole-server only (open request) | — | cline #8855 (2026-06-01) | Med |
+| Zed / Continue | none documented | No cap stated | — | vendor docs, **no visible date, no source-code constant checked** | Low |
+| MCP specification itself | none | **No cap on servers or tools anywhere in the spec** | — | modelcontextprotocol #1251 | High |
+
+### 2c. What people actually run (fleet reality)
+
+| Subject | Kind | 2026 value | 2025 value | Source (date) | Conf. |
+|---|---|---|---|---|---|
+| Official MCP Registry | observed | **26,094** latest-version records (25,800 active); 26,729 including 633 deleted | ~9,652 (2026-05-24) → 18,849 (2026-07-28) | Own full pagination of `/v0.1/servers`, 261 pages, **2026-09-01**; cross-checked via `/v0` and per-server endpoints | High |
+| PulseMCP directory | observed | **~21,982** (drifts hourly; crawl titles cluster 22,000–22,070) | ~4–5k mid-2025 | pulsemcp.com/servers, 2026-09-01. ⚠️ **New-listing ingestion has been paused since ~2026-08-05**, so it undercounts | Med |
+| **Tools per server — distribution** | observed | **median 10** · mean 19.7 · p75 34 · p90 36 · p95 43 · **p99 114** · **max 622**. Only **3.7% expose >50**, **1.2% expose >100** | — | My own computation over MCP Queen's public probe CSV, 5,099 servers returning >0 tools, probe window 2026-07-12→28 | High |
+| GitHub MCP Server | observed | **86 tools / 21 toolsets** stock local; **90 tools / 23 toolsets** with remote extras (⚠️ the claim said 21 toolsets for 90 — wrong). Source registers 120 entries incl. 27 flag-gated variants and 4 insiders-only | 56 (2025); the widely-cited **35** (Feb 2026) is off by 2.5× | Verified against `pkg/github/tools.go` @ main 2026-08-27, release 1.11.0 | High |
+| GitHub **Remote** MCP (gh-aw report) | — | ⚠️ **REFUTED — stale by 6 months.** The cited 79 tools / 19 toolsets (2026-03-01) is superseded by the same weekly series: **97 unique tools / 23 toolsets** (2026-08-30). Also: the 79 was a *docs-mapping* count, not live discovery | — | gh-aw #57163; upstream source @ febc3293 | High |
+| Playwright MCP | observed | **71** `browser_*` tools — but that is the **full opt-in superset**; **default is 24**. Source defines 80, 9 are `skillOnly` and hidden. ⚠️ The capability names "video"/"verification" don't exist (they're `devtools`/`testing`) | 21–25 (2025) | Verified by running `@playwright/mcp@0.0.80` and diffing `tools/list` against the README, 2026-09-01. Count moved 69→71 on 2026-08-31 | High |
+| Atlassian Rovo MCP | observed | ⚠️ **REFUTED.** Not ~183. v2 documents **216 tools** across 12 product areas — but only **21 are "Primary"** and exposed at connection; the rest sit behind `discover` + `execute*`. Full flat list only via `?tools=all`. Compass is gone; five product areas the claim omits exist | ~25 in the 2025 beta | support.atlassian.com supported-tools, `dateModified 2026-09-01`; changelog 2026-07-01 (v2: ">50% context reduction") | High |
+| Filesystem reference server | observed | 13 tools | — | repo README @ main, 2026-09-01 | High |
+| Slack MCP | observed | 11–13 (**sources disagree, not verified against a primary repo**) | 8 in the archived 2025 server | getunblocked blog | Low |
+| Servers per user/org, 2026 | — | **No published 2026 measurement exists.** Report this as a finding | Only figure in circulation: Zuplo "70% run 2–7 servers" — **fieldwork Nov–Dec 2025**, published 13 Jan 2026, and the public blog page doesn't even contain the statistic (it's in the gated report). Clutch's "2 per employee" is Dec 2025 **and an extrapolation onto a hypothetical 10,000-person org** | — | High (that it's unknown) |
+
+### 2d. Degradation literature
+
+| Subject | Kind | Finding | Source (date) | Conf. |
+|---|---|---|---|---|
+| **Mem2ActBench** — the cleanest control | degradation | **Random** distractors: flat 93.50–95.50% across N=1,2,5. **Hard negatives** (semantically similar): 94.50% → 78.00% → 69.75%. Same N, 25-point gap. **Similarity is the cause; count is a proxy** | arXiv:2601.19935 v1; confirmed verbatim in the **ACL 2026 camera-ready** (2026.acl-long.370, p.8179). ⚠️ Paper never names the backbone — the "Qwen2.5-72B" attribution is inferred. N=1 means *zero* distractors. n=400 tasks | High |
+| ToolMATH (Llama3-8B) | degradation | 21.6% → 8.1% with distractors — small models collapse | arXiv:2602.21265 (2026-05-18) | High |
+| ToolMATH (Claude-4.6) "no degradation" | — | ⚠️ **REFUTED as stated.** 98.4% → 97.8% is real, but **tool-call rate collapsed 65.6% → 15.2%** in the same cell — accuracy held because the model stopped calling tools and answered from parametric knowledge. Also: the 12,369 tools are the *corpus*; models never see more than gold + k≤50. The quoted pair is one cell at k=5 | arXiv:2602.21265v2 | High (that the framing is wrong) |
+| **99% Success Paradox** (Meta) | degradation | Selectivity collapses when **λ = K·R̄q/N ∈ [3,5]**. ⚠️ λ scales with **K (how many you show)**, not menu size: 58 tools with 4 relevant is λ≈4 **only if all 58 are in context**; shortlist K=5 → λ≈0.34. Authors call 3–5 "operational thresholds rather than exact cutoffs" | arXiv:2605.18857 v1 (2026-05-14); **ICLR 2026 Blog Track** — an exposition track, not main track | High on existence / Med on sharpness |
+| Same paper, downstream accuracy | degradation | K=10 → K=100: BM25 66%→50%, SPLADE 68%→58%, at ~10× token cost. ⚠️ **One dataset (20 Newsgroups topic classification, not RAG QA), one unnamed LLM, no error bars.** Authors' own limitations section disclaims generalization | same | Low-Med on magnitudes |
+| **How Many Tools Should an Agent See?** (Meta) | degradation | Failure is **rank-dependent, not count-dependent**: fixed top-5 exposure scores **0%** when the gold tool ranks 6th–20th. ⚠️ Ranks are within an **N=50 candidate set**, not the 3,251-tool registry; **Claude Sonnet 4.6 was not involved** in the 0% (pure MiniLM retrieval recall). ⚠️ And **fixed-5 wins on both aggregate metrics** (64.7% vs 61.9% coverage; 73.3% vs 71.7% end-to-end) | arXiv:2605.24660 v1/v2 (v2 = bibliography fixes only); independently cited by arXiv:2606.16364 (BIT, unrelated group) | High |
+| Canary Tools | degradation | Counter-evidence: adding competing tools made GPT-5.2 **more** discriminating (0.178 → 0.118 wrong-tool rate) | arXiv:2608.04719 (2026-08-05) | Med |
+| ToolMenuBench 32.1% vs 85.7% | — | ⚠️ **REFUTED as citable.** Correctly transcribed, but: **0 citations**, not peer reviewed, deterministic **mocked** environment, 30 tasks/cell, no CIs, baseline authored by the filter's own proponents, and the same author's other paper puts the method at 80.1–82.9% on the same backbones. Also mislabeled — averaging across 25/100/250 *destroys* the size-dependence a threshold needs | arXiv:2606.15508v1 (2026-06-13) | Low |
+| RAG-MCP | degradation | >90% below pool position ~30; collapse beyond ~100. ⚠️ **This is the stale 2025 number everyone still quotes** — May 2025, `qwen-max-0125`, and the sweep only ran N=1→100 | arXiv:2505.03275 (2025-05-06) | Med, historical |
+| Anthropic's own MCP eval | vendor | Deferring definitions: Opus 4 **49% → 74%**; Opus 4.5 **79.5% → 88.1%**. Note the gain **shrank 25pp → 8.6pp** on the newer model | anthropic.com/engineering/advanced-tool-use (2025-11-24). **No 2026 refresh found** | High |
+| **Benchmarking the Benchmarks** — the caveat that undercuts everything above | validity | 23 identical LiveMCPBench reruns: **57.9%–76.8%, an 18.9-point spread**; 18.5% evaluator/human misalignment across BFCL v4, τ2-Bench, LiveMCPBench, MCP-Atlas | arXiv:2607.02577 (2026-06-30) | High |
+| "200 tools → 41%, 740 tools → 0–20%" | — | ⚠️ **FABRICATED / UNTRACEABLE.** Blogs attribute it to "RAG-MCP (Anthropic, 2025)". RAG-MCP is Gan & Sun, is **not Anthropic**, and **never tested 200 or 740 tools**. No primary source found | webscraft.org and derivatives | Rejected |
+| presenc.ai "96%/91%/76% at 1/5/20+ tools" | — | Cites only a leaderboard plus "deployment instrumentation across 60+ enterprise customers" — **no reproducible method** | presenc.ai (2026-05) | Rejected |
+| "3 servers = 40 tools = 143,000 tokens" | — | ⚠️ **Arithmetically incoherent**: implies 3,575 tokens/tool vs. the same article's own 500–1,500 range and Anthropic's ~55k for **five** servers | agentmarketcap.ai (2026-04-08) | Rejected |
+| "The Bitter Lesson of Tool Calling" | — | **Contains no tool-count analysis at all** — it compares programmatic vs JSON calling. Listed so it isn't double-counted as evidence | arXiv:2608.06370 (2026-08-06) | High |
+
+---
+
+## 3. What changed since 2025
+
+**The industry stopped capping and started deferring.** That is the whole story, and it happened in a nine-month window:
+
+- **2025-11-24** — Anthropic ships tool search with `defer_loading`, and publishes the first vendor **degradation threshold** as a distinct concept (30–50 tools), separate from any cap.
+- **2026-01-22** — Cursor 2.4: MCP definitions move to JSON files in `.cursor`; the agent receives **names only**. (The blog was 2026-01-06 and forward-looking; staff confirmed on 2026-01-14 it wasn't in stable yet.)
+- **2026-02-05** — Anthropic's tool search leaves beta; no header required. The 10,000-deferred-tool cap becomes a GA documented limit, not a beta relic.
+- **2026-03-05** — OpenAI ships `tool_search` / `defer_loading` on the Responses API (gpt-5.4+). **Notably, OpenAI's answer to large tool surfaces was deferral, not a larger array** — indirect evidence the 128 ceiling was never going to move.
+- **2026-07-01** — Atlassian Rovo MCP v2: "reduced default tool exposure, reducing context window consumption by >50%." 216 tools become 21 primary + `discover`/`execute*`.
+- **2026-08** — Claude Code has tool search **on by default**. Kiro ships Tool Search (off by default, auto-arms at 50k tokens). VS Code's virtual tools have been shipping since v1.103.
+
+Three consequences for anyone reading a 2025 write-up:
+
+1. **Caps now bind on the wire, not on the config file.** VS Code's 128 is a cap on tools *sent* — you can enable far more and it will group them. Cursor's CLI errors where Cursor's IDE doesn't, for exactly this reason: the CLI batches every definition into one request. "How many can I connect" and "how many reach the model" have decoupled.
+2. **The one number that went up is Gemini's**: 128 → **512** on Gemini 3. And Google's own Vertex docs still say 128, so Google's documentation contradicts Google's runtime. Everything else either held (OpenAI 128, Azure 128, VS Code 128) or was never there (Anthropic, Bedrock, Mistral, the MCP spec itself).
+3. **The number everyone quotes for Cursor — 40 — is a 2025 forum artifact.** It is absent from Cursor's current docs (verified by raw-HTML grep across 8 MCP pages on 2026-09-01), Cursor staff now describe the constraint as an upstream per-model provider limit, and multiple 2026-badged third-party "guides" (truefoundry, nxcode, evomap, Medium) are recycling 2025 text without re-verification.
+
+---
+
+## 4. Real limits vs folklore
+
+### Genuinely hard — the API or client rejects the request
+
+| Limit | Where it bites |
+|---|---|
+| **OpenAI 128** (`tools`, Chat Completions) | Real, HTTP 400, reproduced through 2026-07. **But undocumented on the live param** — detect it from the error string at runtime rather than hardcoding trust in 128. |
+| **Azure OpenAI 128** | The only *properly documented* instance of the number (2026-08-20). |
+| **Gemini 3: 512** | Observed only. No Google page states it. |
+| **Anthropic 10,000 deferred tools/request** | Documented; rejection behaviour not independently demonstrated. Also a real enforced 400 if *every* tool is deferred. |
+| **VS Code 128 sent** | Real error text captured (`Tool limit exceeded (132/128)`), but virtualization usually prevents you seeing it. |
+| **Antigravity 100** | Rejects the entire server load. Med confidence, single issue. |
+| **Windsurf 100** | Undated page on a redirected domain. Treat as unverified. |
+| **OpenAI Structured Outputs** (5,000 props / 10 nesting / 120k chars / 1,000 enums) | Hard **only under `strict: true`**. Without `strict`, Responses silently falls back to best-effort — a hard cap and a silent degradation share the same numbers. |
+
+### Defaults you can change
+
+- Claude Code tool search: **on**, `ENABLE_TOOL_SEARCH=false`.
+- Kiro Tool Search: **off**, arms at 5% context / 50k tokens.
+- VS Code `virtualTools.threshold`: default 128, **downward-adjustable only**.
+- Claude Code `MAX_MCP_OUTPUT_TOKENS`: 25,000.
+
+### Degradation thresholds — nothing errors, quality just falls
+
+- **Anthropic 30–50 available tools.** The only vendor-published one, and the most load-bearing number in this whole document. Caveat: undated page, no published methodology.
+- **Mem2ActBench**: the real variable is **distractor similarity**, not count — 94.5%→69.8% with hard negatives, dead flat with random ones at the same N.
+- **Meta's λ = K·R̄q/N ∈ [3,5]**: the real variable is **relevant-to-shown ratio**, not N. Their own word: "operational thresholds rather than exact cutoffs."
+- **Rank, not count**: fixed top-5 retrieval scores 0% when the gold tool ranks 6th — but note that in the same paper fixed-5 still *wins* on both aggregate metrics.
+
+### Blunt calls on widely-repeated numbers
+
+- **"Cursor caps you at 40."** Stale. 2025 forum lore, absent from current docs, recharacterized by staff.
+- **"OpenAI's function-calling API caps at 128."** Half-true in an important way: it's enforced, but it is documented only on the **deprecated** `functions` param and the **sunset** (2026-08-26) Assistants API. The current function-calling guide states no cap — only "fewer than 20… just a soft suggestion."
+- **"Anthropic has no cap."** Wrong as usually stated. No cap on the array; a documented **10,000** on deferred tools.
+- **"200 tools → 41%, 740 → 0–20%."** No primary source exists. Misattributed to a paper that never tested those N.
+- **"GitHub MCP has 35 tools."** Off by 2.5× — it's 86/90, and it's the most-cited per-server count in 2026 write-ups.
+- **"Atlassian Rovo ~183."** It's 216 documented / 21 exposed by default. Both halves of that sentence matter.
+- **"Playwright MCP has 71 tools."** True only with all seven `--caps` values passed. **Default is 24.**
+- **ToolMenuBench's 32.1% vs 85.7%.** Do not cite. Zero citations, mocked environment, baseline written by the method's proponents.
+- **Every effect below ~19 points measured on LiveMCPBench-class harnesses in a single run.** The rerun noise floor is 18.9 points. That is larger than most reported tool-count effects.
+
+---
+
+## 5. Implications for a token break-even argument
+
+The argument under test: *"Above ~40–128 tools a user physically cannot connect everything, so a proxy's value is capability (access at all), not token saving (against an all-loaded baseline that would never have existed)."*
+
+**The capability half of that argument weakens substantially; the token-saving half weakens too, for a different reason. Net: the differentiator moves from 'how many' to 'which client' and 'how well ranked'.**
+
+**Why capability weakens.** The premise is that the cap prevents connection. In 2026 it mostly doesn't:
+
+- The **MCP spec caps nothing**. Anthropic's array caps nothing. Bedrock caps nothing. Claude Code, Kiro, Cline, Zed, Continue document no cap.
+- Where caps exist, deferring clients keep you under them without pruning: VS Code virtualizes above 128, Cursor's IDE sends names only, Claude Code's tool search is on by default.
+- Gemini went 128 → 512.
+- So for a user on Claude Code, Cursor IDE, Kiro or Amp, "I cannot connect these" is **false in 2026**. The counterfactual baseline *is* "everything connected."
+
+**Why token saving also weakens.** If the counterfactual is "everything connected and fully loaded," the proxy's token saving is real and large. But the deferring clients **already capture that saving natively** — Cursor reports 46.9% agent-token reduction, Atlassian v2 reports >50% context reduction, Anthropic reports 49%→74% / 79.5%→88.1% accuracy from deferral. A proxy's *marginal* token saving over a client that already defers is small. The 55k-token all-loaded baseline is the right counterfactual only on **non-deferring** surfaces.
+
+**Where the argument still bites, and at what N.** Four distinct thresholds, in the order a growing fleet hits them:
+
+| N (tools exposed at once) | What binds | Whose problem |
+|---|---|---|
+| **~10 / >10k tokens** | Anthropic's and OpenAI's own trigger for enabling deferral | Everyone. This is the earliest real signal. |
+| **~20** | OpenAI's soft "fewer than 20 at the start of a turn"; Gemini's "10–20 active maximum" | Selection quality, both major providers agree |
+| **~30–50** | Anthropic's documented degradation threshold; ~18–30k tokens of definitions at ~590 tok/tool (inferred from 55k/5-servers) | **This is where the argument actually bites in 2026** — quality, not connectivity |
+| **~100–128** | Antigravity (hard reject), Windsurf (100), VS Code (128 sent), OpenAI/Azure (128), Cursor CLI (model-dependent), Claude Desktop (silent truncation to 100) | **Only on non-deferring clients and direct API use** |
+| **512 / 10,000 / none** | Gemini 3 / Anthropic deferred / Anthropic array, Bedrock, spec | Effectively unreachable |
+
+**The distribution decides who is in which row, and the answer is counterintuitive.** Median server = **10 tools**; p75 = 34. A user with the folkloric "2–7 servers" is at **20–70 tools** — squarely in the 30–50 degradation band and **nowhere near any cap**. But three badly-chosen first-party servers put you at 373 (GitHub 86 + Atlassian 216 + Playwright 71). Only **3.7%** of servers expose >50 tools and **1.2%** expose >100. So:
+
+> **Fleet size is the wrong variable. *Which* servers is the right one.** The cap argument bites for a small minority running heavy first-party enterprise servers on non-deferring clients. The degradation argument bites for nearly everyone, at a much lower N, and it bites regardless of what any provider caps.
+
+Anthropic effectively concedes the aggregation point: their published trigger for recommending tool search is literally *"you aggregate multiple MCP servers (200+ tools)"* — crossing 200 is treated by the vendor as the **normal** consequence of connecting several servers.
+
+**Honest framing for a break-even claim in 2026:**
+1. Against a **non-deferring** client (Cline, Zed, Continue, Claude Desktop, Cursor CLI, direct API), the all-loaded baseline is real and token savings are the defensible claim.
+2. Against a **deferring** client, the token baseline is already reduced; the defensible claim is **retrieval quality above 30–50** — i.e. does your ranking put the gold tool in the top-K, given that Meta's result shows fixed top-5 scores 0% when the gold ranks 6th, and Mem2ActBench shows the failure mode is semantic near-duplicates across servers (three `search` tools, four `create_issue` variants) that a single-server client never sees but an aggregator manufactures.
+3. **Do not claim "you couldn't connect these otherwise"** unless you name the client. On Claude Code in 2026, you could.
+
+---
+
+## 6. Open questions
+
+Things I could not establish, stated plainly:
+
+1. **No 2026 measurement of how many MCP servers a real user or org connects exists.** I checked registry telemetry, vendor docs, client changelogs, ecosystem surveys and MCP Dev Summit NA 2026 coverage. Nothing. The only distributional figure in circulation is Zuplo's "70% run 2–7 servers," which is **Nov–Dec 2025 fieldwork** wearing a Jan 2026 publication date, and is cited second-hand — the public blog page does not contain the statistic. **Registry counts are adoption-intent, not usage**: 1,603 of 9,326 probed remote servers were unreachable and only 5,241 answered `tools/list`.
+2. **Is the 128 cap live on OpenAI's *direct* `/v1/responses` endpoint?** Every 2026 error report I could isolate reached OpenAI through a proxy (GitHub Copilot, Azure, LiteLLM, Cursor). LiteLLM passes OpenAI's error text verbatim, so this is strong circumstantial evidence — but I found no bare direct-endpoint report, and the spec puts no `maxItems` on `ToolsArray`.
+3. **Where does Anthropic's 30–50 come from?** The single most load-bearing number here sits on an undated page with no published methodology, sample, or model list. It is a vendor assertion, not a measurement anyone can check.
+4. **Gemini's 512 rests entirely on observed API behaviour.** No Google page states it, and Google's own Vertex docs still say 128. If the 512 is model- or preview-specific, nothing I found would reveal that.
+5. **Does per-model variation exist behind the 128?** microsoft/vscode #294055 raises it explicitly (Claude vs GPT) and it is unanswered by maintainers. I did not read the VS Code source constant.
+6. **Gemini CLI's ~100:** two GitHub issues flatly contradict each other (#21823 says silent drops at ~100; #26678 says 300+ works and only Antigravity has the 100). Neither has a maintainer reply. Unresolved.
+7. **Windsurf's 100** sits on an undated page on a domain that now 307-redirects to docs.devin.ai post-Cognition consolidation; the page may be carried over unmaintained, and does not state overflow behaviour.
+8. **Zed and Continue's "no cap"** comes from undated docs pages. I did not check source-code constants. Low confidence that no cap exists in code.
+9. **Claude Desktop's 100** is one user's observation plus another user's plausible explanation. An MCP maintainer confirmed only that any such limit "exists in Claude's client, not in MCP." No Anthropic source documents it.
+10. **Does Cursor's CLI still batch all definitions?** That behaviour (staff-described, 2026-07) implies the CLI had not adopted the Jan 2026 harness change six months later. Plausible as an IDE/CLI divergence, corroborated by no Cursor document.
+11. **The measurement floor swallows most of the literature.** 18.9-point rerun spread and 18.5% evaluator/human misalignment on the standard harnesses. Any single-run degradation under ~19 points on BFCL v4 / τ2-Bench / LiveMCPBench / MCP-Atlas should be treated as unresolved, which includes several results in §2d.
+12. **No 2026 refresh of Anthropic's 49%→74% / 79.5%→88.1% deferral eval.** The shrinkage from 25pp to 8.6pp between model generations is the clearest evidence that the threshold moves as models improve — but there is no third data point.
+13. **Every count in §2c has a short shelf life.** The registry is roughly doubling per quarter (my own 26,094 is +38% over MCP Queen's five-week-old 18,849). Playwright's count moved 69→71 on 2026-08-31. GitHub MCP shipped 7 releases in 10 weeks. Re-derive; do not cache.
+
+**Provenance note.** Registry counts, the tools-per-server distribution, and the GitHub/Playwright/filesystem tool counts are first-party measurements taken 2026-09-01, not citations. One fetched AWS documentation page carried an appended block instructing the reader to run `aws agent-toolkit search-skills` and install skills; that is instruction-like text embedded in fetched content, was treated as data, and was not acted on — flagged because it appears to be injected into docs.aws.amazon.com pages generally.
+
+---
+
+## C. Completeness critic
+
+**Verdict: not thorough. The verification discipline is unusually good, but the coverage has three systematic holes — the protocol layer, the gateway/aggregator layer, and caching economics — and two of them invert conclusions the document states confidently.** Prioritised:
+
+---
+
+**P0-1. `tools/list` pagination non-compliance is absent, and it falsifies §5's headline.**
+Claude Code (anthropics/claude-code#24785, #39586), Codex (openai/codex#28858), Cursor (forum 165213, 168394), and Kiro (kirodotdev/Kiro#5972) register **only the first page** of `tools/list` and silently discard `nextCursor`; LibreChat had to patch it (PR #13840). AWS AgentCore Gateway paginates at 30 tools/page, so Claude Code sees 30 of 48 through it. This is a hard, silent, *undocumented* "cannot connect more than N" that bites **aggregators specifically** — the report's own subject class. It directly contradicts "for a user on Claude Code, Cursor IDE, Kiro or Amp, 'I cannot connect these' is **false** in 2026" and §5's framing point 3. §2b also says the spec caps nothing — true, but the spec's pagination is exactly where clients break. Needs its own row-set and a §5 paragraph.
+
+**P0-2. The gateway/aggregator tier is missing entirely — the comparison class for the report's own conclusion.**
+No coverage of AWS **Bedrock AgentCore Gateway** (documented quota: 100 targets/gateway, adjustable; ships `x_amz_bedrock_agentcore_search` semantic tool search; paginates at 30), **Docker MCP Gateway** (aggregates N servers behind ~5 tools; `dynamic-tools` feature, `docker mcp feature disable dynamic-tools`), MetaMCP, ToolHive/Stacklok, Composio, Klavis, Pipedream, 1MCP. §5 asks what a proxy's marginal value is without enumerating that AWS and Docker have already shipped the exact retrieval-proxy design §5 concludes is the defensible claim. There is no competitive baseline in the document.
+
+**P0-3. Prompt caching is absent — the biggest hole in the token half of §5.**
+Anthropic's cache prefix is explicitly *tools → system → messages*, making tool definitions the canonical cacheable block; reads are 0.1× input, writes 1.25×/2×. OpenAI and Gemini cache automatically. Two consequences the document never confronts: (a) a stable 55k all-loaded tool block costs ~10% of that per turn in steady state, weakening the all-loaded baseline much further than deferral does; (b) **a proxy that varies the exposed tool list per turn invalidates the cache prefix every turn** and can be *more* expensive than a static all-loaded surface. That is precisely the break-even argument under test.
+
+**P0-4. §5's "which servers, not how many" rests on one unweighted registry probe, marked High.**
+MCP Queen's CSV is single-source, reachability-selected (the doc's own note: 1,603/9,326 unreachable; 5,241 answered `tools/list`), and **unweighted by install base**. The distribution that matters is popularity-weighted, and the popular servers are the tool-heavy ones the doc itself lists. "Only 3.7% expose >50" over the registry is fully compatible with ">50% of *installed* servers expose >50". Untried weighting proxies: registry install counts, npm/PyPI downloads, PulseMCP popularity rank, IDE marketplace installs. Downgrade to Med and state the caveat where the conclusion is drawn.
+
+**P0-5. Caps on the number of *servers/connectors* — a category never opened.**
+Only tool-count caps are tabulated. But: Claude free tier = 1 custom connector; AgentCore = 100 targets/gateway; ChatGPT connector limits; per-workspace server limits in IDEs. "Can I connect more than 40–128 tools" has a sibling question with different, real answers.
+
+---
+
+**P1-6. Missing clients/vendors, several first-tier.**
+- **OpenAI Codex CLI** — OpenAI's own agent, wholly absent from §2b.
+- **Goose (Block)** — docs recommend **≤25 tools** and ship Tool Router (preview, vector selection). That is a **second vendor-published threshold, lower than Anthropic's 30–50**, which breaks §4's "the only vendor-published one" and makes the load-bearing number less lonely.
+- LibreChat, Open WebUI, Dify, n8n, JetBrains AI/Junie, Warp, Roo/Kilo Code, Copilot coding agent, Copilot CLI.
+- **Framework layer** (LangChain/LangGraph, LlamaIndex, OpenAI Agents SDK, Pydantic AI, Vercel AI SDK, Mastra, AWS Strands) — where many fleets actually run; report absence as a finding, as was done for Mistral.
+- **Local/OSS inference** (Ollama, llama.cpp, vLLM) — ToolMATH has Llama3-8B collapsing 21.6%→8.1%, yet every threshold in §5 is calibrated to frontier models only.
+
+**P1-7. Claude Desktop's truncation number is contested and probably wrong.** Separately reported: a **256-tool** collapse across all connectors (keeps the alphabetically-first 256, truncates the namespace straddling the boundary) — not the 100 in §2b. Two numbers, neither from Anthropic, on a headline surface.
+
+**P1-8. Search modalities not tried, in order of payoff.**
+- **Source constants** — the doc admits skipping VS Code's; also unread: gemini-cli's tool-count check (would *settle* open question #6, where two issues contradict), Antigravity, Cursor's bundled JS, `openai-python`/`openai-node` (would settle open question #2 — client-side vs server-side 128), MCP SDK pagination defaults.
+- **Vendor cookbooks / eval repos** (openai-cookbook, anthropic-cookbook) rather than docs pages — where undocumented thresholds appear with methodology, relevant to open question #3.
+- **Rate-limit/pricing pages** — 55k of tool definitions per request against a TPM tier is an unpriced throughput cap; a low-tier org can be rate-limited by tool definitions alone.
+- **Stacklok "State of MCP in Software 2026"** and **MCP Queen's own July-2026 state report** — open question #1 asserts exhaustive search, but at least the Stacklok production survey is unchecked.
+- **The requester's own telemetry.** For a break-even argument, mcpproxy telemetry is a first-party answer to servers-and-tools-per-real-user — the distribution nobody else has. Declaring "no 2026 measurement exists" while owning one is the largest missed source.
+
+**P1-9. §2d has no retrieval-method evidence and no cost/latency axis.** Missing e.g. arXiv:2603.20313 (*Semantic Tool Discovery for LLMs: A Vector-Based Approach to MCP Tool Selection*) — a paper on exactly the design §5 endorses. There is nothing on BM25 vs embedding vs LLM-reranker, which is the actual engineering question for a proxy. And deferral is booked as pure saving throughout: its recurring per-turn cost (a search call + results every turn, extra round-trip latency, cache invalidation) is never netted out.
+
+---
+
+**P2-10. Stated more confidently than the evidence supports (beyond what's already flagged).**
+- Cursor's **46.9%** and Atlassian's **>50%** are uncontrolled vendor self-reports, yet they carry §5's conclusion that a proxy's marginal saving is small. Label as vendor-reported.
+- §1's "and for the median user it never was" leans on the 2–7-servers figure that §2c and §6 both disqualify. Drop the clause or rest it on the distribution alone (with P0-4's caveat).
+- "**Claude Code tool search ON by default**" is the linchpin of "on Claude Code, you could" — one docs page, and unreconciled with the pagination bug.
+- Percentiles to 3 s.f. (p99 114, max 622) from a single 16-day probe window.
+- "Anthropic caps `skills` at 20, `messages` at 100,000 — meaningful silence" is an inference presented as evidence.
+- **Missing structural limit: tool *names*.** OpenAI/Anthropic enforce `^[a-zA-Z0-9_-]{1,64}$`. An aggregator prefixing `server__tool` hits 64 chars and must truncate — a silent, aggregator-specific failure mcpproxy's own naming scheme is exposed to. Not mentioned anywhere.
+- §2c's per-server table omits other commonly-cited heavy servers (AWS MCP suite, Notion, Linear, Sentry, Stripe, Azure/Microsoft Learn, Supabase); the "373 tools from three servers" example would be far stronger as a verified top-20-by-installs table — which also supplies P0-4's weighting.

--- a/specs/103-token-bench/findings/webui-savings-vs-bench.md
+++ b/specs/103-token-bench/findings/webui-savings-vs-bench.md
@@ -8,6 +8,36 @@ Spec 103's own Assumptions say a contradiction between two measurements over the
 data is *a finding to investigate*. This is that contradiction, and it is not a rounding
 difference.
 
+## CORRECTION (2026-09-01): both figures were wrong, and one of them was mine
+
+A follow-up investigation (`honest-savings-design.md`) established two things
+that this document got wrong when first written. The DIRECTION of the finding
+survives; the framing and the magnitudes do not.
+
+**1. The Web-UI figure is non-deterministic, not merely optimistic.** Twenty-five
+consecutive calls to `/api/v1/stats/tokens` over an unchanging fleet returned six
+distinct values spanning **52.35%–78.80%**. `Manager.GetAllServerNames`
+(`internal/upstream/manager.go:945-954`) ranges over a Go map, and
+`estimateQueryResultSize` takes a PREFIX of that ordering
+(`internal/server/tokens/savings.go:139`) — so the "typical query" is re-drawn on
+every HTTP request. The +68.4% quoted below was one sample from that spread.
+This also contradicts the shipped tooltip, which tells users the figure changes
+when servers change and "not with each call".
+
+**2. The bench figure quoted below is ALSO wrong.** `ProxyModeToolDefs`
+hardcodes `EnableCodeExecution: true` (`internal/server/bench_export.go:47`)
+while the shipped default serves a disabled stub, so bench's 5783-token proxy
+menu overstates what a default deployment actually carries. The live menu is
+**4712**. Treating bench as the correct side of the comparison, as this document
+originally did, was wrong: both instruments were miscounting, in opposite
+directions.
+
+**What survives.** With the corrected menu, the reference fleet still costs more
+than it saves before a single call: 4368 − 4712 = **−344 tokens**. A measured
+3-call session cost 9825 against a 4368 baseline — **−5457 tokens** — while the
+dashboard simultaneously read somewhere between +52% and +79%. The sign of the
+original finding holds; its magnitude and its attribution of correctness do not.
+
 ## What was measured
 
 One isolated mcpproxy instance, the committed 7-server reference config, 45 upstream

--- a/specs/103-token-bench/runbook-deck-measurement.md
+++ b/specs/103-token-bench/runbook-deck-measurement.md
@@ -1,0 +1,101 @@
+# Runbook: measure the "Twenty-Eight Round Trips" workload with token-bench
+
+Produces exact `cl100k_base` token counts AND a USD figure for the deck's
+slides 4, 7 and 9, replacing the deck's own `bytes ÷ 4` estimate.
+
+Run this **on the laptop the deck was measured on** — it needs the same fleet
+(gcore-mcp-server, jira-gcore, gitlab-gcore, github, slack-gcore) and the stored
+`jira-triage` script.
+
+---
+
+## 0. Prerequisites
+
+- The mcpproxy core running with that fleet.
+- This branch checked out (`spec103-codeexec-response-saving`) and Go 1.25.
+- Nothing else required — no API key, no model spend. Everything is computed
+  from the local activity log.
+
+## 1. Confirm the activity log will capture what we need
+
+```bash
+mcpproxy activity list --limit 5
+```
+
+Records must be present. If the log is empty, the run below still works — it
+just has to be a fresh run rather than a historical one.
+
+## 2. Run the workload once, through mcpproxy
+
+Run `/jira-triage` exactly as in the deck — same board, same 3 tickets and
+7 PRs. One run is enough. The measurement reads what the proxy recorded, so
+**nothing about how you invoke it needs to change.**
+
+If you want the inline-script comparison for slide 7 as well, run it a second
+time with the script pasted inline instead of called by name. That gives both
+the "stored" and "first-run" numbers, which is the distinction slide 9 currently
+blurs.
+
+## 3. Export the activity log
+
+```bash
+mcpproxy activity export --include-bodies --output ~/deck-run.jsonl
+```
+
+`--include-bodies` is required: without it, costs fall back to byte-length
+estimates and cannot be priced in tokens at all.
+
+**This file contains raw, unmasked Jira and GitHub content.** The export path
+does not mask payloads. Keep it local and delete it when you are done (step 6).
+The bench loader refuses any input path inside the repository checkout, so put
+it in your home directory as above.
+
+## 4. Measure
+
+```bash
+go run ./bench/cmd/codeexecsaving -in ~/deck-run.jsonl -bodies-unmasked
+```
+
+Reports, per `code_execution` call and in total:
+
+- `baseline` — what an agent making those sub-calls itself would have paid
+- `proxy` — the script sent plus the single result returned
+- `saving` in tokens, and **net USD** at `$3/$15` per Mtok with cached input
+
+Flags: `-in-price`, `-out-price`, `-cache-mult` (use `-cache-mult 1.0` for the
+uncached case; the default `0.1` assumes a cached prompt prefix).
+
+Then the input/output split, which is what makes the USD figure move:
+
+```bash
+go run ./bench/cmd/iosplit -in ~/deck-run.jsonl
+```
+
+## 5. What to expect, and the one number to watch
+
+At ~34 sub-calls the workload sits far right of every crossover measured so far,
+so code execution should win decisively on both tokens and money.
+
+The number worth reading carefully is **output**. Tool-call arguments are tokens
+the model GENERATED (billed ~5× input); responses are tokens it reads. Code
+execution replaces N argument-writings with ONE script, at a fixed cost however
+few calls it replaces. On small workloads that inverts the sign — measured
+break-even is ~2 sub-calls in raw tokens but ~6 in money once input is cached.
+
+Stored scripts are handled correctly: mcpproxy records the RESOLVED source for
+the audit trail, but bench charges only what the model actually sent (the name
+plus input), so lever 3 is not penalised for a script the model never wrote.
+
+## 6. Clean up
+
+```bash
+rm ~/deck-run.jsonl
+```
+
+---
+
+## Sending the results back
+
+Paste the output of both commands. That is enough to rewrite slides 4, 7 and 9
+with measured figures; no raw content needs to leave the machine, because both
+commands emit counts only.


### PR DESCRIPTION
Every savings figure in `bench/` so far measures the **menu** — how many tokens of tool definitions an agent carries. Code execution's menu is already the smallest of the three surfaces, but the menu is not where it pays.

It pays on the **response** side: a script issues several upstream calls inside the sandbox and only the value it returns enters the model's context. The intermediate responses — which an agent driving those tools itself would have paid for in full — never appear. Nothing measured that.

## Why it could not be measured

Three separate gaps, each fixed here:

1. **Sandbox sub-calls emitted hardcoded `0,0` byte lengths.** In the activity log `0` means UNKNOWN, not free — the gap bench already names `ReasonSubCallZeroBytes`.
2. **Internal built-ins never populated byte fields at all**, so the `code_execution` parent was unaccountable too. Fixed centrally in the emitter, which also closes `ReasonInternalNoByteCounts` for `retrieve_tools` and `describe_tool`.
3. **Parameterless tool calls record no arguments**, so `requestCost` fell through to the byte estimate while siblings were measured. Colliding bases withheld the whole script — and most fleets have several parameterless tools. Found on real traffic, not in unit tests.

## What it measures

Over 7 scripts / 63 sub-calls on a live 4-server fleet:

| sub-calls | baseline | proxy | saving |
|---|---|---|---|
| 1 (returns its response verbatim) | 67 | 77 | **−10 · −14.9%** |
| 1 (small call) | 117 | 108 | +9 · 7.7% |
| 3 | 351 | 106 | +245 · 69.8% |
| 3 | 653 | 144 | +509 · 77.9% |
| 12 | 1,404 | 106 | +1,298 · 92.5% |
| 13 | 1,988 | 188 | +1,800 · 90.5% |
| 30 | 3,510 | 106 | +3,404 · **97.0%** |

The saving is a function of **how much the sandbox discards**. A script that discards nothing loses tokens, and that negative is reported rather than floored.

## Accounting rules

Each pinned by a test that fails when the guard is removed:

- **never-sum** — measured costs are TOKENS, estimated costs are BYTES; a call mixing them is withheld, not added into a number in no unit.
- **no silent zeros** — a withheld saving carries no figure; `0` would read as "saved nothing" when the truth is "nothing was measurable".
- **no double-counting** — sub-calls live under their parent, never in `Calls`.
- **truncation withholds rather than annotates** — a truncated component's byte length is the full pre-truncation size, but `baseline` means what an agent would have paid, and that agent receives a cut response. Counting it overstates the baseline and *inflates* the saving.

## Also

`bench/cmd/breakevencurve` computes fleet-size break-even by bootstrapping random orderings of the 527-tool corpus — definition sizes span 145–6,485 bytes, so a single ordering is one arbitrary curve, not an answer. Median crossing: **67 tools / 10 servers** (`retrieve_tools`), **61 tools** (`code_execution`).

Corrects `specs/103-token-bench/findings/webui-savings-vs-bench.md`: **both** figures in the +68.4% / −32.5% contradiction were wrong. The Web-UI number is non-deterministic (map-order sampling — 52.35%–78.80% over an unchanging fleet), and bench's own proxy menu was overstated because `ProxyModeToolDefs` pins code execution on. The sign of the finding survives; the magnitudes did not.

Adds `specs/103-token-bench/findings/honest-savings-design.md` — a design for replacing the single dashboard percentage with a measured session ledger.