### PR TITLE
chore(deps): bump test-fixture deps + close dependabot coverage gaps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,3 +60,109 @@ updates:
       website-dependencies:
         patterns:
           - "*"
+  - package-ecosystem: npm
+    directory: "/e2e/playwright"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      e2e-playwright-dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: npm
+    directory: "/e2e/web-ui-sweep"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      e2e-web-ui-sweep-dependencies:
+        patterns:
+          - "*"
+  # tests/echo-rugpull-server and tests/malicious-mcp-server are local-only
+  # npm fixtures for the quarantine/TPA scanner test suite (tests/README.md):
+  # never published, never shipped, spawned only from test tooling and bound
+  # to localhost. A vulnerable transitive dep here is alert noise, not a real
+  # exposure — but Dependabot previously had NO entry for either directory,
+  # so ten open alerts (5 per fixture, identical) sat unfixed because nothing
+  # ever opened a PR for them. Low limit + own commit prefix keep fixture
+  # bumps from competing with real dependency PRs for review attention.
+  - package-ecosystem: npm
+    directory: "/tests/echo-rugpull-server"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps-fixtures)"
+    groups:
+      echo-rugpull-fixture-dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: npm
+    directory: "/tests/malicious-mcp-server"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps-fixtures)"
+    groups:
+      malicious-mcp-fixture-dependencies:
+        patterns:
+          - "*"
+  # bench/tscg pins @tscg/core to an exact version (1.4.3) on purpose: the
+  # discovery-profiler benchmark (spec 083) reports figures — e.g. "TSCG
+  # (-23.8%)" in specs/085-compact-router/spec.md — that are only comparable
+  # run-to-run if the shim's encoding behavior doesn't drift. Auto-bumping it
+  # would silently invalidate published numbers, the same reason
+  # github.com/mark3labs/mcp-go is excluded from the gomod group above. No
+  # dependabot entry for bench/tscg; re-pin it manually, in its own reviewed
+  # commit, if a bump is ever warranted.
+  #
+  # cmd/mcpfixture/Dockerfile is `FROM scratch` (see the file's own header
+  # comment) — there is no base image for the docker ecosystem to track, so
+  # it has no entry below either.
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+  - package-ecosystem: docker
+    directory: "/docker/scanners/cisco"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps-scanners)"
+  - package-ecosystem: docker
+    directory: "/docker/scanners/proximity"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps-scanners)"
+  - package-ecosystem: docker
+    directory: "/docker/scanners/ramparts"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps-scanners)"
+  - package-ecosystem: docker
+    directory: "/docker/scanners/snyk"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps-scanners)"
+  - package-ecosystem: docker
+    directory: "/docker/scanners/trivy"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps-scanners)"

--- a/tests/echo-rugpull-server/package-lock.json
+++ b/tests/echo-rugpull-server/package-lock.json
@@ -445,9 +445,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -582,9 +582,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.32",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "version": "4.12.34",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
+      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/tests/malicious-mcp-server/package-lock.json
+++ b/tests/malicious-mcp-server/package-lock.json
@@ -445,9 +445,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -582,9 +582,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.32",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "version": "4.12.34",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
+      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
## Summary

Two commits, two different kinds of change:

**1. `chore(tests): bump hono/fast-uri in fixture lockfiles to clear Dependabot alerts`**

Ten open Dependabot alerts (5 identical per fixture) against `tests/echo-rugpull-server/package-lock.json` and `tests/malicious-mcp-server/package-lock.json`:

| Severity | Package | Issue | Fix |
|---|---|---|---|
| high | fast-uri | host confusion via backslash authority | 3.1.5 |
| medium | hono | algorithmic-complexity DoS in language middleware | 4.12.34 |
| medium | hono | ReDoS in CORS middleware | 4.12.34 |
| medium | hono | memo() retains SSR output across requests | 4.12.34 |
| low | hono | proxy helper leaks Connection-listed headers | 4.12.34 |

