### PR TITLE
fix(security): re-derive JWT admin role and scope agent tokens per owner

### DIFF
--- a/docs/development/server-edition-multiuser-auth.md
+++ b/docs/development/server-edition-multiuser-auth.md
@@ -64,21 +64,39 @@ always did, and the bearer-JWT path now does too. The `role` claim inside a JWT
 is informational only; it is minted at login, never revoked, and must not be
 trusted for authorization.
 
-**Read this first: an `admin_emails` edit is NOT hot-reloadable.** The
-middleware captures `*config.ServerEditionConfig` at wiring time, so *no* edit —
-promotion or demotion — takes effect until the process restarts. Everything
-below describes what happens **once the edited config is loaded**, and in
-particular a demotion is *not* immediate: **restart the process before treating
-someone as demoted.**
+**An `admin_emails` edit takes effect on the next request — no restart.** The
+config file is hot-reloadable (`config.LoadFromFile` unmarshals `server_edition`
+in full, and it is not one of the restart-pinned fields), and the middleware
+reads the role through a `ServerEditionConfigProvider` over the runtime's
+current snapshot rather than a pointer captured at wiring time. It is the same
+provider (`Dependencies.ConfigProvider`) the admin-servers check uses; do not
+add a second mechanism, and do not capture `deps.Config.ServerEdition` in a new
+surface that makes a role decision.
 
-Once the edited config is loaded, on both auth paths:
+On both auth paths, once the file watcher has reloaded the edit:
 
-- Removing someone from `admin_emails` demotes them even while they hold an
-  unexpired admin JWT, and they can no longer renew an admin token via
-  `POST /api/v1/auth/token`. No re-login, and no waiting for their JWT to
-  expire — but also not before the restart above.
-- Adding someone promotes them on their next request, without re-login — again,
-  from the restart onward.
+- Removing someone from `admin_emails` demotes them on their next request, even
+  while they hold an unexpired admin JWT, and they can no longer renew an admin
+  token via `POST /api/v1/auth/token`. No re-login, no waiting for the JWT to
+  expire, and no restart.
+- Adding someone promotes them on their next request, without re-login.
+
+Two limits worth stating exactly, because they are what the guarantee does
+*not* cover:
+
+- The edit is live from the moment the **reload lands**, not from the moment the
+  file is saved. A malformed file is rejected and the previous config stays in
+  force (`Config hot-reload failed; keeping previous configuration`), so confirm
+  the reload before treating anyone as demoted.
+- If a reload produces a config with **no `server_edition` block at all**, the
+  provider falls back to the boot-time block rather than emptying the admin
+  list. That is the conservative direction — it can only preserve the list the
+  process started with, never widen it.
+
+`AdminHandlers.adminEmails` is a separate, boot-time copy used **only** to
+label rows in the dashboard response. It is not an access-control input (every
+admin route gates on `requireAdmin` → `AuthContext.IsAdmin()`), so a stale label
+there is cosmetic. Do not grow an authorization check on top of it.
 
 ### Agent tokens and tenant identity (issue #1168)
 
@@ -108,8 +126,19 @@ Once the edited config is loaded, on both auth paths:
   immediately, and the gate **fails closed**: a user store that cannot answer
   denies. `POST /api/v1/admin/users/{id}/disable` additionally **revokes** that
   user's tokens, so re-enabling the account does not resurrect a credential that
-  may be why it was disabled; `enable` deliberately does not un-revoke. An
-  admin-facing surface for revoking a *specific* tenant's token is issue #1179.
+  may be why it was disabled; `enable` deliberately does not un-revoke, and
+  **neither does regenerate** — rotating a revoked token answers `409`
+  (`storage.ErrAgentTokenRevoked`) on both editions' surfaces, because rotation
+  refreshes a live secret and is not an un-revoke by another name. Delete frees
+  the name, so creating a fresh token is the supported path. An admin-facing
+  surface for revoking a *specific* tenant's token is issue #1179.
+- **The owner gate is installed FIRST in `setup.go`, before any fallible step.**
+  `wireServerEditionOAuth` only *logs* `SetupAll`'s error — the process comes up
+  serving traffic either way — so a control installed after `cfg.Validate()`,
+  `EnsureBuckets()`, `GetOrCreateHMACKey()` or the credential store is simply
+  absent whenever one of those fails, and agent tokens would then be ungated.
+  Installed first it fails closed instead. Keep new fallible setup steps *below*
+  it.
 - `RegenerateAgentTokenForOwner`'s `narrowScope` hook can only ever narrow, and
   storage **enforces** that: the hook's return is intersected with the token's
   stored `AllowedServers` before it is persisted (a stored `"*"` counts as

--- a/docs/development/server-edition-multiuser-auth.md
+++ b/docs/development/server-edition-multiuser-auth.md
@@ -95,7 +95,26 @@ Once the edited config is loaded, on both auth paths:
   back in front: it opens a TOCTOU window on delete-then-recreate, and its
   fall-through 500 used to interpolate the storage sentinel into the body.
 - The token cap answers **409** on both editions' surfaces
-  (`ErrAgentTokenLimitReached`). One storage condition, one status.
+  (`ErrAgentTokenLimitReached`). One storage condition, one status. The **body
+  differs by edition on purpose**: `auth.MaxTokens` is counted across the whole
+  `agent_tokens` bucket, so in the server edition it is a *deployment-wide* cap
+  a tenant may be unable to clear, and the message says so and points at an
+  administrator. Do not copy the personal edition's "you have reached the
+  maximum" wording here. A per-owner quota is issue #1177.
+- **A token is only as live as its owner.** `storage.Manager.SetAgentTokenOwnerGate`
+  is installed in `setup.go` over the user store, and `ValidateAgentToken`
+  consults it for every *owned* token (ownerless personal-edition tokens are
+  never gated). A disabled — or deleted — owner's tokens stop authenticating
+  immediately, and the gate **fails closed**: a user store that cannot answer
+  denies. `POST /api/v1/admin/users/{id}/disable` additionally **revokes** that
+  user's tokens, so re-enabling the account does not resurrect a credential that
+  may be why it was disabled; `enable` deliberately does not un-revoke. An
+  admin-facing surface for revoking a *specific* tenant's token is issue #1179.
+- `RegenerateAgentTokenForOwner`'s `narrowScope` hook can only ever narrow, and
+  storage **enforces** that: the hook's return is intersected with the token's
+  stored `AllowedServers` before it is persisted (a stored `"*"` counts as
+  granting everything, so materialising it into a concrete list still works).
+  The contract is not a comment a future caller can violate.
 - An agent token's `AuthContext` carries its owner's `UserID` (so its activity
   is attributable) but stays at `AuthTypeAgent`. Per-user surfaces must gate on
   `IsUser()`, never on a non-empty `UserID`.
@@ -113,9 +132,18 @@ themselves a token over the admin's whole inventory.
 
 - **Entitlement is the per-user door's own predicate**: the caller's personal
   servers plus the admin servers flagged `shared`. `NewUserHandlers` receives
-  the *whole* configuration (`deps.Config.Servers`), so the `Shared` filter is
-  what keeps the admin's private servers out. Reuse
-  `entitledServerNames`; do not write a second definition of entitlement.
+  the *whole* configuration, so the `Shared` filter is what keeps the admin's
+  private servers out. Reuse `entitledServerNames`; do not write a second
+  definition of entitlement.
+- **Read the configuration LIVE, never a boot-time slice.** `NewUserHandlers`
+  takes an `AdminServersProvider` (a function), wired in `setup.go` to
+  `Dependencies.ConfigProvider` over the runtime's current config snapshot. The
+  config is hot-reloadable: a handler built on `deps.Config.Servers` as captured
+  at process start is blind to every server added afterwards, and a tenant could
+  pre-create a personal server named like an admin server that only appears
+  later and walk straight through the collision control below. Any new
+  server-edition surface that makes an authorisation decision from configuration
+  must read it through the provider.
 - **An unentitled name is rejected (400), not silently dropped** — a token that
   quietly sees less than asked is worse than a refusal. The message is
   identical for "another tenant's server", "the admin's unshared server" and
@@ -137,8 +165,14 @@ themselves a token over the admin's whole inventory.
   admin-private upstream was a way to mint a token over it.
   `entitledServerNames` also drops such a collision for a non-admin, so a row
   that predates the refusal (or an admin who later adds a colliding name) cannot
-  resurrect the escalation. The refusal message is identical for a shared and a
-  private collision: naming which would be a server-name existence oracle.
+  resurrect the escalation. **`createServer` answers every unavailable name with
+  one body** — `Server name %q is not available` — whether the holder is a
+  shared admin server, a private admin server, or the caller's own existing
+  server. Two different wordings let a tenant read, from one request, that a
+  name they do not own is in the admin's configuration, and enumerate a private
+  inventory they cannot list. The residual bit (a tenant can subtract their own
+  inventory) closes only when enforcement resolves a server name against an
+  owner rather than as a bare string.
 
 #### Scope is a snapshot, not a live check
 
@@ -177,7 +211,7 @@ carry into the cross-tenant token administration feature.
 | `internal/serveredition/auth/` | OAuth, sessions, JWT tokens, middleware |
 | `internal/serveredition/users/` | User/session models, BBolt store |
 | `internal/serveredition/workspace/` | Per-user workspace for personal upstreams |
-| `internal/serveredition/multiuser/` | Multi-user router, tool filtering, activity isolation |
+| `internal/serveredition/multiuser/` | Multi-user router (**not yet wired** — `NewRouter` has no production caller), tool filtering, activity isolation |
 | `internal/serveredition/api/` | Server REST API endpoints (user, admin, auth) |
 
 ## Server Testing

--- a/docs/development/server-edition-multiuser-auth.md
+++ b/docs/development/server-edition-multiuser-auth.md
@@ -56,6 +56,40 @@ Server edition supports OAuth-based multi-user authentication with Google, GitHu
 - **Admin**: Identified by `admin_emails` config. Sees all activity, manages users.
 - **Build tag**: All server code behind `//go:build server`. Personal edition unaffected.
 
+### Role freshness (issue #1169)
+
+`admin_emails` is the single source of truth for the admin role, and **both**
+auth paths re-derive it from the config on every request — the session path
+always did, and the bearer-JWT path now does too. The `role` claim inside a JWT
+is informational only; it is minted at login, never revoked, and must not be
+trusted for authorization. Consequences:
+
+- Removing someone from `admin_emails` demotes them even while they hold an
+  unexpired admin JWT, and they can no longer renew an admin token via
+  `POST /api/v1/auth/token`.
+- Adding someone promotes them on their next request, without re-login.
+- **Not hot-reloadable.** The middleware captures `*config.ServerEditionConfig`
+  at wiring time, so an `admin_emails` edit takes effect at the next process
+  restart, not immediately — on both auth paths.
+
+### Agent tokens and tenant identity (issue #1168)
+
+- Agent-token names are a **per-owner** namespace: two tenants can each hold a
+  token called `ci`. Storage resolves by `(owner, name)`; the legacy
+  `agent_token_names` index is kept only for ownerless (personal-edition)
+  tokens, and there is no migration.
+- `/api/v1/user/tokens/{name}` revoke, delete and regenerate answer an
+  identical **404** for "does not exist" and "belongs to another tenant", and
+  create no longer reports a conflict on another tenant's name. Do not
+  reintroduce a "not yours" branch — it is a name-existence oracle.
+- An agent token's `AuthContext` carries its owner's `UserID` (so its activity
+  is attributable) but stays at `AuthTypeAgent`. Per-user surfaces must gate on
+  `IsUser()`, never on a non-empty `UserID`.
+- The personal-edition admin surface (`/api/v1/tokens/{name}`) operates in the
+  ownerless namespace and therefore no longer reaches server-edition users'
+  tokens by name. Cross-tenant token administration belongs in
+  `admin_handlers` as its own feature.
+
 ## Key Directories
 
 | Directory | Purpose |

--- a/docs/development/server-edition-multiuser-auth.md
+++ b/docs/development/server-edition-multiuser-auth.md
@@ -90,6 +90,33 @@ trusted for authorization. Consequences:
   tokens by name. Cross-tenant token administration belongs in
   `admin_handlers` as its own feature.
 
+### Token server scope (`allowed_servers`)
+
+`POST /api/v1/user/tokens` constrains the requested `allowed_servers` to what
+the caller may actually reach. `AllowedServers` is the sole input to
+`auth.AuthContext.CanAccessServer`, so persisting it verbatim let a tenant mint
+themselves a token over the admin's whole inventory.
+
+- **Entitlement is the per-user door's own predicate**: the caller's personal
+  servers plus the admin servers flagged `shared`. `NewUserHandlers` receives
+  the *whole* configuration (`deps.Config.Servers`), so the `Shared` filter is
+  what keeps the admin's private servers out. Reuse
+  `entitledServerNames`; do not write a second definition of entitlement.
+- **An unentitled name is rejected (400), not silently dropped** — a token that
+  quietly sees less than asked is worse than a refusal. The message is
+  identical for "another tenant's server", "the admin's unshared server" and
+  "no such server anywhere": a distinguishing message would be a server-name
+  existence oracle, the same defect class as the token-name one above.
+- **`"*"`** is the only wildcard the enforcement layer honours (`s == "*" ||
+  s == name`, in both `auth` and `jsruntime`), so there are no globs to expand.
+  For an admin it stays literal; for a tenant it is materialised into their
+  entitled set at mint time, and refused outright when that set is empty. The
+  expansion is a snapshot — a server added later needs a new token — and the
+  create response echoes the effective list back.
+- **An omitted `allowed_servers` stays empty**, which denies every server at the
+  agent tier. Do not copy the personal edition's "empty means `["*"]`" default:
+  there the only caller is the operator.
+
 ## Key Directories
 
 | Directory | Purpose |

--- a/docs/development/server-edition-multiuser-auth.md
+++ b/docs/development/server-edition-multiuser-auth.md
@@ -62,15 +62,23 @@ Server edition supports OAuth-based multi-user authentication with Google, GitHu
 auth paths re-derive it from the config on every request — the session path
 always did, and the bearer-JWT path now does too. The `role` claim inside a JWT
 is informational only; it is minted at login, never revoked, and must not be
-trusted for authorization. Consequences:
+trusted for authorization.
+
+**Read this first: an `admin_emails` edit is NOT hot-reloadable.** The
+middleware captures `*config.ServerEditionConfig` at wiring time, so *no* edit —
+promotion or demotion — takes effect until the process restarts. Everything
+below describes what happens **once the edited config is loaded**, and in
+particular a demotion is *not* immediate: **restart the process before treating
+someone as demoted.**
+
+Once the edited config is loaded, on both auth paths:
 
 - Removing someone from `admin_emails` demotes them even while they hold an
   unexpired admin JWT, and they can no longer renew an admin token via
-  `POST /api/v1/auth/token`.
-- Adding someone promotes them on their next request, without re-login.
-- **Not hot-reloadable.** The middleware captures `*config.ServerEditionConfig`
-  at wiring time, so an `admin_emails` edit takes effect at the next process
-  restart, not immediately — on both auth paths.
+  `POST /api/v1/auth/token`. No re-login, and no waiting for their JWT to
+  expire — but also not before the restart above.
+- Adding someone promotes them on their next request, without re-login — again,
+  from the restart onward.
 
 ### Agent tokens and tenant identity (issue #1168)
 
@@ -82,6 +90,12 @@ trusted for authorization. Consequences:
   identical **404** for "does not exist" and "belongs to another tenant", and
   create no longer reports a conflict on another tenant's name. Do not
   reintroduce a "not yours" branch — it is a name-existence oracle.
+- Those three do the lookup **inside the mutating transaction** and classify its
+  error (`storage.ErrAgentTokenNotFound` → 404). Do not put a `Get…` preflight
+  back in front: it opens a TOCTOU window on delete-then-recreate, and its
+  fall-through 500 used to interpolate the storage sentinel into the body.
+- The token cap answers **409** on both editions' surfaces
+  (`ErrAgentTokenLimitReached`). One storage condition, one status.
 - An agent token's `AuthContext` carries its owner's `UserID` (so its activity
   is attributable) but stays at `AuthTypeAgent`. Per-user surfaces must gate on
   `IsUser()`, never on a non-empty `UserID`.
@@ -116,6 +130,42 @@ themselves a token over the admin's whole inventory.
 - **An omitted `allowed_servers` stays empty**, which denies every server at the
   agent tier. Do not copy the personal edition's "empty means `["*"]`" default:
   there the only caller is the operator.
+- **A personal server may not take a name used anywhere in the admin
+  configuration**, shared or private. `AllowedServers` is compared by bare
+  string, so "I own a server called X" and "I may reach the admin's X" are
+  indistinguishable at enforcement time — a personal server named after an
+  admin-private upstream was a way to mint a token over it.
+  `entitledServerNames` also drops such a collision for a non-admin, so a row
+  that predates the refusal (or an admin who later adds a colliding name) cannot
+  resurrect the escalation. The refusal message is identical for a shared and a
+  private collision: naming which would be a server-name existence oracle.
+
+#### Scope is a snapshot, not a live check
+
+`resolveTokenServerScope` runs at mint time and **nothing re-validates at use
+time**. Un-sharing a server, or removing a personal one, does **not** revoke the
+grants already written into live tokens — to actually withdraw access, revoke or
+delete the tokens.
+
+Rotation is the one re-check: `POST /api/v1/user/tokens/{name}/regenerate`
+re-runs the entitlement predicate and persists the **narrowed** list
+(`narrowScopeToEntitled`), echoing it back in the response. It only ever narrows,
+and it never rejects — refusing to rotate would leave the over-broad grant in
+place and working. A token that is never rotated is never re-checked.
+
+**Tokens minted with a literal `"*"` before this constraint existed.** The
+enforcement layer honours `"*"` unconditionally, so any such token is a standing
+grant over the whole deployment. There is no migration and no admin-facing
+report: `GET /api/v1/user/tokens` is per-caller, and the server edition has no
+cross-tenant token listing (that belongs in `admin_handlers`, as its own
+feature). Until one exists, an operator audits them straight from storage —
+every record in the `agent_tokens` bucket whose `allowed_servers` contains `"*"`
+and whose `user_id` is non-empty — and revokes them; a tenant's own rotation
+also materialises the star into their entitled set. **This does not block the
+release**: the escalation route is closed for every token minted from here on,
+and a pre-existing `"*"` token could only have been minted by a tenant who was
+already able to mint one, i.e. it is not a new exposure. It is a cleanup item to
+carry into the cross-tenant token administration feature.
 
 ## Key Directories
 

--- a/internal/auth/agent_token.go
+++ b/internal/auth/agent_token.go
@@ -62,6 +62,13 @@ func (t *AgentToken) AuthContext() *AuthContext {
 		AllowedServers: t.AllowedServers,
 		Permissions:    t.Permissions,
 		ProfilePin:     t.ProfilePin,
+		// UserID carries the owning tenant (server edition). Without it an
+		// agent-token request had no tenant identity at all, so its activity
+		// could not be attributed or scoped. It does NOT confer the user tier:
+		// Type stays AuthTypeAgent, so IsUser()/IsAdmin() remain false, and
+		// every per-user surface must gate on IsUser() rather than on a
+		// non-empty UserID.
+		UserID: t.UserID,
 	}
 }
 

--- a/internal/auth/agent_token_identity_test.go
+++ b/internal/auth/agent_token_identity_test.go
@@ -1,0 +1,108 @@
+package auth
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestAgentTokenAuthContext_CarriesUserID: an agent-token request must carry
+// the owning tenant's identity, or its activity cannot be attributed or scoped
+// at all (issue #1168 gap b).
+//
+// BITES: without the fix ac.UserID is "" while the token names an owner.
+func TestAgentTokenAuthContext_CarriesUserID(t *testing.T) {
+	const owner = "01HTEST000000000000000USER"
+
+	tok := &AgentToken{
+		Name:        "ci",
+		TokenPrefix: "mcp_agt_abcd",
+		Permissions: []string{PermRead},
+		UserID:      owner,
+	}
+
+	ac := tok.AuthContext()
+	if ac == nil {
+		t.Fatal("AuthContext() returned nil for a valid token")
+	}
+	if ac.UserID != owner {
+		t.Errorf("UserID = %q, want %q — the agent tier carries no tenant identity", ac.UserID, owner)
+	}
+	if ac.GetUserID() != owner {
+		t.Errorf("GetUserID() = %q, want %q", ac.GetUserID(), owner)
+	}
+
+	// Carrying the owner must NOT promote the tier: everything gated on the
+	// user tier stays closed, and admin stays closed.
+	if ac.Type != AuthTypeAgent {
+		t.Errorf("Type = %q, want %q", ac.Type, AuthTypeAgent)
+	}
+	if ac.IsUser() {
+		t.Error("an agent token must not satisfy IsUser(); per-user surfaces gate on it")
+	}
+	if ac.IsAdmin() {
+		t.Error("an agent token must never be admin")
+	}
+	if ac.CanRevealSecrets() {
+		t.Error("an agent token must never be allowed to reveal secrets")
+	}
+}
+
+// TestAgentTokenAuthContext_FieldParity_Reflective makes the constructor's own
+// doc-comment promise ("so no auth path can silently drop a field") into a
+// mechanical check: every AgentToken field with a same-named counterpart on
+// AuthContext must be carried through. The next field added to AgentToken
+// fails here instead of being dropped in silence — which is exactly how UserID
+// went missing.
+//
+// Fields with no AuthContext counterpart (TokenHash, ExpiresAt, CreatedAt,
+// LastUsedAt, Revoked) are storage bookkeeping and are skipped. Name maps to
+// AgentName and is checked explicitly.
+func TestAgentTokenAuthContext_FieldParity_Reflective(t *testing.T) {
+	tok := &AgentToken{
+		Name:           "ci",
+		TokenPrefix:    "mcp_agt_abcd",
+		AllowedServers: []string{"github"},
+		Permissions:    []string{PermRead},
+		UserID:         "01HTEST000000000000000USER",
+		ProfilePin:     "work",
+	}
+
+	ac := tok.AuthContext()
+	if ac == nil {
+		t.Fatal("AuthContext() returned nil for a valid token")
+	}
+
+	if ac.AgentName != tok.Name {
+		t.Errorf("AgentName = %q, want the token's Name %q", ac.AgentName, tok.Name)
+	}
+
+	tokVal := reflect.ValueOf(*tok)
+	tokType := tokVal.Type()
+	acVal := reflect.ValueOf(*ac)
+	acType := acVal.Type()
+
+	checked := 0
+	for i := 0; i < tokType.NumField(); i++ {
+		f := tokType.Field(i)
+		acField, ok := acType.FieldByName(f.Name)
+		if !ok || acField.Type != f.Type {
+			continue // no same-named, same-typed counterpart
+		}
+		src := tokVal.Field(i)
+		if src.IsZero() {
+			continue // the fixture does not exercise this field
+		}
+		checked++
+		if !reflect.DeepEqual(src.Interface(), acVal.FieldByName(f.Name).Interface()) {
+			t.Errorf("AuthContext() dropped %s: token has %v, context has %v",
+				f.Name, src.Interface(), acVal.FieldByName(f.Name).Interface())
+		}
+	}
+
+	// Guard against the check silently covering nothing (a renamed field, a
+	// changed type). TokenPrefix, AllowedServers, Permissions, UserID and
+	// ProfilePin all have counterparts today.
+	if checked < 5 {
+		t.Fatalf("the reflective parity check only covered %d fields; it is no longer proving anything", checked)
+	}
+}

--- a/internal/httpapi/auth_middleware_test.go
+++ b/internal/httpapi/auth_middleware_test.go
@@ -32,7 +32,7 @@ func (s *testTokenStore) DeleteAgentToken(_ string) error                       
 func (s *testTokenStore) RegenerateAgentToken(_ string, _ string, _ []byte) (*auth.AgentToken, error) {
 	return nil, nil
 }
-func (s *testTokenStore) UpdateAgentTokenLastUsed(_ string) error { return nil }
+func (s *testTokenStore) UpdateAgentTokenLastUsedByHash(_ string) error { return nil }
 
 func (s *testTokenStore) ValidateAgentToken(rawToken string, hmacKey []byte) (*auth.AgentToken, error) {
 	if s.validateFunc != nil {

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -552,7 +552,7 @@ func (s *Server) handleAgentTokenAuth(w http.ResponseWriter, r *http.Request, ne
 
 	// Update last-used timestamp in background
 	go func() {
-		if updateErr := s.tokenStore.UpdateAgentTokenLastUsed(agentToken.Name); updateErr != nil {
+		if updateErr := s.tokenStore.UpdateAgentTokenLastUsedByHash(agentToken.TokenHash); updateErr != nil {
 			s.logger.Warnw("Failed to update agent token last-used timestamp",
 				zap.String("name", agentToken.Name),
 				zap.Error(updateErr))

--- a/internal/httpapi/tokens.go
+++ b/internal/httpapi/tokens.go
@@ -2,6 +2,7 @@ package httpapi
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/contracts"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
 )
 
 // TokenStore defines the storage interface for agent token CRUD operations.
@@ -25,7 +27,10 @@ type TokenStore interface {
 	DeleteAgentToken(name string) error
 	RegenerateAgentToken(name string, newRawToken string, hmacKey []byte) (*auth.AgentToken, error)
 	ValidateAgentToken(rawToken string, hmacKey []byte) (*auth.AgentToken, error)
-	UpdateAgentTokenLastUsed(name string) error
+	// UpdateAgentTokenLastUsedByHash is keyed by the token's HMAC hash, not by
+	// its name: names are unique only within an owner in the server edition,
+	// so a by-name stamp could land on another tenant's token.
+	UpdateAgentTokenLastUsedByHash(hash string) error
 }
 
 // ServerNameLister provides the list of known server names for allowed_servers validation.
@@ -189,9 +194,15 @@ func (s *Server) handleCreateToken(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.tokenStore.CreateAgentToken(agentToken, rawToken, hmacKey); err != nil {
-		// Check for duplicate name
-		if strings.Contains(err.Error(), "already exists") {
-			s.writeError(w, r, http.StatusConflict, err.Error())
+		// Check for duplicate name. Classified on a typed sentinel rather than
+		// a substring of the storage message, so the response never echoes
+		// storage internals.
+		if errors.Is(err, storage.ErrAgentTokenNameExists) || strings.Contains(err.Error(), "already exists") {
+			s.writeError(w, r, http.StatusConflict, fmt.Sprintf("A token named %q already exists", req.Name))
+			return
+		}
+		if errors.Is(err, storage.ErrAgentTokenLimitReached) {
+			s.writeError(w, r, http.StatusConflict, fmt.Sprintf("Maximum number of agent tokens (%d) reached", auth.MaxTokens))
 			return
 		}
 		s.logger.Errorf("Failed to create agent token: %v", err)

--- a/internal/httpapi/tokens.go
+++ b/internal/httpapi/tokens.go
@@ -371,6 +371,14 @@ func (s *Server) handleRegenerateToken(w http.ResponseWriter, r *http.Request) {
 			s.writeError(w, r, http.StatusNotFound, fmt.Sprintf("Token %q not found", name))
 			return
 		}
+		// Rotation refreshes a live secret; it is not an un-revoke. Classified
+		// here so the refusal is a 409 with an actionable body rather than the
+		// generic 500 the fall-through would produce.
+		if errors.Is(err, storage.ErrAgentTokenRevoked) {
+			s.writeError(w, r, http.StatusConflict,
+				fmt.Sprintf("Token %q is revoked and cannot be regenerated. Delete it and create a new token.", name))
+			return
+		}
 		s.logger.Errorf("Failed to regenerate agent token: %v", err)
 		s.writeError(w, r, http.StatusInternalServerError, "Failed to regenerate token")
 		return

--- a/internal/httpapi/tokens_test.go
+++ b/internal/httpapi/tokens_test.go
@@ -102,7 +102,7 @@ func (m *mockTokenStore) ValidateAgentToken(rawToken string, _ []byte) (*auth.Ag
 	return nil, fmt.Errorf("invalid token format")
 }
 
-func (m *mockTokenStore) UpdateAgentTokenLastUsed(_ string) error {
+func (m *mockTokenStore) UpdateAgentTokenLastUsedByHash(_ string) error {
 	return nil
 }
 

--- a/internal/server/config_cow.go
+++ b/internal/server/config_cow.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+)
+
+// configWithAppendedServer returns a NEW *config.Config carrying every server
+// current already had plus sc. It never writes through current.
+//
+// runtime.Config() hands back the PUBLISHED configuration snapshot — the very
+// pointer other goroutines read concurrently and lock-free. Appending to
+// current.Servers in place writes that shared struct's slice header (and, when
+// append has spare capacity, the backing array), while readers are ranging over
+// it: a data race under the Go memory model, and a reader can observe a length
+// that is already past the element it is about to read.
+//
+// The set of concurrent readers is not hypothetical and keeps growing: the
+// background LoadConfiguredServers / DiscoverAndIndexTools passes, the httpapi
+// handlers, and — since the server edition's per-user door — an
+// api.AdminServersProvider call on every authenticated request.
+//
+// Copy-on-write is the convention this package already follows for the config
+// snapshot (see add_registry_source.go and addServerInternal); this is the one
+// helper both server-append sites share so a third cannot drift back to an
+// in-place append. The clone is shallow by design: only the Servers slice is
+// being changed, and every *ServerConfig in it is treated as read-only by
+// everything that reads a published snapshot.
+//
+// Returns nil when current is nil, so callers keep their existing nil guard.
+func configWithAppendedServer(current *config.Config, sc *config.ServerConfig) *config.Config {
+	if current == nil {
+		return nil
+	}
+	updated := *current
+	updated.Servers = append(append([]*config.ServerConfig(nil), current.Servers...), sc)
+	return &updated
+}

--- a/internal/server/config_cow_test.go
+++ b/internal/server/config_cow_test.go
@@ -1,0 +1,121 @@
+package server
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+)
+
+// TestConfigWithAppendedServer_DoesNotMutateThePublishedSnapshot pins the
+// copy-on-write contract that handleAddUpstream violated.
+//
+// handleAddUpstream did:
+//
+//	currentConfig := p.mainServer.runtime.Config()
+//	currentConfig.Servers = append(currentConfig.Servers, serverConfig)
+//
+// where runtime.Config() returns the PUBLISHED snapshot every other goroutine
+// reads lock-free. Both the field write and the backing-array write land in
+// shared state.
+//
+// BITES: replace configWithAppendedServer's body with the in-place form
+//
+//	current.Servers = append(current.Servers, sc); return current
+//
+// and both assertions below fail — the input's length grows and the caller's
+// slice header is the same one that was published.
+func TestConfigWithAppendedServer_DoesNotMutateThePublishedSnapshot(t *testing.T) {
+	published := &config.Config{
+		Listen: "127.0.0.1:8080",
+		Servers: []*config.ServerConfig{
+			{Name: "alpha", URL: "https://alpha.example", Protocol: "http"},
+		},
+	}
+	// Give the slice spare capacity: with cap to grow into, an in-place append
+	// writes the SHARED backing array rather than reallocating, which is the
+	// worse half of the race and the half a len-only check would miss.
+	published.Servers = append(make([]*config.ServerConfig, 0, 8), published.Servers...)
+
+	before := len(published.Servers)
+	beforeFirst := published.Servers[0]
+
+	added := &config.ServerConfig{Name: "beta", URL: "https://beta.example", Protocol: "http"}
+	updated := configWithAppendedServer(published, added)
+
+	require.NotNil(t, updated)
+	assert.Len(t, updated.Servers, before+1, "the returned config must carry the new server")
+	assert.Equal(t, "beta", updated.Servers[before].Name)
+
+	assert.Len(t, published.Servers, before,
+		"the published snapshot must not have grown: readers hold this pointer")
+	assert.Same(t, beforeFirst, published.Servers[0],
+		"the published snapshot's existing entries must be untouched")
+
+	// The clone must not share a backing array with the snapshot, or a LATER
+	// append through the clone would still write memory the snapshot spans.
+	updated.Servers[0] = &config.ServerConfig{Name: "rewritten"}
+	assert.Same(t, beforeFirst, published.Servers[0],
+		"writing through the clone must not reach the published snapshot")
+
+	// Fields other than Servers are carried over.
+	assert.Equal(t, "127.0.0.1:8080", updated.Listen)
+}
+
+// TestConfigWithAppendedServer_NilConfig keeps the caller's nil guard honest.
+func TestConfigWithAppendedServer_NilConfig(t *testing.T) {
+	assert.Nil(t, configWithAppendedServer(nil, &config.ServerConfig{Name: "x"}))
+}
+
+// TestConfigWithAppendedServer_RaceWithSnapshotReaders is the -race half of the
+// proof: it reconstructs the interleaving the fix exists to prevent — a reader
+// ranging over the published snapshot's Servers while an add appends.
+//
+// BITES (under `go test -race`): with the in-place body described above, the
+// race detector reports a write to the config's Servers field and to the
+// backing array concurrent with these reads.
+func TestConfigWithAppendedServer_RaceWithSnapshotReaders(t *testing.T) {
+	published := &config.Config{
+		Servers: append(make([]*config.ServerConfig, 0, 64), &config.ServerConfig{Name: "alpha"}),
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Readers, standing in for AdminServersProvider / LoadConfiguredServers.
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				names := 0
+				for _, s := range published.Servers {
+					if s != nil && s.Name != "" {
+						names++
+					}
+				}
+				_ = names
+			}
+		}()
+	}
+
+	for i := 0; i < 64; i++ {
+		// The production call site publishes the RESULT; the snapshot the
+		// readers hold must be left alone by the append itself.
+		_ = configWithAppendedServer(published, &config.ServerConfig{Name: fmt.Sprintf("s%d", i)})
+	}
+
+	close(stop)
+	wg.Wait()
+
+	assert.Len(t, published.Servers, 1, "no append may have landed in the published snapshot")
+}

--- a/internal/server/connect_socket_e2e_test.go
+++ b/internal/server/connect_socket_e2e_test.go
@@ -211,4 +211,4 @@ func (s *socketE2ETokenStore) DeleteAgentToken(string) error { return nil }
 func (s *socketE2ETokenStore) RegenerateAgentToken(string, string, []byte) (*auth.AgentToken, error) {
 	return nil, fmt.Errorf("not supported")
 }
-func (s *socketE2ETokenStore) UpdateAgentTokenLastUsed(string) error { return nil }
+func (s *socketE2ETokenStore) UpdateAgentTokenLastUsedByHash(string) error { return nil }

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -4870,14 +4870,19 @@ func (p *MCPProxyServer) handleAddUpstream(ctx context.Context, request mcp.Call
 		// Update runtime's in-memory config with the new server
 		// This is CRITICAL for test environments where SaveConfiguration() might fail
 		// Without this, the ConfigService won't know about the new server
+		//
+		// Copy-on-write: runtime.Config() returns the PUBLISHED snapshot that
+		// other goroutines read lock-free — the background reconcile/index
+		// passes, the httpapi handlers, and (server edition) an
+		// AdminServersProvider call on every authenticated request. Appending
+		// to its Servers in place writes shared state under those readers.
+		// See configWithAppendedServer.
 		currentConfig := p.mainServer.runtime.Config()
-		if currentConfig != nil {
-			// Add server to config's server list
-			currentConfig.Servers = append(currentConfig.Servers, serverConfig)
-			p.mainServer.runtime.UpdateConfig(currentConfig, "")
+		if updatedConfig := configWithAppendedServer(currentConfig, serverConfig); updatedConfig != nil {
+			p.mainServer.runtime.UpdateConfig(updatedConfig, "")
 			p.logger.Debug("Updated runtime config with new server",
 				zap.String("server", name),
-				zap.Int("total_servers", len(currentConfig.Servers)))
+				zap.Int("total_servers", len(updatedConfig.Servers)))
 		}
 
 		// Save configuration first to ensure servers are persisted to config file

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1732,11 +1732,8 @@ func (s *Server) AddServer(ctx context.Context, serverConfig *config.ServerConfi
 	// ranging over concurrently. Mutating its Servers slice in place is a data
 	// race, so copy-on-write: clone the config and its server list, append to
 	// the clone, then publish atomically via UpdateConfig.
-	currentConfig := s.runtime.Config()
-	if currentConfig != nil {
-		updatedConfig := *currentConfig
-		updatedConfig.Servers = append(append([]*config.ServerConfig(nil), currentConfig.Servers...), serverConfig)
-		s.runtime.UpdateConfig(&updatedConfig, "")
+	if updatedConfig := configWithAppendedServer(s.runtime.Config(), serverConfig); updatedConfig != nil {
+		s.runtime.UpdateConfig(updatedConfig, "")
 	}
 
 	// Save configuration to file

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -406,7 +406,7 @@ func (s *Server) mcpAuthMiddleware(next http.Handler) http.Handler {
 
 			// Update last-used timestamp in background
 			go func() {
-				if updateErr := storageManager.UpdateAgentTokenLastUsed(agentToken.Name); updateErr != nil {
+				if updateErr := storageManager.UpdateAgentTokenLastUsedByHash(agentToken.TokenHash); updateErr != nil {
 					s.logger.Warn("Failed to update agent token last-used timestamp",
 						zap.String("name", agentToken.Name),
 						zap.Error(updateErr))

--- a/internal/server/serveredition_wire.go
+++ b/internal/server/serveredition_wire.go
@@ -5,6 +5,7 @@ package server
 import (
 	"go.uber.org/zap"
 
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/httpapi"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/serveredition"
 )
@@ -25,11 +26,16 @@ func wireServerEditionOAuth(s *Server, httpAPIServer *httpapi.Server) {
 	}
 
 	deps := serveredition.Dependencies{
-		Router:            httpAPIServer.Router(),
-		DB:                sm.GetDB(),
-		Logger:            s.logger.Sugar(),
-		Config:            cfg,
-		DataDir:           cfg.DataDir,
+		Router:  httpAPIServer.Router(),
+		DB:      sm.GetDB(),
+		Logger:  s.logger.Sugar(),
+		Config:  cfg,
+		DataDir: cfg.DataDir,
+		// Runtime.Config() reads the current snapshot through the config
+		// service's atomic pointer, so this stays correct across hot reloads —
+		// which is load-bearing for the server edition's name-collision and
+		// entitlement checks. See Dependencies.ConfigProvider.
+		ConfigProvider:    func() *config.Config { return s.runtime.Config() },
 		ManagementService: s.runtime.GetManagementService(),
 		StorageManager:    sm,
 	}

--- a/internal/server/workspace.go
+++ b/internal/server/workspace.go
@@ -135,6 +135,14 @@ func principalFromContext(ctx context.Context) string {
 	}
 	switch {
 	case ac.AgentName != "":
+		// Agent token names are unique per owner, not globally: two tenants can
+		// each hold a token called "ci". Qualify the principal with the owning
+		// user so their work sessions (and the work_session_id stamped onto
+		// their activity records) cannot collapse into one. Personal-edition
+		// tokens have no owner and keep the historical bare form.
+		if ac.UserID != "" {
+			return "agent:" + ac.UserID + ":" + ac.AgentName
+		}
 		return "agent:" + ac.AgentName
 	case ac.UserID != "":
 		return "user:" + ac.UserID

--- a/internal/serveredition/api/admin_disable_tokens_test.go
+++ b/internal/serveredition/api/admin_disable_tokens_test.go
@@ -1,0 +1,188 @@
+//go:build server
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+	teamsauth "github.com/smart-mcp-proxy/mcpproxy-go/internal/serveredition/auth"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/serveredition/users"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
+)
+
+// adminTokenTestSetup builds AdminHandlers with a REAL agent-token store wired
+// through SetTokenRevoker, which is what internal/serveredition/setup.go does.
+func adminTokenTestSetup(t *testing.T) (*AdminHandlers, *users.UserStore, *storage.Manager) {
+	t.Helper()
+
+	db, err := bbolt.Open(filepath.Join(t.TempDir(), "users.db"), 0600, &bbolt.Options{Timeout: time.Second})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	userStore := users.NewUserStore(db)
+	require.NoError(t, userStore.EnsureBuckets())
+
+	logger := zap.NewNop().Sugar()
+	tokens, err := storage.NewManager(t.TempDir(), logger)
+	require.NoError(t, err)
+	t.Cleanup(func() { tokens.Close() })
+
+	sessionManager := teamsauth.NewSessionManager(userStore, 24*time.Hour, false)
+	handlers := NewAdminHandlers(userStore, nil, sessionManager, []string{"admin@example.com"}, nil, nil, "", nil, logger)
+	handlers.SetTokenRevoker(tokens)
+
+	return handlers, userStore, tokens
+}
+
+// seedAgentToken writes a token owned by userID and returns its raw value.
+func seedAgentToken(t *testing.T, mgr *storage.Manager, userID, name string) string {
+	t.Helper()
+	raw, err := auth.GenerateToken()
+	require.NoError(t, err)
+	require.NoError(t, mgr.CreateAgentToken(auth.AgentToken{
+		Name:           name,
+		UserID:         userID,
+		AllowedServers: []string{"shared-ok"},
+		Permissions:    []string{auth.PermRead},
+	}, raw, tokenTestHMACKey))
+	return raw
+}
+
+// TestDisableUser_RevokesTheUsersAgentTokens is the persistence half of the
+// disabled-owner fix, at the door an operator actually uses.
+//
+// Disabling an account is the documented remediation for a compromise. It
+// revoked sessions and stopped JWTs, but agent tokens are separate records that
+// nothing touched — so the credential most likely to be in an attacker's hands,
+// the long-lived non-interactive one, survived the remediation entirely.
+//
+// The authentication-path owner gate
+// (storage.Manager.SetAgentTokenOwnerGate, tested in
+// internal/storage/agent_token_lifecycle_test.go) makes the block immediate.
+// This handler ALSO revokes, so that re-enabling the account later does not hand
+// the attacker their token back.
+//
+// Oracle discipline:
+//
+//  1. every token authenticates BEFORE the disable, on the same store — so a
+//     later refusal is the revocation and not a bad fixture or a mis-hashed
+//     token;
+//  2. another user's token is present throughout and must SURVIVE — "did it
+//     revoke?" is only half the property, and a bulk revoke that swept every
+//     tenant would pass a one-sided assertion;
+//  3. the disable response status is pinned to 200, so the assertions below
+//     cannot be passing because the request never reached the handler; and
+//  4. the end state is read back through storage, not inferred from the
+//     response body.
+//
+// BITES: comment out the h.tokenRevoker block in disableUser (leave the field
+// and the setter, so the package still builds) and the two "must not
+// authenticate" assertions fail.
+func TestDisableUser_RevokesTheUsersAgentTokens(t *testing.T) {
+	handlers, store, tokens := adminTokenTestSetup(t)
+
+	victim := createTestUser(t, store, "user-compromised", "victim@example.com", "Victim", "google")
+	bystander := createTestUser(t, store, "user-bystander", "bystander@example.com", "Bystander", "google")
+
+	victimCI := seedAgentToken(t, tokens, victim.ID, "ci")
+	victimDeploy := seedAgentToken(t, tokens, victim.ID, "deploy")
+	bystanderCI := seedAgentToken(t, tokens, bystander.ID, "ci")
+
+	// (1) Positive control: all three authenticate before the disable.
+	for label, raw := range map[string]string{
+		"victim ci":     victimCI,
+		"victim deploy": victimDeploy,
+		"bystander ci":  bystanderCI,
+	} {
+		got, err := tokens.ValidateAgentToken(raw, tokenTestHMACKey)
+		require.NoError(t, err, "positive control: %s must authenticate before the disable", label)
+		require.NotNil(t, got)
+	}
+
+	router := adminTestRouter(handlers, adminAuthContext())
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/"+victim.ID+"/disable", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "the disable must succeed (%s)", w.Body.String())
+
+	// (3) The account really is disabled — the fixture landed.
+	updated, err := store.GetUser(victim.ID)
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+	require.True(t, updated.Disabled, "the user must be disabled, or nothing below is about tokens")
+
+	// (4) Their tokens no longer authenticate...
+	for label, raw := range map[string]string{
+		"victim ci":     victimCI,
+		"victim deploy": victimDeploy,
+	} {
+		got, err := tokens.ValidateAgentToken(raw, tokenTestHMACKey)
+		assert.Nil(t, got, "%s: a disabled user's token must not authenticate", label)
+		assert.Error(t, err, "%s: a disabled user's token must be refused", label)
+	}
+
+	// ...and the refusal is durable, not a live check that a re-enable undoes.
+	for _, name := range []string{"ci", "deploy"} {
+		stored, err := tokens.GetAgentTokenByOwnerAndName(victim.ID, name)
+		require.NoError(t, err)
+		require.NotNil(t, stored, "revoke is a soft delete: the record must remain visible to the operator")
+		assert.True(t, stored.Revoked, "token %q must be revoked on disk", name)
+	}
+
+	// (2) The bystander is untouched.
+	survivor, err := tokens.ValidateAgentToken(bystanderCI, tokenTestHMACKey)
+	require.NoError(t, err, "another user's token must survive the disable")
+	require.NotNil(t, survivor)
+	assert.Equal(t, bystander.ID, survivor.UserID)
+}
+
+// TestEnableUser_DoesNotResurrectRevokedTokens pins the deliberate asymmetry.
+//
+// Re-enabling an account restores the person's access. It must NOT restore the
+// credentials that were burned when the account was disabled — those may be the
+// reason it was disabled. The owner mints new ones.
+//
+// Oracle discipline: the enable is pinned to 200 and the user record is read
+// back as enabled, so "the token still fails" cannot be passing because the
+// enable never happened.
+//
+// BITES: add an un-revoke loop to enableUser and this fails.
+func TestEnableUser_DoesNotResurrectRevokedTokens(t *testing.T) {
+	handlers, store, tokens := adminTokenTestSetup(t)
+
+	user := createTestUser(t, store, "user-rehired", "rehired@example.com", "Rehired", "google")
+	raw := seedAgentToken(t, tokens, user.ID, "ci")
+
+	got, err := tokens.ValidateAgentToken(raw, tokenTestHMACKey)
+	require.NoError(t, err, "positive control: the token must authenticate before the disable")
+	require.NotNil(t, got)
+
+	router := adminTestRouter(handlers, adminAuthContext())
+
+	disable := httptest.NewRecorder()
+	router.ServeHTTP(disable, httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/"+user.ID+"/disable", nil))
+	require.Equal(t, http.StatusOK, disable.Code, "the disable must succeed (%s)", disable.Body.String())
+
+	enable := httptest.NewRecorder()
+	router.ServeHTTP(enable, httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/"+user.ID+"/enable", nil))
+	require.Equal(t, http.StatusOK, enable.Code, "the enable must succeed (%s)", enable.Body.String())
+
+	back, err := store.GetUser(user.ID)
+	require.NoError(t, err)
+	require.NotNil(t, back)
+	require.False(t, back.Disabled, "the user must be enabled again, or the assertion below is vacuous")
+
+	revived, err := tokens.ValidateAgentToken(raw, tokenTestHMACKey)
+	assert.Nil(t, revived, "a token burned by a disable must not come back when the account does")
+	assert.Error(t, err)
+}

--- a/internal/serveredition/api/admin_handlers.go
+++ b/internal/serveredition/api/admin_handlers.go
@@ -61,7 +61,12 @@ func NewAdminHandlers(
 }
 
 // RegisterRoutes registers admin routes on the provided router.
-// The caller should wrap this with AdminOnly middleware.
+//
+// NOTE: enforcement lives in each handler's own requireAdmin call, NOT in
+// middleware. Production (internal/serveredition/setup.go) applies only
+// authMiddleware.Middleware() to this group; ServerEditionAuthMiddleware's
+// AdminOnly() is not used there. Every route added here MUST call requireAdmin
+// as its first statement, or it ships unguarded.
 func (h *AdminHandlers) RegisterRoutes(r chi.Router) {
 	r.Get("/admin/users", h.listUsers)
 	r.Post("/admin/users/{id}/disable", h.disableUser)

--- a/internal/serveredition/api/admin_handlers.go
+++ b/internal/serveredition/api/admin_handlers.go
@@ -22,6 +22,13 @@ import (
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/serveredition/users"
 )
 
+// adminTokenRevoker revokes every agent token an owner holds. Implemented by
+// *storage.Manager; optional, so the handlers work in tests and in deployments
+// with no token storage wired.
+type adminTokenRevoker interface {
+	RevokeAgentTokensForOwner(userID string) (int, error)
+}
+
 // AdminHandlers provides admin-only REST endpoints.
 type AdminHandlers struct {
 	userStore      *users.UserStore
@@ -32,7 +39,16 @@ type AdminHandlers struct {
 	config         *config.Config
 	configPath     string
 	managementSvc  interface{} // management.Service - kept as interface{} to avoid circular imports
+	tokenRevoker   adminTokenRevoker
 	logger         *zap.SugaredLogger
+}
+
+// SetTokenRevoker wires the agent-token store used when disabling a user.
+// Optional: with no revoker, disabling still disables the account and the
+// storage-level owner gate still refuses that user's tokens; only the permanent
+// burn of already-minted credentials is skipped. Passing nil clears it.
+func (h *AdminHandlers) SetTokenRevoker(revoker adminTokenRevoker) {
+	h.tokenRevoker = revoker
 }
 
 // NewAdminHandlers creates a new AdminHandlers instance.
@@ -150,7 +166,28 @@ func (h *AdminHandlers) listUsers(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, profiles)
 }
 
-// disableUser disables a user and revokes all their sessions.
+// disableUser disables a user and revokes all their sessions AND agent tokens.
+//
+// Disabling is the documented remediation for a compromised account, so it has
+// to reach every credential that speaks for that account, not just the
+// interactive ones. Sessions and JWTs were already covered; agent tokens are
+// separate records that nothing here touched, and each one carries the user's
+// UserID into every downstream authorisation and activity decision.
+//
+// Two mechanisms, deliberately:
+//
+//   - storage.Manager's owner gate (installed in internal/serveredition/setup.go)
+//     refuses a disabled owner's tokens on the authentication path, which is what
+//     makes the remediation take effect IMMEDIATELY and covers tokens minted in
+//     the same instant, without this handler having to win a race;
+//   - the revocation below burns them permanently, so RE-ENABLING the account
+//     does not hand the attacker their stolen token back. Revoked is a soft
+//     delete: the records stay visible to the operator, and the owner mints new
+//     tokens once they are re-enabled.
+//
+// Token revocation is non-fatal on error, exactly like session revocation: the
+// account is disabled either way, and the owner gate is the part that must not
+// be missed.
 func (h *AdminHandlers) disableUser(w http.ResponseWriter, r *http.Request) {
 	if !h.requireAdmin(w, r) {
 		return
@@ -186,11 +223,27 @@ func (h *AdminHandlers) disableUser(w http.ResponseWriter, r *http.Request) {
 		// Non-fatal: user is disabled even if session revocation fails.
 	}
 
+	// Revoke the agent tokens they minted. See this handler's doc comment for
+	// why this is done in addition to the authentication-path owner gate.
+	if h.tokenRevoker != nil {
+		revoked, err := h.tokenRevoker.RevokeAgentTokensForOwner(userID)
+		if err != nil {
+			h.logger.Errorw("failed to revoke agent tokens for disabled user", "user_id", userID, "error", err)
+			// Non-fatal: the owner gate already refuses this user's tokens.
+		} else if revoked > 0 {
+			h.logger.Infow("revoked agent tokens for disabled user", "user_id", userID, "count", revoked)
+		}
+	}
+
 	h.logger.Infow("user disabled", "user_id", userID, "email", user.Email)
 	writeJSON(w, http.StatusOK, map[string]string{"message": "User disabled"})
 }
 
 // enableUser enables a previously disabled user.
+//
+// Their agent tokens are NOT un-revoked. disableUser burns them precisely so
+// that re-enabling an account cannot resurrect a credential that may be why the
+// account was disabled; the owner mints new ones.
 func (h *AdminHandlers) enableUser(w http.ResponseWriter, r *http.Request) {
 	if !h.requireAdmin(w, r) {
 		return

--- a/internal/serveredition/api/auth_endpoints.go
+++ b/internal/serveredition/api/auth_endpoints.go
@@ -75,7 +75,9 @@ type TokenResponse struct {
 // getMe returns the current authenticated user's profile.
 func (h *AuthEndpoints) getMe(w http.ResponseWriter, r *http.Request) {
 	ac := auth.AuthContextFromContext(r.Context())
-	if ac == nil || ac.GetUserID() == "" {
+	// Require the user TIER: agent tokens carry their owner's UserID but must
+	// not be able to read that owner's profile.
+	if ac == nil || !ac.IsUser() || ac.GetUserID() == "" {
 		writeError(w, http.StatusUnauthorized, "Authentication required")
 		return
 	}
@@ -103,7 +105,10 @@ func (h *AuthEndpoints) getMe(w http.ResponseWriter, r *http.Request) {
 // generateToken creates a new JWT bearer token for MCP access.
 func (h *AuthEndpoints) generateToken(w http.ResponseWriter, r *http.Request) {
 	ac := auth.AuthContextFromContext(r.Context())
-	if ac == nil || ac.GetUserID() == "" {
+	// Require the user TIER. This is the sharp one: without it, a scoped
+	// read-only agent token carrying its owner's UserID could mint a full user
+	// session JWT for that owner — a privilege upgrade, not a lateral move.
+	if ac == nil || !ac.IsUser() || ac.GetUserID() == "" {
 		writeError(w, http.StatusUnauthorized, "Authentication required")
 		return
 	}

--- a/internal/serveredition/api/auth_endpoints_tier_test.go
+++ b/internal/serveredition/api/auth_endpoints_tier_test.go
@@ -1,0 +1,92 @@
+//go:build server
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/serveredition/users"
+)
+
+// TestAuthEndpoints_RejectAgentTierContext: POST /api/v1/auth/token mints a
+// full user session JWT from the caller's context. Once an agent token carries
+// its owner's UserID, a gate that only checks GetUserID() != "" would let a
+// scoped, read-only agent token upgrade itself into its owner's session
+// credential. Both endpoints must require the user TIER.
+//
+// The test registers on the PRODUCTION route table shape (the same routes
+// setup.go mounts) and runs a positive control first, so a 401 from a
+// mis-typed path cannot masquerade as the guard working.
+//
+// BITES: with UserID plumbed through AuthContext() and the IsUser() guards
+// removed, /auth/me returns the owner's profile (200) and /auth/token returns
+// a signed JWT for the owner (200).
+func TestAuthEndpoints_RejectAgentTierContext(t *testing.T) {
+	endpoints, store := authTestSetup(t)
+
+	user := &users.User{
+		ID:                testUserID,
+		Email:             "owner@example.com",
+		DisplayName:       "Owner",
+		Provider:          "google",
+		ProviderSubjectID: "google-sub-owner",
+		CreatedAt:         time.Now().UTC(),
+		LastLoginAt:       time.Now().UTC(),
+	}
+	require.NoError(t, store.CreateUser(user))
+
+	newRouter := func(ac *auth.AuthContext) *chi.Mux {
+		r := chi.NewRouter()
+		r.Use(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				next.ServeHTTP(w, req.WithContext(auth.WithAuthContext(req.Context(), ac)))
+			})
+		})
+		endpoints.RegisterRoutesWithPrefix(r, "/api/v1")
+		return r
+	}
+
+	call := func(r *chi.Mux, method, target string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(method, target, http.NoBody)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w
+	}
+
+	// Positive control: as the USER, both routes work. This proves the routes
+	// are registered at these paths and the fixture user exists, so the 401s
+	// below are the guard and not a routing mistake.
+	userRouter := newRouter(auth.UserContext(user.ID, user.Email, user.DisplayName, user.Provider))
+	require.Equal(t, http.StatusOK, call(userRouter, http.MethodGet, "/api/v1/auth/me").Code)
+	ctlToken := call(userRouter, http.MethodPost, "/api/v1/auth/token")
+	require.Equal(t, http.StatusOK, ctlToken.Code)
+	require.Contains(t, ctlToken.Body.String(), `"token"`)
+
+	// The agent tier, carrying the SAME owner id.
+	agent := (&auth.AgentToken{
+		Name:        "ci",
+		TokenPrefix: "mcp_agt_abcd",
+		Permissions: []string{auth.PermRead},
+		UserID:      user.ID,
+	}).AuthContext()
+	require.Equal(t, user.ID, agent.GetUserID(), "the fixture must actually carry the owner's id")
+	agentRouter := newRouter(agent)
+
+	me := call(agentRouter, http.MethodGet, "/api/v1/auth/me")
+	assert.Equal(t, http.StatusUnauthorized, me.Code,
+		"an agent token read its owner's profile (body: %s)", me.Body.String())
+
+	tok := call(agentRouter, http.MethodPost, "/api/v1/auth/token")
+	assert.Equal(t, http.StatusUnauthorized, tok.Code,
+		"an agent token minted a user session JWT for its owner (body: %s)", tok.Body.String())
+	assert.NotContains(t, tok.Body.String(), `"token"`,
+		"the response carried a bearer token to an agent-tier caller")
+}

--- a/internal/serveredition/api/user_handlers.go
+++ b/internal/serveredition/api/user_handlers.go
@@ -684,6 +684,160 @@ func (h *UserHandlers) listUserTokens(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]interface{}{"tokens": userTokens})
 }
 
+// errServerScopeLookup marks a server-scope failure that is the SERVER's fault
+// (the per-user store could not be read), so createUserToken can answer 500
+// instead of blaming the caller's request body for it.
+var errServerScopeLookup = errors.New("failed to load server scope")
+
+// entitledServerNames returns the servers the caller may legitimately scope an
+// agent token to.
+//
+// This is deliberately the SAME predicate the per-user door renders through
+// listServers — the user's own personal servers, plus the admin-configured
+// servers flagged Shared — rather than a second, parallel definition of
+// entitlement that could drift from it. If a name is not in this set, the user
+// cannot see the server through /api/v1/user/servers, and a token they mint
+// must not reach it either.
+//
+// h.sharedServers is `deps.Config.Servers`: the WHOLE admin configuration, not
+// just the shared subset (see internal/serveredition/setup.go). The `sc.Shared`
+// filter is therefore load-bearing — dropping it would hand every tenant the
+// admin's private inventory, which is the exact leak this function exists to
+// prevent.
+//
+// An admin_user administers the deployment, so for them the candidate set is
+// the whole configuration; the check degrades to the personal edition's
+// "is this a known server?" validation (internal/httpapi/tokens.go).
+func (h *UserHandlers) entitledServerNames(userID string, isAdmin bool) ([]string, error) {
+	personal, err := h.userStore.ListUserServers(userID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", errServerScopeLookup, err)
+	}
+
+	names := make([]string, 0, len(personal)+len(h.sharedServers))
+	seen := make(map[string]struct{}, len(personal)+len(h.sharedServers))
+	add := func(name string) {
+		if name == "" {
+			return
+		}
+		if _, dup := seen[name]; dup {
+			return
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+
+	for _, sc := range personal {
+		if sc != nil {
+			add(sc.Name)
+		}
+	}
+	for _, sc := range h.sharedServers {
+		if sc == nil {
+			continue
+		}
+		if sc.Shared || isAdmin {
+			add(sc.Name)
+		}
+	}
+
+	return names, nil
+}
+
+// resolveTokenServerScope turns the requested allowed_servers into the list
+// that will actually be persisted, rejecting anything the caller is not
+// entitled to.
+//
+// Rules:
+//
+//   - An OMITTED or empty list is left empty, exactly as before this check
+//     existed. At the agent tier an empty AllowedServers denies every server
+//     (auth.AuthContext.CanAccessServer iterates the list and finds nothing),
+//     so the safe default needs no widening — and note this differs from the
+//     personal edition, where an empty list is rewritten to ["*"] because the
+//     only caller there IS the operator.
+//
+//   - "*" is the only wildcard the enforcement layer understands (both
+//     auth.AuthContext.CanAccessServer and jsruntime.AuthInfo.CanAccessServer
+//     compare `s == "*" || s == name`), so there is no glob to expand: a
+//     pattern like "git*" is just an unentitled name and is rejected below.
+//
+//   - For an ADMIN, "*" keeps its literal meaning: they administer every
+//     server, and freezing the list would silently drop servers added later.
+//
+//   - For a regular tenant, "*" means "every server I can reach", and is
+//     MATERIALISED into that set. Persisting the star itself would leave a
+//     standing grant over the whole deployment that only a downstream filter
+//     stands between; and the enforcement comparison has no notion of an
+//     owner, so the star cannot be re-scoped at use time. The expansion is a
+//     snapshot: a server added to the account afterwards is not in the token
+//     and needs a new one. That is deliberate — a token is a capability, and
+//     the conservative reading of "*" is the set that existed when it was
+//     signed. It is not silent, either: the create response echoes the
+//     effective allowed_servers back to the caller.
+//
+//   - Any other name must be in the entitled set. The rejection message is the
+//     SAME whether the name belongs to another tenant, is one of the admin's
+//     non-shared servers, or does not exist anywhere: distinguishing them would
+//     re-open, on server names, precisely the existence oracle this branch just
+//     closed on token names.
+func (h *UserHandlers) resolveTokenServerScope(r *http.Request, userID string, requested []string) ([]string, error) {
+	if len(requested) == 0 {
+		return requested, nil
+	}
+
+	ac := auth.AuthContextFromContext(r.Context())
+	isAdmin := ac != nil && ac.IsAdmin()
+
+	entitled, err := h.entitledServerNames(userID, isAdmin)
+	if err != nil {
+		return nil, err
+	}
+	allowed := make(map[string]struct{}, len(entitled))
+	for _, name := range entitled {
+		allowed[name] = struct{}{}
+	}
+
+	resolved := make([]string, 0, len(requested))
+	seen := make(map[string]struct{}, len(requested))
+	appendOnce := func(name string) {
+		if _, dup := seen[name]; dup {
+			return
+		}
+		seen[name] = struct{}{}
+		resolved = append(resolved, name)
+	}
+
+	for _, raw := range requested {
+		name := strings.TrimSpace(raw)
+		if name == "" {
+			return nil, errors.New("allowed_servers entries must not be empty")
+		}
+
+		if name == "*" {
+			if isAdmin {
+				// A literal star already subsumes every other entry.
+				return []string{"*"}, nil
+			}
+			if len(entitled) == 0 {
+				return nil, errors.New("no servers are available to scope this token to")
+			}
+			for _, n := range entitled {
+				appendOnce(n)
+			}
+			continue
+		}
+
+		if _, ok := allowed[name]; !ok {
+			// Uniform for "not yours", "not shared" and "does not exist".
+			return nil, fmt.Errorf("server %q is not available to you", name)
+		}
+		appendOnce(name)
+	}
+
+	return resolved, nil
+}
+
 // createUserToken creates a new agent token owned by the authenticated user.
 func (h *UserHandlers) createUserToken(w http.ResponseWriter, r *http.Request) {
 	userID, err := getUserID(r)
@@ -714,6 +868,23 @@ func (h *UserHandlers) createUserToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Constrain the requested server scope to what this caller may actually
+	// reach. Without this the field was persisted VERBATIM, and AllowedServers
+	// is the sole input to auth.AuthContext.CanAccessServer — so a tenant could
+	// mint themselves a token scoped to `["*"]`, or to a server name they have
+	// never been shown, and read the admin's entire inventory through it. See
+	// resolveTokenServerScope.
+	effectiveServers, scopeErr := h.resolveTokenServerScope(r, userID, req.AllowedServers)
+	if scopeErr != nil {
+		if errors.Is(scopeErr, errServerScopeLookup) {
+			h.logger.Errorw("failed to resolve token server scope", "user_id", userID, "error", scopeErr)
+			writeError(w, http.StatusInternalServerError, "Failed to resolve server scope")
+			return
+		}
+		writeError(w, http.StatusBadRequest, scopeErr.Error())
+		return
+	}
+
 	// Parse expiry duration (default 30 days).
 	var expiresAt time.Time
 	if req.ExpiresIn != "" {
@@ -736,7 +907,7 @@ func (h *UserHandlers) createUserToken(w http.ResponseWriter, r *http.Request) {
 
 	token := auth.AgentToken{
 		Name:           req.Name,
-		AllowedServers: req.AllowedServers,
+		AllowedServers: effectiveServers,
 		Permissions:    req.Permissions,
 		ExpiresAt:      expiresAt,
 		CreatedAt:      time.Now().UTC(),

--- a/internal/serveredition/api/user_handlers.go
+++ b/internal/serveredition/api/user_handlers.go
@@ -21,13 +21,33 @@ import (
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
 )
 
+// AdminServersProvider returns the admin configuration's servers — the WHOLE
+// list, shared and private alike — as of NOW.
+//
+// It is a function, not a slice, on purpose. The slice this replaced was
+// captured once, when the handlers were constructed at process start, and the
+// configuration is hot-reloadable: a server the admin added afterwards was
+// invisible to every check built on it. That is not cosmetic. collidesWithAdminConfig
+// is the control that stops a tenant's personal server from lending its name to
+// a token scope (see entitledServerNames); against a boot-time snapshot a tenant
+// could pre-create a personal server named like an admin server that only
+// EXISTS later, and walk through the entitlement check exactly as they did
+// before that control was added. Every collision and entitlement decision must
+// therefore read the live configuration.
+//
+// The returned slice and the ServerConfigs in it are treated as READ-ONLY by
+// every caller here (the shared-server response is a masked copy — see
+// sharedServerResponse). Implementations are expected to hand back the current
+// snapshot rather than a defensive deep copy, so nothing may write through it.
+type AdminServersProvider func() []*config.ServerConfig
+
 // UserHandlers provides REST endpoints for user server management.
 type UserHandlers struct {
-	userStore     *users.UserStore
-	logger        *zap.SugaredLogger
-	sharedServers []*config.ServerConfig
-	tokenStore    tokenStore
-	hmacKey       []byte
+	userStore    *users.UserStore
+	logger       *zap.SugaredLogger
+	adminServers AdminServersProvider
+	tokenStore   tokenStore
+	hmacKey      []byte
 }
 
 // tokenStore defines the interface for agent token storage operations.
@@ -55,14 +75,35 @@ type tokenStore interface {
 }
 
 // NewUserHandlers creates a new UserHandlers instance.
-func NewUserHandlers(userStore *users.UserStore, sharedServers []*config.ServerConfig, tokenStore tokenStore, hmacKey []byte, logger *zap.SugaredLogger) *UserHandlers {
+//
+// adminServers must read the LIVE admin configuration on every call; see
+// AdminServersProvider for why a captured slice is a security defect here. A
+// nil provider is tolerated and means "no admin servers", which is the
+// conservative reading: nothing is shared, and no name collides.
+func NewUserHandlers(userStore *users.UserStore, adminServers AdminServersProvider, tokenStore tokenStore, hmacKey []byte, logger *zap.SugaredLogger) *UserHandlers {
 	return &UserHandlers{
-		userStore:     userStore,
-		logger:        logger,
-		sharedServers: sharedServers,
-		tokenStore:    tokenStore,
-		hmacKey:       hmacKey,
+		userStore:    userStore,
+		logger:       logger,
+		adminServers: adminServers,
+		tokenStore:   tokenStore,
+		hmacKey:      hmacKey,
 	}
+}
+
+// StaticAdminServers adapts a fixed slice to AdminServersProvider. It is for
+// callers that genuinely have no live configuration to read — never for
+// production wiring, which must pass a provider over the current snapshot.
+func StaticAdminServers(servers []*config.ServerConfig) AdminServersProvider {
+	return func() []*config.ServerConfig { return servers }
+}
+
+// adminConfigServers reads the live admin configuration once for the current
+// check. Callers must not hold the result across a request boundary.
+func (h *UserHandlers) adminConfigServers() []*config.ServerConfig {
+	if h.adminServers == nil {
+		return nil
+	}
+	return h.adminServers()
 }
 
 // RegisterRoutes registers all user server management routes on the provided router.
@@ -300,7 +341,7 @@ func (h *UserHandlers) listServers(w http.ResponseWriter, r *http.Request) {
 	}
 
 	shared := make([]*ServerResponse, 0)
-	for _, sc := range h.sharedServers {
+	for _, sc := range h.adminConfigServers() {
 		if sc.Shared {
 			var userEnabled *bool
 			// Apply user preference if set
@@ -338,28 +379,39 @@ func (h *UserHandlers) createServer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Refuse a name already taken by ANY server in the admin configuration,
-	// shared or not.
+	// shared or not — read LIVE, so a server the admin adds after boot is
+	// covered (see AdminServersProvider).
 	//
 	// The `Shared` qualifier that used to be here made the whole entitlement
 	// check on token scope bypassable: a tenant created a personal server named
 	// exactly like one of the admin's PRIVATE upstreams, entitledServerNames
 	// then added that name because they now owned a server called that, and the
 	// token they minted named a server auth.AuthContext.CanAccessServer compares
-	// by bare string — so it reached the admin's server. The same collision is a
-	// routing hazard independent of tokens: multiuser.Router.GetServerForUser
-	// matches the whole configuration BEFORE the caller's workspace, so the name
-	// resolves to the ADMIN's config, credentials and all.
+	// by bare string — so it reached the admin's server. entitledServerNames
+	// excludes such a collision on its own, so this refusal is defence in depth
+	// rather than the only control; it also keeps a tenant from creating a
+	// personal server they could never scope a token to.
 	//
-	// The message is IDENTICAL for a shared and an unshared collision. It has to
-	// be: a distinguishing message would name the admin's private inventory to a
-	// tenant who cannot list it, which is the existence oracle this branch just
-	// closed on token names, reopened one shape over. A refusal necessarily
-	// signals that the name is unavailable — there is no way to reject without
-	// that — but it signals nothing else: not whether the holder is shared,
-	// private or another tenant's, and not one byte of the server's config.
-	for _, existing := range h.sharedServers {
+	// ONE body, for every reason a name can be unavailable: an admin server
+	// (shared or private), or one the caller already owns. The wording used to
+	// differ between those, and the difference was itself the oracle — "is not
+	// available" versus "already exists" told a tenant, in one request, that a
+	// name they do not own is in the admin's configuration, letting them
+	// enumerate a private inventory they cannot list. Refusing at all
+	// necessarily leaks that the name is taken; nothing beyond that leaks now,
+	// and in particular nothing distinguishes the holder.
+	//
+	// What remains, and cannot be closed here: a tenant who knows their own
+	// inventory can subtract it, so a refusal on a name they do not hold still
+	// resolves to "the admin holds it". Removing that last bit means letting the
+	// create succeed, which requires enforcement (auth.AuthContext.CanAccessServer)
+	// to resolve a server name against an OWNER rather than as a bare string.
+	// That is the real fix and it is a larger change than this door.
+	const nameUnavailable = "Server name %q is not available"
+
+	for _, existing := range h.adminConfigServers() {
 		if existing != nil && strings.EqualFold(existing.Name, req.Name) {
-			writeError(w, http.StatusConflict, fmt.Sprintf("Server name %q is not available", req.Name))
+			writeError(w, http.StatusConflict, fmt.Sprintf(nameUnavailable, req.Name))
 			return
 		}
 	}
@@ -372,7 +424,7 @@ func (h *UserHandlers) createServer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if existing != nil {
-		writeError(w, http.StatusConflict, fmt.Sprintf("Server %q already exists", req.Name))
+		writeError(w, http.StatusConflict, fmt.Sprintf(nameUnavailable, req.Name))
 		return
 	}
 
@@ -432,7 +484,7 @@ func (h *UserHandlers) getServer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check shared servers.
-	for _, shared := range h.sharedServers {
+	for _, shared := range h.adminConfigServers() {
 		if shared.Shared && strings.EqualFold(shared.Name, name) {
 			// The caller's own preference belongs on the DETAIL read too.
 			// Rendering it as unset made this route disagree with listServers
@@ -473,7 +525,7 @@ func (h *UserHandlers) updateServer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Reject updates to shared servers.
-	for _, shared := range h.sharedServers {
+	for _, shared := range h.adminConfigServers() {
 		if shared.Shared && strings.EqualFold(shared.Name, name) {
 			writeError(w, http.StatusForbidden, "Cannot update a shared server")
 			return
@@ -547,7 +599,7 @@ func (h *UserHandlers) deleteServer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Reject deletion of shared servers.
-	for _, shared := range h.sharedServers {
+	for _, shared := range h.adminConfigServers() {
 		if shared.Shared && strings.EqualFold(shared.Name, name) {
 			writeError(w, http.StatusForbidden, "Cannot delete a shared server")
 			return
@@ -598,7 +650,7 @@ func (h *UserHandlers) enableServer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check if this is a shared server
-	for _, shared := range h.sharedServers {
+	for _, shared := range h.adminConfigServers() {
 		if shared.Shared && strings.EqualFold(shared.Name, name) {
 			// Store per-user preference for the shared server
 			if err := h.userStore.SetSharedServerPref(userID, shared.Name, req.Enabled); err != nil {
@@ -726,11 +778,16 @@ var errServerScopeLookup = errors.New("failed to load server scope")
 // cannot see the server through /api/v1/user/servers, and a token they mint
 // must not reach it either.
 //
-// h.sharedServers is `deps.Config.Servers`: the WHOLE admin configuration, not
-// just the shared subset (see internal/serveredition/setup.go). The `sc.Shared`
-// filter is therefore load-bearing — dropping it would hand every tenant the
-// admin's private inventory, which is the exact leak this function exists to
-// prevent.
+// h.adminConfigServers() is the live `Config.Servers`: the WHOLE admin
+// configuration, not just the shared subset (see
+// internal/serveredition/setup.go). The `sc.Shared` filter is therefore
+// load-bearing — dropping it would hand every tenant the admin's private
+// inventory, which is the exact leak this function exists to prevent.
+//
+// The configuration is read ONCE here and threaded through the collision check,
+// so every decision in one call is made against a single version of it. Calling
+// the provider per personal server would let a hot reload land mid-loop and
+// produce a set that was never true of any actual configuration.
 //
 // An admin_user administers the deployment, so for them the candidate set is
 // the whole configuration; the check degrades to the personal edition's
@@ -742,19 +799,22 @@ var errServerScopeLookup = errors.New("failed to load server scope")
 // entitlement derived from "I own a server called X" is indistinguishable, at
 // enforcement time, from "I may reach the admin's X" — which is how a personal
 // server named after an admin-private upstream turned into a grant over it.
-// createServer now refuses to mint such a collision, but this set must not
+// createServer also refuses to mint such a collision, but this set must not
 // depend on that: a row created before the refusal existed, or an admin who
-// later adds a server whose name a tenant already used, both produce one.
-// Excluding it costs the tenant only a token scope, never their server, which
-// multiuser.Router would in any case resolve to the admin's config.
+// later adds a server whose name a tenant already used, both produce one — and
+// the second of those is only caught at all because the configuration is read
+// live rather than snapshotted at boot. Excluding it costs the tenant only a
+// token scope, never their server.
 func (h *UserHandlers) entitledServerNames(userID string, isAdmin bool) ([]string, error) {
 	personal, err := h.userStore.ListUserServers(userID)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", errServerScopeLookup, err)
 	}
 
-	names := make([]string, 0, len(personal)+len(h.sharedServers))
-	seen := make(map[string]struct{}, len(personal)+len(h.sharedServers))
+	adminServers := h.adminConfigServers()
+
+	names := make([]string, 0, len(personal)+len(adminServers))
+	seen := make(map[string]struct{}, len(personal)+len(adminServers))
 	add := func(name string) {
 		if name == "" {
 			return
@@ -770,12 +830,12 @@ func (h *UserHandlers) entitledServerNames(userID string, isAdmin bool) ([]strin
 		if sc == nil {
 			continue
 		}
-		if !isAdmin && h.collidesWithAdminConfig(sc.Name) {
+		if !isAdmin && collidesWithAdminConfig(adminServers, sc.Name) {
 			continue
 		}
 		add(sc.Name)
 	}
-	for _, sc := range h.sharedServers {
+	for _, sc := range adminServers {
 		if sc == nil {
 			continue
 		}
@@ -788,14 +848,18 @@ func (h *UserHandlers) entitledServerNames(userID string, isAdmin bool) ([]strin
 }
 
 // collidesWithAdminConfig reports whether name is taken by any server in the
-// admin configuration, shared or private.
+// given admin configuration, shared or private.
+//
+// It takes the configuration rather than reading it, so a caller that makes
+// several decisions makes them all against the same version of a
+// hot-reloadable file.
 //
 // Case-insensitive, matching createServer's refusal, so a case-variant personal
 // server cannot be used to smuggle the name past this check and then be lined up
 // against a case-variant request. It is deliberately BROADER than the exact
 // comparison the enforcement layer performs.
-func (h *UserHandlers) collidesWithAdminConfig(name string) bool {
-	for _, sc := range h.sharedServers {
+func collidesWithAdminConfig(adminServers []*config.ServerConfig, name string) bool {
+	for _, sc := range adminServers {
 		if sc != nil && strings.EqualFold(sc.Name, name) {
 			return true
 		}
@@ -1073,12 +1137,22 @@ func (h *UserHandlers) createUserToken(w http.ResponseWriter, r *http.Request) {
 			// 409, matching the personal edition's twin
 			// (internal/httpapi/tokens.go). One storage condition must not
 			// present as two different statuses depending on which door the
-			// caller knocked on. 409 is also the honest one: the cap is a
-			// permanent conflict with the deployment's state that the caller
-			// resolves by deleting a token, not a transient outage a client
-			// should sit and retry the way a 503 invites.
+			// caller knocked on. 409 is the honest status: the cap is a
+			// standing conflict with the deployment's state, not a transient
+			// outage a client should sit and retry the way a 503 invites.
+			//
+			// The WORDING, though, cannot be the personal edition's. There, the
+			// caller owns every token and "you have reached the maximum" is
+			// both true and actionable. auth.MaxTokens is a DEPLOYMENT-wide cap
+			// counted across all tenants (internal/storage/agent_tokens.go), so
+			// here the caller may hold none of the tokens filling it, and a
+			// message that reads as their own quota sends them to delete tokens
+			// that will not free a slot — or to look for tokens they are not
+			// allowed to see. Say whose limit it is and who can act on it.
+			// A per-owner quota, which would make this the caller's own
+			// problem to fix, is issue #1177.
 			writeError(w, http.StatusConflict,
-				fmt.Sprintf("Maximum number of agent tokens (%d) reached", auth.MaxTokens))
+				fmt.Sprintf("This deployment has reached its limit of %d agent tokens. The limit is shared by all users, so deleting your own tokens may not free a slot; ask an administrator.", auth.MaxTokens))
 		default:
 			writeError(w, http.StatusInternalServerError, "Failed to create token")
 		}

--- a/internal/serveredition/api/user_handlers.go
+++ b/internal/serveredition/api/user_handlers.go
@@ -1044,6 +1044,15 @@ func (h *UserHandlers) writeTokenMutationError(w http.ResponseWriter, op, userID
 		writeError(w, http.StatusNotFound, fmt.Sprintf("Token %q not found", name))
 		return
 	}
+	// A revoked token cannot be rotated back into service. This is NOT an
+	// oracle: the resolve is owner-scoped, so reaching this branch means the
+	// caller owns the record and already sees it, revoked, in their own
+	// GET /api/v1/user/tokens listing.
+	if errors.Is(err, storage.ErrAgentTokenRevoked) {
+		writeError(w, http.StatusConflict,
+			fmt.Sprintf("Token %q is revoked and cannot be regenerated. Delete it and create a new token.", name))
+		return
+	}
 	h.logger.Errorw("failed to "+op+" token", "user_id", userID, "name", name, "error", err)
 	// Never interpolate err: a storage message is not a caller-facing string.
 	writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to %s token", op))

--- a/internal/serveredition/api/user_handlers.go
+++ b/internal/serveredition/api/user_handlers.go
@@ -5,6 +5,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -17,6 +18,7 @@ import (
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/oauth"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/serveredition/users"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
 )
 
 // UserHandlers provides REST endpoints for user server management.
@@ -30,13 +32,18 @@ type UserHandlers struct {
 
 // tokenStore defines the interface for agent token storage operations.
 // Implemented by *storage.Manager.
+// Every by-name method here is OWNER-SCOPED. A bare name is ambiguous in the
+// server edition — two tenants can each hold a token called "ci" — and an
+// owner-blind lookup followed by an ownership re-check would answer "exists,
+// but not yours", which is an oracle for other tenants' token names. Scoping
+// the lookup makes "absent" and "not yours" produce the same nil.
 type tokenStore interface {
 	CreateAgentToken(token auth.AgentToken, rawToken string, hmacKey []byte) error
 	ListAgentTokens() ([]auth.AgentToken, error)
-	GetAgentTokenByName(name string) (*auth.AgentToken, error)
-	RevokeAgentToken(name string) error
-	DeleteAgentToken(name string) error
-	RegenerateAgentToken(name string, newRawToken string, hmacKey []byte) (*auth.AgentToken, error)
+	GetAgentTokenByOwnerAndName(userID, name string) (*auth.AgentToken, error)
+	RevokeAgentTokenForOwner(userID, name string) error
+	DeleteAgentTokenForOwner(userID, name string) error
+	RegenerateAgentTokenForOwner(userID, name string, newRawToken string, hmacKey []byte) (*auth.AgentToken, error)
 }
 
 // NewUserHandlers creates a new UserHandlers instance.
@@ -738,7 +745,17 @@ func (h *UserHandlers) createUserToken(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.tokenStore.CreateAgentToken(token, rawToken, h.hmacKey); err != nil {
 		h.logger.Errorw("failed to create agent token", "user_id", userID, "name", req.Name, "error", err)
-		writeError(w, http.StatusConflict, fmt.Sprintf("Failed to create token: %v", err))
+		// Never echo the raw storage error: it used to name the conflicting
+		// token verbatim, which told the caller that SOMEONE owns that name.
+		// Names are per-owner now, so a duplicate can only be the caller's own.
+		switch {
+		case errors.Is(err, storage.ErrAgentTokenNameExists):
+			writeError(w, http.StatusConflict, fmt.Sprintf("You already have a token named %q", req.Name))
+		case errors.Is(err, storage.ErrAgentTokenLimitReached):
+			writeError(w, http.StatusServiceUnavailable, "Token limit reached; please try again later")
+		default:
+			writeError(w, http.StatusInternalServerError, "Failed to create token")
+		}
 		return
 	}
 
@@ -773,8 +790,10 @@ func (h *UserHandlers) revokeUserToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Verify the token belongs to this user.
-	existing, err := h.tokenStore.GetAgentTokenByName(name)
+	// Owner-scoped lookup: a token owned by someone else resolves to nil, the
+	// same as one that does not exist, so the two cases are indistinguishable
+	// in the response below. There is deliberately no "not yours" branch.
+	existing, err := h.tokenStore.GetAgentTokenByOwnerAndName(userID, name)
 	if err != nil {
 		h.logger.Errorw("failed to get token for revoke", "user_id", userID, "name", name, "error", err)
 		writeError(w, http.StatusInternalServerError, "Failed to get token")
@@ -784,12 +803,8 @@ func (h *UserHandlers) revokeUserToken(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, fmt.Sprintf("Token %q not found", name))
 		return
 	}
-	if existing.UserID != userID {
-		writeError(w, http.StatusForbidden, "Cannot revoke another user's token")
-		return
-	}
 
-	if err := h.tokenStore.RevokeAgentToken(name); err != nil {
+	if err := h.tokenStore.RevokeAgentTokenForOwner(userID, name); err != nil {
 		h.logger.Errorw("failed to revoke token", "user_id", userID, "name", name, "error", err)
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to revoke token: %v", err))
 		return
@@ -819,8 +834,9 @@ func (h *UserHandlers) deleteUserToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Verify the token belongs to this user.
-	existing, err := h.tokenStore.GetAgentTokenByName(name)
+	// Owner-scoped lookup — see revokeUserToken. "Not yours" and "not there"
+	// are the same nil, and therefore the same response.
+	existing, err := h.tokenStore.GetAgentTokenByOwnerAndName(userID, name)
 	if err != nil {
 		h.logger.Errorw("failed to get token for delete", "user_id", userID, "name", name, "error", err)
 		writeError(w, http.StatusInternalServerError, "Failed to get token")
@@ -830,12 +846,8 @@ func (h *UserHandlers) deleteUserToken(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, fmt.Sprintf("Token %q not found", name))
 		return
 	}
-	if existing.UserID != userID {
-		writeError(w, http.StatusForbidden, "Cannot delete another user's token")
-		return
-	}
 
-	if err := h.tokenStore.DeleteAgentToken(name); err != nil {
+	if err := h.tokenStore.DeleteAgentTokenForOwner(userID, name); err != nil {
 		h.logger.Errorw("failed to delete token", "user_id", userID, "name", name, "error", err)
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to delete token: %v", err))
 		return
@@ -864,8 +876,9 @@ func (h *UserHandlers) regenerateUserToken(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Verify the token belongs to this user.
-	existing, err := h.tokenStore.GetAgentTokenByName(name)
+	// Owner-scoped lookup — see revokeUserToken. "Not yours" and "not there"
+	// are the same nil, and therefore the same response.
+	existing, err := h.tokenStore.GetAgentTokenByOwnerAndName(userID, name)
 	if err != nil {
 		h.logger.Errorw("failed to get token for regenerate", "user_id", userID, "name", name, "error", err)
 		writeError(w, http.StatusInternalServerError, "Failed to get token")
@@ -873,10 +886,6 @@ func (h *UserHandlers) regenerateUserToken(w http.ResponseWriter, r *http.Reques
 	}
 	if existing == nil {
 		writeError(w, http.StatusNotFound, fmt.Sprintf("Token %q not found", name))
-		return
-	}
-	if existing.UserID != userID {
-		writeError(w, http.StatusForbidden, "Cannot regenerate another user's token")
 		return
 	}
 
@@ -887,7 +896,7 @@ func (h *UserHandlers) regenerateUserToken(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	updated, err := h.tokenStore.RegenerateAgentToken(name, newRawToken, h.hmacKey)
+	updated, err := h.tokenStore.RegenerateAgentTokenForOwner(userID, name, newRawToken, h.hmacKey)
 	if err != nil {
 		h.logger.Errorw("failed to regenerate token", "user_id", userID, "name", name, "error", err)
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to regenerate token: %v", err))
@@ -909,9 +918,17 @@ func (h *UserHandlers) regenerateUserToken(w http.ResponseWriter, r *http.Reques
 // --- Helpers ---
 
 // getUserID extracts the authenticated user's ID from the request context.
+//
+// The user TIER is required, not merely a non-empty UserID: agent tokens now
+// carry their owner's UserID (so their activity can be attributed and scoped),
+// and a scoped, read-only agent token must never be accepted as its owner's
+// full session on the per-user management surface. Today agent tokens are also
+// rejected upstream by the server-edition auth middleware, but that single
+// branch must not be the whole boundary. IsUser() covers both "user" and
+// "admin_user", so no legitimate server-edition principal is locked out.
 func getUserID(r *http.Request) (string, error) {
 	authCtx := auth.AuthContextFromContext(r.Context())
-	if authCtx == nil || authCtx.GetUserID() == "" {
+	if authCtx == nil || !authCtx.IsUser() || authCtx.GetUserID() == "" {
 		return "", fmt.Errorf("not authenticated")
 	}
 	return authCtx.GetUserID(), nil

--- a/internal/serveredition/api/user_handlers.go
+++ b/internal/serveredition/api/user_handlers.go
@@ -36,14 +36,22 @@ type UserHandlers struct {
 // server edition — two tenants can each hold a token called "ci" — and an
 // owner-blind lookup followed by an ownership re-check would answer "exists,
 // but not yours", which is an oracle for other tenants' token names. Scoping
-// the lookup makes "absent" and "not yours" produce the same nil.
+// the lookup makes "absent" and "not yours" produce the same
+// storage.ErrAgentTokenNotFound.
+//
+// There is deliberately no by-name READ here. The mutators resolve (owner,
+// name) inside their own transaction and report not-found themselves, so a
+// preflight read would only reintroduce the TOCTOU window and the sentinel leak
+// that writeTokenMutationError exists to close.
 type tokenStore interface {
 	CreateAgentToken(token auth.AgentToken, rawToken string, hmacKey []byte) error
 	ListAgentTokens() ([]auth.AgentToken, error)
-	GetAgentTokenByOwnerAndName(userID, name string) (*auth.AgentToken, error)
 	RevokeAgentTokenForOwner(userID, name string) error
 	DeleteAgentTokenForOwner(userID, name string) error
-	RegenerateAgentTokenForOwner(userID, name string, newRawToken string, hmacKey []byte) (*auth.AgentToken, error)
+	// narrowScope re-applies the owner's current server entitlement to the
+	// rotated token; it must only narrow, and must not do I/O (it runs inside
+	// the write transaction). See narrowScopeToEntitled.
+	RegenerateAgentTokenForOwner(userID, name string, newRawToken string, hmacKey []byte, narrowScope func([]string) []string) (*auth.AgentToken, error)
 }
 
 // NewUserHandlers creates a new UserHandlers instance.
@@ -329,10 +337,29 @@ func (h *UserHandlers) createServer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check conflict with shared servers.
-	for _, shared := range h.sharedServers {
-		if shared.Shared && strings.EqualFold(shared.Name, req.Name) {
-			writeError(w, http.StatusConflict, fmt.Sprintf("Server name %q conflicts with a shared server", req.Name))
+	// Refuse a name already taken by ANY server in the admin configuration,
+	// shared or not.
+	//
+	// The `Shared` qualifier that used to be here made the whole entitlement
+	// check on token scope bypassable: a tenant created a personal server named
+	// exactly like one of the admin's PRIVATE upstreams, entitledServerNames
+	// then added that name because they now owned a server called that, and the
+	// token they minted named a server auth.AuthContext.CanAccessServer compares
+	// by bare string — so it reached the admin's server. The same collision is a
+	// routing hazard independent of tokens: multiuser.Router.GetServerForUser
+	// matches the whole configuration BEFORE the caller's workspace, so the name
+	// resolves to the ADMIN's config, credentials and all.
+	//
+	// The message is IDENTICAL for a shared and an unshared collision. It has to
+	// be: a distinguishing message would name the admin's private inventory to a
+	// tenant who cannot list it, which is the existence oracle this branch just
+	// closed on token names, reopened one shape over. A refusal necessarily
+	// signals that the name is unavailable — there is no way to reject without
+	// that — but it signals nothing else: not whether the holder is shared,
+	// private or another tenant's, and not one byte of the server's config.
+	for _, existing := range h.sharedServers {
+		if existing != nil && strings.EqualFold(existing.Name, req.Name) {
+			writeError(w, http.StatusConflict, fmt.Sprintf("Server name %q is not available", req.Name))
 			return
 		}
 	}
@@ -708,6 +735,18 @@ var errServerScopeLookup = errors.New("failed to load server scope")
 // An admin_user administers the deployment, so for them the candidate set is
 // the whole configuration; the check degrades to the personal edition's
 // "is this a known server?" validation (internal/httpapi/tokens.go).
+//
+// A tenant's personal server whose name COLLIDES with one in the admin
+// configuration is excluded (for a non-admin), whether or not the admin's copy
+// is Shared. A bare name is the whole of what CanAccessServer compares, so an
+// entitlement derived from "I own a server called X" is indistinguishable, at
+// enforcement time, from "I may reach the admin's X" — which is how a personal
+// server named after an admin-private upstream turned into a grant over it.
+// createServer now refuses to mint such a collision, but this set must not
+// depend on that: a row created before the refusal existed, or an admin who
+// later adds a server whose name a tenant already used, both produce one.
+// Excluding it costs the tenant only a token scope, never their server, which
+// multiuser.Router would in any case resolve to the admin's config.
 func (h *UserHandlers) entitledServerNames(userID string, isAdmin bool) ([]string, error) {
 	personal, err := h.userStore.ListUserServers(userID)
 	if err != nil {
@@ -728,9 +767,13 @@ func (h *UserHandlers) entitledServerNames(userID string, isAdmin bool) ([]strin
 	}
 
 	for _, sc := range personal {
-		if sc != nil {
-			add(sc.Name)
+		if sc == nil {
+			continue
 		}
+		if !isAdmin && h.collidesWithAdminConfig(sc.Name) {
+			continue
+		}
+		add(sc.Name)
 	}
 	for _, sc := range h.sharedServers {
 		if sc == nil {
@@ -742,6 +785,22 @@ func (h *UserHandlers) entitledServerNames(userID string, isAdmin bool) ([]strin
 	}
 
 	return names, nil
+}
+
+// collidesWithAdminConfig reports whether name is taken by any server in the
+// admin configuration, shared or private.
+//
+// Case-insensitive, matching createServer's refusal, so a case-variant personal
+// server cannot be used to smuggle the name past this check and then be lined up
+// against a case-variant request. It is deliberately BROADER than the exact
+// comparison the enforcement layer performs.
+func (h *UserHandlers) collidesWithAdminConfig(name string) bool {
+	for _, sc := range h.sharedServers {
+		if sc != nil && strings.EqualFold(sc.Name, name) {
+			return true
+		}
+	}
+	return false
 }
 
 // resolveTokenServerScope turns the requested allowed_servers into the list
@@ -838,6 +897,94 @@ func (h *UserHandlers) resolveTokenServerScope(r *http.Request, userID string, r
 	return resolved, nil
 }
 
+// narrowScopeToEntitled trims a stored AllowedServers list to the caller's
+// current entitlement. It is the re-check half of resolveTokenServerScope, and
+// the two must agree on what "*" means.
+//
+// It only ever REMOVES a grant (or, for a tenant's star, replaces one unbounded
+// grant with the bounded set it currently stands for). It cannot widen: every
+// name it emits came from the entitled set the caller was just proved to hold,
+// and an empty result denies every server, which is the safe end of the range.
+//
+// Unlike the mint path there is no rejection here. Refusing to rotate a token
+// whose scope has gone stale would leave the over-broad grant in place and
+// working, punishing the one action that repairs it; trimming actually shrinks
+// the credential, and the handler echoes the result back so the change is
+// visible.
+func narrowScopeToEntitled(current, entitled []string, isAdmin bool) []string {
+	if len(current) == 0 {
+		return current
+	}
+
+	allowed := make(map[string]struct{}, len(entitled))
+	for _, name := range entitled {
+		allowed[name] = struct{}{}
+	}
+
+	narrowed := make([]string, 0, len(current))
+	seen := make(map[string]struct{}, len(current))
+	appendOnce := func(name string) {
+		if _, dup := seen[name]; dup {
+			return
+		}
+		seen[name] = struct{}{}
+		narrowed = append(narrowed, name)
+	}
+
+	for _, raw := range current {
+		name := strings.TrimSpace(raw)
+		if name == "" {
+			continue
+		}
+		if name == "*" {
+			// Same rule as the mint path: an admin administers every server, so
+			// the star stays literal; for a tenant it means "every server I can
+			// reach" and is materialised into that set — which is how a
+			// pre-branch token holding a bare "*" gets its unbounded grant
+			// converted into a bounded one on its first rotation.
+			if isAdmin {
+				return []string{"*"}
+			}
+			for _, n := range entitled {
+				appendOnce(n)
+			}
+			continue
+		}
+		if _, ok := allowed[name]; !ok {
+			continue
+		}
+		appendOnce(name)
+	}
+
+	return narrowed
+}
+
+// writeTokenMutationError classifies an owner-scoped mutator's error into the
+// response, with no preflight read in front of it.
+//
+// The preflight this replaces (GetAgentTokenByOwnerAndName, then a separate
+// mutating transaction) had two defects. It was a TOCTOU window: an owner who
+// concurrently deleted and recreated the name had the in-flight regenerate land
+// on the REPLACEMENT token, and one that vanished between the two calls fell
+// through to the generic 500 branch, whose body interpolated the raw storage
+// error — leaking the ErrAgentTokenNotFound sentinel text into the response.
+// Classifying the mutator's own error closes the window and the leak together:
+// the resolve and the write are one transaction, and 404 is reached by a typed
+// errors.Is rather than by a nil check on an earlier read.
+//
+// The 404 body is byte-identical to an absent token's, because the lookup is
+// owner-scoped and cannot tell "someone else's" from "not there" — that
+// indistinguishability is the whole #1168 fix, and it must survive here.
+func (h *UserHandlers) writeTokenMutationError(w http.ResponseWriter, op, userID, name string, err error) {
+	if errors.Is(err, storage.ErrAgentTokenNotFound) {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("Token %q not found", name))
+		return
+	}
+	h.logger.Errorw("failed to "+op+" token", "user_id", userID, "name", name, "error", err)
+	// Never interpolate err: a storage message is not a caller-facing string.
+	writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to %s token", op))
+}
+
 // createUserToken creates a new agent token owned by the authenticated user.
 func (h *UserHandlers) createUserToken(w http.ResponseWriter, r *http.Request) {
 	userID, err := getUserID(r)
@@ -923,7 +1070,15 @@ func (h *UserHandlers) createUserToken(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, storage.ErrAgentTokenNameExists):
 			writeError(w, http.StatusConflict, fmt.Sprintf("You already have a token named %q", req.Name))
 		case errors.Is(err, storage.ErrAgentTokenLimitReached):
-			writeError(w, http.StatusServiceUnavailable, "Token limit reached; please try again later")
+			// 409, matching the personal edition's twin
+			// (internal/httpapi/tokens.go). One storage condition must not
+			// present as two different statuses depending on which door the
+			// caller knocked on. 409 is also the honest one: the cap is a
+			// permanent conflict with the deployment's state that the caller
+			// resolves by deleting a token, not a transient outage a client
+			// should sit and retry the way a 503 invites.
+			writeError(w, http.StatusConflict,
+				fmt.Sprintf("Maximum number of agent tokens (%d) reached", auth.MaxTokens))
 		default:
 			writeError(w, http.StatusInternalServerError, "Failed to create token")
 		}
@@ -961,23 +1116,11 @@ func (h *UserHandlers) revokeUserToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Owner-scoped lookup: a token owned by someone else resolves to nil, the
-	// same as one that does not exist, so the two cases are indistinguishable
-	// in the response below. There is deliberately no "not yours" branch.
-	existing, err := h.tokenStore.GetAgentTokenByOwnerAndName(userID, name)
-	if err != nil {
-		h.logger.Errorw("failed to get token for revoke", "user_id", userID, "name", name, "error", err)
-		writeError(w, http.StatusInternalServerError, "Failed to get token")
-		return
-	}
-	if existing == nil {
-		writeError(w, http.StatusNotFound, fmt.Sprintf("Token %q not found", name))
-		return
-	}
-
+	// One owner-scoped transaction, no preflight read. The mutator resolves
+	// (owner, name) itself and reports ErrAgentTokenNotFound for both "absent"
+	// and "someone else's" — see writeTokenMutationError.
 	if err := h.tokenStore.RevokeAgentTokenForOwner(userID, name); err != nil {
-		h.logger.Errorw("failed to revoke token", "user_id", userID, "name", name, "error", err)
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to revoke token: %v", err))
+		h.writeTokenMutationError(w, "revoke", userID, name, err)
 		return
 	}
 
@@ -1005,22 +1148,9 @@ func (h *UserHandlers) deleteUserToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Owner-scoped lookup — see revokeUserToken. "Not yours" and "not there"
-	// are the same nil, and therefore the same response.
-	existing, err := h.tokenStore.GetAgentTokenByOwnerAndName(userID, name)
-	if err != nil {
-		h.logger.Errorw("failed to get token for delete", "user_id", userID, "name", name, "error", err)
-		writeError(w, http.StatusInternalServerError, "Failed to get token")
-		return
-	}
-	if existing == nil {
-		writeError(w, http.StatusNotFound, fmt.Sprintf("Token %q not found", name))
-		return
-	}
-
+	// One owner-scoped transaction, no preflight read — see revokeUserToken.
 	if err := h.tokenStore.DeleteAgentTokenForOwner(userID, name); err != nil {
-		h.logger.Errorw("failed to delete token", "user_id", userID, "name", name, "error", err)
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to delete token: %v", err))
+		h.writeTokenMutationError(w, "delete", userID, name, err)
 		return
 	}
 
@@ -1047,19 +1177,6 @@ func (h *UserHandlers) regenerateUserToken(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Owner-scoped lookup — see revokeUserToken. "Not yours" and "not there"
-	// are the same nil, and therefore the same response.
-	existing, err := h.tokenStore.GetAgentTokenByOwnerAndName(userID, name)
-	if err != nil {
-		h.logger.Errorw("failed to get token for regenerate", "user_id", userID, "name", name, "error", err)
-		writeError(w, http.StatusInternalServerError, "Failed to get token")
-		return
-	}
-	if existing == nil {
-		writeError(w, http.StatusNotFound, fmt.Sprintf("Token %q not found", name))
-		return
-	}
-
 	newRawToken, err := auth.GenerateToken()
 	if err != nil {
 		h.logger.Errorw("failed to generate new token", "user_id", userID, "error", err)
@@ -1067,10 +1184,35 @@ func (h *UserHandlers) regenerateUserToken(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	updated, err := h.tokenStore.RegenerateAgentTokenForOwner(userID, name, newRawToken, h.hmacKey)
+	// Re-check the token's server scope against the owner's CURRENT
+	// entitlement, and persist the re-checked list in the same transaction that
+	// rotates the hash.
+	//
+	// resolveTokenServerScope runs once, at mint time, and nothing revalidates
+	// afterwards: when an admin un-shares a server, every token already scoped
+	// to it keeps that grant, and a token minted with a literal "*" before this
+	// branch existed still carries the star the enforcement layer honours
+	// unconditionally. Rotation is the one moment the owner's entitlement is in
+	// hand, so it is where the standing grant gets trimmed. Narrowing only —
+	// see narrowScopeToEntitled — and the response echoes the resulting list, so
+	// nothing is dropped silently. It is not a substitute for revocation: a
+	// token that is never rotated is never re-checked. See the DOCS note.
+	//
+	// The entitlement lookup happens HERE, outside the write transaction: the
+	// hook itself must not do I/O.
+	ac := auth.AuthContextFromContext(r.Context())
+	isAdmin := ac != nil && ac.IsAdmin()
+	entitled, scopeErr := h.entitledServerNames(userID, isAdmin)
+	if scopeErr != nil {
+		h.logger.Errorw("failed to resolve token server scope for regenerate", "user_id", userID, "error", scopeErr)
+		writeError(w, http.StatusInternalServerError, "Failed to resolve server scope")
+		return
+	}
+
+	updated, err := h.tokenStore.RegenerateAgentTokenForOwner(userID, name, newRawToken, h.hmacKey,
+		func(current []string) []string { return narrowScopeToEntitled(current, entitled, isAdmin) })
 	if err != nil {
-		h.logger.Errorw("failed to regenerate token", "user_id", userID, "name", name, "error", err)
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to regenerate token: %v", err))
+		h.writeTokenMutationError(w, "regenerate", userID, name, err)
 		return
 	}
 

--- a/internal/serveredition/api/user_handlers_live_config_test.go
+++ b/internal/serveredition/api/user_handlers_live_config_test.go
@@ -1,0 +1,194 @@
+//go:build server
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+)
+
+// lateAdminServer is a name that is NOT in the admin configuration when the
+// handlers are built, and is added to it afterwards — which is what a config
+// hot reload does.
+const lateAdminServer = "late-admin-db"
+
+// TestTokenScope_ReadsTheLiveAdminConfiguration closes the reopening of the
+// name-collision escalation.
+//
+// The control that stops a personal server from lending its name to a token
+// scope (collidesWithAdminConfig, used by entitledServerNames) compared against
+// a slice CAPTURED WHEN THE HANDLERS WERE CONSTRUCTED, at process start. The
+// configuration is hot-reloadable, so any admin server added afterwards was
+// invisible to it — and a tenant who had already created a personal server of
+// that name walked through the entitlement check exactly as they did before the
+// control existed, minting a token whose bare name
+// auth.AuthContext.CanAccessServer resolves to the ADMIN's server.
+//
+// Oracle discipline:
+//
+//  1. the personal server is created, and a token minted over it, BEFORE the
+//     admin server appears — a positive control on the same router proving the
+//     route, the store and the entitlement path all work, and proving the name
+//     was genuinely free at that moment;
+//  2. the only thing that changes between the control and the probe is the
+//     configuration the provider returns;
+//  3. statuses are PINNED (201 then 400), never asserted as bare parity; and
+//  4. the escalation is checked at its END state — what allowed_servers any
+//     stored token carries — not merely at the refusal.
+//
+// BITES: build the handlers with StaticAdminServers(scopeFixtureServers()) in
+// newTokenTestRigWithServers — the boot-time snapshot this replaced — and the
+// probe mints 201 carrying the admin's server name.
+func TestTokenScope_ReadsTheLiveAdminConfiguration(t *testing.T) {
+	rig := newTokenTestRigWithServers(t, scopeFixtureServers())
+	rig.actAs(userACtx())
+
+	// (1) The name is free right now, so both of these must succeed.
+	created := rig.createServer(t, lateAdminServer)
+	require.Equal(t, http.StatusCreated, created.Code,
+		"positive control: an uncontested personal server must be creatable (%s)", created.Body.String())
+
+	control := rig.createToken(t, "before-reload", []string{lateAdminServer})
+	require.Equal(t, http.StatusCreated, control.Code,
+		"positive control: a token over an entitled personal server must mint (%s)", control.Body.String())
+
+	// (2) The admin now adds a PRIVATE server with that very name — a hot
+	// reload, which is the only thing that changes here.
+	rig.addAdminServer(&config.ServerConfig{
+		Name: lateAdminServer, URL: "https://late.example", Protocol: "http", Enabled: true,
+	})
+
+	// (3) The same request that just succeeded must now be refused.
+	probe := rig.createToken(t, "after-reload", []string{lateAdminServer})
+	require.Equal(t, http.StatusBadRequest, probe.Code,
+		"a name the admin has since taken must stop entitling a token (%s)", probe.Body.String())
+
+	// The wildcard must not smuggle it in either.
+	star := rig.createToken(t, "after-reload-star", []string{"*"})
+	require.Equal(t, http.StatusCreated, star.Code,
+		"the wildcard must still resolve over the remaining entitlement (%s)", star.Body.String())
+	var starResp AgentTokenResponse
+	require.NoError(t, json.Unmarshal(star.Body.Bytes(), &starResp))
+	assert.NotContains(t, starResp.AllowedServers, lateAdminServer,
+		`materialising "*" must not include a name the admin has since taken`)
+	assert.Contains(t, starResp.AllowedServers, scopeSharedServer,
+		"the wildcard must still cover what the tenant may genuinely reach")
+
+	// (4) End state: no token minted AFTER the reload carries the name. The
+	// pre-reload control token does, which is the honest limit of this fix —
+	// a token is a capability frozen at mint time — and is what issue #1179's
+	// admin revocation surface exists to clean up.
+	all, err := rig.store.ListAgentTokens()
+	require.NoError(t, err)
+	require.NotEmpty(t, all, "the control tokens must be in storage, or this sweep proves nothing")
+	for _, tk := range all {
+		if tk.Name == "before-reload" {
+			continue
+		}
+		assert.NotContains(t, tk.AllowedServers, lateAdminServer,
+			"token %q was minted after the reload and must not carry the admin's name", tk.Name)
+	}
+	after, err := rig.store.GetAgentTokenByOwnerAndName(tokenUserA, "after-reload")
+	require.NoError(t, err)
+	assert.Nil(t, after, "the refused mint must not have persisted a token")
+}
+
+// TestCreateServer_ReadsTheLiveAdminConfiguration is the same staleness on the
+// create door: a name the admin takes after boot must stop being available.
+//
+// Oracle discipline: user B creates the name successfully BEFORE the reload
+// (positive control on the same router, and proof the name was free), then the
+// same request from a tenant who does not hold it is refused after.
+//
+// BITES: with a boot-time snapshot the post-reload create returns 201.
+func TestCreateServer_ReadsTheLiveAdminConfiguration(t *testing.T) {
+	rig := newTokenTestRigWithServers(t, scopeFixtureServers())
+
+	rig.actAs(userBCtx())
+	control := rig.createServer(t, lateAdminServer)
+	require.Equal(t, http.StatusCreated, control.Code,
+		"positive control: the name must be free before the reload (%s)", control.Body.String())
+
+	rig.addAdminServer(&config.ServerConfig{
+		Name: lateAdminServer, URL: "https://late.example", Protocol: "http", Enabled: true,
+	})
+
+	rig.actAs(userACtx())
+	probe := rig.createServer(t, lateAdminServer)
+	require.Equal(t, http.StatusConflict, probe.Code,
+		"a name the admin has since taken must no longer be available (%s)", probe.Body.String())
+
+	stored, err := rig.users.GetUserServer(tokenUserA, lateAdminServer)
+	require.NoError(t, err)
+	assert.Nil(t, stored, "the refused personal server must not have been persisted")
+}
+
+// TestCreateServer_UnavailableNameHasOneAnswer closes the existence oracle in a
+// new shape.
+//
+// createServer refused with two different bodies: "Server name %q is not
+// available" when the name was in the ADMIN configuration, and "Server %q
+// already exists" when the caller already owned it. A tenant could therefore
+// ask about any name and read, from the wording alone, whether the admin holds
+// it — enumerating a private inventory they are not allowed to list, one
+// request at a time. Both refusals now answer identically.
+//
+// Oracle discipline: a positive control mints a free name first (proving the
+// route works and that a 409 is a refusal rather than a broken door), the three
+// refusals are compared to each other with only the caller's own input
+// normalised away, and every status is pinned to exactly 409.
+//
+// What this test does NOT claim: that the refusal leaks nothing at all. A
+// tenant who knows their own inventory can still subtract it. Closing that last
+// bit requires enforcement to resolve a server name against an OWNER instead of
+// as a bare string, which is a change well outside this door.
+//
+// BITES: restore `fmt.Sprintf("Server %q already exists", req.Name)` on the
+// own-duplicate branch and the own-versus-admin comparison fails.
+func TestCreateServer_UnavailableNameHasOneAnswer(t *testing.T) {
+	rig := newTokenTestRigWithServers(t, scopeFixtureServers())
+	rig.actAs(userACtx())
+
+	const mine = "a-server-of-my-own"
+	ctrl := rig.createServer(t, mine)
+	require.Equal(t, http.StatusCreated, ctrl.Code,
+		"positive control: a free name must be creatable (%s)", ctrl.Body.String())
+
+	own := rig.createServer(t, mine)
+	private := rig.createServer(t, scopePrivateServer)
+	shared := rig.createServer(t, scopeSharedServer)
+
+	for _, probe := range []struct {
+		label string
+		w     *httptest.ResponseRecorder
+	}{
+		{"own duplicate", own},
+		{"admin private", private},
+		{"admin shared", shared},
+	} {
+		require.Equal(t, http.StatusConflict, probe.w.Code,
+			"%s: expected exactly 409 (%s)", probe.label, probe.w.Body.String())
+	}
+
+	ownBody := normaliseCollisionBody(t, own, mine)
+	privateBody := normaliseCollisionBody(t, private, scopePrivateServer)
+	sharedBody := normaliseCollisionBody(t, shared, scopeSharedServer)
+
+	assert.Equal(t, ownBody, privateBody,
+		"a name the ADMIN holds privately must be indistinguishable from one the caller holds")
+	assert.Equal(t, ownBody, sharedBody,
+		"a name the admin shares must be indistinguishable from one the caller holds")
+
+	// And the caller's own server is intact: the second 409 was a refusal, not
+	// a clobber.
+	survivor, err := rig.users.GetUserServer(tokenUserA, mine)
+	require.NoError(t, err)
+	require.NotNil(t, survivor, "the caller's own server must survive the duplicate refusal")
+}

--- a/internal/serveredition/api/user_handlers_test.go
+++ b/internal/serveredition/api/user_handlers_test.go
@@ -38,7 +38,7 @@ func testSetup(t *testing.T, sharedServers []*config.ServerConfig) (*UserHandler
 	require.NoError(t, store.EnsureBuckets())
 
 	logger := zap.NewNop().Sugar()
-	handlers := NewUserHandlers(store, sharedServers, nil, nil, logger)
+	handlers := NewUserHandlers(store, StaticAdminServers(sharedServers), nil, nil, logger)
 
 	return handlers, store
 }

--- a/internal/serveredition/api/user_handlers_test.go
+++ b/internal/serveredition/api/user_handlers_test.go
@@ -213,7 +213,10 @@ func TestCreateServer_ConflictsWithShared(t *testing.T) {
 
 	var resp map[string]interface{}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Contains(t, resp["message"], "conflicts with a shared server")
+	// The message must NOT say which kind of server holds the name: the same
+	// refusal covers an admin-private collision, where naming it would be a
+	// server-name existence oracle. See TestCreateServer_CollisionMessageIsUniform.
+	assert.Contains(t, resp["message"], "is not available")
 }
 
 func TestCreateServer_MissingName(t *testing.T) {

--- a/internal/serveredition/api/user_token_collision_test.go
+++ b/internal/serveredition/api/user_token_collision_test.go
@@ -1,0 +1,192 @@
+//go:build server
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createServer posts a personal-server create under the rig's current identity.
+func (rig *tokenTestRig) createServer(t *testing.T, name string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(CreateServerRequest{
+		Name:     name,
+		URL:      "http://127.0.0.1:9/" + name,
+		Protocol: "http",
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/user/servers", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	rig.router.ServeHTTP(w, req)
+	return w
+}
+
+// TestCreateUserToken_PersonalServerCannotShadowAdminPrivateServer closes the
+// bypass in the allowed_servers entitlement check.
+//
+// The check asks "is this name in the caller's entitled set?", and that set is
+// "my personal servers, plus the admin servers flagged Shared". createServer only
+// refused a name colliding with a SHARED server, so a tenant could create a
+// personal server named exactly like one of the admin's PRIVATE upstreams; the
+// name then entered their entitled set on the strength of the personal server,
+// and the token they minted named the admin's server as far as
+// auth.AuthContext.CanAccessServer is concerned — it compares bare strings and
+// has no notion of an owner.
+//
+// Oracle discipline:
+//
+//  1. a POSITIVE CONTROL first, on the SAME router: the tenant creates an
+//     ordinary personal server and mints a token scoped to it (201/201), so a
+//     later 409/400 cannot be a broken route, an unwired store or a bad body;
+//  2. an independent proof through the production per-user door that the admin's
+//     private server is INVISIBLE to this tenant — the property the escalation
+//     would have defeated;
+//  3. statuses are PINNED (201, 409, 400), never asserted as bare parity;
+//  4. the escalation is checked at its END state — what allowed_servers any
+//     stored token actually carries — not merely at the refusal.
+//
+// BITES: on unfixed code the shadowing personal server is CREATED (201) and the
+// token naming the admin's private server is MINTED (201) carrying that name.
+func TestCreateUserToken_PersonalServerCannotShadowAdminPrivateServer(t *testing.T) {
+	rig := newTokenTestRigWithServers(t, scopeFixtureServers())
+	rig.actAs(userACtx())
+
+	// (1) Positive control: an ordinary personal server, and a token over it.
+	ctrl := rig.createServer(t, scopeAPersonal)
+	require.Equal(t, http.StatusCreated, ctrl.Code,
+		"positive control: creating an uncontested personal server must succeed (%s)", ctrl.Body.String())
+
+	ctrlTok := rig.createToken(t, "ctrl-token", []string{scopeAPersonal})
+	require.Equal(t, http.StatusCreated, ctrlTok.Code,
+		"positive control: minting a token over an entitled server must succeed (%s)", ctrlTok.Body.String())
+
+	// (2) The admin's private server is invisible through the production door.
+	listed := rig.call(t, http.MethodGet, "/api/v1/user/servers")
+	require.Equal(t, http.StatusOK, listed.Code)
+	var doorway ServerListResponse
+	require.NoError(t, json.Unmarshal(listed.Body.Bytes(), &doorway))
+	for _, s := range doorway.Personal {
+		require.NotEqual(t, scopePrivateServer, s.Name, "the admin's private server must not be listed as personal")
+	}
+	for _, s := range doorway.Shared {
+		require.NotEqual(t, scopePrivateServer, s.Name, "the admin's private server must not be listed as shared")
+	}
+
+	// (3) The collision itself is refused, and really did not land.
+	collide := rig.createServer(t, scopePrivateServer)
+	require.Equal(t, http.StatusConflict, collide.Code,
+		"a personal server may not take an admin-configured name (%s)", collide.Body.String())
+
+	stored, err := rig.users.GetUserServer(tokenUserA, scopePrivateServer)
+	require.NoError(t, err)
+	assert.Nil(t, stored, "the refused personal server must not have been persisted")
+
+	// (4) And the escalation's end state is unreachable: no token may name it.
+	tok := rig.createToken(t, "escalation", []string{scopePrivateServer})
+	require.Equal(t, http.StatusBadRequest, tok.Code,
+		"a token must not be mintable over the admin's private server (%s)", tok.Body.String())
+
+	all, err := rig.store.ListAgentTokens()
+	require.NoError(t, err)
+	require.NotEmpty(t, all, "the positive control's token must be in storage, or this sweep proves nothing")
+	for _, tk := range all {
+		assert.NotContains(t, tk.AllowedServers, scopePrivateServer,
+			"no stored token may carry the admin's private server in its scope (token %q)", tk.Name)
+	}
+}
+
+// TestEntitledServerNames_ExcludesPreExistingCollision covers the collision
+// createServer's refusal cannot reach: a personal row written BEFORE the refusal
+// existed, or one whose name the admin only later added to the configuration.
+// The entitled set must drop it on its own rather than trusting the create path.
+//
+// BITES: without the exclusion in entitledServerNames, both the explicit request
+// and the materialised "*" carry the admin's private server.
+func TestEntitledServerNames_ExcludesPreExistingCollision(t *testing.T) {
+	rig := newTokenTestRigWithServers(t, scopeFixtureServers())
+	rig.actAs(userACtx())
+
+	// Written straight through the user store, exactly as a pre-fix createServer
+	// would have left it — the HTTP route now refuses this name.
+	rig.seedPersonalServer(t, tokenUserA, scopePrivateServer)
+
+	// Positive control on the same rig: an uncontested personal server still
+	// mints, so a 400 below is the collision and not a broken fixture.
+	rig.seedPersonalServer(t, tokenUserA, scopeAPersonal)
+	ctrl := rig.createToken(t, "ctrl-token", []string{scopeAPersonal})
+	require.Equal(t, http.StatusCreated, ctrl.Code,
+		"positive control: an uncontested personal server must remain scopable (%s)", ctrl.Body.String())
+
+	tok := rig.createToken(t, "legacy-collision", []string{scopePrivateServer})
+	require.Equal(t, http.StatusBadRequest, tok.Code,
+		"a pre-existing shadowing personal server must not entitle the admin's name (%s)", tok.Body.String())
+
+	// "*" must not smuggle it in through the materialised set either.
+	star := rig.createToken(t, "legacy-star", []string{"*"})
+	require.Equal(t, http.StatusCreated, star.Code, "the star must still resolve (%s)", star.Body.String())
+	var resp AgentTokenResponse
+	require.NoError(t, json.Unmarshal(star.Body.Bytes(), &resp))
+	assert.NotContains(t, resp.AllowedServers, scopePrivateServer,
+		`materialising "*" must not include an admin-config collision`)
+	assert.Contains(t, resp.AllowedServers, scopeAPersonal,
+		"the star must still cover genuinely owned servers")
+}
+
+// TestCreateServer_CollisionMessageIsUniform pins the anti-oracle property of
+// the refusal: the body a tenant gets for colliding with the admin's PRIVATE
+// server must be identical to the one for a server they can already see, up to
+// the name they themselves sent. A message that distinguished them would let a
+// tenant enumerate the admin's private inventory one name at a time — the same
+// defect class this branch closed on token names.
+//
+// BITES: on unfixed code the private-name request returns 201, so there is no
+// second body to compare and the require below fails on the status.
+func TestCreateServer_CollisionMessageIsUniform(t *testing.T) {
+	rig := newTokenTestRigWithServers(t, scopeFixtureServers())
+	rig.actAs(userACtx())
+
+	sharedCollision := rig.createServer(t, scopeSharedServer)
+	privateCollision := rig.createServer(t, scopePrivateServer)
+
+	require.Equal(t, http.StatusConflict, sharedCollision.Code,
+		"colliding with a shared server must be a conflict (%s)", sharedCollision.Body.String())
+	require.Equal(t, http.StatusConflict, privateCollision.Code,
+		"colliding with an admin-private server must be the SAME conflict (%s)", privateCollision.Body.String())
+
+	// Same body, once the caller's own input is normalised away. Echoing back
+	// what the caller sent is not a disclosure; anything else that differs is.
+	assert.Equal(t,
+		normaliseCollisionBody(t, sharedCollision, scopeSharedServer),
+		normaliseCollisionBody(t, privateCollision, scopePrivateServer),
+		"the refusal must not reveal whether the colliding server is shared or private")
+
+	// And the private refusal leaks nothing about the server behind the name.
+	assert.NotContains(t, privateCollision.Body.String(), "shared",
+		"the private collision must not be described as a shared-server conflict")
+	assert.NotContains(t, privateCollision.Body.String(), "private.example",
+		"the refusal must not echo the admin server's configuration")
+}
+
+// normaliseCollisionBody replaces the caller's own server name with a fixed
+// placeholder so two refusals can be compared for everything EXCEPT that name.
+func normaliseCollisionBody(t *testing.T, w *httptest.ResponseRecorder, name string) string {
+	t.Helper()
+	var envelope map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope),
+		"body did not decode as the handler's error envelope (%q)", w.Body.String())
+	msg, _ := envelope["message"].(string)
+	require.NotEmpty(t, msg, "refusal must carry a message")
+	envelope["message"] = strings.ReplaceAll(msg, name, "<NAME>")
+	out, err := json.Marshal(envelope)
+	require.NoError(t, err)
+	return string(out)
+}

--- a/internal/serveredition/api/user_token_isolation_test.go
+++ b/internal/serveredition/api/user_token_isolation_test.go
@@ -1,0 +1,313 @@
+//go:build server
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/serveredition/users"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
+)
+
+const (
+	tokenUserA = "01HTEST0000000000000USERA"
+	tokenUserB = "01HTEST0000000000000USERB"
+)
+
+var tokenTestHMACKey = []byte("test-hmac-key-32-bytes-long!!!!!")
+
+// tokenTestRig wires UserHandlers over a REAL *storage.Manager and registers
+// the routes through RegisterRoutesWithPrefix — the function
+// internal/serveredition/setup.go actually calls. RegisterRoutes (the nested
+// chi.Route form the older testRouter uses) is never called in production, and
+// a prefix mismatch would silently turn every assertion below into a chi 404.
+//
+// The auth context is chosen per request so one router can serve both tenants.
+type tokenTestRig struct {
+	router *chi.Mux
+	store  *storage.Manager
+	as     *auth.AuthContext
+}
+
+func newTokenTestRig(t *testing.T) *tokenTestRig {
+	t.Helper()
+
+	logger := zap.NewNop().Sugar()
+
+	dbPath := t.TempDir()
+	db, err := bbolt.Open(dbPath+"/users.db", 0600, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	userStore := users.NewUserStore(db)
+	require.NoError(t, userStore.EnsureBuckets())
+
+	mgr, err := storage.NewManager(t.TempDir(), logger)
+	require.NoError(t, err)
+	t.Cleanup(func() { mgr.Close() })
+
+	rig := &tokenTestRig{store: mgr}
+	handlers := NewUserHandlers(userStore, nil, mgr, tokenTestHMACKey, logger)
+
+	r := chi.NewRouter()
+	r.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			ctx := auth.WithAuthContext(req.Context(), rig.as)
+			next.ServeHTTP(w, req.WithContext(ctx))
+		})
+	})
+	handlers.RegisterRoutesWithPrefix(r, "/api/v1")
+	rig.router = r
+
+	return rig
+}
+
+// as switches the identity subsequent calls are made under.
+func (rig *tokenTestRig) actAs(ac *auth.AuthContext) { rig.as = ac }
+
+func (rig *tokenTestRig) call(t *testing.T, method, target string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, target, strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	rig.router.ServeHTTP(w, req)
+	return w
+}
+
+// seedToken writes a token through the STORAGE layer with an explicit owner.
+// Seeding through the HTTP create route would be fragile: createUserToken 400s
+// unless the body carries permissions including "read", and a fixture that
+// silently fails to land is exactly what makes a parity oracle vacuous.
+func (rig *tokenTestRig) seedToken(t *testing.T, owner, name string) {
+	t.Helper()
+	raw, err := auth.GenerateToken()
+	require.NoError(t, err)
+	require.NoError(t, rig.store.CreateAgentToken(auth.AgentToken{
+		Name:        name,
+		UserID:      owner,
+		Permissions: []string{auth.PermRead},
+	}, raw, tokenTestHMACKey))
+}
+
+func userACtx() *auth.AuthContext {
+	return auth.UserContext(tokenUserA, "a@example.com", "User A", "google")
+}
+
+func userBCtx() *auth.AuthContext {
+	return auth.UserContext(tokenUserB, "b@example.com", "User B", "google")
+}
+
+// assertHandlerNotFound checks that the response is the HANDLER's 404 envelope
+// and not chi's NotFoundHandler. chi answers an unregistered path with the
+// plain text "404 page not found\n", which does not decode as the envelope —
+// so decoding it here is what rules out "the route never matched", the most
+// likely way a status-parity assertion passes while exercising nothing.
+func assertHandlerNotFound(t *testing.T, w *httptest.ResponseRecorder, what string) {
+	t.Helper()
+	require.Equal(t, http.StatusNotFound, w.Code, "%s: expected exactly 404", what)
+
+	var envelope struct {
+		Error      string `json:"error"`
+		Message    string `json:"message"`
+		StatusCode int    `json:"status_code"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope),
+		"%s: body did not decode as the handler's error envelope — chi's own 404 would look like this (%q)", what, w.Body.String())
+	assert.Equal(t, http.StatusNotFound, envelope.StatusCode, "%s: envelope status_code", what)
+	assert.Equal(t, http.StatusText(http.StatusNotFound), envelope.Error, "%s: envelope error", what)
+}
+
+// TestUserTokenRoutes_UnownedIsIndistinguishableFromAbsent is the security
+// property the 403->404 collapse exists to deliver: a caller who owns neither
+// an existing-but-unowned token nor a nonexistent one must not be able to tell
+// the two apart.
+//
+// Bare status parity between "unowned" and "absent" is NOT a sufficient oracle
+// — it passes when the fixture never lands (404/404), when the route never
+// matches (chi 404/404), and when the token store is nil (500/500). All three
+// are ruled out here:
+//
+//  1. a POSITIVE CONTROL runs FIRST, on the SAME router and the SAME name, as
+//     the owner, and must succeed — proving the fixture landed, the route
+//     matched and the store is wired;
+//  2. an independent existence proof: the owner's own GET /user/tokens lists
+//     the name, through the production route table;
+//  3. the expected status is PINNED to 404, not merely equal between the two
+//     probes; and
+//  4. the body must decode as the HANDLER's error envelope, which chi's own
+//     plain-text 404 does not.
+//
+// BITES: on unfixed code the unowned probe is 403 ("Cannot revoke another
+// user's token") while the absent probe is 404.
+func TestUserTokenRoutes_UnownedIsIndistinguishableFromAbsent(t *testing.T) {
+	const absentName = "no-such-token-Zq7"
+
+	cases := []struct {
+		label  string
+		method string
+		path   string // %s is the token name
+		// consumesFixture is true when the owner's positive control destroys
+		// the record, so it must be re-seeded before user B probes.
+		consumesFixture bool
+	}{
+		{"revoke", http.MethodDelete, "/api/v1/user/tokens/%s", false},
+		{"delete", http.MethodDelete, "/api/v1/user/tokens/%s/permanent", true},
+		{"regenerate", http.MethodPost, "/api/v1/user/tokens/%s/regenerate", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			rig := newTokenTestRig(t)
+			name := "ci-" + tc.label
+
+			rig.seedToken(t, tokenUserA, name)
+
+			// (2) Independent existence proof through the production routes.
+			rig.actAs(userACtx())
+			listed := rig.call(t, http.MethodGet, "/api/v1/user/tokens")
+			require.Equal(t, http.StatusOK, listed.Code, "owner's token list must be readable")
+			require.Contains(t, listed.Body.String(), name,
+				"the fixture did not land: the owner's own token list does not show %q", name)
+
+			// (1) Positive control, first, same router, same name, as the owner.
+			ctl := rig.call(t, tc.method, fmt.Sprintf(tc.path, name))
+			require.Equal(t, http.StatusOK, ctl.Code,
+				"positive control failed: the owner got %d for %s %s (body: %s)",
+				ctl.Code, tc.method, tc.path, ctl.Body.String())
+
+			if tc.consumesFixture {
+				rig.seedToken(t, tokenUserA, name)
+			}
+
+			// Snapshot A's record AFTER the control, so the final check
+			// attributes any change to user B's probe rather than to the
+			// control (revoke and regenerate both mutate it legitimately).
+			before, err := rig.store.GetAgentTokenByOwnerAndName(tokenUserA, name)
+			require.NoError(t, err)
+			require.NotNil(t, before, "the fixture must exist before user B probes it")
+
+			// The probes: user B owns neither name.
+			rig.actAs(userBCtx())
+			unowned := rig.call(t, tc.method, fmt.Sprintf(tc.path, name))
+			absent := rig.call(t, tc.method, fmt.Sprintf(tc.path, absentName))
+
+			assert.Equal(t, absent.Code, unowned.Code,
+				"%s: an unowned token answers %d while an absent one answers %d — a name-existence oracle",
+				tc.label, unowned.Code, absent.Code)
+
+			// (3) + (4): pin the value, and prove the handler answered.
+			assertHandlerNotFound(t, unowned, tc.label+" (unowned)")
+			assertHandlerNotFound(t, absent, tc.label+" (absent)")
+
+			// The unowned probe must not have mutated A's token.
+			after, err := rig.store.GetAgentTokenByOwnerAndName(tokenUserA, name)
+			require.NoError(t, err)
+			require.NotNil(t, after, "user B's probe deleted user A's token")
+			assert.Equal(t, before.Revoked, after.Revoked, "user B's probe changed the revoked state of user A's token")
+			assert.Equal(t, before.TokenHash, after.TokenHash, "user B's probe regenerated user A's token")
+		})
+	}
+}
+
+// TestCreateUserToken_SameNameAsAnotherUserSucceeds closes the create-path half
+// of the oracle. Collapsing only the revoke/delete/regenerate 403s would move
+// the oracle rather than close it: create would still answer 409 for a name
+// another tenant owns.
+//
+// BITES: on unfixed code the second create returns 409 and echoes the storage
+// string `agent token with name "ci" already exists` verbatim.
+func TestCreateUserToken_SameNameAsAnotherUserSucceeds(t *testing.T) {
+	rig := newTokenTestRig(t)
+
+	rig.seedToken(t, tokenUserA, "ci")
+
+	rig.actAs(userBCtx())
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/user/tokens",
+		strings.NewReader(`{"name":"ci","permissions":["read"]}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	rig.router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code,
+		"user B could not create a token named %q because another tenant owns that name (body: %s)", "ci", w.Body.String())
+	assert.NotContains(t, w.Body.String(), "already exists",
+		"the create path echoed a storage conflict, disclosing that someone owns this name")
+
+	// Both records exist independently and neither clobbered the other.
+	gotA, err := rig.store.GetAgentTokenByOwnerAndName(tokenUserA, "ci")
+	require.NoError(t, err)
+	require.NotNil(t, gotA)
+	gotB, err := rig.store.GetAgentTokenByOwnerAndName(tokenUserB, "ci")
+	require.NoError(t, err)
+	require.NotNil(t, gotB)
+	assert.NotEqual(t, gotA.TokenHash, gotB.TokenHash)
+
+	// A duplicate for the SAME owner is still refused — and without echoing
+	// storage internals.
+	dupe := httptest.NewRequest(http.MethodPost, "/api/v1/user/tokens",
+		strings.NewReader(`{"name":"ci","permissions":["read"]}`))
+	dupe.Header.Set("Content-Type", "application/json")
+	dupeRec := httptest.NewRecorder()
+	rig.router.ServeHTTP(dupeRec, dupe)
+	assert.Equal(t, http.StatusConflict, dupeRec.Code)
+	assert.NotContains(t, dupeRec.Body.String(), "agent token with")
+}
+
+// TestUserTokenRoutes_RejectAgentTierContext: now that an agent token carries
+// its owner's UserID, a non-empty UserID is no longer proof of the user tier.
+// Every /api/v1/user/tokens route must gate on IsUser().
+//
+// BITES: with the UserID field added and getUserID still testing only
+// GetUserID() != "", the agent context is accepted AS the tenant and these
+// routes answer 200/404 instead of 401.
+func TestUserTokenRoutes_RejectAgentTierContext(t *testing.T) {
+	rig := newTokenTestRig(t)
+	rig.seedToken(t, tokenUserA, "ci")
+
+	// Positive control: as the owning USER, the list route works.
+	rig.actAs(userACtx())
+	ok := rig.call(t, http.MethodGet, "/api/v1/user/tokens")
+	require.Equal(t, http.StatusOK, ok.Code)
+	require.Contains(t, ok.Body.String(), "ci")
+
+	// The agent tier: same UserID, agent Type.
+	agent := (&auth.AgentToken{
+		Name:        "ci",
+		TokenPrefix: "mcp_agt_abcd",
+		Permissions: []string{auth.PermRead},
+		UserID:      tokenUserA,
+	}).AuthContext()
+	require.Equal(t, tokenUserA, agent.GetUserID(), "the fixture must actually carry the owner's id")
+	rig.actAs(agent)
+
+	for _, tc := range []struct {
+		method, target string
+	}{
+		{http.MethodGet, "/api/v1/user/tokens"},
+		{http.MethodPost, "/api/v1/user/tokens"},
+		{http.MethodDelete, "/api/v1/user/tokens/ci"},
+		{http.MethodDelete, "/api/v1/user/tokens/ci/permanent"},
+		{http.MethodPost, "/api/v1/user/tokens/ci/regenerate"},
+	} {
+		w := rig.call(t, tc.method, tc.target)
+		assert.Equal(t, http.StatusUnauthorized, w.Code,
+			"%s %s accepted an agent-tier context as its owner (body: %s)", tc.method, tc.target, w.Body.String())
+	}
+
+	// And the token itself is untouched.
+	got, err := rig.store.GetAgentTokenByOwnerAndName(tokenUserA, "ci")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.False(t, got.Revoked)
+}

--- a/internal/serveredition/api/user_token_isolation_test.go
+++ b/internal/serveredition/api/user_token_isolation_test.go
@@ -17,6 +17,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/serveredition/users"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
 )
@@ -38,10 +39,20 @@ var tokenTestHMACKey = []byte("test-hmac-key-32-bytes-long!!!!!")
 type tokenTestRig struct {
 	router *chi.Mux
 	store  *storage.Manager
+	users  *users.UserStore
 	as     *auth.AuthContext
 }
 
 func newTokenTestRig(t *testing.T) *tokenTestRig {
+	t.Helper()
+	return newTokenTestRigWithServers(t, nil)
+}
+
+// newTokenTestRigWithServers is newTokenTestRig with an admin server
+// configuration, so a test can exercise the entitlement predicate (personal +
+// Shared) that createUserToken constrains a token's allowed_servers to. The
+// slice is what setup.go passes: the WHOLE config, shared and unshared alike.
+func newTokenTestRigWithServers(t *testing.T, sharedServers []*config.ServerConfig) *tokenTestRig {
 	t.Helper()
 
 	logger := zap.NewNop().Sugar()
@@ -57,8 +68,8 @@ func newTokenTestRig(t *testing.T) *tokenTestRig {
 	require.NoError(t, err)
 	t.Cleanup(func() { mgr.Close() })
 
-	rig := &tokenTestRig{store: mgr}
-	handlers := NewUserHandlers(userStore, nil, mgr, tokenTestHMACKey, logger)
+	rig := &tokenTestRig{store: mgr, users: userStore}
+	handlers := NewUserHandlers(userStore, sharedServers, mgr, tokenTestHMACKey, logger)
 
 	r := chi.NewRouter()
 	r.Use(func(next http.Handler) http.Handler {

--- a/internal/serveredition/api/user_token_isolation_test.go
+++ b/internal/serveredition/api/user_token_isolation_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -41,6 +42,27 @@ type tokenTestRig struct {
 	store  *storage.Manager
 	users  *users.UserStore
 	as     *auth.AuthContext
+
+	// adminMu guards adminServers, which stands in for the hot-reloadable
+	// admin configuration: the handlers read it through a provider on every
+	// request, exactly as production reads the current config snapshot, so a
+	// test can add a server AFTER the handlers were constructed.
+	adminMu      sync.RWMutex
+	adminServers []*config.ServerConfig
+}
+
+// addAdminServer appends one server to the live admin configuration, standing
+// in for a config hot reload.
+func (rig *tokenTestRig) addAdminServer(sc *config.ServerConfig) {
+	rig.adminMu.Lock()
+	defer rig.adminMu.Unlock()
+	rig.adminServers = append(append([]*config.ServerConfig(nil), rig.adminServers...), sc)
+}
+
+func (rig *tokenTestRig) currentAdminServers() []*config.ServerConfig {
+	rig.adminMu.RLock()
+	defer rig.adminMu.RUnlock()
+	return rig.adminServers
 }
 
 func newTokenTestRig(t *testing.T) *tokenTestRig {
@@ -68,8 +90,10 @@ func newTokenTestRigWithServers(t *testing.T, sharedServers []*config.ServerConf
 	require.NoError(t, err)
 	t.Cleanup(func() { mgr.Close() })
 
-	rig := &tokenTestRig{store: mgr, users: userStore}
-	handlers := NewUserHandlers(userStore, sharedServers, mgr, tokenTestHMACKey, logger)
+	rig := &tokenTestRig{store: mgr, users: userStore, adminServers: sharedServers}
+	// A LIVE provider, as setup.go wires: the handlers must observe a change to
+	// the admin configuration made after this point.
+	handlers := NewUserHandlers(userStore, rig.currentAdminServers, mgr, tokenTestHMACKey, logger)
 
 	r := chi.NewRouter()
 	r.Use(func(next http.Handler) http.Handler {

--- a/internal/serveredition/api/user_token_mutation_test.go
+++ b/internal/serveredition/api/user_token_mutation_test.go
@@ -1,0 +1,207 @@
+//go:build server
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
+)
+
+// mutationRoutes are the three owner-scoped mutators that used to do a preflight
+// read before their transaction.
+var mutationRoutes = []struct {
+	name   string
+	method string
+	path   func(token string) string
+}{
+	{"revoke", http.MethodDelete, func(tok string) string { return "/api/v1/user/tokens/" + tok }},
+	{"delete", http.MethodDelete, func(tok string) string { return "/api/v1/user/tokens/" + tok + "/permanent" }},
+	{"regenerate", http.MethodPost, func(tok string) string { return "/api/v1/user/tokens/" + tok + "/regenerate" }},
+}
+
+// TestUserTokenMutators_NotFoundLeaksNoStorageSentinel pins the two things the
+// preflight got wrong at once.
+//
+// The old shape was: GetAgentTokenByOwnerAndName, then a SEPARATE mutating
+// transaction. If the (owner, name) pair vanished between the two calls, the
+// mutator's storage.ErrAgentTokenNotFound fell through to the generic branch,
+// whose body was fmt.Sprintf("Failed to … token: %v", err) — so the response
+// echoed the storage sentinel's text at 500. The resolve now happens inside the
+// mutating transaction and its error is classified, so the same condition is a
+// 404 whose body is byte-identical to an ordinary absent token's.
+//
+// Oracle discipline: this does NOT assert "the body does not contain the token
+// name" — a 404 echoes the caller's own path parameter, so that would pass
+// vacuously. It asserts STATUS PARITY against a name that exists nowhere, plus
+// an exact-status pin, plus a positive control proving the fixture and the route
+// really work on the same router.
+//
+// BITES: reinstate the preflight and its `fmt.Sprintf("Failed to revoke token:
+// %v", err)` fall-through, and the storage-sentinel assertions below fail.
+func TestUserTokenMutators_NotFoundLeaksNoStorageSentinel(t *testing.T) {
+	for _, route := range mutationRoutes {
+		t.Run(route.name, func(t *testing.T) {
+			rig := newTokenTestRig(t)
+			rig.actAs(userACtx())
+
+			// Positive control on the SAME router: the route works, and the
+			// fixture lands, so a 404 below is about the token and not the path.
+			rig.seedToken(t, tokenUserA, "control")
+			ok := rig.call(t, route.method, route.path("control"))
+			require.Equal(t, http.StatusOK, ok.Code,
+				"positive control: %s must succeed on the caller's own token (%s)", route.name, ok.Body.String())
+
+			// Two ways to be unresolvable: owned by someone else, and nowhere.
+			rig.seedToken(t, tokenUserB, "b-only")
+			foreign := rig.call(t, route.method, route.path("b-only"))
+			absent := rig.call(t, route.method, route.path("no-such-token-Zq7"))
+
+			assertHandlerNotFound(t, foreign, route.name+" on another tenant's token")
+			assertHandlerNotFound(t, absent, route.name+" on an absent token")
+
+			// Status parity between the two, pinned to exactly 404.
+			require.Equal(t, http.StatusNotFound, foreign.Code)
+			require.Equal(t, http.StatusNotFound, absent.Code)
+			assert.Equal(t, absent.Code, foreign.Code,
+				"%s: another tenant's token must be indistinguishable from an absent one", route.name)
+
+			// And no storage internals in either body.
+			for _, w := range []*httptest.ResponseRecorder{foreign, absent} {
+				body := w.Body.String()
+				assert.NotContains(t, body, storage.ErrAgentTokenNotFound.Error(),
+					"%s: the response must not echo the storage sentinel", route.name)
+				assert.NotContains(t, body, "agent token",
+					"%s: the response must not echo storage's wording", route.name)
+			}
+
+			// The other tenant's token really is untouched — the 404 is a
+			// refusal, not a silent success.
+			survivor, err := rig.store.GetAgentTokenByOwnerAndName(tokenUserB, "b-only")
+			require.NoError(t, err)
+			require.NotNil(t, survivor, "another tenant's token must still exist")
+			assert.False(t, survivor.Revoked, "another tenant's token must not have been revoked")
+		})
+	}
+}
+
+// TestCreateUserToken_CapExhaustionIsConflict pins the status the token cap
+// answers with. The same storage condition (storage.ErrAgentTokenLimitReached)
+// used to map to 409 on the personal-edition surface and 503 on this one, so a
+// client's retry behaviour depended on which door it knocked on — and 503
+// invites a retry loop against a condition that will never clear on its own.
+//
+// Oracle discipline: a positive control mints the token immediately BELOW the
+// cap on the same router, so the 409 that follows is exhaustion and not a
+// malformed body or an unwired store.
+//
+// BITES: restore http.StatusServiceUnavailable in createUserToken.
+func TestCreateUserToken_CapExhaustionIsConflict(t *testing.T) {
+	rig := newTokenTestRig(t)
+	rig.actAs(userACtx())
+
+	// Fill to one below the cap through storage, which is far faster than the
+	// HTTP route and exercises the same counter.
+	for i := 0; i < auth.MaxTokens-1; i++ {
+		rig.seedToken(t, tokenUserA, fmt.Sprintf("filler-%03d", i))
+	}
+
+	// Positive control: the last slot below the cap still mints.
+	last := rig.createToken(t, "last-slot", nil)
+	require.Equal(t, http.StatusCreated, last.Code,
+		"positive control: the final slot below the cap must still mint (%s)", last.Body.String())
+
+	over := rig.createToken(t, "one-too-many", nil)
+	require.Equal(t, http.StatusConflict, over.Code,
+		"the token cap must answer 409, matching the personal edition (%s)", over.Body.String())
+	assert.Contains(t, errorMessage(t, over), "Maximum number of agent tokens",
+		"the cap message must say what the conflict is")
+}
+
+// TestRegenerateUserToken_ReNarrowsScopeToCurrentEntitlement pins the one
+// re-check a token's server scope ever gets.
+//
+// resolveTokenServerScope runs at mint time and nothing revalidates afterwards,
+// so un-sharing a server leaves every token already scoped to it holding that
+// grant, and a token minted with a literal "*" before this branch existed still
+// carries the star the enforcement layer honours unconditionally. Rotation is
+// the moment the owner's current entitlement is in hand, so it is where the
+// standing grant gets trimmed.
+//
+// Oracle discipline: the assertion is on the PERSISTED record, read back through
+// storage — a response body could show a narrowed list while storage kept the
+// wide one. A positive control first proves the entitled half survives, so an
+// empty result cannot pass for a narrowing.
+//
+// BITES: drop the narrowScopeToEntitled hook from regenerateUserToken and the
+// reread still shows the un-entitled name (and the bare "*").
+func TestRegenerateUserToken_ReNarrowsScopeToCurrentEntitlement(t *testing.T) {
+	rig := newTokenTestRigWithServers(t, scopeFixtureServers())
+	rig.actAs(userACtx())
+	rig.seedPersonalServer(t, tokenUserA, scopeAPersonal)
+
+	// A token minted before the constraint existed: a literal star, plus a name
+	// its owner is not (or is no longer) entitled to.
+	seedTokenWithScope(t, rig, tokenUserA, "legacy", []string{"*", scopePrivateServer, scopeAPersonal})
+
+	regen := rig.call(t, http.MethodPost, "/api/v1/user/tokens/legacy/regenerate")
+	require.Equal(t, http.StatusOK, regen.Code, "rotation must not be refused (%s)", regen.Body.String())
+
+	var resp AgentTokenResponse
+	require.NoError(t, json.Unmarshal(regen.Body.Bytes(), &resp))
+
+	// Read the PERSISTED record: that is the credential the enforcement layer
+	// will consult, and it is what a body-only assertion would miss.
+	stored, err := rig.store.GetAgentTokenByOwnerAndName(tokenUserA, "legacy")
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+
+	for _, scope := range [][]string{resp.AllowedServers, stored.AllowedServers} {
+		assert.NotContains(t, scope, "*",
+			"a tenant's literal star must be materialised on rotation, never persisted")
+		assert.NotContains(t, scope, scopePrivateServer,
+			"rotation must drop a server the owner is not entitled to")
+		// Positive half: the entitled names survive, so this is a narrowing and
+		// not a blanket wipe that would pass every assertion above.
+		assert.Contains(t, scope, scopeAPersonal, "the owner's own server must survive rotation")
+		assert.Contains(t, scope, scopeSharedServer, "a still-shared server must survive rotation")
+	}
+
+	// Rotation is idempotent: a second one changes nothing.
+	again := rig.call(t, http.MethodPost, "/api/v1/user/tokens/legacy/regenerate")
+	require.Equal(t, http.StatusOK, again.Code)
+	var resp2 AgentTokenResponse
+	require.NoError(t, json.Unmarshal(again.Body.Bytes(), &resp2))
+	assert.ElementsMatch(t, resp.AllowedServers, resp2.AllowedServers,
+		"re-narrowing an already-narrowed scope must be a no-op")
+}
+
+// seedTokenWithScope writes a token with an explicit owner AND server scope,
+// which the HTTP create route would now refuse — that is the point: it stands in
+// for a record minted before the constraint existed.
+func seedTokenWithScope(t *testing.T, rig *tokenTestRig, owner, name string, allowedServers []string) {
+	t.Helper()
+	raw, err := auth.GenerateToken()
+	require.NoError(t, err)
+	require.NoError(t, rig.store.CreateAgentToken(auth.AgentToken{
+		Name:           name,
+		UserID:         owner,
+		AllowedServers: allowedServers,
+		Permissions:    []string{auth.PermRead},
+	}, raw, tokenTestHMACKey))
+
+	// Fixture check: the wide scope really landed, or every assertion about
+	// narrowing it would be vacuous.
+	seeded, err := rig.store.GetAgentTokenByOwnerAndName(owner, name)
+	require.NoError(t, err)
+	require.NotNil(t, seeded, "fixture: the seeded token must exist")
+	require.Contains(t, seeded.AllowedServers, "*", "fixture: the pre-branch star must be persisted")
+}

--- a/internal/serveredition/api/user_token_mutation_test.go
+++ b/internal/serveredition/api/user_token_mutation_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -122,8 +123,61 @@ func TestCreateUserToken_CapExhaustionIsConflict(t *testing.T) {
 	over := rig.createToken(t, "one-too-many", nil)
 	require.Equal(t, http.StatusConflict, over.Code,
 		"the token cap must answer 409, matching the personal edition (%s)", over.Body.String())
-	assert.Contains(t, errorMessage(t, over), "Maximum number of agent tokens",
-		"the cap message must say what the conflict is")
+
+	msg := errorMessage(t, over)
+	assert.Contains(t, msg, fmt.Sprintf("%d", auth.MaxTokens),
+		"the cap message must say what the limit is")
+
+	// The cap is DEPLOYMENT-wide (auth.MaxTokens is counted across the whole
+	// agent_tokens bucket, all owners together), and there is no per-owner
+	// quota — that is issue #1177. So the body must not read as the caller's
+	// own quota: a tenant who holds none of the tokens filling it would go
+	// hunting for tokens of theirs to delete, and deleting every one of them
+	// need not free a slot. It has to say whose limit it is and who can act.
+	assert.Contains(t, strings.ToLower(msg), "administrator",
+		"the cap body must point the caller at someone who can actually act on it")
+	assert.NotRegexp(t, `(?i)\byou(r)? have reached|delete (one of )?your`, msg,
+		"the cap body must not instruct the caller to free a slot they may not control")
+}
+
+// TestCreateUserToken_CapExhaustionDoesNotBlameTheCaller is the Q3 property on
+// its own, with the victim being someone who holds NO tokens at all: the cap is
+// filled entirely by another tenant.
+//
+// Oracle discipline: user B mints successfully at the start (positive control on
+// the same router), so the 409 that follows is the deployment cap and not an
+// unwired store; and the message is asserted for what it must NOT claim, since
+// the defect is a true statement about the wrong subject.
+//
+// BITES: with the old body this fails on "administrator", because the message
+// read "Maximum number of agent tokens (100) reached" — the personal edition's
+// wording, where the caller does own every token.
+func TestCreateUserToken_CapExhaustionDoesNotBlameTheCaller(t *testing.T) {
+	rig := newTokenTestRig(t)
+
+	// Positive control: user B can mint before the cap is filled.
+	rig.actAs(userBCtx())
+	ctrl := rig.createToken(t, "b-first", nil)
+	require.Equal(t, http.StatusCreated, ctrl.Code,
+		"positive control: user B must be able to mint before the cap fills (%s)", ctrl.Body.String())
+
+	// User A fills the rest of the DEPLOYMENT-wide cap.
+	for i := 0; i < auth.MaxTokens-1; i++ {
+		rig.seedToken(t, tokenUserA, fmt.Sprintf("a-filler-%03d", i))
+	}
+
+	over := rig.createToken(t, "b-second", nil)
+	require.Equal(t, http.StatusConflict, over.Code,
+		"the cap must be reported to the blocked tenant (%s)", over.Body.String())
+
+	// User B holds exactly one token. Deleting it frees one slot out of a cap
+	// filled by someone else's 99 — which is precisely why the body must not
+	// tell them to.
+	msg := errorMessage(t, over)
+	assert.Contains(t, strings.ToLower(msg), "shared by all users",
+		"the body must say the limit is not the caller's own")
+	assert.Contains(t, strings.ToLower(msg), "administrator",
+		"the body must name who can act on a deployment-wide limit")
 }
 
 // TestRegenerateUserToken_ReNarrowsScopeToCurrentEntitlement pins the one

--- a/internal/serveredition/api/user_token_revoked_regenerate_test.go
+++ b/internal/serveredition/api/user_token_revoked_regenerate_test.go
@@ -1,0 +1,99 @@
+//go:build server
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegenerateUserToken_RevokedTokenIsRefused is finding N4 on the HTTP
+// surface.
+//
+// Disabling a user revokes every token they minted, and `enableUser` documents
+// that re-enabling must not resurrect them. Regenerate cleared `Revoked`, so the
+// owner could name a burned token and get a working secret back for that very
+// record — undoing an admin's remediation from a tenant route.
+//
+// Oracle discipline: the SAME route, on the SAME token, succeeds first; only the
+// revocation happens in between. And the refusal is checked to be a real one —
+// the response carries no usable secret, and the record stays revoked.
+//
+// BITES: restore `token.Revoked = false` (and drop the ErrAgentTokenRevoked
+// guard) in RegenerateAgentTokenForOwner; the second call returns 200 with a
+// fresh secret.
+func TestRegenerateUserToken_RevokedTokenIsRefused(t *testing.T) {
+	rig := newTokenTestRig(t)
+	rig.actAs(userACtx())
+	rig.seedToken(t, tokenUserA, "ci")
+
+	control := rig.call(t, http.MethodPost, "/api/v1/user/tokens/ci/regenerate")
+	require.Equal(t, http.StatusOK, control.Code,
+		"positive control: a live token must be rotatable (%s)", control.Body.String())
+
+	// An admin disables the owner, which burns their tokens.
+	burned, err := rig.store.RevokeAgentTokensForOwner(tokenUserA)
+	require.NoError(t, err)
+	require.Equal(t, 1, burned, "fixture: the token must actually have been revoked")
+
+	refused := rig.call(t, http.MethodPost, "/api/v1/user/tokens/ci/regenerate")
+	assert.Equal(t, http.StatusConflict, refused.Code,
+		"rotating a revoked token must be refused, not silently un-revoke it (%s)", refused.Body.String())
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(refused.Body.Bytes(), &body))
+	assert.NotContains(t, body, "token", "a refusal must not hand back a usable secret")
+	// The storage sentinel's own text must not be echoed into the response,
+	// which is the leak writeTokenMutationError exists to prevent.
+	assert.NotContains(t, refused.Body.String(), "agent token is revoked")
+
+	stored, err := rig.store.GetAgentTokenByOwnerAndName(tokenUserA, "ci")
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.True(t, stored.Revoked, "the record must still be revoked after the refusal")
+}
+
+// TestRegenerateUserToken_AnotherTenantsRevokedTokenStays404 keeps the #1168
+// indistinguishability intact: the new 409 must be reachable only by the
+// record's own owner, or it becomes an oracle for another tenant's token names.
+func TestRegenerateUserToken_AnotherTenantsRevokedTokenStays404(t *testing.T) {
+	rig := newTokenTestRig(t)
+	rig.actAs(userACtx())
+	rig.seedToken(t, tokenUserA, "ci")
+	require.NoError(t, rig.store.RevokeAgentTokenForOwner(tokenUserA, "ci"))
+
+	rig.actAs(userBCtx())
+	probe := rig.call(t, http.MethodPost, "/api/v1/user/tokens/ci/regenerate")
+	require.Equal(t, http.StatusNotFound, probe.Code,
+		"another tenant must not learn the name exists, let alone that it is revoked (%s)", probe.Body.String())
+
+	// Byte-parity with a name that exists nowhere at all: the two must be
+	// indistinguishable, status AND body.
+	absent := rig.call(t, http.MethodPost, "/api/v1/user/tokens/ci-absent/regenerate")
+	require.Equal(t, http.StatusNotFound, absent.Code)
+	assert.Equal(t,
+		bytesReplaceTokenName(absent.Body.String(), "ci-absent", "ci"),
+		probe.Body.String(),
+		"a revoked token owned by someone else must be byte-identical to an absent one")
+}
+
+// bytesReplaceTokenName normalises the token name a 404 body echoes back, so the
+// parity assertion above compares everything EXCEPT the caller's own path
+// parameter (which a 404 legitimately quotes back).
+func bytesReplaceTokenName(body, from, to string) string {
+	out := make([]byte, 0, len(body))
+	for i := 0; i < len(body); {
+		if i+len(from) <= len(body) && body[i:i+len(from)] == from {
+			out = append(out, to...)
+			i += len(from)
+			continue
+		}
+		out = append(out, body[i])
+		i++
+	}
+	return string(out)
+}

--- a/internal/serveredition/api/user_token_scope_test.go
+++ b/internal/serveredition/api/user_token_scope_test.go
@@ -1,0 +1,319 @@
+//go:build server
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+)
+
+// Server fixture names. "admin-private" is in the admin configuration but NOT
+// flagged Shared, so no ordinary tenant may ever see or reach it.
+const (
+	scopeSharedServer  = "shared-ok"
+	scopePrivateServer = "admin-private"
+	scopeAPersonal     = "a-personal"
+	scopeBPersonal     = "b-personal"
+	scopeAbsentServer  = "no-such-server-Zq7"
+)
+
+const tokenAdminUser = "01HTEST00000000000ADMINUSR"
+
+func adminUserCtx() *auth.AuthContext {
+	return auth.AdminUserContext(tokenAdminUser, "root@example.com", "Root", "google")
+}
+
+// scopeFixtureServers mirrors what setup.go hands NewUserHandlers: the WHOLE
+// admin configuration, of which only the Shared entries are visible to a
+// tenant through /api/v1/user/servers.
+func scopeFixtureServers() []*config.ServerConfig {
+	return []*config.ServerConfig{
+		{Name: scopeSharedServer, URL: "https://shared.example", Protocol: "http", Enabled: true, Shared: true},
+		{Name: scopePrivateServer, URL: "https://private.example", Protocol: "http", Enabled: true},
+	}
+}
+
+// createToken posts a create request under the rig's current identity.
+func (rig *tokenTestRig) createToken(t *testing.T, name string, allowedServers []string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	body := map[string]interface{}{"name": name, "permissions": []string{auth.PermRead}}
+	if allowedServers != nil {
+		body["allowed_servers"] = allowedServers
+	}
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/user/tokens", strings.NewReader(string(raw)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	rig.router.ServeHTTP(w, req)
+	return w
+}
+
+// seedPersonalServer writes a personal server through the user store, the same
+// place createServer persists one.
+func (rig *tokenTestRig) seedPersonalServer(t *testing.T, owner, name string) {
+	t.Helper()
+	require.NoError(t, rig.users.CreateUserServer(owner, &config.ServerConfig{
+		Name:     name,
+		URL:      "https://" + name + ".example",
+		Protocol: "http",
+		Enabled:  true,
+	}))
+}
+
+// errorMessage decodes the handler's error envelope. chi's own 404 is plain
+// text and does not decode, so this also rules out "the route never matched".
+func errorMessage(t *testing.T, w *httptest.ResponseRecorder) string {
+	t.Helper()
+	var envelope struct {
+		Error      string `json:"error"`
+		Message    string `json:"message"`
+		StatusCode int    `json:"status_code"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope),
+		"body did not decode as the handler's error envelope (%q)", w.Body.String())
+	require.Equal(t, w.Code, envelope.StatusCode, "envelope status_code disagrees with the HTTP status")
+	return envelope.Message
+}
+
+// TestCreateUserToken_ScopeConstrainedToEntitledServers is the property that
+// makes the #1166 REST-enumeration scope filter hold in the server edition:
+// a tenant must not be able to WIDEN their own token past what they may see.
+//
+// createUserToken used to persist the requested allowed_servers verbatim, and
+// AllowedServers is the sole input to auth.AuthContext.CanAccessServer — so
+// asking for the admin's unshared server, or for "*", minted a credential that
+// walked straight through the scope filter into the admin's whole inventory.
+//
+// Oracle discipline, matching the rest of this branch:
+//
+//  1. a POSITIVE CONTROL runs FIRST, on the SAME router, minting a token over
+//     the caller's genuinely entitled servers — so a 400 below cannot be the
+//     route failing to match, the store being unwired, or the body being
+//     malformed;
+//  2. an independent entitlement proof through the PRODUCTION per-user door
+//     (GET /api/v1/user/servers), showing exactly which names user A may see;
+//  3. statuses are PINNED (201 / 400), never asserted as bare parity; and
+//  4. every rejection is confirmed at the STORAGE layer — no token record.
+//
+// BITES: on unfixed code every "must be rejected" case returns 201 and the
+// requested scope is persisted verbatim.
+func TestCreateUserToken_ScopeConstrainedToEntitledServers(t *testing.T) {
+	rig := newTokenTestRigWithServers(t, scopeFixtureServers())
+	rig.seedPersonalServer(t, tokenUserA, scopeAPersonal)
+	rig.seedPersonalServer(t, tokenUserB, scopeBPersonal)
+
+	rig.actAs(userACtx())
+
+	// (2) Entitlement proof through the production route table.
+	listed := rig.call(t, http.MethodGet, "/api/v1/user/servers")
+	require.Equal(t, http.StatusOK, listed.Code, "the per-user door must be readable")
+	var doorway ServerListResponse
+	require.NoError(t, json.Unmarshal(listed.Body.Bytes(), &doorway))
+
+	visible := map[string]bool{}
+	for _, s := range doorway.Personal {
+		visible[s.Name] = true
+	}
+	for _, s := range doorway.Shared {
+		visible[s.Name] = true
+	}
+	require.True(t, visible[scopeAPersonal], "fixture did not land: user A cannot see their own %q", scopeAPersonal)
+	require.True(t, visible[scopeSharedServer], "fixture did not land: user A cannot see shared %q", scopeSharedServer)
+	require.False(t, visible[scopePrivateServer], "fixture is wrong: %q must NOT be visible to a tenant", scopePrivateServer)
+	require.False(t, visible[scopeBPersonal], "fixture is wrong: %q must NOT be visible to user A", scopeBPersonal)
+
+	// (1) Positive control: the entitled scope mints, and persists exactly.
+	ctl := rig.createToken(t, "ctl", []string{scopeSharedServer, scopeAPersonal})
+	require.Equal(t, http.StatusCreated, ctl.Code,
+		"positive control failed: an entitled scope was rejected (%s)", ctl.Body.String())
+	stored, err := rig.store.GetAgentTokenByOwnerAndName(tokenUserA, "ctl")
+	require.NoError(t, err)
+	require.NotNil(t, stored, "positive control did not persist a token")
+	require.Equal(t, []string{scopeSharedServer, scopeAPersonal}, stored.AllowedServers,
+		"an entitled scope must be persisted unchanged")
+
+	// The probes: every one of these names is outside user A's entitlement.
+	rejected := []struct {
+		label   string
+		servers []string
+	}{
+		{"admin's unshared server", []string{scopePrivateServer}},
+		{"another tenant's personal server", []string{scopeBPersonal}},
+		{"a server that exists nowhere", []string{scopeAbsentServer}},
+		{"an entitled name smuggling an unentitled one", []string{scopeAPersonal, scopePrivateServer}},
+		{"a glob, which the enforcement layer does not expand", []string{"shared-*"}},
+	}
+
+	for i, tc := range rejected {
+		name := fmt.Sprintf("probe-%d", i)
+		w := rig.createToken(t, name, tc.servers)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code,
+			"%s: expected exactly 400, got %d (%s)", tc.label, w.Code, w.Body.String())
+
+		persisted, err := rig.store.GetAgentTokenByOwnerAndName(tokenUserA, name)
+		require.NoError(t, err)
+		assert.Nil(t, persisted, "%s: a rejected request still minted a token", tc.label)
+	}
+}
+
+// TestCreateUserToken_ScopeRejectionIsNotAnExistenceOracle guards the shape of
+// the refusal. This branch has just collapsed the 403/404 oracle on token
+// names; a message that said "that server is not shared with you" for a real
+// server and "unknown server" for an imaginary one would re-open the same
+// oracle one field over, letting a tenant enumerate the admin's private
+// inventory by minting tokens.
+//
+// BITES: on unfixed code both probes answer 201, so there is no message to
+// compare and the status pin fails first.
+func TestCreateUserToken_ScopeRejectionIsNotAnExistenceOracle(t *testing.T) {
+	rig := newTokenTestRigWithServers(t, scopeFixtureServers())
+	rig.seedPersonalServer(t, tokenUserA, scopeAPersonal)
+	rig.actAs(userACtx())
+
+	// Positive control first: rejections below are the check, not a broken route.
+	ctl := rig.createToken(t, "oracle-ctl", []string{scopeAPersonal})
+	require.Equal(t, http.StatusCreated, ctl.Code,
+		"positive control failed: an entitled scope was rejected (%s)", ctl.Body.String())
+
+	real := rig.createToken(t, "probe-real", []string{scopePrivateServer})
+	fake := rig.createToken(t, "probe-fake", []string{scopeAbsentServer})
+
+	require.Equal(t, http.StatusBadRequest, real.Code, "existing-but-unentitled server: expected 400 (%s)", real.Body.String())
+	require.Equal(t, http.StatusBadRequest, fake.Code, "nonexistent server: expected 400 (%s)", fake.Body.String())
+
+	realMsg := errorMessage(t, real)
+	fakeMsg := errorMessage(t, fake)
+
+	// The only permitted difference is the name the caller itself supplied.
+	normalise := func(msg, name string) string { return strings.ReplaceAll(msg, name, "<NAME>") }
+	assert.Equal(t,
+		normalise(fakeMsg, scopeAbsentServer),
+		normalise(realMsg, scopePrivateServer),
+		"the refusal distinguishes an existing server from an imaginary one — a server-name existence oracle")
+	assert.NotContains(t, realMsg, "shared",
+		"the refusal leaks WHY the server is unreachable, which classifies it for the caller")
+}
+
+// TestCreateUserToken_WildcardMeansOnlyWhatTheCallerMaySee pins the wildcard
+// decision. "*" is the only wildcard auth.AuthContext.CanAccessServer honours,
+// and it matches every server unconditionally — so persisting a tenant's "*"
+// leaves a standing grant over the whole deployment. For a tenant it is
+// materialised into their entitled set; for an admin, who does administer the
+// deployment, it keeps its literal meaning.
+//
+// BITES: on unfixed code the tenant's token stores the literal ["*"].
+func TestCreateUserToken_WildcardMeansOnlyWhatTheCallerMaySee(t *testing.T) {
+	t.Run("tenant wildcard expands to the entitled set", func(t *testing.T) {
+		rig := newTokenTestRigWithServers(t, scopeFixtureServers())
+		rig.seedPersonalServer(t, tokenUserA, scopeAPersonal)
+		rig.seedPersonalServer(t, tokenUserB, scopeBPersonal)
+		rig.actAs(userACtx())
+
+		w := rig.createToken(t, "star", []string{"*"})
+		require.Equal(t, http.StatusCreated, w.Code, "a tenant wildcard should mint, narrowed (%s)", w.Body.String())
+
+		stored, err := rig.store.GetAgentTokenByOwnerAndName(tokenUserA, "star")
+		require.NoError(t, err)
+		require.NotNil(t, stored, "the wildcard request did not persist a token")
+
+		assert.NotContains(t, stored.AllowedServers, "*",
+			"a tenant's token kept the literal wildcard: it can reach every server in the deployment")
+		assert.ElementsMatch(t, []string{scopeAPersonal, scopeSharedServer}, stored.AllowedServers,
+			"the wildcard must materialise to exactly the servers the per-user door shows this tenant")
+
+		// And the caller is told what they actually got.
+		var resp AgentTokenResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.ElementsMatch(t, stored.AllowedServers, resp.AllowedServers,
+			"the response must echo the effective scope, so the narrowing is not silent")
+	})
+
+	t.Run("admin wildcard stays literal", func(t *testing.T) {
+		rig := newTokenTestRigWithServers(t, scopeFixtureServers())
+		rig.actAs(adminUserCtx())
+
+		w := rig.createToken(t, "star", []string{"*"})
+		require.Equal(t, http.StatusCreated, w.Code, "an admin wildcard should mint (%s)", w.Body.String())
+
+		stored, err := rig.store.GetAgentTokenByOwnerAndName(tokenAdminUser, "star")
+		require.NoError(t, err)
+		require.NotNil(t, stored)
+		assert.Equal(t, []string{"*"}, stored.AllowedServers,
+			"an admin administers every server; freezing their wildcard would silently drop servers added later")
+	})
+
+	t.Run("admin may scope to an unshared configured server", func(t *testing.T) {
+		rig := newTokenTestRigWithServers(t, scopeFixtureServers())
+		rig.actAs(adminUserCtx())
+
+		w := rig.createToken(t, "priv", []string{scopePrivateServer})
+		require.Equal(t, http.StatusCreated, w.Code,
+			"an admin's own unshared server must remain scopable (%s)", w.Body.String())
+
+		stored, err := rig.store.GetAgentTokenByOwnerAndName(tokenAdminUser, "priv")
+		require.NoError(t, err)
+		require.NotNil(t, stored)
+		assert.Equal(t, []string{scopePrivateServer}, stored.AllowedServers)
+	})
+
+	t.Run("admin is still held to configured names", func(t *testing.T) {
+		rig := newTokenTestRigWithServers(t, scopeFixtureServers())
+		rig.actAs(adminUserCtx())
+
+		w := rig.createToken(t, "ghost", []string{scopeAbsentServer})
+		assert.Equal(t, http.StatusBadRequest, w.Code,
+			"an unknown server name should be rejected for an admin too (%s)", w.Body.String())
+	})
+
+	t.Run("wildcard with nothing entitled is refused, not silently deny-all", func(t *testing.T) {
+		// No shared servers configured and no personal servers for this user.
+		rig := newTokenTestRigWithServers(t, nil)
+		rig.actAs(userACtx())
+
+		w := rig.createToken(t, "star", []string{"*"})
+		require.Equal(t, http.StatusBadRequest, w.Code,
+			"a wildcard over an empty entitlement set must not mint a mystery token (%s)", w.Body.String())
+
+		stored, err := rig.store.GetAgentTokenByOwnerAndName(tokenUserA, "star")
+		require.NoError(t, err)
+		assert.Nil(t, stored)
+	})
+}
+
+// TestCreateUserToken_OmittedScopeIsUnchanged pins the behaviour the new check
+// deliberately does NOT alter: an omitted allowed_servers stays empty, which at
+// the agent tier already denies every server. Rewriting it to ["*"] the way the
+// personal edition does (where the only caller IS the operator) would be a
+// widening dressed up as a default.
+func TestCreateUserToken_OmittedScopeIsUnchanged(t *testing.T) {
+	rig := newTokenTestRigWithServers(t, scopeFixtureServers())
+	rig.seedPersonalServer(t, tokenUserA, scopeAPersonal)
+	rig.actAs(userACtx())
+
+	w := rig.createToken(t, "bare", nil)
+	require.Equal(t, http.StatusCreated, w.Code, "omitting allowed_servers must still mint (%s)", w.Body.String())
+
+	stored, err := rig.store.GetAgentTokenByOwnerAndName(tokenUserA, "bare")
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.Empty(t, stored.AllowedServers, "an omitted scope must not be widened into a wildcard")
+
+	// And an empty scope really is deny-all at the agent tier, so the default
+	// needs no widening to be safe.
+	assert.False(t, stored.AuthContext().CanAccessServer(scopeSharedServer),
+		"an empty AllowedServers must deny, not allow — otherwise the default above is a hole")
+}

--- a/internal/serveredition/auth/integration_test.go
+++ b/internal/serveredition/auth/integration_test.go
@@ -149,7 +149,7 @@ func setupIntegration(t *testing.T, email, name, userSub string, oauthCfg *confi
 	// -- Components --
 	sessionMgr := NewSessionManager(store, sessionTTL, false)
 	oauthH := NewOAuthHandler(store, sessionMgr, teamsCfg, hmacKey, logger)
-	authMW := NewServerEditionAuthMiddleware(sessionMgr, store, teamsCfg, hmacKey, logger)
+	authMW := NewServerEditionAuthMiddleware(sessionMgr, store, StaticServerEditionConfig(teamsCfg), hmacKey, logger)
 
 	// -- Router --
 	r := chi.NewRouter()

--- a/internal/serveredition/auth/jwt_tokens.go
+++ b/internal/serveredition/auth/jwt_tokens.go
@@ -15,8 +15,13 @@ type UserClaims struct {
 	jwt.RegisteredClaims
 	Email       string `json:"email"`
 	DisplayName string `json:"display_name,omitempty"`
-	Role        string `json:"role"`     // "admin" or "user"
-	Provider    string `json:"provider"` // google, github, microsoft
+	// Role is INFORMATIONAL ONLY and is NOT authoritative for authorization.
+	// It is frozen at mint time and is never revoked, so authorization must
+	// always re-derive the role from the current config (admin_emails) — see
+	// ServerEditionAuthMiddleware.buildAuthContext. ValidateBearerToken still
+	// requires the claim to be non-empty as a well-formedness check.
+	Role     string `json:"role"`     // "admin" or "user" (informational)
+	Provider string `json:"provider"` // google, github, microsoft
 }
 
 // GenerateBearerToken creates a signed JWT with team member claims.

--- a/internal/serveredition/auth/middleware.go
+++ b/internal/serveredition/auth/middleware.go
@@ -168,11 +168,19 @@ func (m *ServerEditionAuthMiddleware) authenticateFromBearer(r *http.Request) (*
 		return nil, nil
 	}
 
-	// Build auth context from JWT claims
-	if claims.Role == "admin" {
-		return coreauth.AdminUserContext(claims.Subject, claims.Email, claims.DisplayName, claims.Provider), nil
-	}
-	return coreauth.UserContext(claims.Subject, claims.Email, claims.DisplayName, claims.Provider), nil
+	// Re-derive the role from the CURRENT config rather than trusting the
+	// frozen `role` claim. The claim is minted at login and is never revoked,
+	// so an admin removed from admin_emails would otherwise keep admin until
+	// the token expires — and could renew it indefinitely via
+	// POST /api/v1/auth/token, which mints a fresh JWT from ac.Role.
+	//
+	// The user record was already loaded above, so this costs no extra lookup,
+	// and it makes the bearer path agree with the session path (which has
+	// always re-derived the role). Identity field parity is exact: GetUser is
+	// keyed by User.ID, so user.ID == claims.Subject, and both mint sites pass
+	// user.ID/user.Email/user.DisplayName/user.Provider — the same four values
+	// buildAuthContext reads, only fresher.
+	return m.buildAuthContext(user), nil
 }
 
 // buildAuthContext creates an AuthContext for the given user, determining the

--- a/internal/serveredition/auth/middleware.go
+++ b/internal/serveredition/auth/middleware.go
@@ -18,21 +18,51 @@ import (
 // treated as JWT bearer tokens.
 const agentTokenPrefix = "mcp_agt_"
 
+// ServerEditionConfigProvider returns the server-edition configuration as of
+// NOW.
+//
+// It is a function, not a struct pointer, for the same reason
+// api.AdminServersProvider is: `admin_emails` is the sole source of truth for
+// the admin role, and the configuration is hot-reloadable. A middleware built
+// on the *config.ServerEditionConfig captured at wiring time answers every
+// later request from the file as it stood at process start, so an operator who
+// edits `admin_emails` — the documented way to promote and, more importantly,
+// to DEMOTE someone — changes nothing until the process restarts. Issue #1169
+// is that gap; moving it from "until the token expires" to "until restart" is
+// not closing it.
+//
+// The returned value is READ-ONLY. Implementations hand back the current
+// snapshot, not a defensive copy.
+type ServerEditionConfigProvider func() *config.ServerEditionConfig
+
+// StaticServerEditionConfig adapts a fixed config to ServerEditionConfigProvider.
+// It is for callers with genuinely no live configuration to read (tests, and
+// embedders with no config service) — never for production wiring, which must
+// pass a provider over the current snapshot.
+func StaticServerEditionConfig(cfg *config.ServerEditionConfig) ServerEditionConfigProvider {
+	return func() *config.ServerEditionConfig { return cfg }
+}
+
 // ServerEditionAuthMiddleware validates user authentication via session cookies
 // or JWT bearer tokens (server edition).
 type ServerEditionAuthMiddleware struct {
 	sessionManager *SessionManager
 	userStore      *users.UserStore
-	teamsConfig    *config.ServerEditionConfig
+	teamsConfig    ServerEditionConfigProvider
 	hmacKey        []byte
 	logger         *zap.SugaredLogger
 }
 
 // NewServerEditionAuthMiddleware creates a new ServerEditionAuthMiddleware.
+//
+// teamsConfig must read the LIVE configuration on every call; see
+// ServerEditionConfigProvider for why a captured pointer is the whole of issue
+// #1169. A nil provider — or one that returns nil — is tolerated and means "no
+// admins", which is the conservative reading for a role decision.
 func NewServerEditionAuthMiddleware(
 	sessionManager *SessionManager,
 	userStore *users.UserStore,
-	teamsConfig *config.ServerEditionConfig,
+	teamsConfig ServerEditionConfigProvider,
 	hmacKey []byte,
 	logger *zap.SugaredLogger,
 ) *ServerEditionAuthMiddleware {
@@ -184,12 +214,35 @@ func (m *ServerEditionAuthMiddleware) authenticateFromBearer(r *http.Request) (*
 }
 
 // buildAuthContext creates an AuthContext for the given user, determining the
-// role from the server config admin email list.
+// role from the CURRENT server config admin email list.
+//
+// Both auth paths land here, so this single read is what makes an
+// `admin_emails` edit take effect on the next request rather than on the next
+// process restart (issue #1169). The provider reads the runtime's published
+// config snapshot, which the file watcher republishes on every hot reload —
+// `server_edition` is loaded whole by config.LoadFromFile and is not among the
+// restart-pinned fields, so the edit really is live.
+//
+// A missing configuration yields a plain user, never an admin: a role decision
+// that cannot be made must not be made in the caller's favour.
 func (m *ServerEditionAuthMiddleware) buildAuthContext(user *users.User) *coreauth.AuthContext {
-	if m.teamsConfig.IsAdminEmail(user.Email) {
+	if m.isAdminEmail(user.Email) {
 		return coreauth.AdminUserContext(user.ID, user.Email, user.DisplayName, user.Provider)
 	}
 	return coreauth.UserContext(user.ID, user.Email, user.DisplayName, user.Provider)
+}
+
+// isAdminEmail resolves the admin list from the live configuration, failing to
+// "not an admin" when there is none to read.
+func (m *ServerEditionAuthMiddleware) isAdminEmail(email string) bool {
+	if m.teamsConfig == nil {
+		return false
+	}
+	cfg := m.teamsConfig()
+	if cfg == nil {
+		return false
+	}
+	return cfg.IsAdminEmail(email)
 }
 
 // writeJSONError writes a JSON-formatted error response.

--- a/internal/serveredition/auth/middleware_test.go
+++ b/internal/serveredition/auth/middleware_test.go
@@ -600,3 +600,117 @@ func TestAdminOnly_NoContext(t *testing.T) {
 		t.Fatalf("expected 401, got %d: %s", rr.Code, rr.Body.String())
 	}
 }
+
+// --- Issue #1169: the bearer path must re-derive the role from config ---
+
+// TestMiddleware_DemotedAdminJWT_DerivesRoleFromConfig pins the demotion
+// direction: a JWT whose frozen `role` claim says "admin" must NOT confer
+// admin when the subject's email is no longer in admin_emails.
+//
+// BITES: on unfixed code authenticateFromBearer branches on claims.Role and
+// returns AdminUserContext, so type=admin_user / role=admin.
+func TestMiddleware_DemotedAdminJWT_DerivesRoleFromConfig(t *testing.T) {
+	s := setupMiddlewareTest(t)
+
+	// s.testUser (user@example.com) is NOT in AdminEmails. The claim lies.
+	token := s.generateJWT(t, s.testUser.ID, s.testUser.Email, s.testUser.DisplayName, "admin", s.testUser.Provider, 1*time.Hour)
+
+	handler := s.middleware.Middleware()(authContextHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/servers", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if body["type"] != coreauth.AuthTypeUser {
+		t.Errorf("stale admin claim conferred admin: expected type %q, got %q", coreauth.AuthTypeUser, body["type"])
+	}
+	if body["role"] != "user" {
+		t.Errorf("stale admin claim conferred admin: expected role %q, got %q", "user", body["role"])
+	}
+}
+
+// TestMiddleware_PromotedUserJWT_DerivesRoleFromConfig pins the REVERSE
+// direction so nobody "hardens" the fix into a demote-only AND of the claim
+// and the config: that variant would silently strand promoted users and
+// re-create the very asymmetry with the session path that #1169 is about.
+//
+// BITES: on unfixed code the frozen role="user" claim wins, so type=user.
+func TestMiddleware_PromotedUserJWT_DerivesRoleFromConfig(t *testing.T) {
+	s := setupMiddlewareTest(t)
+
+	// s.adminUser (admin@example.com) IS in AdminEmails, but the token was
+	// minted before the promotion and carries role="user".
+	token := s.generateJWT(t, s.adminUser.ID, s.adminUser.Email, s.adminUser.DisplayName, "user", s.adminUser.Provider, 1*time.Hour)
+
+	handler := s.middleware.Middleware()(authContextHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/servers", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if body["type"] != coreauth.AuthTypeAdminUser {
+		t.Errorf("stale user claim blocked promotion: expected type %q, got %q", coreauth.AuthTypeAdminUser, body["type"])
+	}
+	if body["role"] != "admin" {
+		t.Errorf("stale user claim blocked promotion: expected role %q, got %q", "admin", body["role"])
+	}
+}
+
+// TestMiddleware_BearerContextFieldParity is deliberately NOT a bite test: it
+// passes both before and after the #1169 fix. It is the anti-regression net
+// for the constructor swap — switching from
+// AdminUserContext(claims.Subject, claims.Email, ...) to
+// buildAuthContext(user) must not silently drop the subject, email, display
+// name or provider. Do not flag it as non-biting; that is its job.
+func TestMiddleware_BearerContextFieldParity(t *testing.T) {
+	s := setupMiddlewareTest(t)
+
+	token := s.generateJWT(t, s.adminUser.ID, s.adminUser.Email, s.adminUser.DisplayName, "admin", s.adminUser.Provider, 1*time.Hour)
+
+	handler := s.middleware.Middleware()(authContextHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/servers", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	for _, tc := range []struct{ field, want string }{
+		{"user_id", s.adminUser.ID},
+		{"email", s.adminUser.Email},
+		{"display_name", s.adminUser.DisplayName},
+		{"provider", s.adminUser.Provider},
+	} {
+		if got, _ := body[tc.field].(string); got != tc.want {
+			t.Errorf("bearer auth context dropped %s: want %q, got %q", tc.field, tc.want, got)
+		}
+	}
+}

--- a/internal/serveredition/auth/middleware_test.go
+++ b/internal/serveredition/auth/middleware_test.go
@@ -86,7 +86,7 @@ func setupMiddlewareTest(t *testing.T) *testMiddlewareSetup {
 	// Logger (discard output in tests)
 	logger := zap.NewNop().Sugar()
 
-	mw := NewServerEditionAuthMiddleware(sessionManager, userStore, teamsConfig, hmacKey, logger)
+	mw := NewServerEditionAuthMiddleware(sessionManager, userStore, StaticServerEditionConfig(teamsConfig), hmacKey, logger)
 
 	return &testMiddlewareSetup{
 		db:             db,

--- a/internal/serveredition/multiuser/activity.go
+++ b/internal/serveredition/multiuser/activity.go
@@ -47,8 +47,19 @@ func (f *ActivityFilter) GetUserActivity(ctx context.Context, limit, offset int)
 		return f.storageProvider.ListActivities(filter)
 	}
 
-	// Regular users only see their own activity
-	if ac == nil || ac.UserID == "" {
+	// Regular users only see their own activity.
+	//
+	// Gated on the user TIER, not merely on a non-empty UserID. Since issue
+	// #1168 an agent token's AuthContext carries its OWNER's UserID so its
+	// activity can be attributed (EnrichRecord below is exactly that, and
+	// deliberately stays UserID-based). A bare `UserID != ""` check would have
+	// let that attribution field double as an authorization claim, handing a
+	// scoped, read-only agent token its owner's entire activity log. The
+	// server-edition middleware already refuses agent tokens on this route, so
+	// this is defence in depth — but the branch's rule is that per-user
+	// surfaces gate on IsUser(), never on a non-empty UserID, and one
+	// middleware branch must not be the whole boundary.
+	if ac == nil || !ac.IsUser() || ac.UserID == "" {
 		return nil, 0, fmt.Errorf("authentication required")
 	}
 

--- a/internal/serveredition/multiuser/activity_agent_tier_test.go
+++ b/internal/serveredition/multiuser/activity_agent_tier_test.go
@@ -1,0 +1,105 @@
+//go:build server
+
+package multiuser
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
+)
+
+// stubActivityProvider is the smallest storage provider GetUserActivity needs.
+// It records whether it was consulted at all, which is what distinguishes
+// "refused before reading" from "read and then filtered to nothing".
+type stubActivityProvider struct {
+	records []*storage.ActivityRecord
+	calls   int
+}
+
+func (s *stubActivityProvider) GetActivity(id string) (*storage.ActivityRecord, error) {
+	for _, r := range s.records {
+		if r.ID == id {
+			return r, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *stubActivityProvider) ListActivities(filter storage.ActivityFilter) ([]*storage.ActivityRecord, int, error) {
+	s.calls++
+	if filter.Offset >= len(s.records) {
+		return nil, len(s.records), nil
+	}
+	end := filter.Offset + filter.Limit
+	if end > len(s.records) {
+		end = len(s.records)
+	}
+	return s.records[filter.Offset:end], len(s.records), nil
+}
+
+// TestActivityFilter_AgentTokenIsNotItsOwnersSession is the sweep finding from
+// the same root cause as the brokered-connection regression: carrying a new
+// field (UserID) through a shared constructor changes every reader of it.
+//
+// GetUserActivity gated on `ac.UserID != ""`. Before issue #1168 an agent token
+// carried no UserID, so that check refused it; afterwards the field is its
+// OWNER's id, and the same check would hand a scoped, read-only agent token its
+// owner's entire activity log. The gate belongs on the user TIER — the rule this
+// branch already applied in getUserID and never propagated here.
+//
+// Oracle discipline: this does NOT assert "the response omits the records" (an
+// empty result is what a working filter and a broken fixture both produce).
+// It asserts the request is REFUSED, and pairs that with a positive control on
+// the same filter and the same fixture proving the owner's session DOES see the
+// records — so an empty agent result cannot be an empty store.
+//
+// BITES: without the IsUser() gate the agent context returns the owner's record.
+func TestActivityFilter_AgentTokenIsNotItsOwnersSession(t *testing.T) {
+	provider := &stubActivityProvider{records: []*storage.ActivityRecord{
+		{ID: "rec-1", UserID: "alice"},
+	}}
+	filter := NewActivityFilter(provider)
+
+	// Positive control: the OWNER's own session sees the record, so the fixture
+	// really landed and the filter really reads it.
+	ownerRecords, ownerTotal, err := filter.GetUserActivity(userCtx("alice"), 10, 0)
+	require.NoError(t, err, "positive control: the owner's session must be able to read their activity")
+	require.Equal(t, 1, ownerTotal, "positive control: the seeded record must be visible to its owner")
+	require.Len(t, ownerRecords, 1)
+	require.Equal(t, "rec-1", ownerRecords[0].ID)
+
+	callsBefore := provider.calls
+
+	// The agent token owned by alice must be refused outright.
+	tok := &auth.AgentToken{Name: "ci", UserID: "alice", Permissions: []string{auth.PermRead}}
+	agentContext := auth.WithAuthContext(context.Background(), tok.AuthContext())
+
+	agentRecords, agentTotal, err := filter.GetUserActivity(agentContext, 10, 0)
+	require.Error(t, err, "an agent token is not its owner's session and must not read their activity log")
+	assert.Nil(t, agentRecords)
+	assert.Zero(t, agentTotal)
+	assert.Equal(t, callsBefore, provider.calls,
+		"the refusal must happen before storage is consulted, not by filtering afterwards")
+}
+
+// TestActivityFilter_EnrichRecordStillAttributesAgentTokens pins the OTHER half
+// of the sweep: attribution is exactly what #1168 added the UserID for, and
+// hardening the authorization gate must not undo it. EnrichRecord stays
+// UserID-based on purpose.
+func TestActivityFilter_EnrichRecordStillAttributesAgentTokens(t *testing.T) {
+	filter := NewActivityFilter(&stubActivityProvider{})
+
+	tok := &auth.AgentToken{Name: "ci", UserID: "alice", Permissions: []string{auth.PermRead}}
+	agentContext := auth.WithAuthContext(context.Background(), tok.AuthContext())
+
+	record := &storage.ActivityRecord{ID: "rec-2"}
+	filter.EnrichRecord(agentContext, record)
+
+	assert.Equal(t, "alice", record.UserID,
+		"an agent token's activity must still be attributed to its owner — that is what #1168 carried the UserID for")
+}

--- a/internal/serveredition/multiuser/router.go
+++ b/internal/serveredition/multiuser/router.go
@@ -160,6 +160,15 @@ func (r *Router) GetServerForUser(ctx context.Context, serverName string) (*Serv
 // It errors if there is no auth context or the server is not accessible to the
 // user; it does not require the server to actually declare an auth_broker block,
 // so callers can key uniformly and decide per server whether to broker.
+//
+// Only a USER-tier context keys as its own user id. Since issue #1168 an agent
+// token's AuthContext carries its OWNER's UserID (so its activity is
+// attributable), and keying straight off GetUserID() would therefore pool an
+// agent-token request onto the owner's own brokered connection — a connection
+// carrying the owner's injected IdP credential, which is precisely the sharing
+// FR-018 exists to prevent. Every non-user tier is namespaced instead, so it can
+// never collide with a user session's entry while two agent tokens of different
+// owners still stay apart. This is one place; see brokerPoolIdentity.
 func (r *Router) BrokeredConnectionKey(ctx context.Context, serverName string) (string, error) {
 	ac := auth.AuthContextFromContext(ctx)
 	if ac == nil {
@@ -170,7 +179,28 @@ func (r *Router) BrokeredConnectionKey(ctx context.Context, serverName string) (
 	if err != nil {
 		return "", err
 	}
-	return broker.ConnectionKey(ac.GetUserID(), info.Config), nil
+	return broker.ConnectionKey(brokerPoolIdentity(ac), info.Config), nil
+}
+
+// nonUserPoolPrefix namespaces the pooling identity of every non-user tier so
+// it cannot collide with a user session's. It contains a character no ULID
+// carries, so no user id can be forged into this namespace either.
+const nonUserPoolPrefix = "non-user:"
+
+// brokerPoolIdentity returns the identity half of a brokered connection's
+// pooling key.
+//
+// A user session keys as its bare user id, exactly as before. Anything else —
+// an agent token (which now carries its owner's UserID), the personal-edition
+// API key, an anonymous back-compat context — keys inside a separate namespace,
+// qualified by tier and by whatever user id it does carry. That keeps two
+// different owners' agent tokens apart while guaranteeing neither of them ever
+// lands on a user session's pool entry.
+func brokerPoolIdentity(ac *auth.AuthContext) string {
+	if ac.IsUser() && ac.GetUserID() != "" {
+		return ac.GetUserID()
+	}
+	return nonUserPoolPrefix + ac.Type + ":" + ac.GetUserID()
 }
 
 // IsServerAccessible returns true if the user from the context can access

--- a/internal/serveredition/multiuser/router.go
+++ b/internal/serveredition/multiuser/router.go
@@ -38,6 +38,23 @@ type ServerInfo struct {
 // Router routes MCP operations to the correct upstream based on user identity.
 // It merges shared servers (from the config file) with personal servers (from
 // the user's workspace) to provide a unified view of accessible servers.
+//
+// NOT YET WIRED. NewRouter has no production caller: internal/serveredition/setup.go
+// constructs the REST surfaces and the auth middleware, and nothing constructs
+// this. Personal servers are consequently reachable through
+// /api/v1/user/servers and nowhere else — no MCP request is routed through here
+// today.
+//
+// That matters when reasoning about security properties. The guards below
+// (brokerPoolIdentity's IsUser() namespacing, the shared-before-personal
+// precedence in GetServerForUser) are correct and are kept for when the router
+// IS wired, but they are LATENT: no argument about a live exposure may rest on
+// them, in either direction. In particular, the personal-server/admin-server
+// name collision that internal/serveredition/api/user_handlers.go refuses is a
+// real escalation today because of TOKEN SCOPE — a bare name is the whole of
+// what auth.AuthContext.CanAccessServer compares — and not because of any
+// routing this file performs. Anyone wiring this router should re-derive those
+// properties rather than inherit them from these comments.
 type Router struct {
 	sharedServers    []*config.ServerConfig
 	workspaceManager *workspace.Manager
@@ -160,6 +177,12 @@ func (r *Router) GetServerForUser(ctx context.Context, serverName string) (*Serv
 // It errors if there is no auth context or the server is not accessible to the
 // user; it does not require the server to actually declare an auth_broker block,
 // so callers can key uniformly and decide per server whether to broker.
+//
+// LATENT, like everything else on this type: nothing constructs the Router
+// (see its doc comment), and broker.ConnectionKey has no other caller, so no
+// brokered connection is pooled by this key in production today. The rule below
+// is correct and must survive to the moment the router IS wired; it is not
+// evidence that a live pooling hazard is currently closed.
 //
 // Only a USER-tier context keys as its own user id. Since issue #1168 an agent
 // token's AuthContext carries its OWNER's UserID (so its activity is

--- a/internal/serveredition/multiuser/router_broker_agent_test.go
+++ b/internal/serveredition/multiuser/router_broker_agent_test.go
@@ -1,0 +1,100 @@
+//go:build server
+
+package multiuser
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+)
+
+// agentCtx builds the request context an agent token produces. Built through
+// auth.AgentToken.AuthContext — the single production constructor for the agent
+// tier — rather than by hand, so this test cannot pass against a hand-written
+// context that happens to differ from what authentication actually installs.
+func agentCtx(owner, tokenName string) context.Context {
+	tok := &auth.AgentToken{Name: tokenName, UserID: owner, Permissions: []string{auth.PermRead}}
+	return auth.WithAuthContext(context.Background(), tok.AuthContext())
+}
+
+// TestRouter_BrokeredConnectionKey_AgentTokenNeverPoolsOntoItsOwner is the
+// regression guard for the second-order cost of issue #1168.
+//
+// FR-018 keys a brokered upstream connection per (user, server) so one user's
+// injected IdP credential is never reused for another. The key's identity half
+// came straight from ac.GetUserID() with no tier check. That was harmless while
+// only user sessions carried a UserID — an agent token keyed as the anonymous
+// "" — but #1168 made an agent token carry its OWNER's UserID so its activity
+// could be attributed. From that moment an agent-token request keyed IDENTICALLY
+// to its owner's own session, so it pooled onto the owner's brokered connection
+// and rode the owner's injected credential.
+//
+// The properties, all three of which must hold together:
+//
+//   - an agent token owned by U must NOT key like U's session (the regression);
+//   - two agent tokens with DIFFERENT owners must still key apart, so the fix
+//     cannot be "collapse every agent back to anonymous";
+//   - a user session's own key is UNCHANGED and still per-user, so the fix does
+//     not quietly break FR-018 itself.
+//
+// BITES: on unfixed code the first assertion fails — the agent key equals the
+// owner's session key exactly.
+func TestRouter_BrokeredConnectionKey_AgentTokenNeverPoolsOntoItsOwner(t *testing.T) {
+	router, _ := setupRouter(t, []string{"shared-ghe"}, nil)
+
+	aliceSession, err := router.BrokeredConnectionKey(userCtx("alice"), "shared-ghe")
+	require.NoError(t, err)
+	require.NotEmpty(t, aliceSession, "positive control: a user session must key at all")
+
+	aliceAgent, err := router.BrokeredConnectionKey(agentCtx("alice", "ci"), "shared-ghe")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, aliceSession, aliceAgent,
+		"an agent token must not pool onto its owner's brokered connection: that connection carries the owner's injected IdP credential")
+
+	// A second token of the SAME owner is the same principal as the first, so it
+	// may share a pool entry with it — but still not with the session.
+	aliceAgent2, err := router.BrokeredConnectionKey(agentCtx("alice", "nightly"), "shared-ghe")
+	require.NoError(t, err)
+	assert.Equal(t, aliceAgent, aliceAgent2, "agent-token pooling must stay stable for one owner")
+	assert.NotEqual(t, aliceSession, aliceAgent2, "no agent token may reach its owner's session pool entry")
+
+	// Different owners must still be kept apart — the fix must not degenerate
+	// into keying every agent token as one anonymous principal.
+	bobAgent, err := router.BrokeredConnectionKey(agentCtx("bob", "ci"), "shared-ghe")
+	require.NoError(t, err)
+	assert.NotEqual(t, aliceAgent, bobAgent,
+		"two owners' agent tokens must not share a brokered connection")
+
+	// And FR-018 itself is intact for sessions.
+	bobSession, err := router.BrokeredConnectionKey(userCtx("bob"), "shared-ghe")
+	require.NoError(t, err)
+	assert.NotEqual(t, aliceSession, bobSession, "FR-018: user sessions stay per-user")
+	assert.NotEqual(t, bobSession, aliceAgent, "an agent token must not land on ANY user's session entry")
+}
+
+// TestRouter_BrokeredConnectionKey_AdminUserSessionKeysAsItself pins that the
+// tier guard reads IsUser(), which covers "admin_user" as well as "user". An
+// admin's own browser session is still a user session and must keep keying by
+// its bare user id — a guard written as `ac.Type == AuthTypeUser` would silently
+// shunt every admin into the non-user namespace.
+func TestRouter_BrokeredConnectionKey_AdminUserSessionKeysAsItself(t *testing.T) {
+	router, _ := setupRouter(t, []string{"shared-ghe"}, nil)
+
+	adminKey, err := router.BrokeredConnectionKey(adminCtx("root"), "shared-ghe")
+	require.NoError(t, err)
+	userKey, err := router.BrokeredConnectionKey(userCtx("root"), "shared-ghe")
+	require.NoError(t, err)
+
+	assert.Equal(t, userKey, adminKey,
+		"an admin_user session is a user session: same identity, same pool entry")
+
+	agentKey, err := router.BrokeredConnectionKey(agentCtx("root", "ci"), "shared-ghe")
+	require.NoError(t, err)
+	assert.NotEqual(t, adminKey, agentKey,
+		"an agent token owned by an admin must still not pool onto the admin's session")
+}

--- a/internal/serveredition/registry.go
+++ b/internal/serveredition/registry.go
@@ -17,11 +17,21 @@ import (
 // These are provided by the server during initialization and passed
 // to each feature's Setup function.
 type Dependencies struct {
-	Router            chi.Router
-	DB                *bbolt.DB
-	Logger            *zap.SugaredLogger
-	Config            *config.Config
-	DataDir           string
+	Router  chi.Router
+	DB      *bbolt.DB
+	Logger  *zap.SugaredLogger
+	Config  *config.Config
+	DataDir string
+	// ConfigProvider returns the CURRENT configuration. Config above is the one
+	// that existed at setup time, and the configuration is hot-reloadable, so a
+	// feature that makes an authorisation decision from a boot-time snapshot
+	// silently stops seeing servers (and settings) added afterwards. Features
+	// must read through this and fall back to Config only when it is nil.
+	//
+	// The runtime publishes each configuration as an immutable snapshot behind
+	// an atomic pointer, so calling this is cheap and lock-free; the value it
+	// returns is READ-ONLY.
+	ConfigProvider    func() *config.Config
 	ManagementService interface{}      // management.Service - kept as interface{} to avoid circular imports
 	StorageManager    *storage.Manager // Shared storage manager for token operations
 }

--- a/internal/serveredition/setup.go
+++ b/internal/serveredition/setup.go
@@ -31,13 +31,49 @@ func setupMultiUserOAuth(deps Dependencies) error {
 
 	cfg := deps.Config.ServerEdition
 
+	// Create user store. Constructing it is infallible; EnsureBuckets below is
+	// not, which is why the owner gate is installed against the store BEFORE
+	// any fallible step runs.
+	userStore := users.NewUserStore(deps.DB)
+
+	// Agent tokens outlive the sessions of the user who minted them, and nothing
+	// re-checked that user afterwards: a disabled account's tokens kept
+	// authenticating, carrying its UserID into every downstream authorisation.
+	// Gate them on the owner's current state. The gate is on the authentication
+	// hot path, so it is a single keyed store read and no more; it fails closed.
+	//
+	// This is deliberately the FIRST thing this function does. SetupAll's error
+	// is only logged by wireServerEditionOAuth — the process comes up either
+	// way — so anything installed after a fallible step is absent from a server
+	// that is nonetheless serving traffic. Installed last, a failure in config
+	// validation, bucket creation, HMAC-key derivation or credential-store
+	// construction left agent tokens UNGATED: the control that stops a disabled
+	// user's tokens authenticating would have been the one thing the failure
+	// removed, which is fail-open on precisely the wrong axis.
+	//
+	// Installed here it fails CLOSED instead: if EnsureBuckets never ran, the
+	// gate's GetUser errors or answers "no such user", and the owned tokens are
+	// refused rather than waved through.
+	if deps.StorageManager != nil {
+		deps.StorageManager.SetAgentTokenOwnerGate(func(userID string) (bool, error) {
+			user, err := userStore.GetUser(userID)
+			if err != nil {
+				return false, err
+			}
+			if user == nil {
+				// The owner is gone from the store entirely. A token for an
+				// identity that no longer exists must not authenticate.
+				return false, nil
+			}
+			return !user.Disabled, nil
+		})
+	}
+
 	// Validate server config
 	if err := cfg.Validate(); err != nil {
 		return fmt.Errorf("server config validation: %w", err)
 	}
 
-	// Create user store
-	userStore := users.NewUserStore(deps.DB)
 	if err := userStore.EnsureBuckets(); err != nil {
 		return fmt.Errorf("creating server buckets: %w", err)
 	}
@@ -68,8 +104,32 @@ func setupMultiUserOAuth(deps Dependencies) error {
 	}
 	oauthHandler.SetCredentialStore(credStore)
 
+	// The LIVE view of the server-edition block, read through the same provider
+	// the admin-servers check uses rather than a second mechanism.
+	//
+	// `admin_emails` is the sole source of truth for the admin role, and it IS
+	// hot-reloadable: the file watcher reloads the whole file (config.LoadFromFile
+	// unmarshals `server_edition` in full), `server_edition` is not one of the
+	// restart-pinned fields, and the result is republished as the snapshot
+	// ConfigProvider reads. Deriving the role from `cfg` — the boot-time pointer
+	// — therefore meant a demotion took effect only on the next process restart,
+	// which is issue #1169 with a different horizon rather than issue #1169
+	// closed.
+	//
+	// Falls back to the boot block when there is no provider (tests, embedders
+	// with no config service) or when a reload dropped the block entirely, which
+	// is the previous behaviour and never widens the admin list.
+	serverEditionConfig := teamsauth.ServerEditionConfigProvider(func() *config.ServerEditionConfig {
+		if deps.ConfigProvider != nil {
+			if live := deps.ConfigProvider(); live != nil && live.ServerEdition != nil {
+				return live.ServerEdition
+			}
+		}
+		return cfg
+	})
+
 	// Create auth middleware
-	authMiddleware := teamsauth.NewServerEditionAuthMiddleware(sessionManager, userStore, cfg, hmacKey, deps.Logger)
+	authMiddleware := teamsauth.NewServerEditionAuthMiddleware(sessionManager, userStore, serverEditionConfig, hmacKey, deps.Logger)
 
 	// Register OAuth routes on the router.
 	// Login and callback are public (no auth required).
@@ -98,26 +158,6 @@ func setupMultiUserOAuth(deps Dependencies) error {
 		}
 		return sharedServers
 	})
-
-	// Agent tokens outlive the sessions of the user who minted them, and nothing
-	// re-checked that user afterwards: a disabled account's tokens kept
-	// authenticating, carrying its UserID into every downstream authorisation.
-	// Gate them on the owner's current state. The gate is on the authentication
-	// hot path, so it is a single keyed store read and no more; it fails closed.
-	if deps.StorageManager != nil {
-		deps.StorageManager.SetAgentTokenOwnerGate(func(userID string) (bool, error) {
-			user, err := userStore.GetUser(userID)
-			if err != nil {
-				return false, err
-			}
-			if user == nil {
-				// The owner is gone from the store entirely. A token for an
-				// identity that no longer exists must not authenticate.
-				return false, nil
-			}
-			return !user.Disabled, nil
-		})
-	}
 
 	// All server edition endpoints that require session cookie or JWT authentication.
 	// Mounted outside the API key group so session cookies work.

--- a/internal/serveredition/setup.go
+++ b/internal/serveredition/setup.go
@@ -80,12 +80,52 @@ func setupMultiUserOAuth(deps Dependencies) error {
 	// Shared servers are the main config servers (admin-configured).
 	sharedServers := deps.Config.Servers
 
+	// The LIVE view of the same thing. The configuration is hot-reloadable, so
+	// the slice above is only true of the process's first moment: a server the
+	// admin adds afterwards is absent from it forever. Every check that decides
+	// what a tenant may name or reach — the personal-server name collision and
+	// the token-scope entitlement set in api.UserHandlers — must read through
+	// this instead, or a tenant can pre-empt a name the admin has not created
+	// yet and walk through the entitlement control on a stale snapshot.
+	//
+	// Falls back to the boot slice when no provider was supplied (tests, and
+	// any embedder that has no config service), which is the previous behaviour.
+	adminServers := teamsapi.AdminServersProvider(func() []*config.ServerConfig {
+		if deps.ConfigProvider != nil {
+			if live := deps.ConfigProvider(); live != nil {
+				return live.Servers
+			}
+		}
+		return sharedServers
+	})
+
+	// Agent tokens outlive the sessions of the user who minted them, and nothing
+	// re-checked that user afterwards: a disabled account's tokens kept
+	// authenticating, carrying its UserID into every downstream authorisation.
+	// Gate them on the owner's current state. The gate is on the authentication
+	// hot path, so it is a single keyed store read and no more; it fails closed.
+	if deps.StorageManager != nil {
+		deps.StorageManager.SetAgentTokenOwnerGate(func(userID string) (bool, error) {
+			user, err := userStore.GetUser(userID)
+			if err != nil {
+				return false, err
+			}
+			if user == nil {
+				// The owner is gone from the store entirely. A token for an
+				// identity that no longer exists must not authenticate.
+				return false, nil
+			}
+			return !user.Disabled, nil
+		})
+	}
+
 	// All server edition endpoints that require session cookie or JWT authentication.
 	// Mounted outside the API key group so session cookies work.
 	authEndpoints := teamsapi.NewAuthEndpoints(userStore, sessionManager, cfg, hmacKey, deps.Logger)
 	configPath := config.GetConfigPath(deps.Config.DataDir)
 	adminHandlers := teamsapi.NewAdminHandlers(userStore, nil, sessionManager, cfg.AdminEmails, sharedServers, deps.Config, configPath, deps.ManagementService, deps.Logger)
-	userHandlers := teamsapi.NewUserHandlers(userStore, sharedServers, deps.StorageManager, hmacKey, deps.Logger)
+	adminHandlers.SetTokenRevoker(deps.StorageManager)
+	userHandlers := teamsapi.NewUserHandlers(userStore, adminServers, deps.StorageManager, hmacKey, deps.Logger)
 	userActivityHandlers := teamsapi.NewUserActivityHandlers(nil, userStore, sharedServers, deps.Logger)
 	// Per-user brokered-credential surfaces (spec 074 T8): list connection
 	// status, disconnect, and the Path B connect/callback flow. Reuses the same

--- a/internal/serveredition/setup_admin_liveness_test.go
+++ b/internal/serveredition/setup_admin_liveness_test.go
@@ -1,0 +1,228 @@
+//go:build server
+
+package serveredition
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+	teamsauth "github.com/smart-mcp-proxy/mcpproxy-go/internal/serveredition/auth"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/serveredition/users"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
+)
+
+// setLiveAdminEmails replaces the admin list the CURRENT configuration carries,
+// which is what editing `admin_emails` and letting the file watcher hot-reload
+// does. Copy-on-write down to the server-edition block, matching the runtime's
+// snapshot publishing.
+func (h *wiringHarness) setLiveAdminEmails(emails []string) {
+	h.configMu.Lock()
+	defer h.configMu.Unlock()
+	nextSE := *h.config.ServerEdition
+	nextSE.AdminEmails = emails
+	next := *h.config
+	next.ServerEdition = &nextSE
+	h.config = &next
+}
+
+// getAdminUsers calls the production admin route as u, over the production
+// route table and middleware chain. It answers 200 for an admin and 403 for a
+// plain user, so its status IS the role decision.
+func (h *wiringHarness) getAdminUsers(t *testing.T, u *users.User) *httptest.ResponseRecorder {
+	t.Helper()
+	// The `role` claim is minted "admin" on purpose in every call below: it is
+	// informational, and a test that varied it could pass by trusting the claim
+	// instead of the config.
+	token, err := teamsauth.GenerateBearerToken(h.hmacKey, u.ID, u.Email, u.DisplayName, "admin", u.Provider, time.Hour)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/users", nil)
+	req.Host = "localhost:8080"
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	h.router.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestSetupMultiUserOAuth_DemotionTakesEffectWithoutRestart is the whole of
+// issue #1169 on the production wiring.
+//
+// The role is derived from `admin_emails`, and the middleware used to hold the
+// *config.ServerEditionConfig captured when setup ran. The configuration is
+// hot-reloadable — config.LoadFromFile unmarshals `server_edition` in full, and
+// it is not among the restart-pinned fields — so an operator who removed an
+// admin from the list changed nothing at all until the process restarted. That
+// is a narrower gap than "until the JWT expires", but it is the same gap: the
+// documented remediation does not take effect when it is applied.
+//
+// Oracle discipline: the SAME request, by the SAME user, with the SAME token,
+// succeeds first. Only the configuration the provider returns changes between
+// the two calls, so a 403 afterwards can only be the live read.
+//
+// BITES: pass `cfg` instead of `serverEditionConfig` to
+// NewServerEditionAuthMiddleware in setup.go and the second call returns 200.
+func TestSetupMultiUserOAuth_DemotionTakesEffectWithoutRestart(t *testing.T) {
+	h := newWiringHarness(t)
+
+	admin := h.mkUser(t, "admin@example.com")
+
+	control := h.getAdminUsers(t, admin)
+	require.Equal(t, http.StatusOK, control.Code,
+		"positive control: the boot admin must reach the admin route (%s)", control.Body.String())
+
+	// The operator edits admin_emails and the file watcher republishes.
+	h.setLiveAdminEmails([]string{"someone-else@example.com"})
+
+	demoted := h.getAdminUsers(t, admin)
+	assert.Equal(t, http.StatusForbidden, demoted.Code,
+		"a user removed from admin_emails must lose admin on their NEXT request, not at the next restart (%s)",
+		demoted.Body.String())
+}
+
+// TestSetupMultiUserOAuth_PromotionTakesEffectWithoutRestart is the other
+// direction, and pins the docs claim that adding someone promotes them on their
+// next request.
+//
+// BITES: same neuter as above — the second call stays 403.
+func TestSetupMultiUserOAuth_PromotionTakesEffectWithoutRestart(t *testing.T) {
+	h := newWiringHarness(t)
+
+	tenant := h.mkUser(t, "tenant@example.com")
+
+	control := h.getAdminUsers(t, tenant)
+	require.Equal(t, http.StatusForbidden, control.Code,
+		"positive control: a plain user must be refused before the reload (%s)", control.Body.String())
+
+	h.setLiveAdminEmails([]string{"admin@example.com", "tenant@example.com"})
+
+	promoted := h.getAdminUsers(t, tenant)
+	assert.Equal(t, http.StatusOK, promoted.Code,
+		"a user added to admin_emails must gain admin on their next request (%s)", promoted.Body.String())
+}
+
+// TestSetupMultiUserOAuth_DroppedServerEditionBlockKeepsBootAdmins pins the
+// fallback: a reload that loses the `server_edition` block entirely must not
+// silently strip every admin (which would lock the deployment's operators out
+// of their own admin surface). It falls back to the boot block — the behaviour
+// before the live read existed — and never WIDENS the list.
+func TestSetupMultiUserOAuth_DroppedServerEditionBlockKeepsBootAdmins(t *testing.T) {
+	h := newWiringHarness(t)
+
+	admin := h.mkUser(t, "admin@example.com")
+	tenant := h.mkUser(t, "tenant@example.com")
+
+	h.configMu.Lock()
+	next := *h.config
+	next.ServerEdition = nil
+	h.config = &next
+	h.configMu.Unlock()
+
+	assert.Equal(t, http.StatusOK, h.getAdminUsers(t, admin).Code,
+		"a config with no server_edition block must fall back to the boot admin list")
+	assert.Equal(t, http.StatusForbidden, h.getAdminUsers(t, tenant).Code,
+		"the fallback must not widen the admin list")
+}
+
+// TestSetupMultiUserOAuth_OwnerGateSurvivesAFailedSetup is finding N3.
+//
+// wireServerEditionOAuth only LOGS SetupAll's error — the process comes up
+// serving traffic either way — so anything setupMultiUserOAuth installs after a
+// fallible step is simply absent from a running server. The agent-token owner
+// gate used to be installed after cfg.Validate(), userStore.EnsureBuckets(),
+// auth.GetOrCreateHMACKey() and broker.NewBBoltAESStore(). A failure in any of
+// them therefore removed the one control that stops a DISABLED user's agent
+// tokens from authenticating: fail-open on exactly the wrong axis.
+//
+// Here setup is made to fail at its first fallible step (an enabled
+// server_edition block with no admin_emails fails Validate), and the gate must
+// still be in force.
+//
+// BITES: move the SetAgentTokenOwnerGate block in setup.go back below
+// `cfg.Validate()` and the assertions below fail — the disabled owner's token
+// validates.
+func TestSetupMultiUserOAuth_OwnerGateSurvivesAFailedSetup(t *testing.T) {
+	tmpDir := t.TempDir()
+	db, err := bbolt.Open(tmpDir+"/test.db", 0600, &bbolt.Options{Timeout: time.Second})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	logger := zap.NewNop().Sugar()
+	tokens, err := storage.NewManager(t.TempDir(), logger)
+	require.NoError(t, err)
+	t.Cleanup(func() { tokens.Close() })
+
+	userStore := users.NewUserStore(db)
+	require.NoError(t, userStore.EnsureBuckets())
+
+	hmacKey, err := auth.GetOrCreateHMACKey(tmpDir)
+	require.NoError(t, err)
+
+	user := users.NewUser("tenant@example.com", "tenant@example.com", "google", "sub-tenant")
+	require.NoError(t, userStore.CreateUser(user))
+
+	mkToken := func(owner, name string) string {
+		raw, gerr := auth.GenerateToken()
+		require.NoError(t, gerr)
+		require.NoError(t, tokens.CreateAgentToken(auth.AgentToken{
+			Name:        name,
+			UserID:      owner,
+			Permissions: []string{auth.PermRead},
+		}, raw, hmacKey))
+		return raw
+	}
+	owned := mkToken(user.ID, "ci")
+	ownerless := mkToken("", "personal")
+
+	// Enabled, but invalid: no admin_emails. cfg.Validate() is the FIRST
+	// fallible step in setupMultiUserOAuth.
+	broken := &config.Config{
+		ServerEdition: &config.ServerEditionConfig{
+			Enabled: true,
+			OAuth: &config.ServerEditionOAuthConfig{
+				Provider:     "google",
+				ClientID:     "test-client-id",
+				ClientSecret: "test-client-secret",
+			},
+		},
+	}
+
+	err = setupMultiUserOAuth(Dependencies{
+		Router:         chi.NewRouter(),
+		DB:             db,
+		Logger:         logger,
+		DataDir:        tmpDir,
+		Config:         broken,
+		ConfigProvider: func() *config.Config { return broken },
+		StorageManager: tokens,
+	})
+	require.Error(t, err, "the harness must actually reproduce a failed setup, or it proves nothing")
+
+	// Positive control: with an ACTIVE owner the token still validates, so the
+	// refusal below is the Disabled flag and not a gate that denies everything.
+	ok, err := tokens.ValidateAgentToken(owned, hmacKey)
+	require.NoError(t, err, "positive control: an active owner's token must validate after a failed setup")
+	require.NotNil(t, ok)
+
+	user.Disabled = true
+	require.NoError(t, userStore.UpdateUser(user))
+
+	denied, err := tokens.ValidateAgentToken(owned, hmacKey)
+	assert.Nil(t, denied, "a disabled owner's token must not authenticate even when setup failed")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrAgentTokenOwnerInactive)
+
+	// The personal edition's ownerless tokens stay unaffected.
+	personal, err := tokens.ValidateAgentToken(ownerless, hmacKey)
+	require.NoError(t, err, "an ownerless token must be unaffected by the owner gate")
+	require.NotNil(t, personal)
+}

--- a/internal/serveredition/setup_role_freshness_test.go
+++ b/internal/serveredition/setup_role_freshness_test.go
@@ -1,0 +1,178 @@
+//go:build server
+
+package serveredition
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"go.etcd.io/bbolt"
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+	teamsauth "github.com/smart-mcp-proxy/mcpproxy-go/internal/serveredition/auth"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/serveredition/users"
+)
+
+// --- Issue #1169: stale admin JWTs on the PRODUCTION route table ---
+
+// serverEditionTestDeps wires the same harness as
+// TestSetupMultiUserOAuth_RegistersRoutes and returns the router, the user
+// store, and the HMAC key setupMultiUserOAuth actually installed.
+func serverEditionTestDeps(t *testing.T) (*chi.Mux, *users.UserStore, []byte) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	db, err := bbolt.Open(tmpDir+"/test.db", 0600, &bbolt.Options{Timeout: 1 * time.Second})
+	if err != nil {
+		t.Fatalf("failed to open bbolt: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	router := chi.NewRouter()
+	deps := Dependencies{
+		Router:  router,
+		DB:      db,
+		Logger:  zap.NewNop().Sugar(),
+		DataDir: tmpDir,
+		Config: &config.Config{
+			ServerEdition: &config.ServerEditionConfig{
+				Enabled:        true,
+				AdminEmails:    []string{"admin@example.com"},
+				SessionTTL:     config.Duration(24 * time.Hour),
+				BearerTokenTTL: config.Duration(24 * time.Hour),
+				OAuth: &config.ServerEditionOAuthConfig{
+					Provider:     "google",
+					ClientID:     "test-client-id",
+					ClientSecret: "test-client-secret",
+				},
+			},
+		},
+	}
+
+	if err := setupMultiUserOAuth(deps); err != nil {
+		t.Fatalf("setupMultiUserOAuth failed: %v", err)
+	}
+
+	// The same key setupMultiUserOAuth loaded: GetOrCreateHMACKey is
+	// idempotent and the key file now exists under tmpDir.
+	hmacKey, err := auth.GetOrCreateHMACKey(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to load HMAC key: %v", err)
+	}
+
+	return router, users.NewUserStore(db), hmacKey
+}
+
+// TestSetupMultiUserOAuth_DemotedAdminJWTIsIndistinguishableFromPlainUser
+// drives the real registration (setupMultiUserOAuth -> chi -> requireAdmin).
+//
+// ORACLE: status parity between a stale role="admin" JWT held by a demoted
+// user and a role="user" JWT held by a plain user, ANCHORED on the exact
+// expected status (403). The anchor is load-bearing: a mis-minted token or a
+// mismatched HMAC key would make both requests 401, and a bare parity assert
+// would then pass vacuously. A POSITIVE CONTROL runs first on the SAME router
+// and SAME route, proving the route matched (chi's NotFoundHandler would give
+// 404), the middleware accepted the token, and the handler really ran.
+//
+// BITES: unfixed, demoted=200 (requireAdmin passes on the frozen claim) while
+// plain=403.
+func TestSetupMultiUserOAuth_DemotedAdminJWTIsIndistinguishableFromPlainUser(t *testing.T) {
+	router, userStore, hmacKey := serverEditionTestDeps(t)
+
+	mkUser := func(email, name string) *users.User {
+		u := users.NewUser(email, name, "google", "sub-"+email)
+		if err := userStore.CreateUser(u); err != nil {
+			t.Fatalf("failed to create user %s: %v", email, err)
+		}
+		return u
+	}
+	adminUser := mkUser("admin@example.com", "Real Admin") // IS in admin_emails
+	demoted := mkUser("demoted@example.com", "Demoted")    // NOT in admin_emails
+	plain := mkUser("plain@example.com", "Plain")          // NOT in admin_emails
+
+	call := func(u *users.User, role string) *httptest.ResponseRecorder {
+		token, err := teamsauth.GenerateBearerToken(hmacKey, u.ID, u.Email, u.DisplayName, role, u.Provider, time.Hour)
+		if err != nil {
+			t.Fatalf("failed to mint token for %s: %v", u.Email, err)
+		}
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/users", nil)
+		req.Host = "localhost:8080"
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		return rec
+	}
+
+	if rec := call(adminUser, "admin"); rec.Code != http.StatusOK {
+		t.Fatalf("positive control failed: a real admin got %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	demotedRec := call(demoted, "admin") // stale, pre-demotion claim
+	plainRec := call(plain, "user")
+
+	if demotedRec.Code != plainRec.Code {
+		t.Errorf("stale admin JWT is distinguishable from a plain user: demoted=%d plain=%d", demotedRec.Code, plainRec.Code)
+	}
+	if demotedRec.Code != http.StatusForbidden {
+		t.Errorf("expected the demoted admin to get %d, got %d (body: %s)", http.StatusForbidden, demotedRec.Code, demotedRec.Body.String())
+	}
+	if plainRec.Code != http.StatusForbidden {
+		t.Errorf("expected the plain user to get %d, got %d", http.StatusForbidden, plainRec.Code)
+	}
+}
+
+// TestSetupMultiUserOAuth_DemotedAdminCannotMintFreshAdminToken closes the
+// renewal loop #1169 misses: generateToken mints a NEW JWT from ac.Role, so on
+// unfixed code a demoted admin renews admin indefinitely and the bug never
+// self-heals at token expiry.
+//
+// BITES: unfixed, the reissued token carries role="admin".
+func TestSetupMultiUserOAuth_DemotedAdminCannotMintFreshAdminToken(t *testing.T) {
+	router, userStore, hmacKey := serverEditionTestDeps(t)
+
+	demoted := users.NewUser("demoted@example.com", "Demoted", "google", "sub-demoted")
+	if err := userStore.CreateUser(demoted); err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+
+	stale, err := teamsauth.GenerateBearerToken(hmacKey, demoted.ID, demoted.Email, demoted.DisplayName, "admin", demoted.Provider, time.Hour)
+	if err != nil {
+		t.Fatalf("failed to mint the stale token: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/token", nil)
+	req.Host = "localhost:8080"
+	req.Header.Set("Authorization", "Bearer "+stale)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	// Anchor: renewal itself must succeed, otherwise the role assertion below
+	// would be satisfied vacuously by an empty/absent token.
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected token renewal to succeed with 200, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode the token response: %v (body: %s)", err, rec.Body.String())
+	}
+	if resp.Token == "" {
+		t.Fatalf("token renewal returned an empty token (body: %s)", rec.Body.String())
+	}
+
+	claims, err := teamsauth.ParseBearerTokenUnverified(resp.Token)
+	if err != nil {
+		t.Fatalf("failed to parse the reissued token: %v", err)
+	}
+	if claims.Role != "user" {
+		t.Errorf("demoted admin renewed an admin token: reissued role=%q, want %q", claims.Role, "user")
+	}
+}

--- a/internal/serveredition/setup_wiring_test.go
+++ b/internal/serveredition/setup_wiring_test.go
@@ -1,0 +1,228 @@
+//go:build server
+
+package serveredition
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+	teamsauth "github.com/smart-mcp-proxy/mcpproxy-go/internal/serveredition/auth"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/serveredition/users"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
+)
+
+// wiringHarness drives the PRODUCTION setup function, with the two dependencies
+// the fixes in this change hang off: a live configuration provider and a real
+// agent-token store.
+type wiringHarness struct {
+	router   *chi.Mux
+	users    *users.UserStore
+	tokens   *storage.Manager
+	hmacKey  []byte
+	configMu sync.RWMutex
+	config   *config.Config
+}
+
+// setLiveServers replaces the servers the CURRENT configuration carries, which
+// is what a hot reload does. Copy-on-write, matching the runtime's snapshot
+// publishing, so a concurrent reader never sees a half-built slice.
+func (h *wiringHarness) setLiveServers(servers []*config.ServerConfig) {
+	h.configMu.Lock()
+	defer h.configMu.Unlock()
+	next := *h.config
+	next.Servers = servers
+	h.config = &next
+}
+
+func (h *wiringHarness) currentConfig() *config.Config {
+	h.configMu.RLock()
+	defer h.configMu.RUnlock()
+	return h.config
+}
+
+func newWiringHarness(t *testing.T) *wiringHarness {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	db, err := bbolt.Open(tmpDir+"/test.db", 0600, &bbolt.Options{Timeout: time.Second})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	logger := zap.NewNop().Sugar()
+	tokens, err := storage.NewManager(t.TempDir(), logger)
+	require.NoError(t, err)
+	t.Cleanup(func() { tokens.Close() })
+
+	h := &wiringHarness{
+		router: chi.NewRouter(),
+		tokens: tokens,
+		config: &config.Config{
+			ServerEdition: &config.ServerEditionConfig{
+				Enabled:        true,
+				AdminEmails:    []string{"admin@example.com"},
+				SessionTTL:     config.Duration(24 * time.Hour),
+				BearerTokenTTL: config.Duration(24 * time.Hour),
+				OAuth: &config.ServerEditionOAuthConfig{
+					Provider:     "google",
+					ClientID:     "test-client-id",
+					ClientSecret: "test-client-secret",
+				},
+			},
+		},
+	}
+
+	require.NoError(t, setupMultiUserOAuth(Dependencies{
+		Router:         h.router,
+		DB:             db,
+		Logger:         logger,
+		DataDir:        tmpDir,
+		Config:         h.currentConfig(),
+		ConfigProvider: h.currentConfig,
+		StorageManager: tokens,
+	}))
+
+	h.users = users.NewUserStore(db)
+	h.hmacKey, err = auth.GetOrCreateHMACKey(tmpDir)
+	require.NoError(t, err)
+
+	return h
+}
+
+func (h *wiringHarness) mkUser(t *testing.T, email string) *users.User {
+	t.Helper()
+	u := users.NewUser(email, email, "google", "sub-"+email)
+	require.NoError(t, h.users.CreateUser(u))
+	return u
+}
+
+// createPersonalServer posts to the production per-user create route as u.
+func (h *wiringHarness) createPersonalServer(t *testing.T, u *users.User, name string) *httptest.ResponseRecorder {
+	t.Helper()
+	token, err := teamsauth.GenerateBearerToken(h.hmacKey, u.ID, u.Email, u.DisplayName, "user", u.Provider, time.Hour)
+	require.NoError(t, err)
+
+	body := `{"name":"` + name + `","url":"http://127.0.0.1:9/` + name + `","protocol":"http"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/user/servers", strings.NewReader(body))
+	req.Host = "localhost:8080"
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	h.router.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestSetupMultiUserOAuth_UserHandlersSeeConfigReloads proves the LIVE
+// configuration is actually threaded through the production wiring, not just
+// available to be threaded.
+//
+// setup.go used to hand api.NewUserHandlers `deps.Config.Servers` — the slice
+// as it stood at process start. The configuration is hot-reloadable, so every
+// name-collision and entitlement decision afterwards was made against a
+// configuration that no longer existed. This drives the real setup function and
+// the real chi route table, so a wiring mistake (provider not passed, fallback
+// taken unconditionally) fails here even though the handler-level tests pass.
+//
+// Oracle discipline: the same request succeeds first, for a different tenant,
+// on the same router — proving the route, the auth middleware and the store all
+// work, and that the name was genuinely free at that moment. The only thing
+// that changes between the two calls is the configuration the provider returns.
+//
+// BITES: pass `sharedServers` instead of `adminServers` to
+// teamsapi.NewUserHandlers in setup.go and the second call returns 201.
+func TestSetupMultiUserOAuth_UserHandlersSeeConfigReloads(t *testing.T) {
+	h := newWiringHarness(t)
+
+	first := h.mkUser(t, "first@example.com")
+	second := h.mkUser(t, "second@example.com")
+
+	control := h.createPersonalServer(t, first, "late-admin-db")
+	require.Equal(t, http.StatusCreated, control.Code,
+		"positive control: the name must be free before the reload (%s)", control.Body.String())
+
+	// A hot reload adds an admin server with that name.
+	h.setLiveServers([]*config.ServerConfig{
+		{Name: "late-admin-db", URL: "https://late.example", Protocol: "http", Enabled: true},
+	})
+
+	probe := h.createPersonalServer(t, second, "late-admin-db")
+	require.Equal(t, http.StatusConflict, probe.Code,
+		"a name the admin took after boot must no longer be available (%s)", probe.Body.String())
+
+	stored, err := h.users.GetUserServer(second.ID, "late-admin-db")
+	require.NoError(t, err)
+	assert.Nil(t, stored, "the refused server must not have been persisted")
+}
+
+// TestSetupMultiUserOAuth_InstallsAgentTokenOwnerGate proves the owner gate is
+// wired to the real user store by the real setup function.
+//
+// storage.Manager exposes the gate, but a gate nobody installs is inert — and
+// the whole disabled-owner fix would then be a no-op in production while every
+// storage-level test passed.
+//
+// Oracle discipline: the token validates first, on the same manager after setup
+// has run, so the later refusal is the user's Disabled flag and not a mis-hashed
+// token; an ownerless token is checked throughout as the personal-edition
+// control; and a token whose owner does not exist at all is checked too, since
+// "unknown user" and "disabled user" must both deny.
+//
+// BITES: remove the SetAgentTokenOwnerGate block from setupMultiUserOAuth and
+// every "must not authenticate" assertion below fails.
+func TestSetupMultiUserOAuth_InstallsAgentTokenOwnerGate(t *testing.T) {
+	h := newWiringHarness(t)
+
+	user := h.mkUser(t, "tenant@example.com")
+
+	mkToken := func(t *testing.T, owner, name string) string {
+		t.Helper()
+		raw, err := auth.GenerateToken()
+		require.NoError(t, err)
+		require.NoError(t, h.tokens.CreateAgentToken(auth.AgentToken{
+			Name:        name,
+			UserID:      owner,
+			Permissions: []string{auth.PermRead},
+		}, raw, h.hmacKey))
+		return raw
+	}
+
+	owned := mkToken(t, user.ID, "ci")
+	ownerless := mkToken(t, "", "personal")
+	orphan := mkToken(t, "01HTEST00000000000GHOSTUSR", "ghost")
+
+	// Positive control: an active owner's token authenticates through the gate
+	// the setup function installed.
+	got, err := h.tokens.ValidateAgentToken(owned, h.hmacKey)
+	require.NoError(t, err, "positive control: an active owner's token must validate")
+	require.NotNil(t, got)
+
+	// A token whose owner is not in the store at all must never authenticate.
+	ghost, err := h.tokens.ValidateAgentToken(orphan, h.hmacKey)
+	assert.Nil(t, ghost, "a token for an identity that does not exist must not authenticate")
+	assert.Error(t, err)
+
+	// Disable the owner through the store the gate reads.
+	user.Disabled = true
+	require.NoError(t, h.users.UpdateUser(user))
+
+	denied, err := h.tokens.ValidateAgentToken(owned, h.hmacKey)
+	assert.Nil(t, denied, "a disabled owner's token must not authenticate")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrAgentTokenOwnerInactive)
+
+	// The personal edition's ownerless tokens are never gated.
+	personal, err := h.tokens.ValidateAgentToken(ownerless, h.hmacKey)
+	require.NoError(t, err, "an ownerless token must be unaffected by the owner gate")
+	require.NotNil(t, personal)
+}

--- a/internal/storage/agent_token_lifecycle_test.go
+++ b/internal/storage/agent_token_lifecycle_test.go
@@ -1,0 +1,357 @@
+package storage
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+)
+
+// TestListAgentTokens_CorruptRecordDoesNotBreakTheListing pins the same blast
+// radius for the LIST path that TestAgentToken_CorruptRecordDoesNotBreakOtherTenants
+// pins for the by-name resolver.
+//
+// ListAgentTokens walks the whole agent_tokens bucket, so aborting on the first
+// row that fails json.Unmarshal turned ONE bad record — a truncated write, a
+// hand-edited DB, a record from a future schema — into a 500 on
+// GET /api/v1/user/tokens for EVERY tenant of the deployment, and on the
+// operator's own `mcpproxy token list` with it. The resolver was fixed for
+// exactly this; the list path was missed.
+//
+// Oracle discipline: a positive control lists the healthy tokens BEFORE the
+// corruption is planted, on the same manager, so a later success cannot be an
+// empty bucket or an unwired store; the count afterwards is pinned exactly, so
+// "returns no error" cannot pass by returning nothing.
+//
+// BITES: restore `return fmt.Errorf("failed to unmarshal agent token: %w", err)`
+// inside ListAgentTokens' ForEach and the require.NoError below fails.
+func TestListAgentTokens_CorruptRecordDoesNotBreakTheListing(t *testing.T) {
+	manager, cleanup := setupTestStorageForAgentTokens(t)
+	defer cleanup()
+
+	a, rawA := makeOwnedTestToken(t, "ci", "userA")
+	require.NoError(t, manager.CreateAgentToken(a, rawA, testHMACKey))
+	b, rawB := makeOwnedTestToken(t, "deploy", "userB")
+	require.NoError(t, manager.CreateAgentToken(b, rawB, testHMACKey))
+
+	// Positive control on the clean store.
+	before, err := manager.ListAgentTokens()
+	require.NoError(t, err, "positive control: a clean store must list")
+	require.Len(t, before, 2, "positive control: both fixtures must be present")
+
+	// Keyed so it sorts into the middle of the bucket, not conveniently last.
+	writeRawAgentTokenRecord(t, manager, "0000corrupt0000", []byte("{not json at all"))
+
+	after, err := manager.ListAgentTokens()
+	require.NoError(t, err,
+		"one unparseable row must not make the listing fail for every tenant")
+	require.Len(t, after, 2,
+		"the healthy tokens must still be listed; only the corrupt row is skipped")
+
+	names := map[string]bool{}
+	for i := range after {
+		names[after[i].Name] = true
+	}
+	assert.True(t, names["ci"], "user A's token must still be listed")
+	assert.True(t, names["deploy"], "user B's token must still be listed")
+}
+
+// TestRegenerateAgentTokenForOwner_NarrowScopeHookCannotWiden closes the gap
+// between the narrowScope contract and its enforcement.
+//
+// The hook's "must only narrow" rule was a doc comment: storage persisted
+// whatever the hook returned, verbatim. Rotation is supposed to be
+// scope-neutral, so a caller whose hook returned a wider list — by accident, or
+// because a later refactor passed the ENTITLED set instead of a filter over the
+// stored one — would have turned the one repair operation into a privilege
+// escalation, silently. The result is now intersected with the token's existing
+// AllowedServers inside the same transaction.
+//
+// Oracle discipline: every case asserts the PERSISTED record read back through
+// storage (a return value could be narrowed while the write was not), and the
+// first subtest is a positive control proving an honest hook still works.
+//
+// BITES: drop intersectAllowedServers from RegenerateAgentTokenForOwner and the
+// "hook cannot widen" subtests persist the widened list.
+func TestRegenerateAgentTokenForOwner_NarrowScopeHookCannotWiden(t *testing.T) {
+	rotate := func(t *testing.T, manager *Manager, owner, name string, hook func([]string) []string) *auth.AgentToken {
+		t.Helper()
+		newRaw, err := auth.GenerateToken()
+		require.NoError(t, err)
+		updated, err := manager.RegenerateAgentTokenForOwner(owner, name, newRaw, testHMACKey, hook)
+		require.NoError(t, err)
+		require.NotNil(t, updated)
+
+		stored, err := manager.GetAgentTokenByOwnerAndName(owner, name)
+		require.NoError(t, err)
+		require.NotNil(t, stored, "the rotated token must still be resolvable")
+		require.Equal(t, updated.AllowedServers, stored.AllowedServers,
+			"the returned scope must be the one that was persisted")
+		return stored
+	}
+
+	seed := func(t *testing.T, manager *Manager, owner, name string, allowed []string) {
+		t.Helper()
+		raw, err := auth.GenerateToken()
+		require.NoError(t, err)
+		require.NoError(t, manager.CreateAgentToken(auth.AgentToken{
+			Name:           name,
+			UserID:         owner,
+			AllowedServers: allowed,
+			Permissions:    []string{"read"},
+		}, raw, testHMACKey))
+	}
+
+	t.Run("positive control: an honest narrowing hook is applied", func(t *testing.T) {
+		manager, cleanup := setupTestStorageForAgentTokens(t)
+		defer cleanup()
+
+		seed(t, manager, "userA", "ci", []string{"alpha", "beta"})
+		stored := rotate(t, manager, "userA", "ci", func(current []string) []string {
+			// The production shape: a filter over what is already there.
+			out := []string{}
+			for _, s := range current {
+				if s == "alpha" {
+					out = append(out, s)
+				}
+			}
+			return out
+		})
+		assert.Equal(t, []string{"alpha"}, stored.AllowedServers,
+			"a genuine narrowing must be persisted, or the intersection has broken rotation")
+	})
+
+	t.Run("a hook that adds a server is intersected away", func(t *testing.T) {
+		manager, cleanup := setupTestStorageForAgentTokens(t)
+		defer cleanup()
+
+		seed(t, manager, "userA", "ci", []string{"alpha"})
+		stored := rotate(t, manager, "userA", "ci", func([]string) []string {
+			return []string{"alpha", "admin-private"}
+		})
+		assert.Equal(t, []string{"alpha"}, stored.AllowedServers,
+			"rotation must not be able to grant a server the token could not already reach")
+		assert.NotContains(t, stored.AllowedServers, "admin-private")
+	})
+
+	t.Run("a hook that replaces the scope wholesale is intersected away", func(t *testing.T) {
+		manager, cleanup := setupTestStorageForAgentTokens(t)
+		defer cleanup()
+
+		seed(t, manager, "userA", "ci", []string{"alpha"})
+		stored := rotate(t, manager, "userA", "ci", func([]string) []string {
+			return []string{"admin-private", "another-tenant"}
+		})
+		assert.Empty(t, stored.AllowedServers,
+			"nothing the token already held survives, so nothing may be granted")
+	})
+
+	t.Run("a hook cannot promote a bounded scope to the wildcard", func(t *testing.T) {
+		manager, cleanup := setupTestStorageForAgentTokens(t)
+		defer cleanup()
+
+		seed(t, manager, "userA", "ci", []string{"alpha"})
+		stored := rotate(t, manager, "userA", "ci", func([]string) []string {
+			return []string{"*"}
+		})
+		assert.NotContains(t, stored.AllowedServers, "*",
+			`"*" is honoured unconditionally by CanAccessServer; rotation must never introduce it`)
+		assert.Empty(t, stored.AllowedServers)
+	})
+
+	t.Run("a stored wildcard may still be materialised into a bounded set", func(t *testing.T) {
+		manager, cleanup := setupTestStorageForAgentTokens(t)
+		defer cleanup()
+
+		// This is the pre-branch token the server edition converts on first
+		// rotation. The intersection must NOT empty it: "*" already granted
+		// everything, so any concrete list is a narrowing.
+		seed(t, manager, "userA", "ci", []string{"*"})
+		stored := rotate(t, manager, "userA", "ci", func([]string) []string {
+			return []string{"alpha", "shared-ok"}
+		})
+		assert.Equal(t, []string{"alpha", "shared-ok"}, stored.AllowedServers,
+			"materialising a stored wildcard is a narrowing and must survive intact")
+	})
+
+	t.Run("nil hook leaves the scope untouched", func(t *testing.T) {
+		manager, cleanup := setupTestStorageForAgentTokens(t)
+		defer cleanup()
+
+		seed(t, manager, "userA", "ci", []string{"alpha", "beta"})
+		stored := rotate(t, manager, "userA", "ci", nil)
+		assert.Equal(t, []string{"alpha", "beta"}, stored.AllowedServers,
+			"the personal edition passes no hook and must be unaffected")
+	})
+}
+
+// TestValidateAgentToken_OwnerGateStopsADisabledOwner is the authentication-path
+// half of the disabled-user fix.
+//
+// A token's authorisation is decided once, when it is minted. Disabling a user
+// revoked their sessions and stopped their JWTs, but their agent tokens were
+// separate records that nothing re-checked: they kept authenticating, carrying
+// the disabled user's UserID into every downstream authorisation and activity
+// decision. Disabling is the documented remediation for a compromised account,
+// so it has to reach those too.
+//
+// Oracle discipline: the token validates FIRST, on the same manager with the
+// gate already installed, so the later refusal is the owner's state changing and
+// not a broken fixture or a mis-hashed token; an ownerless token is validated
+// throughout as the personal-edition control; and the refusal is pinned to the
+// typed sentinel rather than to any message.
+//
+// BITES: delete the agentTokenOwnerActive call from ValidateAgentToken (leave
+// the gate and the setter in place, so the package still builds) and the
+// "disabled" assertions fail.
+func TestValidateAgentToken_OwnerGateStopsADisabledOwner(t *testing.T) {
+	manager, cleanup := setupTestStorageForAgentTokens(t)
+	defer cleanup()
+
+	owned, rawOwned := makeOwnedTestToken(t, "ci", "userA")
+	require.NoError(t, manager.CreateAgentToken(owned, rawOwned, testHMACKey))
+	ownerless, rawOwnerless := makeOwnedTestToken(t, "personal", "")
+	require.NoError(t, manager.CreateAgentToken(ownerless, rawOwnerless, testHMACKey))
+
+	disabled := map[string]bool{}
+	manager.SetAgentTokenOwnerGate(func(userID string) (bool, error) {
+		return !disabled[userID], nil
+	})
+
+	// Positive control: with the gate installed and the owner active, the token
+	// validates. A later refusal is therefore about the owner.
+	got, err := manager.ValidateAgentToken(rawOwned, testHMACKey)
+	require.NoError(t, err, "positive control: an active owner's token must validate")
+	require.NotNil(t, got)
+	require.Equal(t, "userA", got.UserID)
+
+	// Disable the owner. Nothing about the token record changes.
+	disabled["userA"] = true
+
+	got, err = manager.ValidateAgentToken(rawOwned, testHMACKey)
+	assert.Nil(t, got, "a disabled owner's token must not authenticate")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrAgentTokenOwnerInactive),
+		"the refusal must be the typed owner-inactive sentinel, got %v", err)
+
+	// The record itself is untouched: this is a live check, not a mutation.
+	stored, err := manager.GetAgentTokenByOwnerAndName("userA", "ci")
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.False(t, stored.Revoked, "the gate must not have rewritten the record")
+
+	// The personal edition's ownerless tokens are never gated.
+	personal, err := manager.ValidateAgentToken(rawOwnerless, testHMACKey)
+	require.NoError(t, err, "an ownerless token must be unaffected by the owner gate")
+	require.NotNil(t, personal)
+
+	// Re-enabling the owner makes the token work again — the gate is a live
+	// check. (The admin disable handler ALSO revokes, so that a real disable is
+	// not undone this way; see AdminHandlers.disableUser.)
+	disabled["userA"] = false
+	back, err := manager.ValidateAgentToken(rawOwned, testHMACKey)
+	require.NoError(t, err)
+	require.NotNil(t, back)
+}
+
+// TestValidateAgentToken_OwnerGateFailsClosed pins the direction of the failure.
+//
+// A gate that cannot answer — user store unavailable, database error — must
+// deny. The alternative, treating an unanswerable question as "valid", is
+// exactly the hole the gate exists to close, reachable by making the store
+// error.
+//
+// BITES: change the error branch in ValidateAgentToken to fall through to
+// `return token, nil` and this fails.
+func TestValidateAgentToken_OwnerGateFailsClosed(t *testing.T) {
+	manager, cleanup := setupTestStorageForAgentTokens(t)
+	defer cleanup()
+
+	owned, rawOwned := makeOwnedTestToken(t, "ci", "userA")
+	require.NoError(t, manager.CreateAgentToken(owned, rawOwned, testHMACKey))
+
+	// Positive control with a healthy gate.
+	manager.SetAgentTokenOwnerGate(func(string) (bool, error) { return true, nil })
+	got, err := manager.ValidateAgentToken(rawOwned, testHMACKey)
+	require.NoError(t, err, "positive control: a healthy gate must let the token through")
+	require.NotNil(t, got)
+
+	boom := errors.New("user store unavailable")
+	manager.SetAgentTokenOwnerGate(func(string) (bool, error) { return false, boom })
+
+	got, err = manager.ValidateAgentToken(rawOwned, testHMACKey)
+	assert.Nil(t, got, "an unanswerable owner check must deny the token")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrAgentTokenOwnerInactive),
+		"the refusal must be the owner-inactive sentinel, got %v", err)
+	assert.NotContains(t, err.Error(), boom.Error(),
+		"the caller must not be told why the store failed")
+}
+
+// TestRevokeAgentTokensForOwner_BurnsOnlyThatOwnersTokens is the persistence
+// half of the disabled-user fix: re-enabling an account must not hand back the
+// credentials that may be why it was disabled.
+//
+// Oracle discipline: another tenant's token and an OWNERLESS (personal-edition)
+// token are both present and must both survive — "did it revoke?" is only half
+// the property, and a bulk revoke that swept the ownerless namespace would be an
+// outage rather than a remediation.
+//
+// BITES: it is new behaviour; without RevokeAgentTokensForOwner the package does
+// not build, so the bite is shown at the handler level instead
+// (TestDisableUser_RevokesTheUsersAgentTokens). Here the sharp assertions are
+// the survivors and the empty-owner refusal.
+func TestRevokeAgentTokensForOwner_BurnsOnlyThatOwnersTokens(t *testing.T) {
+	manager, cleanup := setupTestStorageForAgentTokens(t)
+	defer cleanup()
+
+	aOne, rawAOne := makeOwnedTestToken(t, "ci", "userA")
+	require.NoError(t, manager.CreateAgentToken(aOne, rawAOne, testHMACKey))
+	aTwo, rawATwo := makeOwnedTestToken(t, "deploy", "userA")
+	require.NoError(t, manager.CreateAgentToken(aTwo, rawATwo, testHMACKey))
+	bOne, rawBOne := makeOwnedTestToken(t, "ci", "userB")
+	require.NoError(t, manager.CreateAgentToken(bOne, rawBOne, testHMACKey))
+	personal, rawPersonal := makeOwnedTestToken(t, "local", "")
+	require.NoError(t, manager.CreateAgentToken(personal, rawPersonal, testHMACKey))
+
+	// Positive control: every token authenticates before the revoke.
+	for _, raw := range []string{rawAOne, rawATwo, rawBOne, rawPersonal} {
+		_, err := manager.ValidateAgentToken(raw, testHMACKey)
+		require.NoError(t, err, "positive control: all four fixtures must validate first")
+	}
+
+	// The ownerless namespace may never be bulk-revoked: "" is every
+	// personal-edition token.
+	_, err := manager.RevokeAgentTokensForOwner("")
+	require.Error(t, err, "an empty owner must be refused, not treated as the ownerless namespace")
+
+	count, err := manager.RevokeAgentTokensForOwner("userA")
+	require.NoError(t, err)
+	assert.Equal(t, 2, count, "both of user A's tokens must be revoked")
+
+	for _, raw := range []string{rawAOne, rawATwo} {
+		_, err := manager.ValidateAgentToken(raw, testHMACKey)
+		assert.Error(t, err, "a revoked token must not authenticate")
+	}
+
+	// The survivors.
+	surviving, err := manager.ValidateAgentToken(rawBOne, testHMACKey)
+	require.NoError(t, err, "another tenant's token must survive")
+	require.NotNil(t, surviving)
+	survivingPersonal, err := manager.ValidateAgentToken(rawPersonal, testHMACKey)
+	require.NoError(t, err, "an ownerless personal-edition token must survive")
+	require.NotNil(t, survivingPersonal)
+
+	// Soft delete: the records are still there for the operator to see.
+	listed, err := manager.ListAgentTokens()
+	require.NoError(t, err)
+	assert.Len(t, listed, 4, "revoke is a soft delete; no record may disappear")
+
+	// Idempotent.
+	again, err := manager.RevokeAgentTokensForOwner("userA")
+	require.NoError(t, err)
+	assert.Equal(t, 0, again, "a second revoke has nothing left to change")
+}

--- a/internal/storage/agent_token_owner_test.go
+++ b/internal/storage/agent_token_owner_test.go
@@ -140,7 +140,7 @@ func TestAgentToken_RevokeAndRegenerateAreOwnerScoped(t *testing.T) {
 	// would for a name nobody has.
 	assert.ErrorIs(t, manager.RevokeAgentTokenForOwner("userC", "ci"), ErrAgentTokenNotFound)
 	assert.ErrorIs(t, manager.RevokeAgentTokenForOwner("userC", "nope"), ErrAgentTokenNotFound)
-	_, err := manager.RegenerateAgentTokenForOwner("userC", "ci", "mcp_agt_whatever", testHMACKey)
+	_, err := manager.RegenerateAgentTokenForOwner("userC", "ci", "mcp_agt_whatever", testHMACKey, nil)
 	assert.ErrorIs(t, err, ErrAgentTokenNotFound)
 
 	// Positive control: the owner CAN revoke, and only their own record moves.
@@ -160,7 +160,7 @@ func TestAgentToken_RevokeAndRegenerateAreOwnerScoped(t *testing.T) {
 	// Regenerate is likewise confined to the owner's record.
 	newRawB, err := auth.GenerateToken()
 	require.NoError(t, err)
-	updatedB, err := manager.RegenerateAgentTokenForOwner("userB", "ci", newRawB, testHMACKey)
+	updatedB, err := manager.RegenerateAgentTokenForOwner("userB", "ci", newRawB, testHMACKey, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "userB", updatedB.UserID)
 	_, err = manager.ValidateAgentToken(newRawB, testHMACKey)

--- a/internal/storage/agent_token_owner_test.go
+++ b/internal/storage/agent_token_owner_test.go
@@ -1,0 +1,235 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+)
+
+// legacyNameIndexEntry reads the raw legacy owner-blind name->hash index so a
+// test can assert what the personal edition sees on disk.
+func legacyNameIndexEntry(t *testing.T, m *Manager, name string) string {
+	t.Helper()
+	var out string
+	err := m.db.db.View(func(tx *bbolt.Tx) error {
+		b := tx.Bucket([]byte(AgentTokenNamesBucket))
+		if b == nil {
+			return nil
+		}
+		if v := b.Get([]byte(name)); v != nil {
+			out = string(v)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	return out
+}
+
+// makeOwnedTestToken builds a token record with an explicit owner.
+func makeOwnedTestToken(t *testing.T, name, userID string) (auth.AgentToken, string) {
+	t.Helper()
+	rawToken, err := auth.GenerateToken()
+	require.NoError(t, err)
+	return auth.AgentToken{
+		Name:           name,
+		UserID:         userID,
+		AllowedServers: []string{"*"},
+		Permissions:    []string{"read"},
+	}, rawToken
+}
+
+// TestAgentToken_SameNameDifferentOwners: token names are a PER-OWNER
+// namespace, so two tenants can each hold a token called "ci".
+//
+// BITE VERIFICATION NOTE: this test calls the new owner-scoped methods, so
+// simply reverting the whole change makes the package fail to BUILD, which
+// proves nothing. To see it bite, keep the new methods and make the duplicate
+// check in CreateAgentToken owner-blind again (resolve with
+// findAgentTokenHashLocked ignoring token.UserID); the second create then
+// fails with ErrAgentTokenNameExists.
+func TestAgentToken_SameNameDifferentOwners(t *testing.T) {
+	manager, cleanup := setupTestStorageForAgentTokens(t)
+	defer cleanup()
+
+	tokenA, rawA := makeOwnedTestToken(t, "ci", "userA")
+	tokenB, rawB := makeOwnedTestToken(t, "ci", "userB")
+
+	require.NoError(t, manager.CreateAgentToken(tokenA, rawA, testHMACKey))
+	require.NoError(t, manager.CreateAgentToken(tokenB, rawB, testHMACKey),
+		"a second tenant must be able to name their token %q", "ci")
+
+	gotA, err := manager.GetAgentTokenByOwnerAndName("userA", "ci")
+	require.NoError(t, err)
+	require.NotNil(t, gotA)
+	gotB, err := manager.GetAgentTokenByOwnerAndName("userB", "ci")
+	require.NoError(t, err)
+	require.NotNil(t, gotB)
+
+	assert.NotEqual(t, gotA.TokenHash, gotB.TokenHash, "the two owners must resolve to different records")
+	assert.Equal(t, "userA", gotA.UserID)
+	assert.Equal(t, "userB", gotB.UserID)
+
+	// A third tenant sees nothing, and so does the ownerless namespace the
+	// personal edition uses.
+	gotC, err := manager.GetAgentTokenByOwnerAndName("userC", "ci")
+	require.NoError(t, err)
+	assert.Nil(t, gotC)
+	gotBare, err := manager.GetAgentTokenByName("ci")
+	require.NoError(t, err)
+	assert.Nil(t, gotBare, "a user-owned name must not be resolvable in the ownerless namespace")
+
+	// Same owner, same name is still a conflict — and it is a typed one, so
+	// handlers never have to echo a storage string.
+	dupe, rawDupe := makeOwnedTestToken(t, "ci", "userA")
+	err = manager.CreateAgentToken(dupe, rawDupe, testHMACKey)
+	assert.ErrorIs(t, err, ErrAgentTokenNameExists)
+}
+
+// TestAgentToken_DeleteForOwnerLeavesOtherOwner guards the sharpest regression
+// a per-owner namespace could cause: one tenant's delete nuking another
+// tenant's live credential.
+func TestAgentToken_DeleteForOwnerLeavesOtherOwner(t *testing.T) {
+	manager, cleanup := setupTestStorageForAgentTokens(t)
+	defer cleanup()
+
+	tokenA, rawA := makeOwnedTestToken(t, "ci", "userA")
+	tokenB, rawB := makeOwnedTestToken(t, "ci", "userB")
+	require.NoError(t, manager.CreateAgentToken(tokenA, rawA, testHMACKey))
+	require.NoError(t, manager.CreateAgentToken(tokenB, rawB, testHMACKey))
+
+	// Positive control: both raw tokens authenticate before the delete.
+	_, err := manager.ValidateAgentToken(rawA, testHMACKey)
+	require.NoError(t, err)
+	_, err = manager.ValidateAgentToken(rawB, testHMACKey)
+	require.NoError(t, err)
+
+	require.NoError(t, manager.DeleteAgentTokenForOwner("userA", "ci"))
+
+	// A's is gone...
+	gotA, err := manager.GetAgentTokenByOwnerAndName("userA", "ci")
+	require.NoError(t, err)
+	assert.Nil(t, gotA)
+	_, err = manager.ValidateAgentToken(rawA, testHMACKey)
+	assert.Error(t, err)
+
+	// ...B's is untouched and still authenticates.
+	gotB, err := manager.GetAgentTokenByOwnerAndName("userB", "ci")
+	require.NoError(t, err)
+	require.NotNil(t, gotB)
+	validatedB, err := manager.ValidateAgentToken(rawB, testHMACKey)
+	require.NoError(t, err, "one tenant's delete revoked another tenant's live credential")
+	assert.Equal(t, "userB", validatedB.UserID)
+}
+
+// TestAgentToken_RevokeAndRegenerateAreOwnerScoped: the mutators must refuse a
+// name they do not own, and must not touch the other owner's record.
+func TestAgentToken_RevokeAndRegenerateAreOwnerScoped(t *testing.T) {
+	manager, cleanup := setupTestStorageForAgentTokens(t)
+	defer cleanup()
+
+	tokenA, rawA := makeOwnedTestToken(t, "ci", "userA")
+	tokenB, rawB := makeOwnedTestToken(t, "ci", "userB")
+	require.NoError(t, manager.CreateAgentToken(tokenA, rawA, testHMACKey))
+	require.NoError(t, manager.CreateAgentToken(tokenB, rawB, testHMACKey))
+
+	// userC owns nothing: both mutators report the same "not found" as they
+	// would for a name nobody has.
+	assert.ErrorIs(t, manager.RevokeAgentTokenForOwner("userC", "ci"), ErrAgentTokenNotFound)
+	assert.ErrorIs(t, manager.RevokeAgentTokenForOwner("userC", "nope"), ErrAgentTokenNotFound)
+	_, err := manager.RegenerateAgentTokenForOwner("userC", "ci", "mcp_agt_whatever", testHMACKey)
+	assert.ErrorIs(t, err, ErrAgentTokenNotFound)
+
+	// Positive control: the owner CAN revoke, and only their own record moves.
+	require.NoError(t, manager.RevokeAgentTokenForOwner("userA", "ci"))
+	gotA, err := manager.GetAgentTokenByOwnerAndName("userA", "ci")
+	require.NoError(t, err)
+	require.NotNil(t, gotA)
+	assert.True(t, gotA.Revoked)
+
+	gotB, err := manager.GetAgentTokenByOwnerAndName("userB", "ci")
+	require.NoError(t, err)
+	require.NotNil(t, gotB)
+	assert.False(t, gotB.Revoked, "revoking one tenant's token revoked another's")
+	_, err = manager.ValidateAgentToken(rawB, testHMACKey)
+	assert.NoError(t, err)
+
+	// Regenerate is likewise confined to the owner's record.
+	newRawB, err := auth.GenerateToken()
+	require.NoError(t, err)
+	updatedB, err := manager.RegenerateAgentTokenForOwner("userB", "ci", newRawB, testHMACKey)
+	require.NoError(t, err)
+	assert.Equal(t, "userB", updatedB.UserID)
+	_, err = manager.ValidateAgentToken(newRawB, testHMACKey)
+	assert.NoError(t, err)
+	// A's record is still the revoked one, not B's regenerated hash.
+	gotA, err = manager.GetAgentTokenByOwnerAndName("userA", "ci")
+	require.NoError(t, err)
+	require.NotNil(t, gotA)
+	assert.True(t, gotA.Revoked)
+	assert.NotEqual(t, updatedB.TokenHash, gotA.TokenHash)
+}
+
+// TestAgentToken_LastUsedByHashStampsOnlyThatRecord: the auth hot path stamps
+// by hash, which is unique across owners, so it can never touch the other
+// tenant's token.
+func TestAgentToken_LastUsedByHashStampsOnlyThatRecord(t *testing.T) {
+	manager, cleanup := setupTestStorageForAgentTokens(t)
+	defer cleanup()
+
+	tokenA, rawA := makeOwnedTestToken(t, "ci", "userA")
+	tokenB, rawB := makeOwnedTestToken(t, "ci", "userB")
+	require.NoError(t, manager.CreateAgentToken(tokenA, rawA, testHMACKey))
+	require.NoError(t, manager.CreateAgentToken(tokenB, rawB, testHMACKey))
+
+	validatedB, err := manager.ValidateAgentToken(rawB, testHMACKey)
+	require.NoError(t, err)
+	require.NoError(t, manager.UpdateAgentTokenLastUsedByHash(validatedB.TokenHash))
+
+	gotB, err := manager.GetAgentTokenByOwnerAndName("userB", "ci")
+	require.NoError(t, err)
+	require.NotNil(t, gotB)
+	require.NotNil(t, gotB.LastUsedAt, "the owner's own token must be stamped")
+
+	gotA, err := manager.GetAgentTokenByOwnerAndName("userA", "ci")
+	require.NoError(t, err)
+	require.NotNil(t, gotA)
+	assert.Nil(t, gotA.LastUsedAt, "using one tenant's token stamped another tenant's record")
+}
+
+// TestAgentToken_PersonalEditionNamespaceUnchanged: ownerless tokens keep the
+// exact behaviour the personal edition has always had, including the legacy
+// bare-name index entry, so a rollback reads back what it wrote.
+func TestAgentToken_PersonalEditionNamespaceUnchanged(t *testing.T) {
+	manager, cleanup := setupTestStorageForAgentTokens(t)
+	defer cleanup()
+
+	token, raw := makeTestToken("ci")
+	require.NoError(t, manager.CreateAgentToken(token, raw, testHMACKey))
+
+	got, err := manager.GetAgentTokenByName("ci")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Empty(t, got.UserID)
+
+	// Global uniqueness still holds within the ownerless namespace.
+	dupe, rawDupe := makeTestToken("ci")
+	assert.ErrorIs(t, manager.CreateAgentToken(dupe, rawDupe, testHMACKey), ErrAgentTokenNameExists)
+
+	// The legacy index entry is still written for ownerless tokens.
+	assert.Equal(t, got.TokenHash, legacyNameIndexEntry(t, manager, "ci"),
+		"the personal edition's legacy name index must be unchanged")
+
+	// ...and it is NOT written for owned tokens.
+	owned, rawOwned := makeOwnedTestToken(t, "owned-only", "userA")
+	require.NoError(t, manager.CreateAgentToken(owned, rawOwned, testHMACKey))
+	assert.Empty(t, legacyNameIndexEntry(t, manager, "owned-only"),
+		"a user-owned name must not claim the global index slot")
+
+	require.NoError(t, manager.DeleteAgentToken("ci"))
+	assert.Empty(t, legacyNameIndexEntry(t, manager, "ci"),
+		"deleting an ownerless token must free its legacy index entry")
+}

--- a/internal/storage/agent_token_regenerate_test.go
+++ b/internal/storage/agent_token_regenerate_test.go
@@ -1,0 +1,198 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+)
+
+// TestAgentToken_RegenerateDoesNotResurrectARevokedToken is finding N4.
+//
+// Disabling a user REVOKES every agent token they minted, and enableUser
+// documents why: "re-enabling an account cannot resurrect a credential that may
+// be why the account was disabled". RegenerateAgentTokenForOwner set
+// `token.Revoked = false`, so the owner could walk straight back through that
+// guarantee — name the burned token, get a fresh working secret for the very
+// record the admin burned. Rotation refreshes a live credential's secret; it is
+// not an un-revoke, and the two operations sit on opposite sides of a privilege
+// boundary (an admin revokes, the tenant rotates).
+//
+// Oracle discipline: the SAME rotation succeeds first, on the same token,
+// before it is revoked — so the later refusal is the Revoked flag and not a
+// broken rotation path.
+//
+// BITES: restore `token.Revoked = false` (and drop the ErrAgentTokenRevoked
+// guard) in RegenerateAgentTokenForOwner; the rotation succeeds and the token
+// authenticates again.
+func TestAgentToken_RegenerateDoesNotResurrectARevokedToken(t *testing.T) {
+	manager, cleanup := setupTestStorageForAgentTokens(t)
+	defer cleanup()
+
+	token, raw := makeOwnedTestToken(t, "ci", "userA")
+	require.NoError(t, manager.CreateAgentToken(token, raw, testHMACKey))
+
+	// Positive control: rotation works on a LIVE token.
+	firstRaw, err := auth.GenerateToken()
+	require.NoError(t, err)
+	rotated, err := manager.RegenerateAgentTokenForOwner("userA", "ci", firstRaw, testHMACKey, nil)
+	require.NoError(t, err, "positive control: a live token must be rotatable")
+	require.NotNil(t, rotated)
+	assert.False(t, rotated.Revoked)
+
+	// An admin disables the owner, which burns their tokens.
+	burned, err := manager.RevokeAgentTokensForOwner("userA")
+	require.NoError(t, err)
+	require.Equal(t, 1, burned, "fixture: the token must actually have been revoked")
+
+	secondRaw, err := auth.GenerateToken()
+	require.NoError(t, err)
+	resurrected, err := manager.RegenerateAgentTokenForOwner("userA", "ci", secondRaw, testHMACKey, nil)
+	require.Error(t, err, "a revoked token must not be rotatable")
+	assert.ErrorIs(t, err, ErrAgentTokenRevoked)
+	assert.Nil(t, resurrected)
+
+	// The refusal must be a real refusal, not a cosmetic one: the new secret
+	// must not authenticate, and the record must still be revoked.
+	got, err := manager.ValidateAgentToken(secondRaw, testHMACKey)
+	assert.Nil(t, got, "the would-be rotated secret must not authenticate")
+	assert.Error(t, err)
+
+	stored, err := manager.GetAgentTokenByOwnerAndName("userA", "ci")
+	require.NoError(t, err)
+	require.NotNil(t, stored, "revoke is a soft delete: the record stays visible to the operator")
+	assert.True(t, stored.Revoked, "the record must still be revoked")
+	assert.Equal(t, auth.HashToken(firstRaw, testHMACKey), stored.TokenHash,
+		"a refused rotation must not have rotated the hash either")
+}
+
+// TestAgentToken_RegenerateRefusalIsOwnerScoped keeps the #1168 fix intact: the
+// revoked branch must be reachable ONLY by the record's own owner, so it can
+// never become an oracle for another tenant's token names. A different tenant
+// asking about the same name gets the ordinary not-found.
+func TestAgentToken_RegenerateRefusalIsOwnerScoped(t *testing.T) {
+	manager, cleanup := setupTestStorageForAgentTokens(t)
+	defer cleanup()
+
+	token, raw := makeOwnedTestToken(t, "ci", "userA")
+	require.NoError(t, manager.CreateAgentToken(token, raw, testHMACKey))
+	require.NoError(t, manager.RevokeAgentTokenForOwner("userA", "ci"))
+
+	newRaw, err := auth.GenerateToken()
+	require.NoError(t, err)
+	_, err = manager.RegenerateAgentTokenForOwner("userB", "ci", newRaw, testHMACKey, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAgentTokenNotFound,
+		"another tenant must not learn that the name exists, let alone that it is revoked")
+	assert.NotErrorIs(t, err, ErrAgentTokenRevoked)
+}
+
+// TestAgentToken_RegenerateDoesNotStompForeignLegacyNameEntry is finding N5.
+//
+// The repoint rule was `userID == "" || indexed == oldHash`. The first disjunct
+// claimed the legacy owner-blind slot for ANY ownerless rotation, regardless of
+// what the entry held — including the pre-upgrade server-edition entry the
+// AgentTokenNamesBucket comment promises to preserve so a rollback is not
+// stranded. That is the same stomp CreateAgentToken was fixed for on this
+// branch, left behind on the third maintenance path, and it contradicts the
+// branch's own no-migration rollback rationale.
+//
+// BITES: restore the `userID == "" ||` disjunct and the index below points at
+// the rotated ownerless token instead of the pre-upgrade tenant's hash.
+func TestAgentToken_RegenerateDoesNotStompForeignLegacyNameEntry(t *testing.T) {
+	manager, cleanup := setupTestStorageForAgentTokens(t)
+	defer cleanup()
+
+	// Pre-upgrade deployment: a tenant's owned token plus the owner-blind index
+	// entry the OLD code wrote for it.
+	tenantToken, tenantRaw := makeOwnedTestToken(t, "ci", "userA")
+	require.NoError(t, manager.CreateAgentToken(tenantToken, tenantRaw, testHMACKey))
+	tenantHash := auth.HashToken(tenantRaw, testHMACKey)
+	require.NoError(t, manager.db.db.Update(func(tx *bbolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists([]byte(AgentTokenNamesBucket))
+		if err != nil {
+			return err
+		}
+		return b.Put([]byte("ci"), []byte(tenantHash))
+	}))
+
+	// An ownerless (personal-edition) token of the same name. Create already
+	// declines to claim the occupied slot, which is the fixture this test needs.
+	ownerless, ownerlessRaw := makeOwnedTestToken(t, "ci", "")
+	require.NoError(t, manager.CreateAgentToken(ownerless, ownerlessRaw, testHMACKey))
+	require.Equal(t, tenantHash, legacyNameIndexEntry(t, manager, "ci"),
+		"fixture: the pre-upgrade entry must still hold the slot before the rotation under test")
+
+	newRaw, err := auth.GenerateToken()
+	require.NoError(t, err)
+	rotated, err := manager.RegenerateAgentToken("ci", newRaw, testHMACKey)
+	require.NoError(t, err, "the ownerless token must still be rotatable")
+	require.NotNil(t, rotated)
+
+	assert.Equal(t, tenantHash, legacyNameIndexEntry(t, manager, "ci"),
+		"the pre-upgrade tenant's index entry must survive a rotation it has nothing to do with")
+
+	// Declining the index costs the rotated token nothing: resolution is by scan.
+	resolved, err := manager.GetAgentTokenByOwnerAndName("", "ci")
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+	assert.Equal(t, auth.HashToken(newRaw, testHMACKey), resolved.TokenHash)
+	authed, err := manager.ValidateAgentToken(newRaw, testHMACKey)
+	require.NoError(t, err, "the rotated secret must authenticate")
+	require.NotNil(t, authed)
+}
+
+// TestAgentToken_RegenerateKeepsItsOwnLegacyNameEntryInStep is the other side
+// of the rule: when the index DOES point at the record being rotated, it must
+// follow the new hash — that is the whole reason the index is maintained. This
+// keeps the N5 guard from being too strict and silently stranding the personal
+// edition's own lookups.
+func TestAgentToken_RegenerateKeepsItsOwnLegacyNameEntryInStep(t *testing.T) {
+	manager, cleanup := setupTestStorageForAgentTokens(t)
+	defer cleanup()
+
+	ownerless, raw := makeOwnedTestToken(t, "deploy-bot", "")
+	require.NoError(t, manager.CreateAgentToken(ownerless, raw, testHMACKey))
+	require.Equal(t, auth.HashToken(raw, testHMACKey), legacyNameIndexEntry(t, manager, "deploy-bot"),
+		"fixture: an ownerless create claims the free slot")
+
+	newRaw, err := auth.GenerateToken()
+	require.NoError(t, err)
+	_, err = manager.RegenerateAgentToken("deploy-bot", newRaw, testHMACKey)
+	require.NoError(t, err)
+
+	assert.Equal(t, auth.HashToken(newRaw, testHMACKey),
+		legacyNameIndexEntry(t, manager, "deploy-bot"),
+		"the index must follow the record it points at across a rotation")
+}
+
+// TestAgentToken_RegenerateKeepsAnOwnedTokensOwnLegacyEntryInStep covers the
+// pre-per-owner-scoping case: an OWNED token whose name predates the scoping
+// still holds the legacy slot, and rotating it must keep that entry live rather
+// than leaving it dangling at a hash that no longer exists.
+func TestAgentToken_RegenerateKeepsAnOwnedTokensOwnLegacyEntryInStep(t *testing.T) {
+	manager, cleanup := setupTestStorageForAgentTokens(t)
+	defer cleanup()
+
+	owned, raw := makeOwnedTestToken(t, "ci", "userA")
+	require.NoError(t, manager.CreateAgentToken(owned, raw, testHMACKey))
+	oldHash := auth.HashToken(raw, testHMACKey)
+	require.NoError(t, manager.db.db.Update(func(tx *bbolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists([]byte(AgentTokenNamesBucket))
+		if err != nil {
+			return err
+		}
+		return b.Put([]byte("ci"), []byte(oldHash))
+	}))
+
+	newRaw, err := auth.GenerateToken()
+	require.NoError(t, err)
+	_, err = manager.RegenerateAgentTokenForOwner("userA", "ci", newRaw, testHMACKey, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, auth.HashToken(newRaw, testHMACKey), legacyNameIndexEntry(t, manager, "ci"),
+		"an entry that pointed at this very record must follow it")
+}

--- a/internal/storage/agent_token_resilience_test.go
+++ b/internal/storage/agent_token_resilience_test.go
@@ -71,16 +71,20 @@ func TestAgentToken_CorruptRecordDoesNotBreakOtherTenants(t *testing.T) {
 	require.NoError(t, manager.CreateAgentToken(other, rawOther, testHMACKey),
 		"a corrupt row must not stop another tenant creating a token")
 
-	// Revoke, regenerate and delete on the healthy record.
-	require.NoError(t, manager.RevokeAgentTokenForOwner("userA", "ci"),
-		"a corrupt row must not break revoke")
-
+	// Regenerate, revoke and delete on the healthy record. Regenerate comes
+	// FIRST: a revoked token is no longer rotatable (rotation is not an
+	// un-revoke), so revoking first would make regenerate answer
+	// ErrAgentTokenRevoked and stop exercising the corrupt-row tolerance this
+	// test is about.
 	newRaw, err := auth.GenerateToken()
 	require.NoError(t, err)
 	regenerated, err := manager.RegenerateAgentTokenForOwner("userA", "ci", newRaw, testHMACKey, nil)
 	require.NoError(t, err, "a corrupt row must not break regenerate")
 	require.NotNil(t, regenerated)
-	assert.False(t, regenerated.Revoked, "regenerate clears the revoked flag")
+	assert.False(t, regenerated.Revoked, "a live token stays live across rotation")
+
+	require.NoError(t, manager.RevokeAgentTokenForOwner("userA", "ci"),
+		"a corrupt row must not break revoke")
 
 	require.NoError(t, manager.DeleteAgentTokenForOwner("userA", "ci"),
 		"a corrupt row must not break delete")

--- a/internal/storage/agent_token_resilience_test.go
+++ b/internal/storage/agent_token_resilience_test.go
@@ -1,0 +1,210 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+)
+
+// writeRawAgentTokenRecord plants an arbitrary byte string into the
+// agent_tokens bucket under the given key, bypassing every validation the
+// normal write path performs. This is how a truncated write, a hand-edited DB
+// or a record from a future schema actually appears at rest.
+func writeRawAgentTokenRecord(t *testing.T, m *Manager, key string, value []byte) {
+	t.Helper()
+	require.NoError(t, m.db.db.Update(func(tx *bbolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists([]byte(AgentTokensBucket))
+		if err != nil {
+			return err
+		}
+		return b.Put([]byte(key), value)
+	}))
+}
+
+// TestAgentToken_CorruptRecordDoesNotBreakOtherTenants pins the blast radius of
+// one unparseable row.
+//
+// The owner-scoped lookup WALKS the whole agent_tokens bucket (a bare name is
+// ambiguous once names are per-owner, so it cannot read a single indexed
+// record). Returning an error on the first row that fails json.Unmarshal
+// therefore turned every management operation — create, revoke, delete,
+// regenerate, for EVERY tenant of the deployment — into a 500 as soon as one
+// record went bad. The indexed read it replaced could not do that: it only ever
+// touched the one record it was asked for.
+//
+// The contract now: skip the bad row, log it, keep going. One corrupt record
+// degrades to "that token is unresolvable" and nothing more.
+//
+// Oracle discipline: a positive control runs FIRST on the same manager, so a
+// later success cannot be an empty bucket or an unwired store; and every
+// mutator is exercised, because the defect was in the shared resolver they all
+// call, not in any one of them.
+//
+// BITES: restore the `return fmt.Errorf("failed to unmarshal agent token: %w",
+// err)` inside findAgentTokenHashLocked's ForEach and every assertion below
+// that touches an operation after the corrupt row fails with that error.
+func TestAgentToken_CorruptRecordDoesNotBreakOtherTenants(t *testing.T) {
+	manager, cleanup := setupTestStorageForAgentTokens(t)
+	defer cleanup()
+
+	// Positive control BEFORE the corruption: the store works at all.
+	healthy, rawHealthy := makeOwnedTestToken(t, "ci", "userA")
+	require.NoError(t, manager.CreateAgentToken(healthy, rawHealthy, testHMACKey),
+		"positive control: a plain create must succeed on a clean store")
+
+	// Now plant an unparseable record. Keyed like a real hash so it sorts into
+	// the middle of the bucket rather than being conveniently last.
+	writeRawAgentTokenRecord(t, manager, "0000corrupt0000", []byte("{not json at all"))
+
+	// Every by-name path must still work for every OTHER token.
+	found, err := manager.GetAgentTokenByOwnerAndName("userA", "ci")
+	require.NoError(t, err, "a corrupt row must not break a healthy token's lookup")
+	require.NotNil(t, found)
+	assert.Equal(t, "ci", found.Name)
+
+	// Create for a different tenant.
+	other, rawOther := makeOwnedTestToken(t, "ci", "userB")
+	require.NoError(t, manager.CreateAgentToken(other, rawOther, testHMACKey),
+		"a corrupt row must not stop another tenant creating a token")
+
+	// Revoke, regenerate and delete on the healthy record.
+	require.NoError(t, manager.RevokeAgentTokenForOwner("userA", "ci"),
+		"a corrupt row must not break revoke")
+
+	newRaw, err := auth.GenerateToken()
+	require.NoError(t, err)
+	regenerated, err := manager.RegenerateAgentTokenForOwner("userA", "ci", newRaw, testHMACKey, nil)
+	require.NoError(t, err, "a corrupt row must not break regenerate")
+	require.NotNil(t, regenerated)
+	assert.False(t, regenerated.Revoked, "regenerate clears the revoked flag")
+
+	require.NoError(t, manager.DeleteAgentTokenForOwner("userA", "ci"),
+		"a corrupt row must not break delete")
+
+	// And the corrupt row itself degrades to "unresolvable", not to an error.
+	gone, err := manager.GetAgentTokenByOwnerAndName("userA", "ci")
+	require.NoError(t, err)
+	assert.Nil(t, gone, "the deleted token must now resolve to nothing, without an error")
+}
+
+// TestAgentToken_CreateDoesNotStompForeignLegacyNameEntry pins the rollback
+// promise the AgentTokenNamesBucket comment makes.
+//
+// That comment says a pre-upgrade server-edition entry is deliberately left in
+// place so a rollback is not stranded — but CreateAgentToken used to Put the
+// name->hash mapping unconditionally, so creating an OWNERLESS token of the same
+// name overwrote exactly the entry the comment promises to preserve. On the old
+// code that entry is how a tenant's token resolves by name, so the overwrite
+// repoints their name at somebody else's credential record.
+//
+// The slot is now CLAIMED: taken when free or dangling, left alone when a live
+// record holds it.
+//
+// BITES: drop the claimAgentTokenNameSlot guard and the index entry below points
+// at the new ownerless token's hash instead of the pre-upgrade tenant's.
+func TestAgentToken_CreateDoesNotStompForeignLegacyNameEntry(t *testing.T) {
+	manager, cleanup := setupTestStorageForAgentTokens(t)
+	defer cleanup()
+
+	// A pre-upgrade server-edition deployment: a tenant's owned token, plus the
+	// owner-blind index entry the OLD code wrote for it.
+	tenantToken, tenantRaw := makeOwnedTestToken(t, "ci", "userA")
+	require.NoError(t, manager.CreateAgentToken(tenantToken, tenantRaw, testHMACKey))
+	tenantHash := auth.HashToken(tenantRaw, testHMACKey)
+	require.NoError(t, manager.db.db.Update(func(tx *bbolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists([]byte(AgentTokenNamesBucket))
+		if err != nil {
+			return err
+		}
+		return b.Put([]byte("ci"), []byte(tenantHash))
+	}))
+	require.Equal(t, tenantHash, legacyNameIndexEntry(t, manager, "ci"),
+		"fixture: the pre-upgrade index entry must be in place before the create under test")
+
+	// Now the personal edition creates an OWNERLESS token with the same name.
+	ownerless, ownerlessRaw := makeOwnedTestToken(t, "ci", "")
+	require.NoError(t, manager.CreateAgentToken(ownerless, ownerlessRaw, testHMACKey),
+		"an ownerless token must still be creatable alongside a tenant's same-named one")
+
+	assert.Equal(t, tenantHash, legacyNameIndexEntry(t, manager, "ci"),
+		"the pre-upgrade tenant's index entry must survive: overwriting it is the rollback stranding the bucket comment promises not to cause")
+
+	// The new token is unaffected by not holding the index: resolution is by scan.
+	resolved, err := manager.GetAgentTokenByOwnerAndName("", "ci")
+	require.NoError(t, err)
+	require.NotNil(t, resolved, "the ownerless token must resolve without owning the legacy index slot")
+	assert.Equal(t, auth.HashToken(ownerlessRaw, testHMACKey), resolved.TokenHash)
+}
+
+// TestAgentToken_CreateClaimsDanglingLegacyNameEntry is the other side of the
+// claim rule: an entry pointing at a hash that is no longer in agent_tokens
+// resolves to nothing on any code path, so no rollback depends on it and the
+// personal edition should reclaim the slot. Without this the guard would be too
+// strict — one stale byte would permanently deny the index to its rightful
+// owner.
+func TestAgentToken_CreateClaimsDanglingLegacyNameEntry(t *testing.T) {
+	manager, cleanup := setupTestStorageForAgentTokens(t)
+	defer cleanup()
+
+	require.NoError(t, manager.db.db.Update(func(tx *bbolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists([]byte(AgentTokenNamesBucket))
+		if err != nil {
+			return err
+		}
+		return b.Put([]byte("ci"), []byte("hash-of-a-token-that-no-longer-exists"))
+	}))
+
+	ownerless, ownerlessRaw := makeOwnedTestToken(t, "ci", "")
+	require.NoError(t, manager.CreateAgentToken(ownerless, ownerlessRaw, testHMACKey))
+
+	assert.Equal(t, auth.HashToken(ownerlessRaw, testHMACKey), legacyNameIndexEntry(t, manager, "ci"),
+		"a dangling index entry points at nothing and must be reclaimed")
+}
+
+// TestAgentToken_RegenerateNarrowsScope pins the narrowing hook that closes the
+// "un-sharing does not revoke live grants" gap at rotation time. It must apply
+// the caller's filter to what is PERSISTED, not merely to what is returned —
+// otherwise the trimmed grant stays live in storage.
+//
+// BITES: drop the `if narrowScope != nil` block in
+// RegenerateAgentTokenForOwner; the reread below still shows ["*"].
+func TestAgentToken_RegenerateNarrowsScope(t *testing.T) {
+	manager, cleanup := setupTestStorageForAgentTokens(t)
+	defer cleanup()
+
+	// A pre-branch token: a literal star, which the enforcement layer honours
+	// unconditionally.
+	token, raw := makeOwnedTestToken(t, "legacy", "userA")
+	require.Equal(t, []string{"*"}, token.AllowedServers, "fixture: the token starts with a star")
+	require.NoError(t, manager.CreateAgentToken(token, raw, testHMACKey))
+
+	newRaw, err := auth.GenerateToken()
+	require.NoError(t, err)
+
+	updated, err := manager.RegenerateAgentTokenForOwner("userA", "legacy", newRaw, testHMACKey,
+		func([]string) []string { return []string{"only-this"} })
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+	assert.Equal(t, []string{"only-this"}, updated.AllowedServers, "the returned record must carry the narrowed scope")
+
+	// The persisted record is what actually matters: the returned struct could
+	// be narrowed while storage kept the star.
+	reread, err := manager.GetAgentTokenByOwnerAndName("userA", "legacy")
+	require.NoError(t, err)
+	require.NotNil(t, reread)
+	assert.Equal(t, []string{"only-this"}, reread.AllowedServers,
+		"the narrowed scope must be PERSISTED, not just returned")
+
+	// A nil hook leaves the scope alone — the personal edition's contract.
+	plain, plainRaw := makeOwnedTestToken(t, "plain", "userA")
+	require.NoError(t, manager.CreateAgentToken(plain, plainRaw, testHMACKey))
+	plainNewRaw, err := auth.GenerateToken()
+	require.NoError(t, err)
+	plainUpdated, err := manager.RegenerateAgentTokenForOwner("userA", "plain", plainNewRaw, testHMACKey, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"*"}, plainUpdated.AllowedServers, "a nil hook must not touch the scope")
+}

--- a/internal/storage/agent_tokens.go
+++ b/internal/storage/agent_tokens.go
@@ -27,13 +27,18 @@ const (
 	// tenant's token.
 	//
 	// For that rollback promise to be true, all THREE maintenance paths must
-	// leave a foreign entry alone, not just the two that already did. Create
-	// used to Put unconditionally, overwriting whatever the name pointed at —
-	// including a pre-upgrade tenant's entry, the very thing the paragraph
-	// above promises to preserve. It now claims the slot only when the slot is
-	// free, or when the entry it holds dangles (its hash is no longer in
-	// agent_tokens). Delete and regenerate already required the entry to point
-	// at the very record being mutated.
+	// leave a foreign entry alone. Only delete already did, by requiring the
+	// entry to point at the very record being removed.
+	//
+	//   - Create used to Put unconditionally, overwriting whatever the name
+	//     pointed at — including a pre-upgrade tenant's entry, the very thing
+	//     the paragraph above promises to preserve. It now CLAIMS the slot:
+	//     taken when free, or when the entry it holds dangles (its hash is no
+	//     longer in agent_tokens); left alone when a live record holds it.
+	//   - Regenerate used to repoint unconditionally for any OWNERLESS
+	//     rotation (`userID == "" || …`), with the same stomp. It now follows
+	//     the entry only when the entry points at the record being rotated, and
+	//     otherwise applies create's claim rule.
 	AgentTokenNamesBucket = "agent_token_names" //nolint:gosec // bucket name, not a credential
 )
 
@@ -61,6 +66,15 @@ var (
 	// "absent" from "owned by someone else" in their response: the lookup is
 	// owner-scoped, so both produce this same error.
 	ErrAgentTokenNotFound = errors.New("agent token not found")
+
+	// ErrAgentTokenRevoked is returned by RegenerateAgentTokenForOwner when the
+	// named token has been revoked. Rotation refreshes a LIVE credential's
+	// secret; it is not an un-revoke.
+	//
+	// It is safe to report to the token's owner: the lookup that produced it is
+	// owner-scoped, so it can only ever describe a record the caller already
+	// owns and can already see in their own token list.
+	ErrAgentTokenRevoked = errors.New("agent token is revoked")
 )
 
 // findAgentTokenHashLocked resolves an (owner, name) pair to the hash key of
@@ -580,6 +594,22 @@ func (m *Manager) RegenerateAgentTokenForOwner(userID, name string, newRawToken 
 			return ErrAgentTokenNotFound
 		}
 
+		// A revoked token is BURNED, and rotation must not resurrect it.
+		//
+		// This used to set Revoked = false, which quietly made regenerate an
+		// un-revoke by another name — and across a privilege boundary.
+		// Disabling a user revokes every token they minted precisely so that
+		// re-enabling the account cannot hand back the credential that may be
+		// why it was disabled (see RevokeAgentTokensForOwner and the enableUser
+		// handler, which documents exactly that). But regenerate is a TENANT
+		// operation: once re-enabled, the owner could name the burned token and
+		// get a working secret for the very record an admin had burned,
+		// contradicting the guarantee enable makes. Deletion frees the name, so
+		// creating a fresh token is the supported path and nothing is stuck.
+		if token.Revoked {
+			return ErrAgentTokenRevoked
+		}
+
 		tokenBucket := tx.Bucket([]byte(AgentTokensBucket))
 		if tokenBucket == nil {
 			return ErrAgentTokenNotFound
@@ -590,10 +620,10 @@ func (m *Manager) RegenerateAgentTokenForOwner(userID, name string, newRawToken 
 			return fmt.Errorf("failed to delete old agent token hash: %w", err)
 		}
 
-		// Update token with new hash and prefix, clear revoked status
+		// Update token with new hash and prefix. Revoked is deliberately NOT
+		// touched: it is false here, because a revoked token was refused above.
 		token.TokenHash = newHash
 		token.TokenPrefix = newPrefix
-		token.Revoked = false
 
 		// Re-apply the caller's current server entitlement, if they supplied
 		// one. Narrowing only, enforced by the intersection below rather than
@@ -612,12 +642,37 @@ func (m *Manager) RegenerateAgentTokenForOwner(userID, name string, newRawToken 
 			return fmt.Errorf("failed to store regenerated agent token: %w", err)
 		}
 
-		// Keep the legacy owner-blind index in step only where it is
-		// maintained (ownerless tokens) or where it still points at this very
-		// record, so one owner's regenerate can never repoint another's entry.
+		// Keep the legacy owner-blind index in step, without ever stomping an
+		// entry that belongs to somebody else.
+		//
+		// Two ways to earn the Put, and `userID == ""` is not one of them. That
+		// disjunct claimed the slot for any ownerless rotation regardless of
+		// what the entry held — including the pre-upgrade server-edition entry
+		// the AgentTokenNamesBucket comment promises to leave intact, which on
+		// a rollback is a live tenant's token. It also contradicted the two
+		// sibling paths: create goes through claimAgentTokenNameSlot and delete
+		// requires the entry to point at the record being removed, so regenerate
+		// was the one maintenance path that could strand a rollback.
+		//
+		//  1. The entry still points at THIS record (its hash is oldHash) —
+		//     true for an owned token whose name predates per-owner scoping,
+		//     and the ordinary case for an ownerless one. Keeping it in step is
+		//     the whole point of the index.
+		//  2. The token is ownerless AND the slot is free or DANGLES — the same
+		//     rule create applies, so an ownerless token whose index entry went
+		//     missing can re-establish it without displacing a live record.
+		//     Evaluated after the Delete/Put above, so an entry pointing at
+		//     oldHash already reads as dangling; case 1 is what makes the
+		//     intent explicit rather than incidental.
+		//
+		// Declining the Put costs this token nothing: findAgentTokenHashLocked
+		// resolves by scan and never reads this index.
 		if nameBucket := tx.Bucket([]byte(AgentTokenNamesBucket)); nameBucket != nil {
 			indexed := nameBucket.Get([]byte(name))
-			repoint := userID == "" || (indexed != nil && string(indexed) == string(oldHash))
+			repoint := indexed != nil && string(indexed) == string(oldHash)
+			if !repoint && userID == "" {
+				repoint = claimAgentTokenNameSlot(tx, nameBucket, name)
+			}
 			if repoint {
 				if err := nameBucket.Put([]byte(name), []byte(newHash)); err != nil {
 					return fmt.Errorf("failed to update agent token name mapping: %w", err)

--- a/internal/storage/agent_tokens.go
+++ b/internal/storage/agent_tokens.go
@@ -50,6 +50,12 @@ var (
 	// is reached.
 	ErrAgentTokenLimitReached = errors.New("maximum number of agent tokens reached")
 
+	// ErrAgentTokenOwnerInactive is returned by ValidateAgentToken when a
+	// token's OWNER is no longer allowed to authenticate — disabled, or gone
+	// from the user store entirely. The token record itself may be perfectly
+	// valid; the identity it speaks for is not.
+	ErrAgentTokenOwnerInactive = errors.New("token owner is not active")
+
 	// ErrAgentTokenNotFound is returned by the owner-scoped mutators when the
 	// (owner, name) pair resolves to nothing. Callers MUST NOT distinguish
 	// "absent" from "owned by someone else" in their response: the lookup is
@@ -304,6 +310,15 @@ func (m *Manager) GetAgentTokenByHash(hash string) (*auth.AgentToken, error) {
 }
 
 // ListAgentTokens returns all stored agent tokens.
+//
+// A record that fails to unmarshal is SKIPPED, not fatal, for the same reason
+// findAgentTokenHashLocked skips one: this walks the whole bucket, so aborting
+// on the first bad row lets a single unparseable entry — a truncated write, a
+// hand-edited DB, a record from a future schema — turn every listing into a
+// 500 for EVERY tenant of the deployment, and for the operator's own
+// `mcpproxy token list` with it. Skipping degrades the blast radius to "that
+// one token is not listed". The skip is logged at WARN with the bucket key so
+// an operator can find the row; that key is an HMAC hash, not a credential.
 func (m *Manager) ListAgentTokens() ([]auth.AgentToken, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -319,7 +334,11 @@ func (m *Manager) ListAgentTokens() ([]auth.AgentToken, error) {
 		return tokenBucket.ForEach(func(k, v []byte) error {
 			var token auth.AgentToken
 			if err := json.Unmarshal(v, &token); err != nil {
-				return fmt.Errorf("failed to unmarshal agent token: %w", err)
+				if m.logger != nil {
+					m.logger.Warnw("skipping unparseable agent token record",
+						"bucket", AgentTokensBucket, "key", string(k), "error", err)
+				}
+				return nil
 			}
 			tokens = append(tokens, token)
 			return nil
@@ -370,6 +389,87 @@ func (m *Manager) RevokeAgentTokenForOwner(userID, name string) error {
 
 		return tokenBucket.Put(hash, updatedData)
 	})
+}
+
+// RevokeAgentTokensForOwner marks every token owned by userID as revoked and
+// returns how many it changed. An owner with no tokens is not an error.
+//
+// It is the credential half of disabling a user. The owner gate
+// (SetAgentTokenOwnerGate) already stops a disabled user's tokens the moment
+// they are disabled, but the gate is a live check: RE-ENABLING the account
+// would hand every previously minted token straight back, including the one
+// that caused the disable. Since disabling is the documented remediation for a
+// compromised account, the credentials minted under it are burned outright.
+// Revoked is a soft delete — the records stay, so the operator can still see
+// what existed — and the owner mints new tokens after being re-enabled.
+//
+// userID must not be empty: "" is the OWNERLESS namespace, i.e. every
+// personal-edition token, and a bulk revoke of it would be an outage rather
+// than a remediation.
+func (m *Manager) RevokeAgentTokensForOwner(userID string) (int, error) {
+	if userID == "" {
+		return 0, fmt.Errorf("agent token owner cannot be empty")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	revoked := 0
+
+	err := m.db.db.Update(func(tx *bbolt.Tx) error {
+		tokenBucket := tx.Bucket([]byte(AgentTokensBucket))
+		if tokenBucket == nil {
+			return nil
+		}
+
+		// Collect first: bbolt forbids mutating a bucket while iterating it.
+		type pending struct {
+			hash  []byte
+			token auth.AgentToken
+		}
+		var todo []pending
+
+		err := tokenBucket.ForEach(func(k, v []byte) error {
+			var token auth.AgentToken
+			if err := json.Unmarshal(v, &token); err != nil {
+				// Same tolerance as every other full-bucket walk here: one
+				// corrupt row must not abort a security remediation for the
+				// rows that ARE parseable.
+				if m.logger != nil {
+					m.logger.Warnw("skipping unparseable agent token record",
+						"bucket", AgentTokensBucket, "key", string(k), "error", err)
+				}
+				return nil
+			}
+			if token.UserID != userID || token.Revoked {
+				return nil
+			}
+			todo = append(todo, pending{hash: append([]byte(nil), k...), token: token})
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+
+		for i := range todo {
+			todo[i].token.Revoked = true
+			data, err := json.Marshal(todo[i].token)
+			if err != nil {
+				return fmt.Errorf("failed to marshal agent token: %w", err)
+			}
+			if err := tokenBucket.Put(todo[i].hash, data); err != nil {
+				return fmt.Errorf("failed to revoke agent token: %w", err)
+			}
+			revoked++
+		}
+
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	return revoked, nil
 }
 
 // DeleteAgentToken permanently removes an agent token, deleting both the record
@@ -443,11 +543,20 @@ func (m *Manager) RegenerateAgentToken(name string, newRawToken string, hmacKey 
 // re-checks it afterwards: un-sharing a server does not revoke the grants
 // already written into live tokens. Rotation is the one moment the owner's
 // current entitlement is known, so the server edition passes a filter that drops
-// anything they may no longer reach (see resolveTokenServerScope). It MUST only
-// ever narrow — a hook that widened would hand the caller a privilege escalation
-// through the one operation that is supposed to be neutral — and it MUST NOT do
-// I/O: it runs inside a write transaction while m.mu is held, so the caller
-// computes the entitled set before the call and passes a pure filter.
+// anything they may no longer reach (see resolveTokenServerScope).
+//
+// The hook can only ever NARROW, and that is ENFORCED here rather than merely
+// documented: whatever it returns is intersected with the token's stored
+// AllowedServers by intersectAllowedServers before anything is persisted. A
+// future caller that returned a wider list — or a constant, or the entitled set
+// itself — therefore cannot turn rotation, the one operation that is supposed to
+// be scope-neutral, into a privilege escalation. Hooks are still expected to
+// behave; the intersection is what makes misbehaving harmless instead of
+// load-bearing on a comment.
+//
+// The hook MUST NOT do I/O: it runs inside a write transaction while m.mu is
+// held, so the caller computes the entitled set before the call and passes a
+// pure filter.
 func (m *Manager) RegenerateAgentTokenForOwner(userID, name string, newRawToken string, hmacKey []byte, narrowScope func([]string) []string) (*auth.AgentToken, error) {
 	if name == "" {
 		return nil, fmt.Errorf("agent token name cannot be empty")
@@ -487,9 +596,10 @@ func (m *Manager) RegenerateAgentTokenForOwner(userID, name string, newRawToken 
 		token.Revoked = false
 
 		// Re-apply the caller's current server entitlement, if they supplied
-		// one. Narrowing only; see the doc comment.
+		// one. Narrowing only, enforced by the intersection below rather than
+		// trusted from the hook; see the doc comment.
 		if narrowScope != nil {
-			token.AllowedServers = narrowScope(token.AllowedServers)
+			token.AllowedServers = intersectAllowedServers(token.AllowedServers, narrowScope(token.AllowedServers))
 		}
 
 		updatedData, err := json.Marshal(token)
@@ -520,6 +630,56 @@ func (m *Manager) RegenerateAgentTokenForOwner(userID, name string, newRawToken 
 	})
 
 	return updated, err
+}
+
+// intersectAllowedServers returns the entries of proposed that the token's
+// current scope already granted. It is the storage-side enforcement of the
+// narrow-only contract on RegenerateAgentTokenForOwner's hook: the result can
+// never grant a server the token could not already reach, whatever the hook
+// returns.
+//
+// A stored "*" is treated as granting everything, so replacing it with a
+// concrete list is a narrowing and survives the intersection intact. That case
+// is not hypothetical: it is exactly how a token minted before per-owner
+// scoping existed — carrying a bare "*" — gets its unbounded grant converted
+// into a bounded one on its first rotation. Without the wildcard rule the
+// intersection would empty such a token instead, quietly bricking it.
+//
+// Order and duplicates follow proposed, so the hook still decides the shape of
+// the list it is allowed to produce.
+func intersectAllowedServers(current, proposed []string) []string {
+	if len(proposed) == 0 {
+		return nil
+	}
+
+	granted := make(map[string]struct{}, len(current))
+	wildcard := false
+	for _, name := range current {
+		if name == "*" {
+			wildcard = true
+		}
+		granted[name] = struct{}{}
+	}
+
+	out := make([]string, 0, len(proposed))
+	seen := make(map[string]struct{}, len(proposed))
+	for _, name := range proposed {
+		if !wildcard {
+			if _, ok := granted[name]; !ok {
+				continue
+			}
+		}
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // UpdateAgentTokenLastUsed updates the LastUsedAt timestamp for an OWNERLESS
@@ -614,8 +774,54 @@ func (m *Manager) GetAgentTokenCount() (int, error) {
 	return count, err
 }
 
+// agentTokenOwnerGate reports whether the user a token belongs to may still
+// authenticate. It is consulted on the authentication hot path, so it must be
+// cheap and must not block; a store lookup keyed by user id is what the server
+// edition installs.
+//
+// It is called ONLY for owned tokens (UserID != ""), never for the personal
+// edition's ownerless ones.
+type agentTokenOwnerGate func(userID string) (active bool, err error)
+
+// SetAgentTokenOwnerGate installs the predicate ValidateAgentToken consults for
+// every OWNED agent token. Passing nil removes it. Safe to call at any time.
+//
+// It exists because a token's authorisation is decided once, when the token is
+// minted, and nothing re-checks the identity behind it afterwards. Disabling a
+// user is the documented remediation for a compromised account — it revokes
+// their sessions and stops their JWTs — but the agent tokens they minted are
+// separate records that kept authenticating, still carrying that user's UserID
+// into every downstream authorisation and activity decision. The gate closes
+// that: the token is only as live as its owner.
+//
+// It FAILS CLOSED. A gate that errors denies the token rather than falling back
+// to "valid", because the failure mode of the alternative is precisely the hole
+// this closes. The personal edition installs no gate and is unaffected — its
+// tokens are all ownerless.
+func (m *Manager) SetAgentTokenOwnerGate(gate agentTokenOwnerGate) {
+	m.ownerGate.Store(gate)
+}
+
+// agentTokenOwnerActive applies the installed gate, if any. Reports true when
+// no gate is installed or the token is ownerless.
+func (m *Manager) agentTokenOwnerActive(userID string) (bool, error) {
+	if userID == "" {
+		return true, nil
+	}
+	v := m.ownerGate.Load()
+	if v == nil {
+		return true, nil
+	}
+	gate, _ := v.(agentTokenOwnerGate)
+	if gate == nil {
+		return true, nil
+	}
+	return gate(userID)
+}
+
 // ValidateAgentToken hashes the raw token and looks it up in storage.
-// Returns the token if found and valid (not expired, not revoked).
+// Returns the token if found and valid (not expired, not revoked) and its owner
+// is still allowed to authenticate.
 // Returns an error describing why validation failed.
 func (m *Manager) ValidateAgentToken(rawToken string, hmacKey []byte) (*auth.AgentToken, error) {
 	if !auth.ValidateTokenFormat(rawToken) {
@@ -638,6 +844,23 @@ func (m *Manager) ValidateAgentToken(rawToken string, hmacKey []byte) (*auth.Age
 
 	if token.IsExpired() {
 		return nil, fmt.Errorf("token has expired")
+	}
+
+	// The identity behind the token must still be live. Checked LAST so a
+	// revoked or expired token keeps its own, more specific answer, and so the
+	// gate is not consulted for credentials that were going to be refused
+	// anyway.
+	active, err := m.agentTokenOwnerActive(token.UserID)
+	if err != nil {
+		// Fail closed: a user store that cannot answer must not mean "yes".
+		if m.logger != nil {
+			m.logger.Warnw("denying agent token: owner status could not be determined",
+				"user_id", token.UserID, "token_prefix", token.TokenPrefix, "error", err)
+		}
+		return nil, ErrAgentTokenOwnerInactive
+	}
+	if !active {
+		return nil, ErrAgentTokenOwnerInactive
 	}
 
 	return token, nil

--- a/internal/storage/agent_tokens.go
+++ b/internal/storage/agent_tokens.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -11,14 +12,100 @@ import (
 
 // Bucket names for agent token storage.
 const (
-	AgentTokensBucket     = "agent_tokens"      //nolint:gosec // bucket name, not a credential
+	AgentTokensBucket = "agent_tokens" //nolint:gosec // bucket name, not a credential
+	// AgentTokenNamesBucket is a LEGACY, owner-blind name->hash index keyed by
+	// the bare token name. It is maintained only for tokens with no owner
+	// (UserID == ""), i.e. every personal-edition token, so the personal
+	// edition is byte-identical on disk and a rollback sees exactly what it
+	// wrote. Owner-scoped lookups never consult it — see
+	// findAgentTokenHashLocked. Entries left behind by a pre-upgrade
+	// server-edition deployment are simply not read; they are deliberately NOT
+	// swept, because sweeping them would strand those tokens on a rollback
+	// while every by-name path on the old code already re-checks ownership and
+	// can therefore only deny, never act on the wrong tenant's token.
 	AgentTokenNamesBucket = "agent_token_names" //nolint:gosec // bucket name, not a credential
 )
 
+// Sentinel errors returned by CreateAgentToken so callers can classify the
+// failure without matching on error strings (and without echoing a storage
+// message that would disclose another tenant's token name).
+var (
+	// ErrAgentTokenNameExists is returned when the OWNER already has a token
+	// with that name. Names are scoped per owner, so this never fires because
+	// of a different tenant's token.
+	ErrAgentTokenNameExists = errors.New("agent token with this name already exists")
+
+	// ErrAgentTokenLimitReached is returned when the deployment-wide token cap
+	// is reached.
+	ErrAgentTokenLimitReached = errors.New("maximum number of agent tokens reached")
+
+	// ErrAgentTokenNotFound is returned by the owner-scoped mutators when the
+	// (owner, name) pair resolves to nothing. Callers MUST NOT distinguish
+	// "absent" from "owned by someone else" in their response: the lookup is
+	// owner-scoped, so both produce this same error.
+	ErrAgentTokenNotFound = errors.New("agent token not found")
+)
+
+// findAgentTokenHashLocked resolves an (owner, name) pair to the hash key of
+// the authoritative record inside the given transaction. It scans the
+// agent_tokens bucket, which always carries both Name and UserID, rather than
+// consulting the legacy owner-blind name index. Returns (nil, nil) when the
+// pair does not resolve.
+//
+// A scan is correct and cheap here: the bucket is capped at auth.MaxTokens
+// entries and only low-frequency management operations resolve by name (the
+// authentication hot path resolves by hash). It is also constant-time with
+// respect to ownership — the whole bucket is walked regardless — so it adds no
+// timing oracle for "does another tenant own this name?".
+//
+// The caller must complete this scan before mutating the bucket: bbolt forbids
+// mutating a bucket while iterating it.
+func findAgentTokenHashLocked(tx *bbolt.Tx, userID, name string) ([]byte, *auth.AgentToken, error) {
+	tokenBucket := tx.Bucket([]byte(AgentTokensBucket))
+	if tokenBucket == nil {
+		return nil, nil, nil
+	}
+
+	var (
+		foundHash  []byte
+		foundToken *auth.AgentToken
+	)
+
+	err := tokenBucket.ForEach(func(k, v []byte) error {
+		if foundToken != nil {
+			return nil
+		}
+		var token auth.AgentToken
+		if err := json.Unmarshal(v, &token); err != nil {
+			return fmt.Errorf("failed to unmarshal agent token: %w", err)
+		}
+		if token.Name != name || token.UserID != userID {
+			return nil
+		}
+		// bbolt page memory is only valid for the life of the transaction and
+		// the key may be reused; copy it before returning.
+		foundHash = append([]byte(nil), k...)
+		foundToken = &token
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return foundHash, foundToken, nil
+}
+
 // CreateAgentToken stores a new agent token. It hashes the raw token using
-// the provided HMAC key, stores the AgentToken record keyed by hash in the
-// "agent_tokens" bucket, and creates a name->hash mapping in "agent_token_names".
-// Returns an error if the name already exists or the max token limit is reached.
+// the provided HMAC key and stores the AgentToken record keyed by hash in the
+// "agent_tokens" bucket.
+//
+// Token names are unique PER OWNER (token.UserID), not globally: two tenants
+// can each hold a token called "ci". Ownerless tokens (UserID == "", every
+// personal-edition token) additionally get a bare-name entry in the legacy
+// "agent_token_names" index so the personal edition is unchanged on disk.
+//
+// Returns ErrAgentTokenNameExists if the same owner already has that name, or
+// ErrAgentTokenLimitReached if the deployment-wide cap is reached.
 func (m *Manager) CreateAgentToken(token auth.AgentToken, rawToken string, hmacKey []byte) error {
 	if token.Name == "" {
 		return fmt.Errorf("agent token name cannot be empty")
@@ -46,15 +133,21 @@ func (m *Manager) CreateAgentToken(token auth.AgentToken, rawToken string, hmacK
 			return fmt.Errorf("failed to create agent_token_names bucket: %w", err)
 		}
 
-		// Check for duplicate name
-		if existing := nameBucket.Get([]byte(token.Name)); existing != nil {
-			return fmt.Errorf("agent token with name %q already exists", token.Name)
+		// Check for a duplicate name WITHIN THIS OWNER's namespace. Scanning
+		// must finish before any Put below: bbolt forbids mutating a bucket
+		// while it is being iterated.
+		existingHash, _, err := findAgentTokenHashLocked(tx, token.UserID, token.Name)
+		if err != nil {
+			return err
+		}
+		if existingHash != nil {
+			return ErrAgentTokenNameExists
 		}
 
 		// Enforce max token limit
 		count := tokenBucket.Stats().KeyN
 		if count >= auth.MaxTokens {
-			return fmt.Errorf("maximum number of agent tokens (%d) reached", auth.MaxTokens)
+			return ErrAgentTokenLimitReached
 		}
 
 		// Marshal and store
@@ -67,17 +160,37 @@ func (m *Manager) CreateAgentToken(token auth.AgentToken, rawToken string, hmacK
 			return fmt.Errorf("failed to store agent token: %w", err)
 		}
 
-		if err := nameBucket.Put([]byte(token.Name), []byte(hash)); err != nil {
-			return fmt.Errorf("failed to store agent token name mapping: %w", err)
+		// Maintain the legacy owner-blind index only for ownerless tokens, so
+		// the personal edition is byte-identical. A user-owned name must never
+		// claim the global slot, or one tenant's name would shadow another's.
+		if token.UserID == "" {
+			if err := nameBucket.Put([]byte(token.Name), []byte(hash)); err != nil {
+				return fmt.Errorf("failed to store agent token name mapping: %w", err)
+			}
 		}
 
 		return nil
 	})
 }
 
-// GetAgentTokenByName retrieves an agent token by its name.
+// GetAgentTokenByName retrieves an OWNERLESS agent token by its name — that
+// is, GetAgentTokenByOwnerAndName("", name). Every personal-edition token is
+// ownerless, so this is unchanged for the personal edition; it deliberately
+// does NOT resolve a server-edition user's token, because token names are
+// unique only within an owner and a bare name is therefore ambiguous.
 // Returns nil if not found.
 func (m *Manager) GetAgentTokenByName(name string) (*auth.AgentToken, error) {
+	return m.GetAgentTokenByOwnerAndName("", name)
+}
+
+// GetAgentTokenByOwnerAndName retrieves the token called name owned by userID.
+// Use "" as userID for ownerless (personal-edition) tokens.
+//
+// Returns nil when the pair does not resolve — whether because no such token
+// exists or because the name belongs to a different owner. Callers must not
+// distinguish those two cases in a response: doing so turns the endpoint into
+// an oracle for other tenants' token names.
+func (m *Manager) GetAgentTokenByOwnerAndName(userID, name string) (*auth.AgentToken, error) {
 	if name == "" {
 		return nil, fmt.Errorf("agent token name cannot be empty")
 	}
@@ -88,31 +201,11 @@ func (m *Manager) GetAgentTokenByName(name string) (*auth.AgentToken, error) {
 	var token *auth.AgentToken
 
 	err := m.db.db.View(func(tx *bbolt.Tx) error {
-		nameBucket := tx.Bucket([]byte(AgentTokenNamesBucket))
-		if nameBucket == nil {
-			return nil
+		_, found, err := findAgentTokenHashLocked(tx, userID, name)
+		if err != nil {
+			return err
 		}
-
-		hash := nameBucket.Get([]byte(name))
-		if hash == nil {
-			return nil
-		}
-
-		tokenBucket := tx.Bucket([]byte(AgentTokensBucket))
-		if tokenBucket == nil {
-			return nil
-		}
-
-		data := tokenBucket.Get(hash)
-		if data == nil {
-			return nil
-		}
-
-		token = &auth.AgentToken{}
-		if err := json.Unmarshal(data, token); err != nil {
-			return fmt.Errorf("failed to unmarshal agent token: %w", err)
-		}
-
+		token = found
 		return nil
 	})
 
@@ -179,8 +272,16 @@ func (m *Manager) ListAgentTokens() ([]auth.AgentToken, error) {
 	return tokens, err
 }
 
-// RevokeAgentToken marks an agent token as revoked by name.
+// RevokeAgentToken marks an OWNERLESS agent token as revoked by name.
+// Equivalent to RevokeAgentTokenForOwner("", name).
 func (m *Manager) RevokeAgentToken(name string) error {
+	return m.RevokeAgentTokenForOwner("", name)
+}
+
+// RevokeAgentTokenForOwner marks the token called name owned by userID as
+// revoked. Returns ErrAgentTokenNotFound when the (owner, name) pair does not
+// resolve, whether because it is absent or because it belongs to someone else.
+func (m *Manager) RevokeAgentTokenForOwner(userID, name string) error {
 	if name == "" {
 		return fmt.Errorf("agent token name cannot be empty")
 	}
@@ -189,29 +290,18 @@ func (m *Manager) RevokeAgentToken(name string) error {
 	defer m.mu.Unlock()
 
 	return m.db.db.Update(func(tx *bbolt.Tx) error {
-		nameBucket := tx.Bucket([]byte(AgentTokenNamesBucket))
-		if nameBucket == nil {
-			return fmt.Errorf("agent token %q not found", name)
+		// Resolve first; the scan must finish before the Put below.
+		hash, token, err := findAgentTokenHashLocked(tx, userID, name)
+		if err != nil {
+			return err
 		}
-
-		hash := nameBucket.Get([]byte(name))
-		if hash == nil {
-			return fmt.Errorf("agent token %q not found", name)
+		if token == nil {
+			return ErrAgentTokenNotFound
 		}
 
 		tokenBucket := tx.Bucket([]byte(AgentTokensBucket))
 		if tokenBucket == nil {
-			return fmt.Errorf("agent token %q not found", name)
-		}
-
-		data := tokenBucket.Get(hash)
-		if data == nil {
-			return fmt.Errorf("agent token %q not found", name)
-		}
-
-		var token auth.AgentToken
-		if err := json.Unmarshal(data, &token); err != nil {
-			return fmt.Errorf("failed to unmarshal agent token: %w", err)
+			return ErrAgentTokenNotFound
 		}
 
 		token.Revoked = true
@@ -231,6 +321,13 @@ func (m *Manager) RevokeAgentToken(name string) error {
 // name so a new token can be created with the same name. Returns an error if the
 // token does not exist.
 func (m *Manager) DeleteAgentToken(name string) error {
+	return m.DeleteAgentTokenForOwner("", name)
+}
+
+// DeleteAgentTokenForOwner permanently removes the token called name owned by
+// userID. Returns ErrAgentTokenNotFound when the (owner, name) pair does not
+// resolve, whether because it is absent or because it belongs to someone else.
+func (m *Manager) DeleteAgentTokenForOwner(userID, name string) error {
 	if name == "" {
 		return fmt.Errorf("agent token name cannot be empty")
 	}
@@ -239,20 +336,25 @@ func (m *Manager) DeleteAgentToken(name string) error {
 	defer m.mu.Unlock()
 
 	return m.db.db.Update(func(tx *bbolt.Tx) error {
-		nameBucket := tx.Bucket([]byte(AgentTokenNamesBucket))
-		if nameBucket == nil {
-			return fmt.Errorf("agent token %q not found", name)
+		// Resolve first; the scan must finish before any Delete below.
+		hash, token, err := findAgentTokenHashLocked(tx, userID, name)
+		if err != nil {
+			return err
+		}
+		if token == nil {
+			return ErrAgentTokenNotFound
 		}
 
-		hash := nameBucket.Get([]byte(name))
-		if hash == nil {
-			return fmt.Errorf("agent token %q not found", name)
-		}
-
-		// Delete the name->hash mapping first so the name is freed even if the
-		// record is somehow missing.
-		if err := nameBucket.Delete([]byte(name)); err != nil {
-			return fmt.Errorf("failed to delete agent token name mapping: %w", err)
+		// Drop the legacy owner-blind index entry only when it points at THIS
+		// record, so a delete can never remove another owner's mapping. For an
+		// ownerless token that is the entry CreateAgentToken wrote; for a
+		// user-owned token it clears a stale pre-upgrade entry, if any.
+		if nameBucket := tx.Bucket([]byte(AgentTokenNamesBucket)); nameBucket != nil {
+			if indexed := nameBucket.Get([]byte(name)); indexed != nil && string(indexed) == string(hash) {
+				if err := nameBucket.Delete([]byte(name)); err != nil {
+					return fmt.Errorf("failed to delete agent token name mapping: %w", err)
+				}
+			}
 		}
 
 		tokenBucket := tx.Bucket([]byte(AgentTokensBucket))
@@ -271,6 +373,13 @@ func (m *Manager) DeleteAgentToken(name string) error {
 // old hash entry and creates a new one with the new raw token's hash.
 // Returns the updated token record.
 func (m *Manager) RegenerateAgentToken(name string, newRawToken string, hmacKey []byte) (*auth.AgentToken, error) {
+	return m.RegenerateAgentTokenForOwner("", name, newRawToken, hmacKey)
+}
+
+// RegenerateAgentTokenForOwner regenerates the token called name owned by
+// userID. Returns ErrAgentTokenNotFound when the (owner, name) pair does not
+// resolve, whether because it is absent or because it belongs to someone else.
+func (m *Manager) RegenerateAgentTokenForOwner(userID, name string, newRawToken string, hmacKey []byte) (*auth.AgentToken, error) {
 	if name == "" {
 		return nil, fmt.Errorf("agent token name cannot be empty")
 	}
@@ -284,29 +393,18 @@ func (m *Manager) RegenerateAgentToken(name string, newRawToken string, hmacKey 
 	var updated *auth.AgentToken
 
 	err := m.db.db.Update(func(tx *bbolt.Tx) error {
-		nameBucket := tx.Bucket([]byte(AgentTokenNamesBucket))
-		if nameBucket == nil {
-			return fmt.Errorf("agent token %q not found", name)
+		// Resolve first; the scan must finish before the Delete/Put below.
+		oldHash, token, err := findAgentTokenHashLocked(tx, userID, name)
+		if err != nil {
+			return err
 		}
-
-		oldHash := nameBucket.Get([]byte(name))
-		if oldHash == nil {
-			return fmt.Errorf("agent token %q not found", name)
+		if token == nil {
+			return ErrAgentTokenNotFound
 		}
 
 		tokenBucket := tx.Bucket([]byte(AgentTokensBucket))
 		if tokenBucket == nil {
-			return fmt.Errorf("agent token %q not found", name)
-		}
-
-		data := tokenBucket.Get(oldHash)
-		if data == nil {
-			return fmt.Errorf("agent token %q not found", name)
-		}
-
-		var token auth.AgentToken
-		if err := json.Unmarshal(data, &token); err != nil {
-			return fmt.Errorf("failed to unmarshal agent token: %w", err)
+			return ErrAgentTokenNotFound
 		}
 
 		// Remove old hash entry
@@ -329,22 +427,65 @@ func (m *Manager) RegenerateAgentToken(name string, newRawToken string, hmacKey 
 			return fmt.Errorf("failed to store regenerated agent token: %w", err)
 		}
 
-		// Update name mapping to point to new hash
-		if err := nameBucket.Put([]byte(name), []byte(newHash)); err != nil {
-			return fmt.Errorf("failed to update agent token name mapping: %w", err)
+		// Keep the legacy owner-blind index in step only where it is
+		// maintained (ownerless tokens) or where it still points at this very
+		// record, so one owner's regenerate can never repoint another's entry.
+		if nameBucket := tx.Bucket([]byte(AgentTokenNamesBucket)); nameBucket != nil {
+			indexed := nameBucket.Get([]byte(name))
+			repoint := userID == "" || (indexed != nil && string(indexed) == string(oldHash))
+			if repoint {
+				if err := nameBucket.Put([]byte(name), []byte(newHash)); err != nil {
+					return fmt.Errorf("failed to update agent token name mapping: %w", err)
+				}
+			}
 		}
 
-		updated = &token
+		updated = token
 		return nil
 	})
 
 	return updated, err
 }
 
-// UpdateAgentTokenLastUsed updates the LastUsedAt timestamp for a token identified by name.
+// UpdateAgentTokenLastUsed updates the LastUsedAt timestamp for an OWNERLESS
+// token identified by name.
+//
+// Deprecated: token names are unique only within an owner, so a bare name is
+// ambiguous in the server edition. Authentication paths hold the validated
+// record and must call UpdateAgentTokenLastUsedByHash instead.
 func (m *Manager) UpdateAgentTokenLastUsed(name string) error {
 	if name == "" {
 		return fmt.Errorf("agent token name cannot be empty")
+	}
+
+	m.mu.RLock()
+	token, err := func() (*auth.AgentToken, error) {
+		defer m.mu.RUnlock()
+		var found *auth.AgentToken
+		err := m.db.db.View(func(tx *bbolt.Tx) error {
+			_, t, err := findAgentTokenHashLocked(tx, "", name)
+			found = t
+			return err
+		})
+		return found, err
+	}()
+	if err != nil {
+		return err
+	}
+	if token == nil {
+		return ErrAgentTokenNotFound
+	}
+
+	return m.UpdateAgentTokenLastUsedByHash(token.TokenHash)
+}
+
+// UpdateAgentTokenLastUsedByHash updates the LastUsedAt timestamp for the token
+// stored under the given HMAC hash. The hash is the authoritative, unambiguous
+// key: unlike a name it is unique across owners, so this cannot stamp another
+// tenant's token.
+func (m *Manager) UpdateAgentTokenLastUsedByHash(hash string) error {
+	if hash == "" {
+		return fmt.Errorf("agent token hash cannot be empty")
 	}
 
 	now := time.Now().UTC()
@@ -353,24 +494,14 @@ func (m *Manager) UpdateAgentTokenLastUsed(name string) error {
 	defer m.mu.Unlock()
 
 	return m.db.db.Update(func(tx *bbolt.Tx) error {
-		nameBucket := tx.Bucket([]byte(AgentTokenNamesBucket))
-		if nameBucket == nil {
-			return fmt.Errorf("agent token %q not found", name)
-		}
-
-		hash := nameBucket.Get([]byte(name))
-		if hash == nil {
-			return fmt.Errorf("agent token %q not found", name)
-		}
-
 		tokenBucket := tx.Bucket([]byte(AgentTokensBucket))
 		if tokenBucket == nil {
-			return fmt.Errorf("agent token %q not found", name)
+			return ErrAgentTokenNotFound
 		}
 
-		data := tokenBucket.Get(hash)
+		data := tokenBucket.Get([]byte(hash))
 		if data == nil {
-			return fmt.Errorf("agent token %q not found", name)
+			return ErrAgentTokenNotFound
 		}
 
 		var token auth.AgentToken
@@ -385,7 +516,7 @@ func (m *Manager) UpdateAgentTokenLastUsed(name string) error {
 			return fmt.Errorf("failed to marshal agent token: %w", err)
 		}
 
-		return tokenBucket.Put(hash, updatedData)
+		return tokenBucket.Put([]byte(hash), updatedData)
 	})
 }
 

--- a/internal/storage/agent_tokens.go
+++ b/internal/storage/agent_tokens.go
@@ -18,11 +18,22 @@ const (
 	// (UserID == ""), i.e. every personal-edition token, so the personal
 	// edition is byte-identical on disk and a rollback sees exactly what it
 	// wrote. Owner-scoped lookups never consult it — see
-	// findAgentTokenHashLocked. Entries left behind by a pre-upgrade
-	// server-edition deployment are simply not read; they are deliberately NOT
-	// swept, because sweeping them would strand those tokens on a rollback
-	// while every by-name path on the old code already re-checks ownership and
-	// can therefore only deny, never act on the wrong tenant's token.
+	// findAgentTokenHashLocked.
+	//
+	// Entries left behind by a pre-upgrade server-edition deployment are not
+	// read, and are deliberately NOT swept: sweeping them would strand those
+	// tokens on a rollback, while every by-name path on the old code already
+	// re-checks ownership and can therefore only deny, never act on the wrong
+	// tenant's token.
+	//
+	// For that rollback promise to be true, all THREE maintenance paths must
+	// leave a foreign entry alone, not just the two that already did. Create
+	// used to Put unconditionally, overwriting whatever the name pointed at —
+	// including a pre-upgrade tenant's entry, the very thing the paragraph
+	// above promises to preserve. It now claims the slot only when the slot is
+	// free, or when the entry it holds dangles (its hash is no longer in
+	// agent_tokens). Delete and regenerate already required the entry to point
+	// at the very record being mutated.
 	AgentTokenNamesBucket = "agent_token_names" //nolint:gosec // bucket name, not a credential
 )
 
@@ -60,7 +71,18 @@ var (
 //
 // The caller must complete this scan before mutating the bucket: bbolt forbids
 // mutating a bucket while iterating it.
-func findAgentTokenHashLocked(tx *bbolt.Tx, userID, name string) ([]byte, *auth.AgentToken, error) {
+//
+// A record that fails to unmarshal is SKIPPED, not fatal. Because this walks
+// the whole bucket rather than reading one indexed record, aborting on the
+// first bad row would let a single unparseable entry — a truncated write, a
+// hand-edited DB, a record from a future schema — turn create, revoke, delete
+// and regenerate into a 500 for EVERY tenant of the deployment, which the
+// indexed read it replaced could not do. Skipping degrades the blast radius to
+// "that one token is unresolvable": the corrupt row's own (owner, name) stops
+// resolving, so its management operations answer not-found, and every other
+// token keeps working. The skip is logged at WARN with the bucket key so an
+// operator can find the row; that key is an HMAC hash, not a credential.
+func (m *Manager) findAgentTokenHashLocked(tx *bbolt.Tx, userID, name string) ([]byte, *auth.AgentToken, error) {
 	tokenBucket := tx.Bucket([]byte(AgentTokensBucket))
 	if tokenBucket == nil {
 		return nil, nil, nil
@@ -77,7 +99,11 @@ func findAgentTokenHashLocked(tx *bbolt.Tx, userID, name string) ([]byte, *auth.
 		}
 		var token auth.AgentToken
 		if err := json.Unmarshal(v, &token); err != nil {
-			return fmt.Errorf("failed to unmarshal agent token: %w", err)
+			if m.logger != nil {
+				m.logger.Warnw("skipping unparseable agent token record",
+					"bucket", AgentTokensBucket, "key", string(k), "error", err)
+			}
+			return nil
 		}
 		if token.Name != name || token.UserID != userID {
 			return nil
@@ -136,7 +162,7 @@ func (m *Manager) CreateAgentToken(token auth.AgentToken, rawToken string, hmacK
 		// Check for a duplicate name WITHIN THIS OWNER's namespace. Scanning
 		// must finish before any Put below: bbolt forbids mutating a bucket
 		// while it is being iterated.
-		existingHash, _, err := findAgentTokenHashLocked(tx, token.UserID, token.Name)
+		existingHash, _, err := m.findAgentTokenHashLocked(tx, token.UserID, token.Name)
 		if err != nil {
 			return err
 		}
@@ -163,14 +189,45 @@ func (m *Manager) CreateAgentToken(token auth.AgentToken, rawToken string, hmacK
 		// Maintain the legacy owner-blind index only for ownerless tokens, so
 		// the personal edition is byte-identical. A user-owned name must never
 		// claim the global slot, or one tenant's name would shadow another's.
+		//
+		// The slot is CLAIMED, not overwritten. An unconditional Put stomps
+		// whatever the name already pointed at — including the pre-upgrade
+		// server-edition entry the bucket comment above promises to leave
+		// intact for a rollback, which on the old code is a live tenant's
+		// token. A DANGLING entry (its hash no longer in agent_tokens) is fair
+		// game: nothing can resolve through it, on this code or a rollback.
+		// Declining the Put costs the new token nothing —
+		// findAgentTokenHashLocked resolves by scan and never reads this index.
 		if token.UserID == "" {
-			if err := nameBucket.Put([]byte(token.Name), []byte(hash)); err != nil {
-				return fmt.Errorf("failed to store agent token name mapping: %w", err)
+			if claimAgentTokenNameSlot(tx, nameBucket, token.Name) {
+				if err := nameBucket.Put([]byte(token.Name), []byte(hash)); err != nil {
+					return fmt.Errorf("failed to store agent token name mapping: %w", err)
+				}
 			}
 		}
 
 		return nil
 	})
+}
+
+// claimAgentTokenNameSlot reports whether the legacy owner-blind name index may
+// be pointed at a newly created OWNERLESS token.
+//
+// True when the name is unclaimed, or when the entry it holds DANGLES — its
+// hash is absent from agent_tokens, so nothing resolves through it on this code
+// or on a rollback. False when a live record already holds the slot, which in
+// practice means a pre-upgrade server-edition tenant's token: overwriting that
+// is precisely the rollback stranding the bucket comment promises not to cause.
+func claimAgentTokenNameSlot(tx *bbolt.Tx, nameBucket *bbolt.Bucket, name string) bool {
+	indexed := nameBucket.Get([]byte(name))
+	if indexed == nil {
+		return true
+	}
+	tokenBucket := tx.Bucket([]byte(AgentTokensBucket))
+	if tokenBucket == nil {
+		return true
+	}
+	return tokenBucket.Get(indexed) == nil
 }
 
 // GetAgentTokenByName retrieves an OWNERLESS agent token by its name — that
@@ -201,7 +258,7 @@ func (m *Manager) GetAgentTokenByOwnerAndName(userID, name string) (*auth.AgentT
 	var token *auth.AgentToken
 
 	err := m.db.db.View(func(tx *bbolt.Tx) error {
-		_, found, err := findAgentTokenHashLocked(tx, userID, name)
+		_, found, err := m.findAgentTokenHashLocked(tx, userID, name)
 		if err != nil {
 			return err
 		}
@@ -291,7 +348,7 @@ func (m *Manager) RevokeAgentTokenForOwner(userID, name string) error {
 
 	return m.db.db.Update(func(tx *bbolt.Tx) error {
 		// Resolve first; the scan must finish before the Put below.
-		hash, token, err := findAgentTokenHashLocked(tx, userID, name)
+		hash, token, err := m.findAgentTokenHashLocked(tx, userID, name)
 		if err != nil {
 			return err
 		}
@@ -337,7 +394,7 @@ func (m *Manager) DeleteAgentTokenForOwner(userID, name string) error {
 
 	return m.db.db.Update(func(tx *bbolt.Tx) error {
 		// Resolve first; the scan must finish before any Delete below.
-		hash, token, err := findAgentTokenHashLocked(tx, userID, name)
+		hash, token, err := m.findAgentTokenHashLocked(tx, userID, name)
 		if err != nil {
 			return err
 		}
@@ -373,13 +430,25 @@ func (m *Manager) DeleteAgentTokenForOwner(userID, name string) error {
 // old hash entry and creates a new one with the new raw token's hash.
 // Returns the updated token record.
 func (m *Manager) RegenerateAgentToken(name string, newRawToken string, hmacKey []byte) (*auth.AgentToken, error) {
-	return m.RegenerateAgentTokenForOwner("", name, newRawToken, hmacKey)
+	return m.RegenerateAgentTokenForOwner("", name, newRawToken, hmacKey, nil)
 }
 
 // RegenerateAgentTokenForOwner regenerates the token called name owned by
 // userID. Returns ErrAgentTokenNotFound when the (owner, name) pair does not
 // resolve, whether because it is absent or because it belongs to someone else.
-func (m *Manager) RegenerateAgentTokenForOwner(userID, name string, newRawToken string, hmacKey []byte) (*auth.AgentToken, error) {
+//
+// narrowScope, when non-nil, is applied to the stored AllowedServers inside the
+// same transaction that rotates the hash, and its result is persisted. It exists
+// because a token's server scope is decided once, at mint time, and nothing
+// re-checks it afterwards: un-sharing a server does not revoke the grants
+// already written into live tokens. Rotation is the one moment the owner's
+// current entitlement is known, so the server edition passes a filter that drops
+// anything they may no longer reach (see resolveTokenServerScope). It MUST only
+// ever narrow — a hook that widened would hand the caller a privilege escalation
+// through the one operation that is supposed to be neutral — and it MUST NOT do
+// I/O: it runs inside a write transaction while m.mu is held, so the caller
+// computes the entitled set before the call and passes a pure filter.
+func (m *Manager) RegenerateAgentTokenForOwner(userID, name string, newRawToken string, hmacKey []byte, narrowScope func([]string) []string) (*auth.AgentToken, error) {
 	if name == "" {
 		return nil, fmt.Errorf("agent token name cannot be empty")
 	}
@@ -394,7 +463,7 @@ func (m *Manager) RegenerateAgentTokenForOwner(userID, name string, newRawToken 
 
 	err := m.db.db.Update(func(tx *bbolt.Tx) error {
 		// Resolve first; the scan must finish before the Delete/Put below.
-		oldHash, token, err := findAgentTokenHashLocked(tx, userID, name)
+		oldHash, token, err := m.findAgentTokenHashLocked(tx, userID, name)
 		if err != nil {
 			return err
 		}
@@ -416,6 +485,12 @@ func (m *Manager) RegenerateAgentTokenForOwner(userID, name string, newRawToken 
 		token.TokenHash = newHash
 		token.TokenPrefix = newPrefix
 		token.Revoked = false
+
+		// Re-apply the caller's current server entitlement, if they supplied
+		// one. Narrowing only; see the doc comment.
+		if narrowScope != nil {
+			token.AllowedServers = narrowScope(token.AllowedServers)
+		}
 
 		updatedData, err := json.Marshal(token)
 		if err != nil {
@@ -463,7 +538,7 @@ func (m *Manager) UpdateAgentTokenLastUsed(name string) error {
 		defer m.mu.RUnlock()
 		var found *auth.AgentToken
 		err := m.db.db.View(func(tx *bbolt.Tx) error {
-			_, t, err := findAgentTokenHashLocked(tx, "", name)
+			_, t, err := m.findAgentTokenHashLocked(tx, "", name)
 			found = t
 			return err
 		})

--- a/internal/storage/agent_tokens_test.go
+++ b/internal/storage/agent_tokens_test.go
@@ -243,10 +243,6 @@ func TestAgentTokenRegenerate(t *testing.T) {
 	err := mgr.CreateAgentToken(token, rawToken, testHMACKey)
 	require.NoError(t, err)
 
-	// Revoke the original (to verify regeneration clears revoked status)
-	err = mgr.RevokeAgentToken("regen-bot")
-	require.NoError(t, err)
-
 	// Generate new token
 	newRawToken, err := auth.GenerateToken()
 	require.NoError(t, err)
@@ -259,7 +255,7 @@ func TestAgentTokenRegenerate(t *testing.T) {
 	assert.Equal(t, "regen-bot", updated.Name)
 	assert.Equal(t, []string{"github", "gitlab"}, updated.AllowedServers)
 	assert.Equal(t, []string{auth.PermRead, auth.PermWrite}, updated.Permissions)
-	assert.False(t, updated.Revoked, "regeneration should clear revoked status")
+	assert.False(t, updated.Revoked, "a live token stays live across rotation")
 
 	// Verify new hash
 	newHash := auth.HashToken(newRawToken, testHMACKey)

--- a/internal/storage/manager.go
+++ b/internal/storage/manager.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
@@ -25,6 +26,12 @@ type Manager struct {
 	mu       sync.RWMutex
 	logger   *zap.SugaredLogger
 	asyncMgr *AsyncManager
+
+	// ownerGate is consulted by ValidateAgentToken for every OWNED token.
+	// Installed by the server edition; nil (and therefore inert) in the
+	// personal edition, where every token is ownerless. See
+	// SetAgentTokenOwnerGate.
+	ownerGate atomic.Value // agentTokenOwnerGate
 }
 
 // NewManager creates a new storage manager


### PR DESCRIPTION
Closes #1168, #1169.

Server-edition auth. All changes are behind `//go:build server`; the personal edition is behaviourally unchanged, and there is **no storage migration** — existing on-disk tokens resolve as before.

### #1169 — admin demotion did not take effect until token expiry

The session path re-derived the admin role from `admin_emails` on every request; the bearer-JWT path trusted `claims.Role` verbatim. Removing someone from `admin_emails` left them with full admin — every `AdminOnly()` route and `CanRevealSecrets()` — until their JWT expired, by default 24 hours. The JWT path now re-derives the role the way the session path does, with field parity proven rather than assumed.

### #1168 — token names were a global namespace, and `AuthContext()` dropped `UserID`

Two tenants could not both have a token named `ci`, and the revoke path's 403-vs-404 split was a name-probing oracle. Separately, `AuthContext()` copied every field except `UserID`, so an agent-token request carried no tenant identity — under a constructor whose own doc comment says it exists "so no auth path can silently drop a field".

Name resolution is now owner-scoped, and unowned and absent are indistinguishable on revoke, delete and regenerate. The TOCTOU preflight is gone in favour of classifying the mutator's own error, which closes the window and a leaked sentinel string together.

A proposed one-time migration sweep was **dropped**: its justification — that a rolled-back binary could resolve `ci` to the wrong tenant — is false, since every user-facing by-name path already re-checks ownership after the lookup and denies. The sweep bought nothing and its rollback behaviour would have stranded existing tokens.

### Found while fixing these

- **Carrying `UserID` introduced a regression.** `multiuser.Router.BrokeredConnectionKey` keyed the connection pool off `GetUserID()` with no `IsUser()` guard, so an agent token would pool onto its owner's brokered upstream connection — carrying the owner's injected IdP credential. Previously it keyed as anonymous. Guarded, plus a sweep of every other `GetUserID()` consumer. (`multiuser.Router` has no production caller yet; the guard is correct for when it is wired, and the comments now say so instead of resting on it.)
- **`allowed_servers` was accepted verbatim** on `POST /api/v1/user/tokens`, with no intersection against the tenant's entitled set — so a user could mint `["*"]` and walk straight through the #1166 scope filter. Now intersected, read **live** from the config rather than a boot-time snapshot, which was itself the first fix's blind spot.
- **A disabled user's agent tokens kept authenticating.** Disabling an account is the documented remediation for a compromised user, and it did not revoke their minted credentials. Now fail-closed via an owner gate, with revocation on the disable path.

### Follow-ups filed, deliberately not bundled

- #1177 — `auth.MaxTokens` is a deployment-wide cap, so one tenant can exhaust it for everyone. The misleading 409 body is fixed here; the per-owner quota is not.
- #1179 — admins cannot revoke a specific tenant's token by name (an accepted consequence of owner-scoped names), and un-sharing a server does not revoke live grants.

### Review

Two `opencode` (gpt-5.6-sol) rounds, both BLOCKING; 14 genuine findings closed, 1 false positive rejected with evidence. 27 tests. The oracle tests carry a positive control on the same router and pin exact status values, rather than asserting bare parity — a sibling test in this package passes today only because a nil store makes both answers 500.
