### PR TITLE
feat(bench): name the counterfactual behind code-execution savings

### DIFF
--- a/bench/cmd/codeexecsaving/main.go
+++ b/bench/cmd/codeexecsaving/main.go
@@ -14,6 +14,17 @@ import (
 	"github.com/smart-mcp-proxy/mcpproxy-go/bench/replaycorpus"
 )
 
+// glossFor spells out a baseline mode, because "direct" alone is ambiguous in
+// this codebase: config.RoutingModeDirect is also "direct" and means every
+// upstream tool exposed THROUGH the proxy, where responses ARE cut at
+// tool_response_limit — nearly the opposite of what it means here.
+func glossFor(m replaycorpus.BaselineMode) string {
+	if m == replaycorpus.BaselineProxy {
+		return "agent calls through this proxy, responses cut at tool_response_limit"
+	}
+	return "agent talks to the upstream servers itself, no proxy in the path"
+}
+
 func main() {
 	in := flag.String("in", "", "activity export JSONL (must live outside the repository)")
 	inPrice := flag.Float64("in-price", 3.0, "USD per Mtok, input")
@@ -23,9 +34,20 @@ func main() {
 	// request and response CONTENT unmasked. With the sub-call byte counts now
 	// emitted, bodies-off still yields a byte-basis figure.
 	bodies := flag.Bool("bodies-unmasked", false, "read recorded bodies and count real TOKENS (reads unmasked content)")
+	baseline := flag.String("baseline", "direct",
+		"counterfactual the saving is measured against: "+
+			"direct (agent talks to the upstream servers itself, no proxy in the path — nothing truncates) or "+
+			"proxy (agent calls through this proxy's call_tool_* path — responses cut at tool_response_limit)")
 	flag.Parse()
 	if *in == "" {
 		fmt.Fprintln(os.Stderr, "-in is required")
+		os.Exit(2)
+	}
+	// Refused rather than defaulted: a typo'd -baseline that quietly produced
+	// the OTHER figure is the failure the selector exists to remove.
+	mode, err := replaycorpus.ParseBaselineMode(*baseline)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(2)
 	}
 
@@ -38,9 +60,11 @@ func main() {
 		fmt.Fprintln(os.Stderr, "load:", err)
 		os.Exit(1)
 	}
-	rep := replaycorpus.CodeExecSavingsFor(corpus.Sessions)
+	rep := replaycorpus.CodeExecSavingsFor(corpus.Sessions, mode)
 
-	fmt.Printf("sessions %d  bodies=%v\n", len(corpus.Sessions), policy)
+	// The bare word "direct" collides with config.RoutingModeDirect, which is a
+	// PROXIED mode that does truncate. Never print it unglossed.
+	fmt.Printf("sessions %d  bodies=%v  baseline=%s (%s)\n", len(corpus.Sessions), policy, mode, glossFor(mode))
 	for _, w := range corpus.Warnings {
 		fmt.Println("  warning:", w)
 	}
@@ -58,14 +82,30 @@ func main() {
 		if b == string(replaycorpus.CostMeasured) {
 			unit = "tokens"
 		}
+		baselineLabel := "baseline (agent calls the upstream servers itself)"
+		if mode == replaycorpus.BaselineProxy {
+			baselineLabel = "baseline (agent calls through this proxy, responses cut)"
+		}
 		fmt.Printf("\n[%s] %d call(s), %d sub-call(s) — unit: %s\n", b, k.Calls, k.SubCalls, unit)
-		fmt.Printf("  baseline (agent makes the sub-calls itself) : %d\n", k.Baseline)
-		fmt.Printf("  proxy    (script sent + result returned)    : %d\n", k.Proxy)
-		fmt.Printf("  saving                                      : %+d", k.Saving)
+		fmt.Printf("  %-55s: %d\n", baselineLabel, k.Baseline)
+		fmt.Printf("  %-55s: %d\n", "proxy (script sent + result returned)", k.Proxy)
+		fmt.Printf("  %-55s: %+d", "saving", k.Saving)
 		if k.Baseline > 0 {
 			fmt.Printf("  (%.1f%% of baseline)", 100*float64(k.Saving)/float64(k.Baseline))
 		}
 		fmt.Println()
+		// A total that tolerates truncation must publish the magnitude, not
+		// just the fact — see doc.go's third invariant.
+		if k.TruncatedSubCalls > 0 {
+			fmt.Printf("  NOTE: includes %d sub-call response(s) counted at their full pre-truncation\n", k.TruncatedSubCalls)
+			fmt.Printf("        size (%d of the baseline). The recorded text was cut at 8KB; the byte\n", k.TruncatedBaseline)
+			fmt.Println("        length was not. -baseline=proxy withholds these calls entirely.")
+			// The whole-call figure, not just the component: proxy mode discards
+			// the entire call, so this is what the published total would lose.
+			fmt.Printf("        %d call(s), %d of the saving above, exist only because direct\n",
+				k.TruncatedCalls, k.TruncatedCallSaving)
+			fmt.Println("        mode tolerates truncation.")
+		}
 	}
 	// Money, not just tokens: a call's ARGUMENTS are output (billed ~5x) and its
 	// RESPONSE is input, so the token total is not proportional to cost. Priced
@@ -94,6 +134,26 @@ func main() {
 
 	for reason, n := range rep.Withheld {
 		fmt.Printf("\nwithheld: %d call(s) — %s\n", n, reason)
+	}
+	// Under proxy, a reader seeing a pile of truncation withholds would
+	// otherwise conclude nothing was measurable. Say how many the other
+	// counterfactual recovers — without printing a second headline number,
+	// because two savings figures on one screen is how the wrong one gets
+	// quoted.
+	if mode == replaycorpus.BaselineProxy && rep.Withheld[replaycorpus.ReasonTruncatedSubCallOverstates] > 0 {
+		alt := replaycorpus.CodeExecSavingsFor(corpus.Sessions, replaycorpus.BaselineDirect)
+		recovered := 0
+		for _, sv := range alt.Savings {
+			if sv.Basis != replaycorpus.CostUnavailable && sv.TruncatedSubCalls > 0 {
+				recovered++
+			}
+		}
+		fmt.Printf("  -baseline=direct counts %d of them (no proxy in the path, so nothing truncates)\n", recovered)
+	}
+	if len(rep.Withheld) > 0 {
+		fmt.Println("\n(withheld reasons are not comparable across baselines: a call withheld for")
+		fmt.Println(" truncation under proxy is re-tested under direct and may withhold for a")
+		fmt.Println(" different reason.)")
 	}
 	if b, err := json.MarshalIndent(rep.Savings, "", " "); err == nil && len(rep.Savings) > 0 {
 		fmt.Println("\nper-call detail:")

--- a/bench/replaycorpus/codeexec.go
+++ b/bench/replaycorpus/codeexec.go
@@ -12,11 +12,90 @@
 // is what this file computes, and nothing else in bench measures it.
 package replaycorpus
 
-import "math"
+import (
+	"fmt"
+	"math"
+)
 
 // CodeExecToolName is the built-in whose activity records parent a sandbox's
 // sub-calls. Sub-calls join to it by parent_id (see group.go).
 const CodeExecToolName = "code_execution"
+
+// BaselineMode selects WHICH counterfactual the word "baseline" names. The two
+// are not refinements of one another: they answer different questions and
+// legitimately produce different numbers from the same log. Before this type
+// existed the accounting implemented BaselineProxy and never said so, which is
+// the defect it fixes — a saving whose denominator is unstated cannot be
+// quoted.
+//
+// It is a string type for the same reason CostBasis and ExclusionReason are: a
+// report prints it verbatim and rows must sort deterministically (SC-002).
+type BaselineMode string
+
+const (
+	// BaselineDirect is the agent wired STRAIGHT to the upstream MCP servers,
+	// with mcpproxy nowhere in the path. Nothing truncates, so a sub-call's
+	// full pre-truncation response_bytes is exactly what that agent reads —
+	// the recorded truncation is an artefact of the RECORD
+	// (subCallActivityResponseLimit cuts the stored string at 8KB while
+	// subCallByteSizes measures the whole result), not of the workload.
+	//
+	// NAME COLLISION, read this before using the word: internal/config's
+	// RoutingModeDirect is ALSO "direct" and means the opposite kind of thing
+	// — every upstream tool exposed THROUGH the proxy, where responses ARE cut
+	// at ToolResponseLimit. Never print this value bare; always gloss it as
+	// "no proxy in the path".
+	//
+	// It is the DEFAULT, and that is a deliberate change of published meaning.
+	// tool_response_limit is an MCPPROXY feature: charging the counterfactual
+	// agent for it answers "what did code execution save over call_tool_*"
+	// rather than "what did mcpproxy save me". It also brings this figure into
+	// line with the harness's own denominator — bench/modematrix.go's
+	// baselineCell, "the same agent doing the same tasks with every upstream
+	// tool inline", which every other published percentage here is measured
+	// against. And the withhold it replaces is not statistically neutral: it
+	// fires precisely on the LARGEST responses, the ones with most to save, so
+	// the surviving population was biased small in a way no exclusion counter
+	// showed as a magnitude.
+	BaselineDirect BaselineMode = "direct"
+
+	// BaselineProxy is the agent making the same calls through THIS proxy's
+	// call_tool_* path, where each content block is cut at
+	// config.ToolResponseLimit (20000 by default) before the model reads it.
+	// Counting the full pre-truncation size then overstates the baseline, and
+	// an overstated baseline inflates the saving — the one direction of error a
+	// savings figure must never make — so a truncated sub-call withholds the
+	// whole call. This is the behaviour that existed before the selector, bit
+	// for bit.
+	BaselineProxy BaselineMode = "proxy"
+)
+
+// orDefault maps the zero value onto the default in ONE place, so no branch
+// downstream has to decide what "" means. An unknown non-empty value also
+// resolves to BaselineDirect: a bench library must not panic mid-report. The
+// CLI refuses a typo instead of resolving it — see ParseBaselineMode.
+func (m BaselineMode) orDefault() BaselineMode {
+	if m == BaselineProxy {
+		return BaselineProxy
+	}
+	return BaselineDirect
+}
+
+// ParseBaselineMode turns operator input into the vocabulary, or refuses. Exact
+// match only: no case folding, no trimming, no prefix. A typo'd -baseline that
+// quietly produced the OTHER figure is the exact failure this change exists to
+// remove, so "" is rejected too.
+func ParseBaselineMode(s string) (BaselineMode, error) {
+	switch BaselineMode(s) {
+	case BaselineDirect:
+		return BaselineDirect, nil
+	case BaselineProxy:
+		return BaselineProxy, nil
+	default:
+		return "", fmt.Errorf("unknown baseline %q: want %q (agent talks to the upstream servers itself, no proxy in the path) or %q (agent calls through this proxy, responses cut at tool_response_limit)",
+			s, BaselineDirect, BaselineProxy)
+	}
+}
 
 // CodeExecSaving is the response-side saving of ONE code_execution call.
 //
@@ -61,6 +140,27 @@ type CodeExecSaving struct {
 	BaselineInput  int `json:"baseline_input,omitempty"`
 	ProxyOutput    int `json:"proxy_output,omitempty"`
 	ProxyInput     int `json:"proxy_input,omitempty"`
+
+	// Mode is the counterfactual that produced this figure, stamped on EVERY
+	// return path including a withheld one — a withheld line still has to say
+	// which baseline refused it, since proxy refuses calls direct accepts. No
+	// omitempty: a figure whose denominator is optional is the ambiguity being
+	// removed.
+	Mode BaselineMode `json:"baseline_mode"`
+
+	// TruncatedSubCalls counts the baseline components that contributed ONLY
+	// because BaselineDirect tolerates truncation; BaselineProxy withholds the
+	// whole call instead, so it is always 0 there. doc.go's third invariant
+	// lets a truncated record contribute but never SILENTLY: this counter and
+	// TruncatedBaseline are that annotation, and direct mode is outside the
+	// invariant without them.
+	TruncatedSubCalls int `json:"truncated_sub_calls,omitempty"`
+
+	// TruncatedBaseline is how much of Baseline those components contributed,
+	// in the unit Basis implies. The count alone cannot answer the only
+	// question worth asking of a tolerated figure — how much of this rests on
+	// data the conservative mode would have thrown away.
+	TruncatedBaseline int `json:"truncated_baseline,omitempty"`
 }
 
 // amount returns the cost in the unit its basis implies, and whether a figure
@@ -90,15 +190,31 @@ func (c Cost) amount() (int, bool) {
 //     number in no unit at all;
 //   - a parent that is not a code_execution call, which is a caller error
 //     rather than a measurement.
-func CodeExecSavingFor(parent *ReplayCall) CodeExecSaving {
-	out := CodeExecSaving{}
+//
+// mode selects the counterfactual the baseline names; the zero value is
+// BaselineDirect. The parameter is deliberately required rather than carried on
+// Options or inferred from CostBasis: a caller that recompiled clean and
+// silently reported the OTHER number is the whole risk this selector exists to
+// remove, and reporting one loaded corpus both ways — without a second,
+// bodies-on, unmasked read — is the affordance that matters.
+func CodeExecSavingFor(parent *ReplayCall, mode BaselineMode) CodeExecSaving {
+	mode = mode.orDefault()
+	out := CodeExecSaving{Mode: mode}
 	if parent == nil {
-		return CodeExecSaving{Basis: CostUnavailable, Reason: ReasonNotACall}
+		return CodeExecSaving{Mode: mode, Basis: CostUnavailable, Reason: ReasonNotACall}
 	}
 	out.ParentID = parent.RequestID
 	out.SubCalls = len(parent.SubCalls)
 	if parent.ToolName != CodeExecToolName {
-		return CodeExecSaving{ParentID: out.ParentID, Basis: CostUnavailable, Reason: ReasonNotACall}
+		// Deliberately not routed through withheld(): a not-a-call figure
+		// reports SubCalls: 0, because counting the sub-calls of something that
+		// is not a code_execution call describes nothing.
+		return CodeExecSaving{ParentID: out.ParentID, Mode: mode,
+			Basis: CostUnavailable, Reason: ReasonNotACall}
+	}
+	withheld := func(reason ExclusionReason) CodeExecSaving {
+		return CodeExecSaving{ParentID: out.ParentID, SubCalls: out.SubCalls,
+			Mode: mode, Basis: CostUnavailable, Reason: reason}
 	}
 
 	// Collect every component first so a single pass can decide the basis.
@@ -108,32 +224,66 @@ func CodeExecSavingFor(parent *ReplayCall) CodeExecSaving {
 		cost      Cost
 		child     bool
 		generated bool
+		// record is the sub-call record's own Flags.Truncated. Kept beside the
+		// Cost so the tolerated set under BaselineDirect is EXACTLY the set
+		// BaselineProxy withholds on: a record flagged truncated whose Cost
+		// happens to carry no Truncated marker would otherwise contribute with
+		// no annotation, which is the silence doc.go's third rule forbids.
+		record bool
 	}
 	// generated marks a component the MODEL WROTE — a call's arguments — as
 	// opposed to one it read. The distinction is the billing direction.
 	comps := []component{
-		{parent.RequestCost, false, true},
-		{parent.ResponseCost, false, false},
+		{parent.RequestCost, false, true, false},
+		{parent.ResponseCost, false, false, false},
 	}
 	for _, sub := range parent.SubCalls {
-		comps = append(comps, component{sub.RequestCost, true, true},
-			component{sub.ResponseCost, true, false})
+		// Guarded HERE because this is the first dereference: the nil check
+		// further down used to be the only one, which made it unreachable and
+		// gave a false sense that nil entries were handled.
+		if sub == nil {
+			continue
+		}
+		comps = append(comps, component{sub.RequestCost, true, true, sub.Flags.Truncated},
+			component{sub.ResponseCost, true, false, sub.Flags.Truncated})
 	}
 
 	basis := CostBasis("")
 	baselineOut, baselineIn, proxyOut, proxyIn := 0, 0, 0, 0
-	// Any truncation anywhere in the call withholds it — see
-	// ReasonTruncatedSubCallOverstates. Checked before the components are
-	// summed so no partial total is ever built.
-	truncatedAnywhere := parent.Flags.Truncated
-	for _, sub := range parent.SubCalls {
-		if sub != nil && sub.Flags.Truncated {
-			truncatedAnywhere = true
-		}
+	truncatedSubCalls, truncatedBaseline := 0, 0
+
+	// A truncated PARENT withholds in BOTH modes, and the reason has nothing to
+	// do with which agent we are comparing against. The parent's response is
+	// the PROXY term — what the model actually read — and mcpproxy really did
+	// cut it at ToolResponseLimit (forwardContentResult) while response_bytes
+	// records the full pre-truncation size. Counting the full size overstates
+	// the proxy term and so UNDERSTATES the saving: conservative, still wrong,
+	// and no baseline choice repairs it. (Unreachable on real data:
+	// code_execution emits through emitActivityInternalToolCall, which passes
+	// responseTruncated=false, and a truncated internal record is already
+	// withheld by responseCost as ReasonTruncatedRetrieveOverstates — the
+	// OPPOSITE direction, where the log stores more than the agent consumed.)
+	if parent.Flags.Truncated {
+		return withheld(ReasonTruncatedSubCallOverstates)
 	}
-	if truncatedAnywhere {
-		return CodeExecSaving{ParentID: out.ParentID, SubCalls: out.SubCalls,
-			Basis: CostUnavailable, Reason: ReasonTruncatedSubCallOverstates}
+	// A truncated SUB-CALL is the only place the two counterfactuals disagree.
+	// Under BaselineProxy the agent's own call would have been cut at
+	// ToolResponseLimit, so the full size overstates the baseline and the whole
+	// call is withheld before any component is summed — no partial total is
+	// ever built. Under BaselineDirect nothing truncates and the full size is
+	// exactly what that agent reads, so the loop runs and annotates.
+	//
+	// Consequence for anyone diffing two runs: because this short-circuit is
+	// gone under direct, a call that reported truncated_sub_call_overstates_saving
+	// may now report mixed_cost_basis or sub_call_zero_bytes — the reason it was
+	// always going to hit second. WITHHELD-BY-REASON TALLIES ARE NOT COMPARABLE
+	// ACROSS MODES, and a reason that moved represents no change in the data.
+	if mode == BaselineProxy {
+		for _, sub := range parent.SubCalls {
+			if sub != nil && sub.Flags.Truncated {
+				return withheld(ReasonTruncatedSubCallOverstates)
+			}
+		}
 	}
 	for _, c := range comps {
 		amount, ok := c.cost.amount()
@@ -142,24 +292,39 @@ func CodeExecSavingFor(parent *ReplayCall) CodeExecSaving {
 			if reason == "" {
 				reason = ReasonNoByteCounts
 			}
-			return CodeExecSaving{ParentID: out.ParentID, SubCalls: out.SubCalls,
-				Basis: CostUnavailable, Reason: reason}
+			return withheld(reason)
 		}
 		if basis == "" {
 			basis = c.cost.Basis
 		} else if basis != c.cost.Basis {
-			return CodeExecSaving{ParentID: out.ParentID, SubCalls: out.SubCalls,
-				Basis: CostUnavailable, Reason: ReasonMixedCostBasis}
+			return withheld(ReasonMixedCostBasis)
 		}
-		// A truncated component's byte length is the FULL pre-truncation size,
-		// but the baseline means "what an agent would have paid making this
-		// call itself" and that agent receives a cut response. Counting the
-		// full size overstates the baseline, and an overstated baseline
-		// inflates the saving — so withhold rather than annotate. Annotating
-		// leaves the wrong number in the headline with a footnote beside it.
-		if c.cost.Truncated {
-			return CodeExecSaving{ParentID: out.ParentID, SubCalls: out.SubCalls,
-				Basis: CostUnavailable, Reason: ReasonTruncatedSubCallOverstates}
+		// Truncation only ever cuts a RESPONSE — requestCost never sets
+		// Truncated (flags.go) — so charging the request side of a truncated
+		// record would count one cut response twice and overstate how much of
+		// this figure is soft.
+		truncated := !c.generated && (c.cost.Truncated || c.record)
+		if truncated {
+			// The parent's own components are the proxy term: withheld in both
+			// modes, for the reason the pre-pass states. A sub-call's are the
+			// baseline term, and under BaselineDirect they are counted at their
+			// FULL pre-truncation byte length — which is trustworthy only
+			// because the sandbox truncation is record-only
+			// (subCallActivityResponseLimit cuts the stored string; the value
+			// the sandbox received and subCallByteSizes measured was whole).
+			// Never substitute the stored TEXT here: it is capped at 8KB and
+			// would understate.
+			//
+			// The mode is read HERE and nowhere else. responseCost takes no
+			// mode on purpose — the counterfactual is a scoring choice, not a
+			// classification one, and doc.go's classify-once rule forbids
+			// re-deriving a flag downstream. Do not "finish the job" by
+			// threading it into the loader.
+			if !c.child || mode == BaselineProxy {
+				return withheld(ReasonTruncatedSubCallOverstates)
+			}
+			truncatedSubCalls++
+			truncatedBaseline += amount
 		}
 		switch {
 		case c.child && c.generated:
@@ -179,12 +344,18 @@ func CodeExecSavingFor(parent *ReplayCall) CodeExecSaving {
 	out.Baseline = baselineOut + baselineIn
 	out.Proxy = proxyOut + proxyIn
 	out.Saving = out.Baseline - out.Proxy
+	out.TruncatedSubCalls, out.TruncatedBaseline = truncatedSubCalls, truncatedBaseline
 	return out
 }
 
 // CodeExecReport aggregates response-side savings, bucketed BY BASIS so a
 // measured total and an estimated one are never added together.
 type CodeExecReport struct {
+	// Mode is the counterfactual every figure below is measured against. It is
+	// on the report as well as on each saving so a report read alone still
+	// states its own denominator.
+	Mode BaselineMode `json:"baseline_mode"`
+
 	// Buckets is keyed by basis: "measured" totals are tokens, "estimated"
 	// totals are bytes.
 	Buckets map[CostBasis]*CodeExecBucket `json:"buckets"`
@@ -203,12 +374,32 @@ type CodeExecBucket struct {
 	Baseline int `json:"baseline"`
 	Proxy    int `json:"proxy"`
 	Saving   int `json:"saving"`
+
+	// How much of Baseline above rests on components BaselineProxy would have
+	// thrown away. Always 0 under BaselineProxy. A total that tolerates
+	// truncation has to carry the magnitude beside it, not just a count — see
+	// CodeExecSaving.TruncatedBaseline.
+	TruncatedSubCalls int `json:"truncated_sub_calls,omitempty"`
+	TruncatedBaseline int `json:"truncated_baseline,omitempty"`
+
+	// TruncatedCalls and TruncatedCallSaving are the WHOLE-CALL figures, and
+	// they are the ones to quote when asking "what does the mode change cost
+	// me in confidence". TruncatedBaseline above is only the truncated
+	// COMPONENT's contribution, but BaselineProxy does not drop a component —
+	// it drops the entire call, its untruncated sub-calls and its proxy term
+	// with it. Reporting only the component magnitude therefore understates
+	// how much of the published total exists solely because direct mode
+	// tolerated truncation.
+	TruncatedCalls      int `json:"truncated_calls,omitempty"`
+	TruncatedCallSaving int `json:"truncated_call_saving,omitempty"`
 }
 
 // CodeExecSavingsFor walks sessions and reports the response-side saving of
-// every code_execution call in them.
-func CodeExecSavingsFor(sessions []*ReplaySession) *CodeExecReport {
-	rep := &CodeExecReport{Buckets: map[CostBasis]*CodeExecBucket{}}
+// every code_execution call in them, against the counterfactual mode names (the
+// zero value is BaselineDirect).
+func CodeExecSavingsFor(sessions []*ReplaySession, mode BaselineMode) *CodeExecReport {
+	mode = mode.orDefault()
+	rep := &CodeExecReport{Mode: mode, Buckets: map[CostBasis]*CodeExecBucket{}}
 	for _, session := range sessions {
 		if session == nil {
 			continue
@@ -219,7 +410,7 @@ func CodeExecSavingsFor(sessions []*ReplaySession) *CodeExecReport {
 			if call == nil || call.ToolName != CodeExecToolName {
 				continue
 			}
-			saving := CodeExecSavingFor(call)
+			saving := CodeExecSavingFor(call, mode)
 			rep.Savings = append(rep.Savings, saving)
 			if saving.Basis == CostUnavailable {
 				if rep.Withheld == nil {
@@ -238,6 +429,12 @@ func CodeExecSavingsFor(sessions []*ReplaySession) *CodeExecReport {
 			bucket.Baseline += saving.Baseline
 			bucket.Proxy += saving.Proxy
 			bucket.Saving += saving.Saving
+			bucket.TruncatedSubCalls += saving.TruncatedSubCalls
+			bucket.TruncatedBaseline += saving.TruncatedBaseline
+			if saving.TruncatedSubCalls > 0 {
+				bucket.TruncatedCalls++
+				bucket.TruncatedCallSaving += saving.Saving
+			}
 		}
 	}
 	return rep
@@ -252,11 +449,24 @@ func CodeExecSavingsFor(sessions []*ReplaySession) *CodeExecReport {
 //
 //   - a withheld saving has no figures at all, and 0.0 would read as "code
 //     execution was free" instead of "nothing was measurable";
+//
 //   - an ESTIMATED saving is BYTE lengths, not tokens, so pricing it per-token
 //     would be wrong by roughly the bytes-per-token ratio and would look
 //     entirely plausible.
+//
+//   - a saving that TOLERATED a truncated sub-call is not priced, whichever
+//     mode produced it. Today that is belt-and-braces: responseCost refuses to
+//     tokenize cut text, so such a saving is CostEstimated and the basis guard
+//     above already rejects it. That is a property of the current loader, not
+//     of this function, and a future path that tokenized a partially-cut
+//     response would silently start pricing tolerated data. The rule money
+//     obeys is stated here and ENFORCED here rather than inherited from a
+//     coincidence two files away.
 func (s CodeExecSaving) PricedSavingUSD(inPerMTok, outPerMTok, cacheMult float64) (float64, bool) {
 	if s.Basis != CostMeasured {
+		return 0, false
+	}
+	if s.TruncatedSubCalls > 0 {
 		return 0, false
 	}
 	// Reject prices that cannot produce a meaningful figure. NaN and +/-Inf

--- a/bench/replaycorpus/codeexec_test.go
+++ b/bench/replaycorpus/codeexec_test.go
@@ -1,7 +1,9 @@
 package replaycorpus
 
 import (
+	"encoding/json"
 	"math"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,7 +34,7 @@ func TestCodeExecSaving_MeasuresTheResponseSideDifference(t *testing.T) {
 		subCall(measured(40), measured(600)),
 	)
 
-	got := CodeExecSavingFor(parent)
+	got := CodeExecSavingFor(parent, BaselineDirect)
 
 	require.Equal(t, CostMeasured, got.Basis)
 	assert.Equal(t, 3, got.SubCalls)
@@ -44,7 +46,7 @@ func TestCodeExecSaving_MeasuresTheResponseSideDifference(t *testing.T) {
 // A script that dispatches nothing costs tokens and returns none. That is a
 // real loss and must be reported as one rather than filtered out or floored.
 func TestCodeExecSaving_NoSubCallsIsARealNegative(t *testing.T) {
-	got := CodeExecSavingFor(codeExecCall(measured(500), measured(20)))
+	got := CodeExecSavingFor(codeExecCall(measured(500), measured(20)), BaselineDirect)
 
 	require.Equal(t, CostMeasured, got.Basis)
 	assert.Equal(t, 0, got.SubCalls)
@@ -59,7 +61,7 @@ func TestCodeExecSaving_NeverSumsAcrossBases(t *testing.T) {
 		subCall(measured(10), estimated(4000)),
 	)
 
-	got := CodeExecSavingFor(parent)
+	got := CodeExecSavingFor(parent, BaselineDirect)
 
 	require.Equal(t, CostUnavailable, got.Basis)
 	assert.Equal(t, ReasonMixedCostBasis, got.Reason)
@@ -75,7 +77,7 @@ func TestCodeExecSaving_UnavailableComponentWithholdsTheWhole(t *testing.T) {
 		subCall(measured(10), unavailable()),
 	)
 
-	got := CodeExecSavingFor(parent)
+	got := CodeExecSavingFor(parent, BaselineDirect)
 
 	require.Equal(t, CostUnavailable, got.Basis)
 	assert.Equal(t, ReasonSubCallZeroBytes, got.Reason, "the reason must survive to the caller")
@@ -88,7 +90,7 @@ func TestCodeExecSaving_EstimatedBasisIsBytes(t *testing.T) {
 		subCall(estimated(100), estimated(5000)),
 	)
 
-	got := CodeExecSavingFor(parent)
+	got := CodeExecSavingFor(parent, BaselineDirect)
 
 	require.Equal(t, CostEstimated, got.Basis)
 	assert.Equal(t, 5100-600, got.Saving)
@@ -98,30 +100,38 @@ func TestCodeExecSaving_EstimatedBasisIsBytes(t *testing.T) {
 // This previously asserted that truncation merely set an annotation flag while
 // the saving was still computed and published — which is exactly the defect
 // cross-model review caught, so the assertion is inverted rather than dropped.
-func TestCodeExecSaving_TruncationWithholds(t *testing.T) {
+//
+// It pins the PROXY counterfactual specifically: the agent it compares against
+// dispatches through call_tool_*, where each block is cut at ToolResponseLimit,
+// so the full pre-truncation size overstates the baseline. That is a property of
+// THAT comparison, not a universal truth — under BaselineDirect the same
+// sub-call fixtures are counted, see the mirror tests below.
+func TestCodeExecSaving_TruncationWithholdsUnderProxyBaseline(t *testing.T) {
 	sub := subCall(measured(10), Cost{Basis: CostMeasured, Tokens: 900, Truncated: true})
-	got := CodeExecSavingFor(codeExecCall(measured(100), measured(50), sub))
+	got := CodeExecSavingFor(codeExecCall(measured(100), measured(50), sub), BaselineProxy)
 	require.Equal(t, CostUnavailable, got.Basis, "a truncated sub-call understates nothing — it OVERstates the baseline")
 	assert.Equal(t, ReasonTruncatedSubCallOverstates, got.Reason)
 
 	flagged := subCall(measured(10), measured(900))
 	flagged.Flags.Truncated = true
-	got2 := CodeExecSavingFor(codeExecCall(measured(100), measured(50), flagged))
+	got2 := CodeExecSavingFor(codeExecCall(measured(100), measured(50), flagged), BaselineProxy)
 	assert.Equal(t, CostUnavailable, got2.Basis, "the call-level flag must withhold too")
 
 	parentCut := codeExecCall(measured(100), measured(50), subCall(measured(10), measured(900)))
 	parentCut.Flags.Truncated = true
-	assert.Equal(t, CostUnavailable, CodeExecSavingFor(parentCut).Basis,
-		"a truncated PARENT understates the proxy cost, which also inflates the saving")
+	assert.Equal(t, CostUnavailable, CodeExecSavingFor(parentCut, BaselineProxy).Basis,
+		"a truncated PARENT overstates the proxy cost — response_bytes is pre-truncation while "+
+			"the model read the cut text — so it UNDERstates the saving; wrong either way, and "+
+			"no baseline choice repairs it")
 }
 
 func TestCodeExecSaving_RejectsNonCodeExecParents(t *testing.T) {
 	other := &ReplayCall{RequestID: "x", ToolName: "retrieve_tools", RequestCost: measured(1), ResponseCost: measured(1)}
-	got := CodeExecSavingFor(other)
+	got := CodeExecSavingFor(other, BaselineDirect)
 	require.Equal(t, CostUnavailable, got.Basis)
 	assert.Equal(t, ReasonNotACall, got.Reason)
 
-	assert.Equal(t, CostUnavailable, CodeExecSavingFor(nil).Basis)
+	assert.Equal(t, CostUnavailable, CodeExecSavingFor(nil, BaselineDirect).Basis)
 }
 
 // The aggregate must bucket by basis rather than producing one blended total,
@@ -137,7 +147,7 @@ func TestCodeExecSavingsFor_BucketsByBasisAndCountsWithheld(t *testing.T) {
 		},
 	}}
 
-	rep := CodeExecSavingsFor(sessions)
+	rep := CodeExecSavingsFor(sessions, BaselineDirect)
 
 	require.Len(t, rep.Buckets, 2, "measured and estimated must stay separate")
 	assert.Equal(t, 760, rep.Buckets[CostMeasured].Saving)
@@ -158,7 +168,7 @@ func TestCodeExecSavingsFor_DoesNotRevisitSubCalls(t *testing.T) {
 		CallCount:     1, SubCallCount: 1,
 	}}
 
-	rep := CodeExecSavingsFor(sessions)
+	rep := CodeExecSavingsFor(sessions, BaselineDirect)
 
 	assert.Len(t, rep.Savings, 1, "exactly one code_execution call was made")
 	assert.Equal(t, 760, rep.Buckets[CostMeasured].Saving)
@@ -262,14 +272,19 @@ func TestRequestCost_EmptyArgsWithLargePayloadStaysEstimated(t *testing.T) {
 // falls to an estimate while its siblings are measured, and the never-sum guard
 // withholds. With bodies OFF everything is estimated, the bases agree, and the
 // inflated number went straight into the total.
-func TestCodeExecSaving_TruncatedSubCallWithholdsRatherThanInflates(t *testing.T) {
+//
+// All of the above is the PROXY counterfactual's rationale and is still exactly
+// true of it. Under BaselineDirect the same fixture is counted, because that
+// agent has no proxy in the path and nothing cuts its response — see
+// TestCodeExecSaving_DirectBaselineCountsTruncatedSubCallAtFullSize.
+func TestCodeExecSaving_TruncatedSubCallWithholdsRatherThanInflates_UnderProxyBaseline(t *testing.T) {
 	huge := subCall(estimated(40), Cost{Basis: CostEstimated, Bytes: 250_000, Truncated: true})
 	parent := codeExecCall(estimated(400), estimated(200),
 		subCall(estimated(50), estimated(900)),
 		huge,
 	)
 
-	got := CodeExecSavingFor(parent)
+	got := CodeExecSavingFor(parent, BaselineProxy)
 
 	require.Equal(t, CostUnavailable, got.Basis,
 		"the full pre-truncation size would inflate the baseline and so the saving")
@@ -280,12 +295,12 @@ func TestCodeExecSaving_TruncatedSubCallWithholdsRatherThanInflates(t *testing.T
 
 // The aggregate must not carry an inflated total either — the withheld call is
 // counted under its reason and contributes nothing to any bucket.
-func TestCodeExecSavingsFor_TruncatedSubCallNeverReachesTheTotal(t *testing.T) {
+func TestCodeExecSavingsFor_TruncatedSubCallNeverReachesTheTotal_UnderProxyBaseline(t *testing.T) {
 	clean := codeExecCall(estimated(400), estimated(200), subCall(estimated(50), estimated(900)))
 	dirty := codeExecCall(estimated(400), estimated(200),
 		subCall(estimated(40), Cost{Basis: CostEstimated, Bytes: 250_000, Truncated: true}))
 
-	rep := CodeExecSavingsFor([]*ReplaySession{{WorkSessionID: "w", Calls: []*ReplayCall{clean, dirty}}})
+	rep := CodeExecSavingsFor([]*ReplaySession{{WorkSessionID: "w", Calls: []*ReplayCall{clean, dirty}}}, BaselineProxy)
 
 	require.NotNil(t, rep.Buckets[CostEstimated])
 	assert.Equal(t, 1, rep.Buckets[CostEstimated].Calls)
@@ -309,7 +324,7 @@ func TestCodeExecSaving_SplitsByBillingDirection(t *testing.T) {
 		subCall(measured(12), measured(105)),
 	)
 
-	got := CodeExecSavingFor(parent)
+	got := CodeExecSavingFor(parent, BaselineDirect)
 
 	require.Equal(t, CostMeasured, got.Basis)
 	assert.Equal(t, 36, got.BaselineOutput, "three calls of arguments the model would have written")
@@ -334,7 +349,7 @@ func TestCodeExecSaving_SplitsByBillingDirection(t *testing.T) {
 // A withheld saving has no numbers to price, and must not return a confident 0.
 func TestCodeExecSaving_PricedSavingRefusesWithheldFigures(t *testing.T) {
 	parent := codeExecCall(measured(100), measured(50), subCall(measured(10), unavailable()))
-	got := CodeExecSavingFor(parent)
+	got := CodeExecSavingFor(parent, BaselineDirect)
 	require.Equal(t, CostUnavailable, got.Basis)
 
 	_, ok := got.PricedSavingUSD(3.0, 15.0, 0.1)
@@ -345,7 +360,7 @@ func TestCodeExecSaving_PricedSavingRefusesWithheldFigures(t *testing.T) {
 // wrong by roughly the bytes-per-token ratio and would look entirely plausible.
 func TestCodeExecSaving_PricedSavingRefusesByteEstimates(t *testing.T) {
 	parent := codeExecCall(estimated(400), estimated(200), subCall(estimated(100), estimated(5000)))
-	got := CodeExecSavingFor(parent)
+	got := CodeExecSavingFor(parent, BaselineDirect)
 	require.Equal(t, CostEstimated, got.Basis)
 
 	_, ok := got.PricedSavingUSD(3.0, 15.0, 0.1)
@@ -390,7 +405,7 @@ func TestBillableArguments_DropsServerResolvedScriptSource(t *testing.T) {
 // and would be reported as a confident dollar figure.
 func TestCodeExecSaving_PricedSavingRejectsNonsensePrices(t *testing.T) {
 	got := CodeExecSavingFor(codeExecCall(measured(78), measured(11),
-		subCall(measured(12), measured(105))))
+		subCall(measured(12), measured(105))), BaselineDirect)
 	require.Equal(t, CostMeasured, got.Basis)
 
 	_, ok := got.PricedSavingUSD(3.0, 15.0, 0.1)
@@ -409,4 +424,342 @@ func TestCodeExecSaving_PricedSavingRejectsNonsensePrices(t *testing.T) {
 		_, ok := got.PricedSavingUSD(bad.in, bad.out, bad.cacheMul)
 		assert.False(t, ok, "%s must be refused, not reported", bad.name)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// BaselineMode: the same log, two legitimate counterfactuals.
+// ---------------------------------------------------------------------------
+
+// The mirror of TestCodeExecSaving_TruncatedSubCallWithholdsRatherThanInflates_UnderProxyBaseline,
+// on the identical fixture. An agent wired straight to the upstream servers has
+// no proxy to cut its response, so the full pre-truncation size is exactly what
+// it reads and the call is countable. Two modes, one input, two right answers.
+func TestCodeExecSaving_DirectBaselineCountsTruncatedSubCallAtFullSize(t *testing.T) {
+	huge := subCall(estimated(40), Cost{Basis: CostEstimated, Bytes: 250_000, Truncated: true})
+	parent := codeExecCall(estimated(400), estimated(200),
+		subCall(estimated(50), estimated(900)),
+		huge,
+	)
+
+	got := CodeExecSavingFor(parent, BaselineDirect)
+
+	require.Equal(t, CostEstimated, got.Basis, "nothing truncates the counterfactual agent, so nothing is withheld")
+	assert.Equal(t, 250_990, got.Baseline)
+	assert.Equal(t, 600, got.Proxy)
+	assert.Equal(t, 250_390, got.Saving)
+	assert.Equal(t, 90, got.BaselineOutput, "two calls of arguments")
+	assert.Equal(t, 250_900, got.BaselineInput)
+	assert.Equal(t, 1, got.TruncatedSubCalls, "the tolerated component must be counted...")
+	assert.Equal(t, 250_000, got.TruncatedBaseline, "...and its magnitude published, not just its existence")
+	assert.Equal(t, BaselineDirect, got.Mode)
+}
+
+// The seam guard. The relaxation is deliberately NARROWER than "tolerate
+// Flags.Truncated": the parent's response is the PROXY term — what the model
+// actually read, after mcpproxy cut it at ToolResponseLimit — so counting its
+// full pre-truncation size overstates the proxy cost and understates the saving.
+// That is wrong under both counterfactuals and no baseline choice repairs it.
+func TestCodeExecSaving_DirectBaselineStillWithholdsATruncatedParent(t *testing.T) {
+	flagged := codeExecCall(measured(100), measured(50), subCall(measured(10), measured(900)))
+	flagged.Flags.Truncated = true
+
+	costCut := codeExecCall(estimated(400), Cost{Basis: CostEstimated, Bytes: 9_000, Truncated: true},
+		subCall(estimated(50), estimated(900)))
+
+	for _, tc := range []struct {
+		name   string
+		parent *ReplayCall
+	}{
+		{"call-level flag on the parent", flagged},
+		{"truncation marked on the parent's own response cost", costCut},
+	} {
+		for _, mode := range []BaselineMode{BaselineDirect, BaselineProxy} {
+			got := CodeExecSavingFor(tc.parent, mode)
+			require.Equal(t, CostUnavailable, got.Basis, "%s / %s", tc.name, mode)
+			assert.Equal(t, ReasonTruncatedSubCallOverstates, got.Reason, "%s / %s", tc.name, mode)
+			assert.Equal(t, mode, got.Mode, "a withheld line still has to say which baseline refused it")
+		}
+	}
+}
+
+// The blast radius is ONE gate. Every other refusal is a property of the record
+// rather than of the comparison, so both modes must agree exactly.
+func TestCodeExecSaving_DirectBaselineStillWithholdsEveryOtherReason(t *testing.T) {
+	sensitive := subCall(estimated(50), Cost{Basis: CostUnavailable, Reason: ReasonSensitive})
+	// The OPPOSITE truncation direction: for a built-in the log stores MORE
+	// than the agent consumed, so counting it overstates mcpproxy's own cost.
+	// Correct under both counterfactuals, and untouched by this change.
+	retrieveCut := subCall(estimated(50), Cost{Basis: CostUnavailable, Reason: ReasonTruncatedRetrieveOverstates})
+
+	for _, tc := range []struct {
+		name   string
+		parent *ReplayCall
+		basis  CostBasis
+		reason ExclusionReason
+	}{
+		{"nil parent", nil, CostUnavailable, ReasonNotACall},
+		{"not a code_execution call",
+			&ReplayCall{RequestID: "x", ToolName: "retrieve_tools", RequestCost: measured(1), ResponseCost: measured(1)},
+			CostUnavailable, ReasonNotACall},
+		{"sub-call with no honest figure",
+			codeExecCall(measured(100), measured(50), subCall(measured(10), unavailable())),
+			CostUnavailable, ReasonSubCallZeroBytes},
+		{"sensitive body",
+			codeExecCall(estimated(400), estimated(200), sensitive),
+			CostUnavailable, ReasonSensitive},
+		{"truncated internal retrieve_tools",
+			codeExecCall(estimated(400), estimated(200), retrieveCut),
+			CostUnavailable, ReasonTruncatedRetrieveOverstates},
+		{"measured and estimated components mixed",
+			codeExecCall(measured(100), measured(50), subCall(measured(10), estimated(4000))),
+			CostUnavailable, ReasonMixedCostBasis},
+	} {
+		direct := CodeExecSavingFor(tc.parent, BaselineDirect)
+		proxy := CodeExecSavingFor(tc.parent, BaselineProxy)
+		require.Equal(t, tc.basis, direct.Basis, "%s under direct", tc.name)
+		assert.Equal(t, tc.reason, direct.Reason, "%s under direct", tc.name)
+		assert.Equal(t, direct.Basis, proxy.Basis, "%s: the two modes must agree", tc.name)
+		assert.Equal(t, direct.Reason, proxy.Reason, "%s: the two modes must agree", tc.name)
+	}
+}
+
+// You did not invalidate anyone's untruncated numbers. On a corpus with no
+// truncation anywhere the two reports are identical but for the label.
+func TestCodeExecSaving_DirectAndProxyAgreeWhenNothingWasTruncated(t *testing.T) {
+	sessions := []*ReplaySession{
+		{WorkSessionID: "w1", Calls: []*ReplayCall{
+			codeExecCall(measured(120), measured(80),
+				subCall(measured(30), measured(900)),
+				subCall(measured(25), measured(1500))),
+			codeExecCall(measured(500), measured(20)),
+		}},
+		{WorkSessionID: "w2", Calls: []*ReplayCall{
+			codeExecCall(estimated(400), estimated(200), subCall(estimated(100), estimated(5000))),
+			codeExecCall(measured(100), measured(50), subCall(measured(10), unavailable())),
+		}},
+	}
+
+	direct := CodeExecSavingsFor(sessions, BaselineDirect)
+	proxy := CodeExecSavingsFor(sessions, BaselineProxy)
+
+	require.Equal(t, BaselineDirect, direct.Mode)
+	require.Equal(t, BaselineProxy, proxy.Mode)
+	// Normalise only the label; everything else must already match.
+	proxy.Mode = direct.Mode
+	for i := range proxy.Savings {
+		proxy.Savings[i].Mode = direct.Savings[i].Mode
+	}
+	assert.True(t, reflect.DeepEqual(direct, proxy),
+		"with nothing truncated the counterfactual cannot matter:\ndirect %+v\nproxy  %+v", direct, proxy)
+}
+
+// The record's own Flags.Truncated must annotate too, not just Cost.Truncated.
+// The loader can produce a call-level flag beside a cost that carries no marker,
+// and without component.record that component would contribute in silence —
+// which is exactly what doc.go's third invariant forbids.
+func TestCodeExecSaving_TruncationAnnotationCoversTheRecordFlagToo(t *testing.T) {
+	flagged := subCall(measured(10), measured(900))
+	flagged.Flags.Truncated = true
+
+	got := CodeExecSavingFor(codeExecCall(measured(100), measured(50), flagged), BaselineDirect)
+
+	require.Equal(t, CostMeasured, got.Basis, "direct counts it")
+	assert.Equal(t, 910, got.Baseline)
+	assert.Equal(t, 1, got.TruncatedSubCalls, "and says so")
+	assert.Equal(t, 900, got.TruncatedBaseline,
+		"the RESPONSE side only — truncation never cuts arguments, and charging both would double-count")
+}
+
+// Direct mode rescues LESS than its name suggests, and a talk claiming "the
+// withheld calls are now countable" is wrong in exactly the flattering
+// direction. On the bodies-on path responseCost refuses to tokenize cut text
+// (flags.go), so the truncated component falls to an ESTIMATE while its measured
+// siblings stay tokens — and the never-sum rule withholds regardless of mode.
+// Direct rescues the bodies-OFF, all-estimated population. The 8KB stored text
+// must never be tokenized as a "fix": it would understate.
+func TestCodeExecSaving_BodiesOnTruncatedSubCallIsMixedBasisNotCounted(t *testing.T) {
+	parent := codeExecCall(measured(400), measured(200),
+		subCall(measured(50), measured(900)),
+		subCall(measured(40), Cost{Basis: CostEstimated, Bytes: 250_000, Truncated: true}),
+	)
+
+	got := CodeExecSavingFor(parent, BaselineDirect)
+
+	require.Equal(t, CostUnavailable, got.Basis)
+	assert.Equal(t, ReasonMixedCostBasis, got.Reason)
+	assert.Zero(t, got.Saving)
+}
+
+// The zero value resolves to direct in ONE place, and the label is on every
+// return path. The marshalled-bytes assertions below cannot catch a later
+// `omitempty` on Mode — orDefault() means the field is never the zero value, so
+// it would be emitted anyway — so the tag is asserted directly, which is the
+// only form of that check that can actually fail.
+func TestCodeExecSaving_ZeroModeIsDirectAndAlwaysStamped(t *testing.T) {
+	parent := codeExecCall(measured(120), measured(80), subCall(measured(30), measured(900)))
+	assert.Equal(t, CodeExecSavingFor(parent, BaselineDirect), CodeExecSavingFor(parent, ""),
+		`"" must mean direct, decided once`)
+
+	withheldCall := codeExecCall(measured(100), measured(50), subCall(measured(10), unavailable()))
+	notACall := &ReplayCall{RequestID: "x", ToolName: "retrieve_tools", RequestCost: measured(1), ResponseCost: measured(1)}
+	for _, tc := range []struct {
+		name string
+		v    interface{}
+	}{
+		{"counted saving", CodeExecSavingFor(parent, "")},
+		{"withheld saving", CodeExecSavingFor(withheldCall, "")},
+		{"not a code_execution call", CodeExecSavingFor(notACall, "")},
+		{"nil parent", CodeExecSavingFor(nil, "")},
+		{"report", CodeExecSavingsFor([]*ReplaySession{{WorkSessionID: "w", Calls: []*ReplayCall{parent}}}, "")},
+	} {
+		b, err := json.Marshal(tc.v)
+		require.NoError(t, err, tc.name)
+		assert.Contains(t, string(b), `"baseline_mode":"direct"`,
+			"%s: a figure whose denominator is optional is the ambiguity being removed", tc.name)
+	}
+
+	clean, err := json.Marshal(CodeExecSavingFor(parent, BaselineProxy))
+	require.NoError(t, err)
+	assert.NotContains(t, string(clean), "truncated_sub_calls",
+		"an untruncated figure must not carry a zeroed annotation")
+	assert.NotContains(t, string(clean), "truncated_baseline")
+
+	// Directly, not via a marshalled instance: `omitempty` here would un-label
+	// any figure that ever did carry the zero value, and a published saving
+	// whose denominator is unstated is the ambiguity this type exists to remove.
+	for _, tc := range []struct {
+		typ   reflect.Type
+		field string
+	}{
+		{reflect.TypeOf(CodeExecSaving{}), "Mode"},
+		{reflect.TypeOf(CodeExecReport{}), "Mode"},
+	} {
+		f, ok := tc.typ.FieldByName(tc.field)
+		require.True(t, ok, "%s.%s must exist", tc.typ.Name(), tc.field)
+		assert.Equal(t, `json:"baseline_mode"`, string(f.Tag),
+			"%s.%s must be stamped unconditionally — no omitempty", tc.typ.Name(), tc.field)
+	}
+}
+
+// The proxy pre-pass is load-bearing for HEAD equivalence and only the REASON
+// distinguishes it from letting the component loop catch the same call: without
+// the pre-pass this fixture reports mixed_cost_basis, because the measured
+// sibling is summed before the truncated component is reached. Pinning the
+// withhold alone would pass either way.
+func TestCodeExecSaving_ProxyPrePassWinsTheReasonRace(t *testing.T) {
+	// Flags.Truncated is what the pre-pass reads (the loader sets it in
+	// classify); the estimated response beside measured parent costs is what
+	// makes the basis clash reachable in the same component.
+	sub := subCall(measured(10), Cost{Basis: CostEstimated, Bytes: 90_000, Truncated: true})
+	sub.Flags.Truncated = true
+	parent := codeExecCall(measured(100), measured(50), sub)
+
+	got := CodeExecSavingFor(parent, BaselineProxy)
+	require.Equal(t, CostUnavailable, got.Basis)
+	assert.Equal(t, ReasonTruncatedSubCallOverstates, got.Reason,
+		"truncation must be reported before the basis clash it would otherwise hide")
+
+	// Same fixture under direct: the pre-pass is gone, so the mixed basis the
+	// pre-pass was masking is what surfaces. Documents that withheld-by-reason
+	// tallies are not comparable across modes.
+	assert.Equal(t, ReasonMixedCostBasis, CodeExecSavingFor(parent, BaselineDirect).Reason)
+}
+
+// The headline behaviour change, asserted as a pair on one fixture.
+func TestCodeExecSavingsFor_DirectAndProxyDisagreeOnTheSameSessions(t *testing.T) {
+	clean := codeExecCall(estimated(400), estimated(200), subCall(estimated(50), estimated(900)))
+	dirty := codeExecCall(estimated(400), estimated(200),
+		subCall(estimated(40), Cost{Basis: CostEstimated, Bytes: 250_000, Truncated: true}))
+	sessions := []*ReplaySession{{WorkSessionID: "w", Calls: []*ReplayCall{clean, dirty}}}
+
+	proxy := CodeExecSavingsFor(sessions, BaselineProxy)
+	require.NotNil(t, proxy.Buckets[CostEstimated])
+	assert.Equal(t, 1, proxy.Buckets[CostEstimated].Calls)
+	assert.Equal(t, 350, proxy.Buckets[CostEstimated].Saving)
+	assert.Zero(t, proxy.Buckets[CostEstimated].TruncatedSubCalls, "proxy tolerates nothing")
+	assert.Equal(t, 1, proxy.Withheld[ReasonTruncatedSubCallOverstates])
+
+	direct := CodeExecSavingsFor(sessions, BaselineDirect)
+	require.NotNil(t, direct.Buckets[CostEstimated])
+	assert.Equal(t, 2, direct.Buckets[CostEstimated].Calls)
+	assert.Equal(t, 350+249_440, direct.Buckets[CostEstimated].Saving)
+	assert.Equal(t, 1, direct.Buckets[CostEstimated].TruncatedSubCalls)
+	assert.Equal(t, 250_000, direct.Buckets[CostEstimated].TruncatedBaseline)
+	assert.Empty(t, direct.Withheld)
+	assert.Equal(t, BaselineDirect, direct.Mode)
+}
+
+// Direct is a strict relaxation: it counts everything proxy counts, at the SAME
+// figure. An implementation that perturbed an untruncated call would pass the
+// pair test above and fail here.
+func TestCodeExecSavingsFor_DirectCountsAtLeastAsManyCallsAsProxy(t *testing.T) {
+	truncated := subCall(estimated(40), Cost{Basis: CostEstimated, Bytes: 250_000, Truncated: true})
+	flagged := subCall(estimated(20), estimated(700))
+	flagged.Flags.Truncated = true
+	sessions := []*ReplaySession{{WorkSessionID: "w", Calls: []*ReplayCall{
+		codeExecCall(estimated(400), estimated(200), subCall(estimated(50), estimated(900))),
+		codeExecCall(estimated(400), estimated(200), truncated),
+		codeExecCall(estimated(400), estimated(200), flagged),
+		codeExecCall(measured(120), measured(80), subCall(measured(30), measured(900))),
+		codeExecCall(measured(100), measured(50), subCall(measured(10), unavailable())),
+	}}}
+
+	direct := CodeExecSavingsFor(sessions, BaselineDirect)
+	proxy := CodeExecSavingsFor(sessions, BaselineProxy)
+
+	countedIn := func(rep *CodeExecReport) int {
+		n := 0
+		for _, k := range rep.Buckets {
+			n += k.Calls
+		}
+		return n
+	}
+	assert.GreaterOrEqual(t, countedIn(direct), countedIn(proxy))
+
+	require.Len(t, direct.Savings, len(proxy.Savings))
+	for i := range proxy.Savings {
+		if proxy.Savings[i].Basis == CostUnavailable {
+			continue
+		}
+		assert.Equal(t, proxy.Savings[i].Saving, direct.Savings[i].Saving,
+			"call %d was countable under proxy and must be unchanged under direct", i)
+		assert.Equal(t, proxy.Savings[i].Basis, direct.Savings[i].Basis)
+	}
+}
+
+// A typo'd -baseline that quietly produced the OTHER figure is the failure this
+// selector exists to remove, so the parser refuses everything it does not know
+// exactly — the empty string included.
+func TestParseBaselineMode_RejectsAnythingElse(t *testing.T) {
+	got, err := ParseBaselineMode("direct")
+	require.NoError(t, err)
+	assert.Equal(t, BaselineDirect, got)
+	got, err = ParseBaselineMode("proxy")
+	require.NoError(t, err)
+	assert.Equal(t, BaselineProxy, got)
+
+	for _, bad := range []string{"", "Direct", "DIRECT", " direct", "dir", "proxi", "baseline"} {
+		_, err := ParseBaselineMode(bad)
+		require.Error(t, err, "%q must be refused, not resolved", bad)
+		assert.Contains(t, err.Error(), "direct", "%q: the error must name both valid values", bad)
+		assert.Contains(t, err.Error(), "proxy", "%q: the error must name both valid values", bad)
+	}
+}
+
+// The USD headline never rests on tolerated data, so it does not move when the
+// default counterfactual flips: a truncated component is estimated-basis in
+// every path the loader can produce, and an estimated saving is bytes, which
+// PricedSavingUSD refuses to price as tokens.
+func TestCodeExecSaving_TruncatedSavingStaysUnpriceable(t *testing.T) {
+	parent := codeExecCall(estimated(400), estimated(200),
+		subCall(estimated(50), estimated(900)),
+		subCall(estimated(40), Cost{Basis: CostEstimated, Bytes: 250_000, Truncated: true}),
+	)
+
+	got := CodeExecSavingFor(parent, BaselineDirect)
+	require.Equal(t, CostEstimated, got.Basis)
+	require.Equal(t, 1, got.TruncatedSubCalls)
+
+	_, ok := got.PricedSavingUSD(3.0, 15.0, 0.1)
+	assert.False(t, ok, "byte lengths cannot be priced as tokens, tolerated or not")
 }

--- a/bench/replaycorpus/doc.go
+++ b/bench/replaycorpus/doc.go
@@ -35,7 +35,13 @@
 // exists to prevent, so a truncated record either carries an explicitly
 // annotated estimate derived from its pre-truncation byte length, or is
 // excluded and counted. Every exclusion is counted and reportable (FR-002,
-// FR-003, SC-008): silence is never success.
+// FR-003, SC-008): silence is never success. Note that the first branch is a
+// real one: codeexec.go's BaselineDirect COUNTS a truncated sub-call, at its
+// full pre-truncation byte length, and stays inside this rule only because
+// CodeExecSaving.TruncatedSubCalls and TruncatedBaseline publish how many such
+// components contributed and how much of the baseline they are. Without that
+// annotation direct mode would be outside the invariant, which is why those two
+// fields are load-bearing rather than decorative.
 //
 // The binding contract for the input shape is
 // specs/103-token-bench/contracts/replay-input.md.

--- a/bench/replaycorpus/flags.go
+++ b/bench/replaycorpus/flags.go
@@ -116,6 +116,20 @@ const (
 	// considering later is to count the truncated component at its STORED
 	// length and publish the result as a lower bound — more informative, and it
 	// needs a saving type that can express "at least".
+	//
+	// SCOPE, since this is now conditional: everything above describes
+	// BaselineProxy, the counterfactual where the agent's own call goes through
+	// call_tool_* and IS cut at ToolResponseLimit. Under BaselineDirect the
+	// agent talks to the upstream servers with no proxy in the path, nothing
+	// truncates, and the full pre-truncation size is exactly what it reads — so
+	// codeexec.go counts the sub-call and annotates it (TruncatedSubCalls /
+	// TruncatedBaseline) instead of firing this reason. The PARENT half is
+	// unconditional: the parent's response is the proxy term, mcpproxy really
+	// did cut it, and this reason still fires for it in both modes.
+	//
+	// Corollary for anyone comparing two runs: a call withheld here under proxy
+	// is re-tested under direct and may withhold under a DIFFERENT reason, so
+	// per-reason tallies are not comparable across baselines.
 	ReasonTruncatedSubCallOverstates ExclusionReason = "truncated_sub_call_overstates_saving"
 )
 


### PR DESCRIPTION
## Description

`CodeExecSavingFor` documents its baseline as *"what an agent would have paid making this call itself"* and silently means **through this proxy**. Those are two different questions, with two different answers from the same log — and a saving whose denominator is unstated cannot be quoted.

This adds `BaselineMode` and a `-baseline` flag to `codeexecsaving`:

- **`direct`** *(new default)* — the agent is wired straight to the upstream MCP servers, no proxy in the path. Nothing truncates, so a sub-call's full pre-truncation `response_bytes` is exactly what it reads. The recorded truncation is an artefact of the **record**: `subCallActivityResponseLimit` cuts the stored string at 8 KB while `subCallByteSizes` measures the whole result, and the value handed to the sandbox is never cut.
- **`proxy`** — today's behaviour, bit for bit. The agent calls through `call_tool_*`, where `forwardContentResult` cuts each content block at `tool_response_limit`, so counting the full size overstates the baseline and a truncated sub-call withholds the whole call.

### Why the default changes

`tool_response_limit` is an mcpproxy feature. Charging the counterfactual agent for it answers *"what did code execution save over `call_tool_*`"* rather than *"what did mcpproxy save me"* — and the latter is what users mean. It also brings this figure into line with the harness's own denominator, `modematrix`'s `baselineCell`: *"the same agent doing the same tasks with every upstream tool inline"*.

The withhold it replaces is also not statistically neutral: it fires precisely on the **largest** responses, the ones with the most to save, so the surviving population was biased small in a way no exclusion counter showed as a magnitude. On a real 69-sub-call workload it withheld the entire measurement.

### Direct mode never contributes silently

`TruncatedSubCalls` / `TruncatedBaseline` carry the component magnitude; `TruncatedCalls` / `TruncatedCallSaving` carry the whole-call figures `proxy` would have discarded (it drops the whole call, not the component — reporting only the component understates what the mode change bought). The CLI prints both beside any total that rests on them. `PricedSavingUSD` now *enforces* that money never rests on tolerated data, instead of relying on the loader happening never to tokenize cut text.

Unchanged in both modes: a truncated **parent** still withholds — its response is the proxy term and mcpproxy really did cut it, which no baseline choice repairs. `ReasonTruncatedRetrieveOverstates` is untouched; that is the opposite direction, where the log stores *more* than the agent consumed.

⚠️ **Withheld-by-reason tallies are not comparable across modes.** A call that reported `truncated_sub_call_overstates_saving` may now report the reason it was always going to hit second (`mixed_cost_basis`, `sub_call_zero_bytes`). That is a relabelling, not a change in the data.

### Naming

`internal/config` already uses `RoutingModeDirect = "direct"` for a proxied mode that *does* truncate, so the value is glossed everywhere it is printed and the collision is called out in the `BaselineDirect` doc comment. Happy to rename to `unproxied` if you'd prefer the ambiguity gone permanently.

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests that prove my fix is effective or my feature works
- [x] All existing tests pass

`go build ./bench/...`, `go vet ./bench/...`, `go test ./bench/...` and `go test -race ./bench/...` all clean. Changes are confined to `bench/` (5 files).

Existing truncation tests were renamed, not deleted, and now pass `BaselineProxy` explicitly so they keep asserting the old semantics. New coverage: direct/proxy disagreement on one fixture, the zero value resolving to `direct` in one place, the `baseline_mode` stamp asserted on the struct tag (not a marshalled instance, which can never carry the zero value), and the proxy pre-pass pinned by **reason ordering** — without it that fixture reports `mixed_cost_basis`, so asserting the withhold alone would pass either way.