**Honest risk framing**: both fixtures are local-only, never-published, never-shipped test servers for the quarantine/TPA scanner suite (`tests/README.md`), spawned as stdio subprocesses and bound to localhost. `hono`/`fast-uri` are transitive deps of `@modelcontextprotocol/sdk`/`ajv` that these fixtures don't even import directly. Real-world exposure is close to zero — this is alert-noise hygiene, not a security fix.

Bumped `fast-uri` 3.1.4→3.1.5 and `hono` 4.12.32→4.12.34 in both lockfiles (both stay within their existing semver ranges, so `package.json` is untouched), keeping the two fixtures on identical versions.

**Verification** (no automated Go test drives these directories directly — only `tests/test-quarantine.sh`, a manual QA script, and `specs/094-filter-diagnostics/quickstart.md`):
- `npm install` resolves cleanly in both directories at the exact target versions, and a second `npm install` is a no-op (lockfile is self-consistent).
- MCP stdio round-trip (`initialize` → `tools/list` → `tools/call`) against both `index.js` files succeeds — verified with a small script that speaks JSON-RPC over stdio.
- Built a throwaway `mcpproxy` binary (`go build -o /tmp/mcpproxy-fixture-check ./cmd/mcpproxy`) and ran it against an isolated config (high port, scratch data dir) pointing at both fixtures: both connect and index successfully (`echo-rugpull`: 2 tools, `malicious`: 3 tools, confirmed via `/api/v1/status` and `/api/v1/servers`). Did **not** run `./scripts/test-api-e2e.sh` (it blanket-pkills mcpproxy processes and would have hit other agents' running instances on this machine — port 8080 was already occupied by another instance).
- No API changes in hono 4.12.34 affect these fixtures.

**2. `chore(ci): close dependabot coverage gaps across npm/docker manifests`**

The real defect: `.github/dependabot.yml` never watched either test-fixture directory, so Dependabot could never have opened a PR for the alerts above — they could only be found by reading the alert list by hand. Chose **option (a)**: add both directories, grouped, with a low `open-pull-requests-limit: 3` and a distinct `chore(deps-fixtures)` commit prefix so fixture bumps don't crowd out real dependency PRs in review.

Swept the rest of the repo for manifests the config also missed:

| Manifest | Decision |
|---|---|
| `e2e/playwright/package.json`, `e2e/web-ui-sweep/package.json` | **Added.** Real CI tooling (OAuth E2E tests, the web-ui-sweep release gate), not fixtures. |
| `bench/tscg/package.json` | **Deliberately excluded**, documented inline. Pins `@tscg/core@1.4.3` exactly for discovery-profiler benchmark reproducibility (spec 083) — published numbers (e.g. "TSCG (-23.8%)") are only comparable if the shim doesn't drift. Same rationale as the existing `mcp-go` ignore rule. An ignore-only entry would never produce a PR anyway (the shim is zero-dep). |
| Root `Dockerfile` (shipped server-edition image) + `docker/scanners/{cisco,proximity,ramparts,snyk,trivy}/Dockerfile` (built and pushed to `ghcr.io/smart-mcp-proxy/scanner-*` by `scanner-images.yml`) | **Added** — real, shipped, security-relevant base images with zero prior Dependabot coverage. Arguably higher-value than the fixture bumps in this PR. |
| `cmd/mcpfixture/Dockerfile` | **Excluded**, documented inline. `FROM scratch`, nothing to track. |
| `go.mod` (single module at repo root) | Already covered by the existing `gomod:/` entry. |

## Test plan

- [x] `npm install` in both fixture directories resolves at pinned versions, stable across repeat installs
- [x] MCP stdio protocol round-trip against both fixture servers (initialize/tools-list/tools-call)
- [x] Real `mcpproxy` binary connects to and indexes both fixtures via an isolated, non-conflicting instance
- [x] `.github/dependabot.yml` parses as valid YAML (14 update entries)
- [x] `git push` pre-push hooks passed (go build, OpenAPI spec check)