### PR TITLE
feat(058): adopt mcp-go v1.0.0, pinned inert on both protocol hops

### DIFF
--- a/bench/mcpcall_test.go
+++ b/bench/mcpcall_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
+	servertest "github.com/mark3labs/mcp-go/server/servertest"
 )
 
 // zeroLatencyIsClockArtifact reports whether a zero client-measured latency is
@@ -93,7 +94,7 @@ func newFixtureMCPServer(t *testing.T, respText string) (*httptest.Server, *atom
 			return mcp.NewToolResultText(respText), nil
 		},
 	)
-	ts := mcpserver.NewTestStreamableHTTPServer(srv)
+	ts := servertest.NewTestStreamableHTTPServer(srv)
 	t.Cleanup(ts.Close)
 	return ts, &calls, &lastQuery
 }
@@ -212,7 +213,7 @@ func TestMCPCaller_RetrieveToolsLimit(t *testing.T) {
 			return mcp.NewToolResultText(fixture), nil
 		},
 	)
-	ts := mcpserver.NewTestStreamableHTTPServer(srv)
+	ts := servertest.NewTestStreamableHTTPServer(srv)
 	defer ts.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -247,7 +248,7 @@ func TestMCPCaller_ToolError(t *testing.T) {
 			return mcp.NewToolResultError("index unavailable: boom"), nil
 		},
 	)
-	ts := mcpserver.NewTestStreamableHTTPServer(srv)
+	ts := servertest.NewTestStreamableHTTPServer(srv)
 	defer ts.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
 	github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf
-	github.com/mark3labs/mcp-go v0.57.0
+	github.com/mark3labs/mcp-go v1.0.0
 	github.com/oklog/ulid/v2 v2.1.2
 	github.com/pkoukk/tiktoken-go v0.1.8
 	github.com/prometheus/client_golang v1.24.1

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
-github.com/mark3labs/mcp-go v0.57.0 h1:jzWKyCzdWnwnZt05cvcQQ+ngiUl2RnixXJa7Kj4qP1E=
-github.com/mark3labs/mcp-go v0.57.0/go.mod h1:+8WclSK1ZUweCP3hvktSji8n8ABG/95QaEkeVE/Uwas=
+github.com/mark3labs/mcp-go v1.0.0 h1:CZqCzXwUiTOstkIdW1MyOZGuM+LaKMEJSu+ZYluN4DU=
+github.com/mark3labs/mcp-go v1.0.0/go.mod h1:r2fW4o3wsoJ7IMsx1Wuq5xeP8PRGXPDfNveoGAYbb/s=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2JC/oIi4=

--- a/internal/hash/hash.go
+++ b/internal/hash/hash.go
@@ -98,6 +98,17 @@ func canonicalSchemaFromBytes(schemaJSON []byte) (json.RawMessage, error) {
 		return nil, err
 	}
 
+	// Same library-drift protection NormalizeJSON applies. This file holds TWO
+	// normalizers over the same decoded schema, and they back different hashes:
+	// NormalizeJSON feeds the Spec-032 approval hash, while this one feeds
+	// ToolHash/ComputeToolHashWithOutputSchema, i.e. ToolMetadata.Hash written
+	// at internal/upstream/core/client.go. Canonicalizing only one of them would
+	// leave the other drifting across a library upgrade — the exact defect the
+	// canonicalization exists to prevent, just on the other code path.
+	if hasHoistedDefsWithDraft07Refs(parsed) {
+		canonicalizeSchemaRefs(parsed)
+	}
+
 	canonical, err := json.Marshal(parsed)
 	if err != nil {
 		return nil, err

--- a/internal/hash/hash.go
+++ b/internal/hash/hash.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 type toolHashContract struct {
@@ -106,12 +107,14 @@ func canonicalSchemaFromBytes(schemaJSON []byte) (json.RawMessage, error) {
 
 // NormalizeJSON parses s and re-serializes it with object keys sorted, so that
 // semantically identical JSON with different key order or whitespace produces a
-// stable, comparable string. Empty or non-JSON input is returned unchanged.
+// stable, comparable string. It also canonicalizes JSON Schema draft-07 local
+// references (see canonicalizeSchemaRefs). Empty or non-JSON input is returned
+// unchanged.
 //
 // This is the single canonical JSON normalizer shared by the upstream tool
 // capture (internal/upstream/core) and the tool-approval hash
 // (internal/runtime), so a schema hashes identically no matter which path
-// observed it.
+// observed it — or which version of the MCP library decoded it.
 func NormalizeJSON(s string) string {
 	if s == "" {
 		return s
@@ -120,11 +123,80 @@ func NormalizeJSON(s string) string {
 	if err := json.Unmarshal([]byte(s), &parsed); err != nil {
 		return s
 	}
+	if hasHoistedDefsWithDraft07Refs(parsed) {
+		canonicalizeSchemaRefs(parsed)
+	}
 	normalized, err := json.Marshal(parsed)
 	if err != nil {
 		return s
 	}
 	return string(normalized)
+}
+
+// draft07RefPrefix is the local-definition pointer prefix used by JSON Schema
+// draft-07. Drafts 2019-09 and later spell the same thing "#/$defs/".
+const (
+	draft07RefPrefix = "#/definitions/"
+	modernRefPrefix  = "#/$defs/"
+)
+
+// hasHoistedDefsWithDraft07Refs reports whether a document carries the specific
+// signature of a schema whose definitions were hoisted into "$defs" while its
+// "$ref" pointers were left spelling the old location: a root "$defs" and no
+// root "definitions".
+//
+// The narrowness is the point. A "$ref" of "#/definitions/X" is CORRECT in a
+// document that still has a "definitions" block, and rewriting it there would
+// point it at a member that does not exist — breaking Spec 056 output-schema
+// validation, which consumes this same normalized JSON. Only the hoisted-yet-
+// unrewritten combination is unambiguously the artifact described on
+// canonicalizeSchemaRefs, so only that combination is touched.
+func hasHoistedDefsWithDraft07Refs(root interface{}) bool {
+	doc, ok := root.(map[string]interface{})
+	if !ok {
+		return false
+	}
+	if _, hasDefs := doc["$defs"]; !hasDefs {
+		return false
+	}
+	if _, hasDefinitions := doc["definitions"]; hasDefinitions {
+		return false
+	}
+	return true
+}
+
+// canonicalizeSchemaRefs rewrites draft-07 local refs ("#/definitions/X") to
+// their modern spelling ("#/$defs/X") in place. Call it only when
+// hasHoistedDefsWithDraft07Refs approves the document.
+//
+// This exists because a tool's approval hash is computed over the MCP library's
+// DECODED input schema, not over the bytes the upstream sent
+// (mcp.Tool.RawInputSchema is `json:"-"`, so the original is discarded on
+// decode). Library versions disagree on the spelling they emit for one
+// identical wire schema: mcp-go hoisted `definitions` into `$defs` for a long
+// time while leaving the pointers dangling, and v1.0.0 began rewriting them.
+// Hashing the decoder's output verbatim therefore lets a library upgrade change
+// the hash of a tool nobody touched, which Spec 032 reports as a changed —
+// potentially rug-pulled — tool.
+//
+// Only the exact local-definition prefix is rewritten. Self-references such as
+// "#/properties/x", absolute URLs and already-modern pointers are left alone,
+// because rewriting those would change what a schema means rather than how it
+// is spelled.
+func canonicalizeSchemaRefs(node interface{}) {
+	switch v := node.(type) {
+	case map[string]interface{}:
+		if ref, ok := v["$ref"].(string); ok && strings.HasPrefix(ref, draft07RefPrefix) {
+			v["$ref"] = modernRefPrefix + strings.TrimPrefix(ref, draft07RefPrefix)
+		}
+		for _, child := range v {
+			canonicalizeSchemaRefs(child)
+		}
+	case []interface{}:
+		for _, item := range v {
+			canonicalizeSchemaRefs(item)
+		}
+	}
 }
 
 // StringHash computes SHA-256 hash of a string

--- a/internal/hash/schema_ref_test.go
+++ b/internal/hash/schema_ref_test.go
@@ -136,3 +136,42 @@ func findRef(node interface{}) string {
 	}
 	return ""
 }
+
+// This file holds two normalizers over the same decoded schema, backing two
+// different hashes: NormalizeJSON feeds the Spec-032 approval hash, and
+// canonicalSchemaFromBytes (via ToolHash/ComputeToolHashWithOutputSchema) feeds
+// ToolMetadata.Hash. A cross-review of the original fix caught that only the
+// first had been canonicalized, which left the second drifting across the
+// library upgrade — the same defect, on the other path.
+func TestToolHashSurvivesDecoderRefRewrite(t *testing.T) {
+	stored, err := ToolHash("srv", "tool", "desc", json.RawMessage(decodedByV057))
+	if err != nil {
+		t.Fatalf("hashing the pre-bump schema: %v", err)
+	}
+	current, err := ToolHash("srv", "tool", "desc", json.RawMessage(decodedByV100))
+	if err != nil {
+		t.Fatalf("hashing the post-bump schema: %v", err)
+	}
+
+	if stored != current {
+		t.Errorf("ToolMetadata.Hash must survive the library's ref rewrite too,\n"+
+			"or the tool re-hashes on upgrade even though the upstream is unchanged\nstored:  %s\ncurrent: %s", stored, current)
+	}
+}
+
+// The output-schema half of the same contract takes the string path
+// (canonicalSchemaFromString), so it needs its own guard.
+func TestToolHashOutputSchemaSurvivesDecoderRefRewrite(t *testing.T) {
+	stored, err := ToolHashWithOutputSchema("srv", "tool", "desc", nil, decodedByV057)
+	if err != nil {
+		t.Fatalf("hashing the pre-bump output schema: %v", err)
+	}
+	current, err := ToolHashWithOutputSchema("srv", "tool", "desc", nil, decodedByV100)
+	if err != nil {
+		t.Fatalf("hashing the post-bump output schema: %v", err)
+	}
+
+	if stored != current {
+		t.Errorf("the output-schema hash must survive the rewrite as well\nstored:  %s\ncurrent: %s", stored, current)
+	}
+}

--- a/internal/hash/schema_ref_test.go
+++ b/internal/hash/schema_ref_test.go
@@ -1,0 +1,138 @@
+package hash
+
+import (
+	"encoding/json"
+	"sort"
+	"testing"
+)
+
+// A tool's approval hash (Spec 032) is computed over the LIBRARY-DECODED input
+// schema: internal/upstream/core/client.go marshals mcp.Tool.InputSchema, and
+// mcp.Tool.RawInputSchema is `json:"-"`, so the bytes the upstream actually sent
+// are discarded on decode and cannot be recovered.
+//
+// That couples a security signal to the library version. Given one draft-07
+// schema on the wire, the two decoders disagree about the ref spelling they
+// emit (captured by running each version against the same input):
+//
+//	v0.57.0: {"$defs":{...},"properties":{"filter":{"$ref":"#/definitions/Filter"}},...}
+//	v1.0.0:  {"$defs":{...},"properties":{"filter":{"$ref":"#/$defs/Filter"}},...}
+//
+// v0.57.0 hoisted `definitions` into `$defs` but left the pointers dangling;
+// v1.0.0 added rewriteDraft07LocalRefs and fixes them. So a hash stored by the
+// old decoder cannot be reproduced by the new one, the formula-migration hatch
+// in tool_quarantine.go does not absorb it, and every affected tool is reported
+// as "changed" — a rug-pull signal — after an upgrade that changed nothing
+// upstream.
+//
+// The fixtures below are therefore written as the OLD decoder's literal output,
+// not produced by decoding. Decoding here would only exercise the currently
+// linked library and pass whatever it happens to emit, proving nothing.
+const (
+	// decodedByV057 is what the v0.57.0 decoder emitted for a draft-07 schema
+	// with a `definitions` block: `$defs` hoisted, pointers left dangling.
+	decodedByV057 = `{"$defs":{"Filter":{"type":"string"}},"properties":{"filter":{"$ref":"#/definitions/Filter"},"list":{"items":{"$ref":"#/definitions/Filter"},"type":"array"}},"required":[],"type":"object"}`
+
+	// decodedByV100 is what v1.0.0 emits for the same wire input.
+	decodedByV100 = `{"$defs":{"Filter":{"type":"string"}},"properties":{"filter":{"$ref":"#/$defs/Filter"},"list":{"items":{"$ref":"#/$defs/Filter"},"type":"array"}},"required":[],"type":"object"}`
+)
+
+// The load-bearing assertion: a hash stored under the old decoder must still be
+// reproducible under the new one. Without ref canonicalization in NormalizeJSON
+// this fails, and every tool whose upstream sends draft-07 local refs is
+// re-quarantined on the first start after the library bump.
+func TestNormalizeJSONSurvivesDecoderRefRewrite(t *testing.T) {
+	old := NormalizeJSON(decodedByV057)
+	current := NormalizeJSON(decodedByV100)
+
+	if old != current {
+		t.Errorf("a schema hash stored by the pre-bump decoder must survive the bump,\n"+
+			"or Spec 032 reports every affected tool as changed after an upgrade that changed nothing\n"+
+			"stored:  %s\ncurrent: %s", old, current)
+	}
+}
+
+// The common case: no refs at all. Canonicalization must not touch it, or the
+// normalizer would move every tool's hash the moment it shipped.
+func TestNormalizeJSONLeavesPlainSchemaAlone(t *testing.T) {
+	plain := `{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}`
+
+	if got, want := NormalizeJSON(plain), `{"properties":{"query":{"type":"string"}},"required":["query"],"type":"object"}`; got != want {
+		t.Errorf("a schema with no refs must only have its keys sorted\ngot:  %s\nwant: %s", got, want)
+	}
+}
+
+// Refs that are not draft-07 local pointers must survive verbatim. Rewriting a
+// "#/properties/..." self-reference or an absolute URL would corrupt the schema
+// and change what the validator enforces.
+func TestNormalizeJSONPreservesNonDraft07Refs(t *testing.T) {
+	cases := map[string]string{
+		"self reference":  `{"type":"object","properties":{"a":{"$ref":"#/properties/b"},"b":{"type":"string"}}}`,
+		"absolute url":    `{"type":"object","properties":{"a":{"$ref":"https://example.com/s.json#/definitions/X"}}}`,
+		"already modern":  `{"type":"object","properties":{"a":{"$ref":"#/$defs/X"}},"$defs":{"X":{"type":"string"}}}`,
+		"no defs sibling": `{"type":"object","properties":{"a":{"$ref":"#/definitions/Absent"}}}`,
+
+		// The hazard that decided the narrow rule. NormalizeJSON is also applied
+		// to a tool's RAW output schema, which reaches the Spec 056 validator
+		// (captureOutputSchemaJSON -> OutputSchemaJSON -> applyToolOutputSchemaJSON).
+		// Raw bytes keep their `definitions` block, so rewriting the pointer to
+		// "#/$defs/" there would aim it at a member that does not exist and break
+		// validation for a schema that was correct.
+		"definitions block intact": `{"type":"object","properties":{"a":{"$ref":"#/definitions/X"}},"definitions":{"X":{"type":"string"}}}`,
+	}
+
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			var before, after interface{}
+			if err := json.Unmarshal([]byte(raw), &before); err != nil {
+				t.Fatalf("fixture is not valid JSON: %v", err)
+			}
+			normalized := NormalizeJSON(raw)
+			if err := json.Unmarshal([]byte(normalized), &after); err != nil {
+				t.Fatalf("normalizer produced invalid JSON: %v", err)
+			}
+
+			if got, want := findRef(after), findRef(before); got != want {
+				t.Errorf("a non-draft-07 $ref must survive normalization unchanged: got %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+// A malformed or non-JSON input must still be returned unchanged, the contract
+// NormalizeJSON already documents.
+func TestNormalizeJSONPassesThroughNonJSON(t *testing.T) {
+	for _, raw := range []string{"", "not json", `{"unterminated":`} {
+		if got := NormalizeJSON(raw); got != raw {
+			t.Errorf("non-JSON input must be returned unchanged: got %q, want %q", got, raw)
+		}
+	}
+}
+
+// findRef returns the first "$ref" value found anywhere in the decoded document,
+// walking keys in sorted order so the result is deterministic.
+func findRef(node interface{}) string {
+	switch v := node.(type) {
+	case map[string]interface{}:
+		if ref, ok := v["$ref"].(string); ok {
+			return ref
+		}
+		keys := make([]string, 0, len(v))
+		for key := range v {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			if got := findRef(v[key]); got != "" {
+				return got
+			}
+		}
+	case []interface{}:
+		for _, item := range v {
+			if got := findRef(item); got != "" {
+				return got
+			}
+		}
+	}
+	return ""
+}

--- a/internal/server/content_forward.go
+++ b/internal/server/content_forward.go
@@ -36,6 +36,28 @@ func logCacheStoreFailure(logger *zap.Logger, err error, toolName, cacheKey stri
 	)
 }
 
+// proxyResultEnvelope builds the mcp.Result envelope mcpproxy puts on a
+// forwarded tool result (Spec 058 FR-016b).
+//
+// Only _meta is relayed. Copying the upstream's envelope wholesale would also
+// replay its ResultType — a 2026-07-28 field telling the CLIENT how to
+// interpret the response — while mcp.CallToolResult embeds MultiRoundTripResult
+// separately, so the inputRequests and requestState that make an
+// "input_required" answerable were dropped on the same hop. The client was left
+// told to supply input it had no way to supply.
+//
+// Leaving ResultType unset lets mcp-go stamp the value appropriate to the era
+// mcpproxy is answering on, which is the only party that knows it.
+//
+// Both forwarding paths (forwardContentResult here, and the direct-surface
+// handler in mcp_routing.go) call this, so the two cannot drift apart.
+func proxyResultEnvelope(ctr *mcp.CallToolResult) mcp.Result {
+	if ctr == nil {
+		return mcp.Result{}
+	}
+	return mcp.Result{Meta: ctr.Meta}
+}
+
 // forwardContentResult preserves non-text content blocks (ImageContent, AudioContent,
 // EmbeddedResource) from an upstream CallToolResult while applying truncation only to
 // TextContent blocks. This fixes issue #368 where all content types were being
@@ -128,7 +150,7 @@ func forwardContentResult(result interface{}, truncator *truncate.Truncator, cac
 	}
 
 	forwarded = &mcp.CallToolResult{
-		Result:            ctr.Result,
+		Result:            proxyResultEnvelope(ctr),
 		Content:           newContent,
 		StructuredContent: ctr.StructuredContent,
 		IsError:           ctr.IsError,

--- a/internal/server/content_forward.go
+++ b/internal/server/content_forward.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"go.uber.org/zap"
@@ -55,7 +56,48 @@ func proxyResultEnvelope(ctr *mcp.CallToolResult) mcp.Result {
 	if ctr == nil {
 		return mcp.Result{}
 	}
-	return mcp.Result{Meta: ctr.Meta}
+	return mcp.Result{Meta: relaySafeResultMeta(ctr.Meta)}
+}
+
+// hopScopedResultMetaKeys are reserved _meta keys that describe the HOP a result
+// travelled over rather than the payload it carries, so they must not survive a
+// proxy hop.
+//
+// serverInfo is the one that bites. mcp-go stamps mcpproxy's own identity into
+// an outgoing modern result only when the field is still absent
+// (server/response.go decorateResult: `if meta.ServerInfo() == nil`). Relaying
+// an upstream's serverInfo therefore does not merely add noise — it suppresses
+// mcpproxy's identity and makes its response claim to BE the upstream server.
+// protocolVersion is hop-scoped for the same reason: the era mcpproxy negotiated
+// upstream is not the era it is answering on.
+var hopScopedResultMetaKeys = []string{
+	mcp.MetaKeyServerInfo,
+	mcp.MetaKeyProtocolVersion,
+}
+
+// relaySafeResultMeta copies meta minus the hop-scoped keys, leaving trace
+// context and any upstream-specific fields intact. It returns nil when nothing
+// survives, so no empty _meta object is emitted.
+func relaySafeResultMeta(meta *mcp.Meta) *mcp.Meta {
+	if meta == nil {
+		return nil
+	}
+
+	var fields map[string]any
+	for key, value := range meta.AdditionalFields {
+		if slices.Contains(hopScopedResultMetaKeys, key) {
+			continue
+		}
+		if fields == nil {
+			fields = make(map[string]any, len(meta.AdditionalFields))
+		}
+		fields[key] = value
+	}
+
+	if fields == nil && meta.ProgressToken == nil {
+		return nil
+	}
+	return &mcp.Meta{ProgressToken: meta.ProgressToken, AdditionalFields: fields}
 }
 
 // forwardContentResult preserves non-text content blocks (ImageContent, AudioContent,

--- a/internal/server/content_forward_test.go
+++ b/internal/server/content_forward_test.go
@@ -776,10 +776,15 @@ func TestForwardContentResult_PreservesResultMeta(t *testing.T) {
 	assert.Equal(t, "abc123", forwarded.Meta.AdditionalFields["trace-id"])
 }
 
-// proxyResultEnvelope is the single decision point both forwarding paths share,
-// so testing it covers the direct-surface handler too — that path needs a fully
-// wired proxy to reach, and duplicating the assertion there would only test the
-// duplication.
+// proxyResultEnvelope is the single decision point both forwarding paths are
+// written to share.
+//
+// Note what these tests do NOT establish: nothing here asserts that the
+// direct-mode handler (internal/server/mcp_routing.go) actually calls the
+// helper. Reaching that handler needs a fully wired proxy with a live upstream
+// manager, so the /mcp/all surface's FR-016b guarantee currently rests on the
+// call site staying as written. Covering it for real belongs with the direct-
+// surface work in spec 058 US3, which builds the harness that can drive it.
 func TestProxyResultEnvelope(t *testing.T) {
 	t.Run("drops the upstream result type", func(t *testing.T) {
 		envelope := proxyResultEnvelope(&mcp.CallToolResult{

--- a/internal/server/content_forward_test.go
+++ b/internal/server/content_forward_test.go
@@ -795,10 +795,57 @@ func TestProxyResultEnvelope(t *testing.T) {
 
 		envelope := proxyResultEnvelope(&mcp.CallToolResult{Result: mcp.Result{Meta: meta}})
 
-		assert.Same(t, meta, envelope.Meta, "_meta carries trace context and must survive the hop")
+		require.NotNil(t, envelope.Meta, "_meta carries trace context and must survive the hop")
+		assert.Equal(t, "abc123", envelope.Meta.AdditionalFields["trace-id"])
+		assert.NotSame(t, meta, envelope.Meta,
+			"the relayed _meta must be a copy: hop-scoped keys are filtered out of it, and mutating the upstream's map would corrupt the record the activity log holds")
 	})
 
 	t.Run("tolerates a nil result", func(t *testing.T) {
 		assert.Equal(t, mcp.Result{}, proxyResultEnvelope(nil))
 	})
+}
+
+// The cross-review of this change caught a real defect here. mcp-go stamps
+// mcpproxy's own identity into an outgoing modern result ONLY when the field is
+// still absent (server/response.go decorateResult: `if meta.ServerInfo() == nil`).
+// Relaying an upstream's serverInfo therefore suppresses mcpproxy's identity and
+// makes its own response claim to be the upstream server — a misattribution a
+// client has no way to detect.
+func TestProxyResultEnvelope_StripsHopScopedMeta(t *testing.T) {
+	upstream := &mcp.CallToolResult{
+		Result: mcp.Result{Meta: &mcp.Meta{AdditionalFields: map[string]any{
+			mcp.MetaKeyServerInfo:      map[string]any{"name": "some-upstream", "version": "9.9.9"},
+			mcp.MetaKeyProtocolVersion: "2026-07-28",
+			"traceparent":              "00-abc-def-01",
+			"vendor.example/custom":    "keep me",
+		}}},
+	}
+
+	envelope := proxyResultEnvelope(upstream)
+
+	require.NotNil(t, envelope.Meta)
+	assert.NotContains(t, envelope.Meta.AdditionalFields, mcp.MetaKeyServerInfo,
+		"relaying the upstream's serverInfo suppresses mcpproxy's own identity, so its response would claim to be the upstream")
+	assert.NotContains(t, envelope.Meta.AdditionalFields, mcp.MetaKeyProtocolVersion,
+		"the era negotiated upstream is not the era mcpproxy is answering on")
+	assert.Equal(t, "00-abc-def-01", envelope.Meta.AdditionalFields["traceparent"],
+		"trace context describes the call, not the hop, and must survive")
+	assert.Equal(t, "keep me", envelope.Meta.AdditionalFields["vendor.example/custom"],
+		"upstream-specific metadata is not ours to drop")
+}
+
+// A _meta carrying nothing but hop-scoped keys must not leave an empty object
+// behind: an empty _meta still reads as "present" to mcp-go's ServerInfo check.
+func TestProxyResultEnvelope_DropsMetaThatBecomesEmpty(t *testing.T) {
+	upstream := &mcp.CallToolResult{
+		Result: mcp.Result{Meta: &mcp.Meta{AdditionalFields: map[string]any{
+			mcp.MetaKeyServerInfo: map[string]any{"name": "some-upstream"},
+		}}},
+	}
+
+	envelope := proxyResultEnvelope(upstream)
+
+	assert.Nil(t, envelope.Meta,
+		"nothing relay-safe survived, so no _meta should be emitted at all")
 }

--- a/internal/server/content_forward_test.go
+++ b/internal/server/content_forward_test.go
@@ -722,3 +722,83 @@ func TestForwardContentResult_FallbackPathStoresCache(t *testing.T) {
 	assert.Equal(t, "fallback:tool", store.calls[0].toolName)
 	assert.Contains(t, store.calls[0].content, `"rows"`, "fallback path should persist the JSON-serialized full result")
 }
+
+// Spec 058 FR-016b. mcp.CallToolResult embeds mcp.Result, which carries
+// ResultType — a field that only came into existence with the 2026-07-28
+// revision, and which the protocol defines as instructing the CLIENT how to
+// interpret the response.
+//
+// forwardContentResult used to copy that envelope wholesale (`Result: ctr.Result`).
+// The embedded MultiRoundTripResult was never copied, so an upstream returning
+// input_required produced the worst possible pairing downstream: mcpproxy told
+// the client "I need more input" while stripping the inputRequests and the
+// requestState that would let it answer. The client cannot proceed and cannot
+// know why.
+//
+// mcpproxy is not the upstream. It must speak for itself, and let the library
+// stamp the result type appropriate to the era it is answering on.
+func TestForwardContentResult_DoesNotForwardUpstreamResultType(t *testing.T) {
+	upstream := &mcp.CallToolResult{
+		Result: mcp.Result{ResultType: mcp.ResultTypeInputRequired},
+		MultiRoundTripResult: mcp.MultiRoundTripResult{
+			InputRequests: mcp.InputRequests{},
+			RequestState:  "upstream-opaque-token",
+		},
+		Content: []mcp.Content{mcp.TextContent{Type: "text", Text: "needs input"}},
+	}
+
+	forwarded, _, _ := forwardContentResult(upstream, nil, nil, zap.NewNop(), "some_tool", nil)
+
+	require.NotNil(t, forwarded)
+	assert.Empty(t, string(forwarded.ResultType),
+		"an upstream's resultType must not be replayed as mcpproxy's own; "+
+			"claiming input_required while dropping inputRequests leaves the client unable to answer or to diagnose")
+	assert.Empty(t, forwarded.RequestState,
+		"an upstream requestState must never reach the client verbatim (it is upstream-scoped and would let a continuation be redirected)")
+	assert.Empty(t, forwarded.InputRequests,
+		"input requests are reported through the FR-015 notice, not smuggled through the forwarded envelope")
+}
+
+// The rest of the envelope is legitimate passthrough: _meta carries trace
+// context and similar per-response metadata that a proxy should preserve.
+func TestForwardContentResult_PreservesResultMeta(t *testing.T) {
+	upstream := &mcp.CallToolResult{
+		Result: mcp.Result{
+			Meta: &mcp.Meta{AdditionalFields: map[string]any{"trace-id": "abc123"}},
+		},
+		Content: []mcp.Content{mcp.TextContent{Type: "text", Text: "ok"}},
+	}
+
+	forwarded, _, _ := forwardContentResult(upstream, nil, nil, zap.NewNop(), "some_tool", nil)
+
+	require.NotNil(t, forwarded)
+	require.NotNil(t, forwarded.Meta, "response _meta must survive the proxy hop so trace context is not lost")
+	assert.Equal(t, "abc123", forwarded.Meta.AdditionalFields["trace-id"])
+}
+
+// proxyResultEnvelope is the single decision point both forwarding paths share,
+// so testing it covers the direct-surface handler too — that path needs a fully
+// wired proxy to reach, and duplicating the assertion there would only test the
+// duplication.
+func TestProxyResultEnvelope(t *testing.T) {
+	t.Run("drops the upstream result type", func(t *testing.T) {
+		envelope := proxyResultEnvelope(&mcp.CallToolResult{
+			Result: mcp.Result{ResultType: mcp.ResultTypeInputRequired},
+		})
+
+		assert.Empty(t, string(envelope.ResultType),
+			"mcpproxy answers for itself; the era-appropriate result type is stamped by the library")
+	})
+
+	t.Run("relays response meta", func(t *testing.T) {
+		meta := &mcp.Meta{AdditionalFields: map[string]any{"trace-id": "abc123"}}
+
+		envelope := proxyResultEnvelope(&mcp.CallToolResult{Result: mcp.Result{Meta: meta}})
+
+		assert.Same(t, meta, envelope.Meta, "_meta carries trace context and must survive the hop")
+	})
+
+	t.Run("tolerates a nil result", func(t *testing.T) {
+		assert.Equal(t, mcp.Result{}, proxyResultEnvelope(nil))
+	})
+}

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -3652,6 +3652,11 @@ func connectDirectClient(t *testing.T, env *TestEnvironment, route string, onNot
 	t.Helper()
 
 	base := strings.TrimSuffix(env.proxyAddr, "/mcp")
+	// Spec 058: mcp-go deprecated WithContinuousListening because 2026-07-28
+	// removed the standalone GET stream. Keeping it here is deliberate — it
+	// holds this client on a legacy protocol version, which is what this test
+	// exercises, and matches the client-facing FR-028 pin.
+	//nolint:staticcheck // SA1019: legacy GET stream is the behavior under test.
 	httpTransport, err := transport.NewStreamableHTTP(base+route, transport.WithContinuousListening())
 	require.NoError(t, err)
 

--- a/internal/server/mcp_routing.go
+++ b/internal/server/mcp_routing.go
@@ -593,7 +593,7 @@ func (p *MCPProxyServer) makeDirectModeHandler(entry *directCatalogEntry) mcpser
 				}
 			}
 			forwarded = &mcp.CallToolResult{
-				Result:            ctr.Result,
+				Result:            proxyResultEnvelope(ctr),
 				Content:           newContent,
 				StructuredContent: ctr.StructuredContent,
 				IsError:           ctr.IsError,

--- a/internal/server/mcp_routing_test.go
+++ b/internal/server/mcp_routing_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
+	servertest "github.com/mark3labs/mcp-go/server/servertest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -958,7 +959,7 @@ func TestRefreshPrompts_AggregatesBuiltinsAndUpstream(t *testing.T) {
 	proxy.config.QuarantineEnabled = &qOff // spec 100: these tests verify aggregation, not the rug-pull baseline
 
 	upstreamSrv := newTestRefreshPromptsUpstream(t)
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstreamSrv)
+	testServer := servertest.NewTestStreamableHTTPServer(upstreamSrv)
 	t.Cleanup(testServer.Close)
 
 	um := upstream.NewManager(zap.NewNop(), proxy.config, nil, secret.NewResolver(), nil)
@@ -997,7 +998,7 @@ func TestRefreshPrompts_RugPullBaseline_WithholdsFirstSeen(t *testing.T) {
 	proxy.config.AggregateUpstreamPrompts = true
 
 	upstreamSrv := newTestRefreshPromptsUpstream(t)
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstreamSrv)
+	testServer := servertest.NewTestStreamableHTTPServer(upstreamSrv)
 	t.Cleanup(testServer.Close)
 
 	um := upstream.NewManager(zap.NewNop(), proxy.config, nil, secret.NewResolver(), nil)
@@ -1035,7 +1036,7 @@ func TestRefreshPrompts_AggregationDisabled_BuiltinsOnly(t *testing.T) {
 	proxy.config.AggregateUpstreamPrompts = false // the default — safe posture
 
 	upstreamSrv := newTestRefreshPromptsUpstream(t)
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstreamSrv)
+	testServer := servertest.NewTestStreamableHTTPServer(upstreamSrv)
 	t.Cleanup(testServer.Close)
 
 	um := upstream.NewManager(zap.NewNop(), proxy.config, nil, secret.NewResolver(), nil)
@@ -1086,7 +1087,7 @@ func TestRefreshPrompts_ReadsLiveAggregateFlag(t *testing.T) {
 	proxy.config = &boot
 
 	upstreamSrv := newTestRefreshPromptsUpstream(t)
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstreamSrv)
+	testServer := servertest.NewTestStreamableHTTPServer(upstreamSrv)
 	t.Cleanup(testServer.Close)
 
 	um := upstream.NewManager(zap.NewNop(), live, nil, secret.NewResolver(), nil)
@@ -1139,7 +1140,7 @@ func TestRefreshPrompts_PopulatesRoutingModeServers(t *testing.T) {
 	proxy.config.QuarantineEnabled = &qOff // spec 100: these tests verify aggregation, not the rug-pull baseline
 
 	upstreamSrv := newTestRefreshPromptsUpstream(t)
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstreamSrv)
+	testServer := servertest.NewTestStreamableHTTPServer(upstreamSrv)
 	t.Cleanup(testServer.Close)
 
 	um := upstream.NewManager(zap.NewNop(), proxy.config, nil, secret.NewResolver(), nil)

--- a/internal/server/protocol_era_test.go
+++ b/internal/server/protocol_era_test.go
@@ -1,0 +1,226 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Spec 058 FR-028 keeps the client-facing Streamable HTTP surface on the legacy
+// protocol era until the stateless work lands. These tests assert that on the
+// wire, against a transport built from the same helper production uses, because
+// the alternative — reading the option list back — cannot distinguish a pin that
+// is applied from one that is merely constructed.
+//
+// Test names here deliberately avoid the substring "MCP": release-qa-gate.yml
+// and e2e-tests.yml skip on that bare substring, so a test named for it runs in
+// unit CI and is silently skipped by the race suite.
+
+// legacyProtocolEra is the era the client-facing surface must negotiate while
+// the FR-028 pin is in place.
+const legacyProtocolEra = "2025-11-25"
+
+// pinnedTestServer serves a bare tool over the same options every client-facing
+// endpoint is built with. It intentionally does NOT go through the proxy: the
+// subject under test is clientFacingStreamableOptions, and a full proxy would
+// add slow setup without making the assertion stronger.
+func pinnedTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	srv := mcpserver.NewMCPServer("pin-probe", "1.0.0")
+	srv.AddTool(
+		mcp.NewTool("ping_probe", mcp.WithDescription("probe tool")),
+		func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return mcp.NewToolResultText("pong"), nil
+		},
+	)
+
+	streamable := mcpserver.NewStreamableHTTPServer(srv, clientFacingStreamableOptions()...)
+	httpServer := httptest.NewServer(streamable)
+	t.Cleanup(httpServer.Close)
+	return httpServer
+}
+
+func connectProbeClient(t *testing.T, url string, opts ...client.ClientOption) *client.Client {
+	t.Helper()
+
+	httpTransport, err := transport.NewStreamableHTTP(url)
+	require.NoError(t, err)
+
+	c := client.NewClient(httpTransport, opts...)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	require.NoError(t, c.Start(ctx))
+	t.Cleanup(func() { _ = c.Close() })
+
+	_, err = c.Initialize(ctx, mcp.InitializeRequest{})
+	require.NoError(t, err)
+	return c
+}
+
+// The load-bearing assertion. An UNPINNED v1.0.0 client is modern-first: it
+// probes server/discover before falling back to a legacy handshake. Against the
+// pinned surface it must land on the legacy era anyway.
+func TestClientFacingSurfacePinsLegacyEra(t *testing.T) {
+	httpServer := pinnedTestServer(t)
+
+	c := connectProbeClient(t, httpServer.URL)
+
+	assert.Equal(t, legacyProtocolEra, c.ProtocolVersion(),
+		"an unpinned client must negotiate down to the legacy era while FR-028's pin is in place; "+
+			"a modern negotiation here means the pin is missing from this transport")
+}
+
+// A session id proves the legacy path was actually taken. The modern era binds
+// none, so this is the observable that distinguishes "negotiated legacy" from
+// "reported legacy but served statelessly".
+func TestClientFacingSurfaceBindsASessionIDUnderThePin(t *testing.T) {
+	httpServer := pinnedTestServer(t)
+
+	c := connectProbeClient(t, httpServer.URL)
+
+	streamable, ok := c.GetTransport().(*transport.StreamableHTTP)
+	require.True(t, ok, "expected a Streamable HTTP transport")
+	assert.NotEmpty(t, streamable.GetSessionId(),
+		"the legacy era binds a session id; an empty one means the modern, stateless path served this request")
+}
+
+// The pin must not break tool use — the whole point is that it is inert for
+// existing clients. Asserted for a client pinned to EITHER era, because a
+// client that asks for 2026-07-28 must still be served (by negotiating down)
+// rather than refused.
+func TestClientFacingSurfaceStillServesToolsUnderThePin(t *testing.T) {
+	httpServer := pinnedTestServer(t)
+
+	forEachEra(t, func(t *testing.T, era protocolEra) {
+		c := connectProbeClient(t, httpServer.URL, era.options...)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		tools, err := c.ListTools(ctx, mcp.ListToolsRequest{})
+		require.NoError(t, err, "a client requesting the %s era must still be served while the pin holds", era.name)
+		require.Len(t, tools.Tools, 1)
+		assert.Equal(t, "ping_probe", tools.Tools[0].Name)
+	})
+}
+
+// ─── Era-pinned harness (Spec 058, plan Phase 2) ────────────────────────────
+//
+// Every later acceptance test must run under BOTH eras, and must pin the era it
+// claims to test. The reason is specific: while the FR-028 pin holds, an
+// unpinned client negotiates DOWN, so an assertion of the form
+// `c.ProtocolVersion() == "2026-07-28"` is satisfied by absence — the test
+// passes without ever exercising the modern path. forEachEra removes that
+// failure mode by making the era an explicit input and verifying the client
+// actually reached it before the body runs.
+
+type protocolEra struct {
+	name    string
+	version string
+	options []client.ClientOption
+}
+
+// legacyEra and modernEra are the two eras a client may be pinned to.
+func legacyEra() protocolEra {
+	return protocolEra{
+		name:    "legacy",
+		version: mcp.LATEST_LEGACY_PROTOCOL_VERSION,
+		options: []client.ClientOption{client.WithProtocolVersion(mcp.LATEST_LEGACY_PROTOCOL_VERSION)},
+	}
+}
+
+func modernEra() protocolEra {
+	return protocolEra{
+		name:    "modern",
+		version: mcp.LATEST_PROTOCOL_VERSION,
+		options: []client.ClientOption{client.WithProtocolVersion(mcp.LATEST_PROTOCOL_VERSION)},
+	}
+}
+
+// forEachEra runs body once per protocol era as a subtest.
+//
+// It does not assert the negotiated era itself — a server may legitimately be
+// pinned, and refusing to run would make the harness unusable under FR-028.
+// Instead it hands the era to the body, which decides what the negotiated
+// version must be. Use requireEra when the body's assertions are only meaningful
+// on a specific era.
+func forEachEra(t *testing.T, body func(t *testing.T, era protocolEra)) {
+	t.Helper()
+
+	for _, era := range []protocolEra{legacyEra(), modernEra()} {
+		era := era
+		t.Run(era.name, func(t *testing.T) {
+			body(t, era)
+		})
+	}
+}
+
+// requireEra fails the test unless the client actually negotiated the era it was
+// pinned to. Call this before asserting era-specific behavior; without it, a
+// server-side pin silently turns a modern-era test into a second legacy run.
+//
+// It takes require.TestingT rather than *testing.T so the harness can be
+// verified against a recorder — see TestEraHarnessRejectsAnEraTheServerDidNotServe.
+func requireEra(t require.TestingT, c *client.Client, era protocolEra) {
+	if h, ok := t.(interface{ Helper() }); ok {
+		h.Helper()
+	}
+
+	require.Equal(t, era.version, c.ProtocolVersion(),
+		"this test asserts %s-era behavior but the connection negotiated %q; "+
+			"the assertions below would pass without exercising the %s path",
+		era.name, c.ProtocolVersion(), era.name)
+}
+
+// eraRecorder captures a testify failure without aborting the calling goroutine,
+// so the harness's own guard can be asserted. A bare &testing.T{} cannot serve
+// here: require calls FailNow, which runtime.Goexit()s and panics outside a real
+// test goroutine.
+type eraRecorder struct {
+	failed  bool
+	message string
+}
+
+func (r *eraRecorder) Errorf(format string, args ...interface{}) {
+	r.message = fmt.Sprintf(format, args...)
+}
+
+func (r *eraRecorder) FailNow() { r.failed = true }
+
+// Proves the harness bites, rather than trusting that it does. Against the
+// pinned surface the legacy era is reachable and the modern era is not, so
+// requireEra must accept the first and reject the second. A harness that
+// silently accepted both would let every later modern-era test pass vacuously.
+func TestEraHarnessRejectsAnEraTheServerDidNotServe(t *testing.T) {
+	httpServer := pinnedTestServer(t)
+
+	t.Run("legacy is reachable and accepted", func(t *testing.T) {
+		era := legacyEra()
+		c := connectProbeClient(t, httpServer.URL, era.options...)
+		requireEra(t, c, era)
+	})
+
+	t.Run("modern is unreachable and rejected", func(t *testing.T) {
+		era := modernEra()
+		c := connectProbeClient(t, httpServer.URL, era.options...)
+
+		recorder := &eraRecorder{}
+		requireEra(recorder, c, era)
+
+		require.True(t, recorder.failed,
+			"requireEra must fail when the server pin prevented the requested era; "+
+				"otherwise every modern-era test in this package can pass without testing anything")
+		assert.Contains(t, recorder.message, legacyProtocolEra,
+			"the failure should name the era actually negotiated, so the cause is obvious")
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2501,10 +2501,19 @@ func (s *Server) streamingNoDeadline(next http.Handler) http.Handler {
 
 // clientFacingStreamableOptions returns the options every client-facing
 // Streamable HTTP transport must be built with. It exists so the set cannot
-// drift between the five endpoints that serve MCP (/mcp, /mcp/all, /mcp/code,
+// drift between the five Streamable HTTP endpoints (/mcp, /mcp/all, /mcp/code,
 // /mcp/call and /mcp/p/<slug>) — a pin applied to four of five would leave one
-// door open on a different protocol era, which is the failure this helper is
-// designed to make impossible.
+// door open on a different protocol era.
+//
+// SCOPE, precisely: this covers the Streamable HTTP surfaces and nothing else.
+// mcp-go offers no equivalent option for stdio (server/stdio.go exposes only
+// error-logger, context-func and worker-pool options), and the protocol era is
+// decided per request from params._meta by the shared handler, with the version
+// gate living inside the Streamable HTTP transport. So a client speaking stdio
+// to `mcpproxy serve` in stdio mode can still opt into 2026-07-28 and be served
+// it. That gap is tracked with the rest of the stateless work (spec 058 US3);
+// it is not reachable by default, since an empty listen address is rewritten to
+// the HTTP default during config validation.
 //
 // The options are deliberately not configurable:
 //

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -942,11 +942,8 @@ func (s *Server) Start(ctx context.Context) error {
 		// watcher hot-reloads — and reporting it would name a surface /mcp is
 		// not serving.
 		s.runtime.SetServedRoutingMode(config.ResolveRoutingMode(routingMode))
-		// mcp-go's built-in DNS-rebinding protection is disabled in favor of
-		// hostValidationMiddleware, which applies the same check but honors the
-		// trusted_hosts allowlist for reverse-proxy deployments (GH #898).
 		streamableServer := server.NewStreamableHTTPServer(s.mcpProxy.GetMCPServerForMode(routingMode),
-			server.WithDisableLocalhostProtection(true))
+			clientFacingStreamableOptions()...)
 
 		// Create custom HTTP server for handling multiple routes
 		if err := s.startCustomHTTPServer(ctx, streamableServer); err != nil {
@@ -2502,6 +2499,34 @@ func (s *Server) streamingNoDeadline(next http.Handler) http.Handler {
 	})
 }
 
+// clientFacingStreamableOptions returns the options every client-facing
+// Streamable HTTP transport must be built with. It exists so the set cannot
+// drift between the five endpoints that serve MCP (/mcp, /mcp/all, /mcp/code,
+// /mcp/call and /mcp/p/<slug>) — a pin applied to four of five would leave one
+// door open on a different protocol era, which is the failure this helper is
+// designed to make impossible.
+//
+// The options are deliberately not configurable:
+//
+//   - DisableLocalhostProtection: mcp-go's built-in DNS-rebinding protection is
+//     replaced by hostValidationMiddleware, which applies the same check but
+//     honors the trusted_hosts allowlist for reverse-proxy deployments (#898).
+//
+//   - StreamableHTTPProtocolVersions, pinned to the legacy set: mcp-go v1.0.0
+//     serves MCP 2026-07-28 on the same endpoint, and that era binds no session
+//     id. Spec 058 FR-028 keeps the client-facing surface on the legacy versions
+//     until the stateless work (spec 058 US3) has landed, because session-keyed
+//     behavior — profile selection above all — silently degrades without it.
+//     Lifting this pin is a deliberate, separately verified change; it is a
+//     function rather than a package variable so it cannot be flipped at
+//     runtime or from a test.
+func clientFacingStreamableOptions() []server.StreamableHTTPOption {
+	return []server.StreamableHTTPOption{
+		server.WithDisableLocalhostProtection(true),
+		server.WithStreamableHTTPProtocolVersions(mcp.LegacyProtocolVersions()...),
+	}
+}
+
 func (s *Server) startCustomHTTPServer(ctx context.Context, streamableServer *server.StreamableHTTPServer) error {
 	cfg := s.runtime.Config()
 	if cfg == nil {
@@ -2622,21 +2647,21 @@ func (s *Server) startCustomHTTPServer(ctx context.Context, streamableServer *se
 	// Each endpoint always serves its specific routing mode regardless of config.
 	// /mcp/all → direct mode (all tools with serverName__toolName naming)
 	directStreamable := server.NewStreamableHTTPServer(s.mcpProxy.GetMCPServerForMode(config.RoutingModeDirect),
-		server.WithDisableLocalhostProtection(true))
+		clientFacingStreamableOptions()...)
 	directHandler := s.streamingNoDeadline(s.hostValidationMiddleware(s.mcpAuthMiddleware(loggingHandler(directStreamable))))
 	mux.Handle("/mcp/all", directHandler)
 	mux.Handle("/mcp/all/", directHandler)
 
 	// /mcp/code → code_execution mode (JS orchestration)
 	codeExecStreamable := server.NewStreamableHTTPServer(s.mcpProxy.GetMCPServerForMode(config.RoutingModeCodeExecution),
-		server.WithDisableLocalhostProtection(true))
+		clientFacingStreamableOptions()...)
 	codeExecHandler := s.streamingNoDeadline(s.hostValidationMiddleware(s.mcpAuthMiddleware(loggingHandler(codeExecStreamable))))
 	mux.Handle("/mcp/code", codeExecHandler)
 	mux.Handle("/mcp/code/", codeExecHandler)
 
 	// /mcp/call → retrieve_tools mode (focused: retrieve_tools + call_tool_read/write/destructive)
 	callToolStreamable := server.NewStreamableHTTPServer(s.mcpProxy.GetMCPServerForMode(config.RoutingModeRetrieveTools),
-		server.WithDisableLocalhostProtection(true))
+		clientFacingStreamableOptions()...)
 	callToolHandler := s.streamingNoDeadline(s.hostValidationMiddleware(s.mcpAuthMiddleware(loggingHandler(callToolStreamable))))
 	mux.Handle("/mcp/call", callToolHandler)
 	mux.Handle("/mcp/call/", callToolHandler)
@@ -2645,7 +2670,7 @@ func (s *Server) startCustomHTTPServer(ctx context.Context, streamableServer *se
 	// Profile resolution is done by profileMiddleware which runs AFTER mcpAuthMiddleware
 	// so that agent-token scope can compose downstream with the profile scope.
 	profileStreamable := server.NewStreamableHTTPServer(s.mcpProxy.GetMCPServerForMode(config.RoutingModeRetrieveTools),
-		server.WithDisableLocalhostProtection(true))
+		clientFacingStreamableOptions()...)
 	profileHandler := s.streamingNoDeadline(s.hostValidationMiddleware(s.mcpAuthMiddleware(s.profileMiddleware(loggingHandler(profileStreamable)))))
 	mux.Handle("/mcp/p/", profileHandler)
 	mux.Handle("/mcp/p", profileHandler)

--- a/internal/upstream/core/client.go
+++ b/internal/upstream/core/client.go
@@ -295,6 +295,17 @@ func (c *Client) Ping(ctx context.Context) error {
 		return fmt.Errorf("client not connected")
 	}
 
+	// Spec 058: mcp-go deprecated Ping because the RPC was removed in protocol
+	// 2026-07-28, where it returns success WITHOUT sending anything — a health
+	// probe that always passes is worse than none, since it reports a dead
+	// upstream as healthy.
+	//
+	// This remains a real probe today only because the upstream handshake is
+	// pinned to the legacy era (FR-027, connection_lifecycle.go). Lifting that
+	// pin MUST come with an era-aware replacement, or spec 074's health loop
+	// goes blind; that is tracked as a required task of the pin lift, not as
+	// cleanup.
+	//nolint:staticcheck // SA1019: valid on the legacy era this client is pinned to; see above.
 	return client.Ping(ctx)
 }
 

--- a/internal/upstream/core/connection_lifecycle.go
+++ b/internal/upstream/core/connection_lifecycle.go
@@ -94,6 +94,24 @@ func (c *Client) initialize(ctx context.Context) error {
 			zap.String("formatted_json", string(respBytes)))
 	}
 
+	// Spec 058 FR-027: the pin above controls what mcpproxy ASKS for; this
+	// checks what it got. mcp-go accepts a modern answer to a legacy request —
+	// initializeLegacy validates only mcp.IsValidProtocolVersion, which is true
+	// for 2026-07-28, and then applies it — so a server answering with the
+	// modern era would silently flip this hop to it, exactly the outcome the pin
+	// exists to prevent (Ping stops sending anything, server-initiated requests
+	// disappear).
+	//
+	// Rejecting restores the pre-bump contract rather than inventing one: under
+	// mcp-go v0.57.0, 2026-07-28 was absent from ValidProtocolVersions, so this
+	// same answer failed the handshake outright. A compliant server will not do
+	// this — it must answer with a version the client can speak — so this fires
+	// only for a genuinely misbehaving upstream.
+	if negotiated := serverInfo.ProtocolVersion; mcp.IsModernProtocol(negotiated) {
+		return fmt.Errorf("upstream answered MCP protocol version %s to a %s request; mcpproxy does not yet serve the 2026-07-28 era on the upstream hop (spec 058 FR-027)",
+			negotiated, initRequest.Params.ProtocolVersion)
+	}
+
 	c.serverInfo = serverInfo
 	c.logger.Info("MCP initialization successful",
 		zap.String("server_name", serverInfo.ServerInfo.Name),

--- a/internal/upstream/core/connection_lifecycle.go
+++ b/internal/upstream/core/connection_lifecycle.go
@@ -16,7 +16,14 @@ import (
 // initialize performs MCP initialization handshake
 func (c *Client) initialize(ctx context.Context) error {
 	initRequest := mcp.InitializeRequest{}
-	initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	// Spec 058 FR-027: pinned to the newest LEGACY revision rather than
+	// mcp.LATEST_PROTOCOL_VERSION, which mcp-go v1.0.0 redefined to 2026-07-28.
+	// Sending the latest constant would have made the library upgrade alone
+	// switch every upstream hop to the new protocol era, where Ping is a no-op
+	// (so Spec-074 health probes stop proving liveness) and server-initiated
+	// requests are gone (so roots-based workspace discovery cannot work).
+	// Lifting this pin is a separate, separately verified change.
+	initRequest.Params.ProtocolVersion = mcp.LATEST_LEGACY_PROTOCOL_VERSION
 	initRequest.Params.ClientInfo = mcp.Implementation{
 		Name:    "mcpproxy-go",
 		Version: "1.0.0",

--- a/internal/upstream/core/prompts_test.go
+++ b/internal/upstream/core/prompts_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
+	servertest "github.com/mark3labs/mcp-go/server/servertest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -75,7 +76,7 @@ func connectedTestClient(t *testing.T, url string, exposePrompts *bool) *Client 
 
 func TestClient_ListPrompts_ReturnsUpstreamPrompts(t *testing.T) {
 	upstream := newTestPromptUpstream(t, true, nil)
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstream)
+	testServer := servertest.NewTestStreamableHTTPServer(upstream)
 	defer testServer.Close()
 
 	c := connectedTestClient(t, testServer.URL, nil)
@@ -88,7 +89,7 @@ func TestClient_ListPrompts_ReturnsUpstreamPrompts(t *testing.T) {
 
 func TestClient_ListPrompts_NoCapability_ReturnsNil(t *testing.T) {
 	upstream := newTestPromptUpstream(t, false, nil)
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstream)
+	testServer := servertest.NewTestStreamableHTTPServer(upstream)
 	defer testServer.Close()
 
 	c := connectedTestClient(t, testServer.URL, nil)
@@ -101,7 +102,7 @@ func TestClient_ListPrompts_NoCapability_ReturnsNil(t *testing.T) {
 func TestClient_ListPrompts_ExposePromptsFalse_SkipsUpstreamCall(t *testing.T) {
 	calls := 0
 	upstream := newTestPromptUpstream(t, true, &calls)
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstream)
+	testServer := servertest.NewTestStreamableHTTPServer(upstream)
 	defer testServer.Close()
 
 	c := connectedTestClient(t, testServer.URL, config.BoolPtr(false))
@@ -121,7 +122,7 @@ func TestClient_ListPrompts_ExposePromptsFalse_SkipsUpstreamCall(t *testing.T) {
 func TestClient_SetExposePrompts_TakesEffectWithoutReconnect(t *testing.T) {
 	calls := 0
 	upstream := newTestPromptUpstream(t, true, &calls)
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstream)
+	testServer := servertest.NewTestStreamableHTTPServer(upstream)
 	defer testServer.Close()
 
 	c := connectedTestClient(t, testServer.URL, nil)
@@ -147,7 +148,7 @@ func TestClient_SetExposePrompts_TakesEffectWithoutReconnect(t *testing.T) {
 
 func TestClient_GetPrompt_ReturnsUpstreamResult(t *testing.T) {
 	upstream := newTestPromptUpstream(t, true, nil)
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstream)
+	testServer := servertest.NewTestStreamableHTTPServer(upstream)
 	defer testServer.Close()
 
 	c := connectedTestClient(t, testServer.URL, nil)
@@ -167,7 +168,7 @@ func TestClient_GetPrompt_ReturnsUpstreamResult(t *testing.T) {
 func TestClient_GetPrompt_ExposePromptsFalse_ReturnsErrorNoUpstreamCall(t *testing.T) {
 	calls := 0
 	upstream := newTestPromptUpstream(t, true, &calls)
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstream)
+	testServer := servertest.NewTestStreamableHTTPServer(upstream)
 	defer testServer.Close()
 
 	c := connectedTestClient(t, testServer.URL, config.BoolPtr(false))
@@ -186,7 +187,7 @@ func TestClient_GetPrompt_ExposePromptsFalse_ReturnsErrorNoUpstreamCall(t *testi
 func TestClient_GetPrompt_SetExposePromptsFalse_TakesEffectWithoutReconnect(t *testing.T) {
 	calls := 0
 	upstream := newTestPromptUpstream(t, true, &calls)
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstream)
+	testServer := servertest.NewTestStreamableHTTPServer(upstream)
 	defer testServer.Close()
 
 	c := connectedTestClient(t, testServer.URL, nil)
@@ -225,7 +226,7 @@ func TestClient_ListPrompts_NotConnected_ReturnsError(t *testing.T) {
 
 func TestClient_ListPrompts_ServerInfoNil_ReturnsError(t *testing.T) {
 	upstream := newTestPromptUpstream(t, true, nil)
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstream)
+	testServer := servertest.NewTestStreamableHTTPServer(upstream)
 	defer testServer.Close()
 
 	c := connectedTestClient(t, testServer.URL, nil)
@@ -244,7 +245,7 @@ func TestClient_ListPrompts_ServerInfoNil_ReturnsError(t *testing.T) {
 
 func TestClient_ListPrompts_UpstreamError_ReturnsWrappedError(t *testing.T) {
 	upstream := newTestPromptUpstream(t, true, nil)
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstream)
+	testServer := servertest.NewTestStreamableHTTPServer(upstream)
 	c := connectedTestClient(t, testServer.URL, nil)
 
 	// Close the upstream out from under an already-connected client so the
@@ -268,7 +269,7 @@ func TestClient_GetPrompt_NotConnected_ReturnsError(t *testing.T) {
 
 func TestClient_GetPrompt_UpstreamError_ReturnsWrappedError(t *testing.T) {
 	upstream := newTestPromptUpstream(t, true, nil)
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstream)
+	testServer := servertest.NewTestStreamableHTTPServer(upstream)
 	c := connectedTestClient(t, testServer.URL, nil)
 
 	testServer.Close()
@@ -309,7 +310,7 @@ func newPaginatedPromptUpstream(t *testing.T, count, pageLimit int) *mcpserver.M
 
 func TestClient_ListPrompts_FollowsPaginationAcrossPages(t *testing.T) {
 	upstream := newPaginatedPromptUpstream(t, 5, 2) // 3 pages: [2][2][1]
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstream)
+	testServer := servertest.NewTestStreamableHTTPServer(upstream)
 	defer testServer.Close()
 
 	c := connectedTestClient(t, testServer.URL, nil)
@@ -321,7 +322,7 @@ func TestClient_ListPrompts_FollowsPaginationAcrossPages(t *testing.T) {
 
 func TestClient_ListPrompts_StopsAtItemCap(t *testing.T) {
 	upstream := newPaginatedPromptUpstream(t, 250, 50) // 5 pages available
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstream)
+	testServer := servertest.NewTestStreamableHTTPServer(upstream)
 	defer testServer.Close()
 
 	c := connectedTestClient(t, testServer.URL, nil)
@@ -336,7 +337,7 @@ func TestClient_ListPrompts_StopsAtItemCap(t *testing.T) {
 func TestClient_ListPrompts_EndlessCursorTerminatesAtPageCap(t *testing.T) {
 	// 60 prompts at 1/page => a NextCursor on every page; the page cap must cut it.
 	upstream := newPaginatedPromptUpstream(t, maxListPromptsPages+10, 1)
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstream)
+	testServer := servertest.NewTestStreamableHTTPServer(upstream)
 	defer testServer.Close()
 
 	c := connectedTestClient(t, testServer.URL, nil)
@@ -354,7 +355,7 @@ func TestClient_ListPrompts_EndlessCursorTerminatesAtPageCap(t *testing.T) {
 // QA; this asserts the dispatch + callback the proxy relies on.)
 func TestClient_HandlePromptsListChanged_FiresCallback(t *testing.T) {
 	upstream := newTestPromptUpstream(t, true, nil)
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstream)
+	testServer := servertest.NewTestStreamableHTTPServer(upstream)
 	defer testServer.Close()
 
 	c := connectedTestClient(t, testServer.URL, nil)
@@ -378,7 +379,7 @@ func TestClient_HandlePromptsListChanged_FiresCallback(t *testing.T) {
 // safe when no callback is registered.
 func TestClient_HandlePromptsListChanged_NilCallbackNoPanic(t *testing.T) {
 	upstream := newTestPromptUpstream(t, true, nil)
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstream)
+	testServer := servertest.NewTestStreamableHTTPServer(upstream)
 	defer testServer.Close()
 
 	c := connectedTestClient(t, testServer.URL, nil)

--- a/internal/upstream/core/protocol_pin_test.go
+++ b/internal/upstream/core/protocol_pin_test.go
@@ -142,6 +142,61 @@ func TestUpstreamHandshakeRequestsLegacyProtocolVersion(t *testing.T) {
 	}
 }
 
+// The pin above controls what mcpproxy ASKS for. This asserts what it ACCEPTS,
+// which the first version of the pin left open: mcp-go validates a legacy
+// handshake's answer only with mcp.IsValidProtocolVersion — true for
+// 2026-07-28 — and then applies it, so a server answering modern silently
+// flipped the hop to the era the pin exists to avoid. Under the previous
+// library that answer failed the handshake, so accepting it was itself a
+// behavior change introduced by the bump.
+func TestUpstreamRejectsAModernNegotiatedEra(t *testing.T) {
+	disableOAuthForTest(t)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		_ = json.Unmarshal(body, &req)
+
+		if req.Method == "initialize" {
+			// Answer with the modern era regardless of what was requested.
+			writeJSONRPC(w, req.ID, map[string]any{
+				"protocolVersion": "2026-07-28",
+				"capabilities":    map[string]any{"tools": map[string]any{}},
+				"serverInfo":      map[string]any{"name": "rogue", "version": "1.0.0"},
+			})
+			return
+		}
+		if len(req.ID) == 0 {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		writeJSONRPC(w, req.ID, map[string]any{})
+	}))
+	defer upstream.Close()
+
+	cfg := &config.ServerConfig{
+		Name:     "rogue-era",
+		Protocol: "streamable-http",
+		URL:      upstream.URL,
+		Enabled:  true,
+	}
+	client, err := NewClient("rogue-era", cfg, zap.NewNop(), nil, nil, nil, secret.NewResolver())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err = client.Connect(ctx)
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	require.Error(t, err, "an upstream that answers 2026-07-28 must not be accepted while the hop is pinned to the legacy era")
+	assert.Contains(t, err.Error(), "2026-07-28",
+		"the error should name the era the upstream answered so the cause is diagnosable")
+}
+
 // Guards the constant this file asserts against: if a future library release
 // redefines the legacy constant too, the pin's meaning changes and the failure
 // should point here rather than showing up as a puzzling wire mismatch.

--- a/internal/upstream/core/protocol_pin_test.go
+++ b/internal/upstream/core/protocol_pin_test.go
@@ -1,0 +1,151 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/secret"
+)
+
+// Spec 058 FR-027 pins the UPSTREAM-facing handshake to the legacy protocol era,
+// and this asserts it on the wire rather than by reading the constant back.
+//
+// The distinction matters because the risk here is a constant that changes
+// underneath us: mcp-go v1.0.0 redefined mcp.LATEST_PROTOCOL_VERSION from
+// 2025-11-25 to 2026-07-28, so the code that used to request the legacy era kept
+// compiling and silently began requesting the modern one. A test asserting
+// "the request carries mcp.LATEST_LEGACY_PROTOCOL_VERSION" would have gone on
+// passing through exactly that change. Capturing the literal string a real
+// upstream receives is the only form that cannot.
+//
+// When the pin is deliberately lifted, this test should be updated in the same
+// change, with the negotiated era asserted per-hop instead.
+const expectedUpstreamProtocolVersion = "2025-11-25"
+
+// captureInitialize records the protocolVersion of the first initialize request
+// it receives, then answers with a minimal but valid legacy initialize result so
+// the client can finish connecting.
+type initializeCapture struct {
+	mu       sync.Mutex
+	versions []string
+}
+
+func (c *initializeCapture) recorded() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.versions...)
+}
+
+func (c *initializeCapture) handler(t *testing.T) http.Handler {
+	t.Helper()
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		var req struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+			Params struct {
+				ProtocolVersion string `json:"protocolVersion"`
+			} `json:"params"`
+		}
+		if err := json.Unmarshal(body, &req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		switch req.Method {
+		case "initialize":
+			c.mu.Lock()
+			c.versions = append(c.versions, req.Params.ProtocolVersion)
+			c.mu.Unlock()
+
+			// Echo the era the client asked for, which is what a legacy-only
+			// upstream does when it supports the requested version.
+			writeJSONRPC(w, req.ID, map[string]any{
+				"protocolVersion": req.Params.ProtocolVersion,
+				"capabilities":    map[string]any{"tools": map[string]any{}},
+				"serverInfo":      map[string]any{"name": "pin-probe", "version": "1.0.0"},
+			})
+		case "tools/list":
+			writeJSONRPC(w, req.ID, map[string]any{"tools": []any{}})
+		default:
+			// Notifications carry no id and need no response.
+			if len(req.ID) == 0 {
+				w.WriteHeader(http.StatusAccepted)
+				return
+			}
+			writeJSONRPC(w, req.ID, map[string]any{})
+		}
+	})
+}
+
+func writeJSONRPC(w http.ResponseWriter, id json.RawMessage, result map[string]any) {
+	w.Header().Set("Content-Type", "application/json")
+	payload := map[string]any{"jsonrpc": "2.0", "result": result}
+	if len(id) > 0 {
+		payload["id"] = json.RawMessage(id)
+	}
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+// The load-bearing assertion: an upstream sees the legacy era, not 2026-07-28.
+func TestUpstreamHandshakeRequestsLegacyProtocolVersion(t *testing.T) {
+	disableOAuthForTest(t)
+
+	capture := &initializeCapture{}
+	upstream := httptest.NewServer(capture.handler(t))
+	defer upstream.Close()
+
+	cfg := &config.ServerConfig{
+		Name:     "pin-probe",
+		Protocol: "streamable-http",
+		URL:      upstream.URL,
+		Enabled:  true,
+	}
+	client, err := NewClient("pin-probe", cfg, zap.NewNop(), nil, nil, nil, secret.NewResolver())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	require.NoError(t, client.Connect(ctx))
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	recorded := capture.recorded()
+	require.NotEmpty(t, recorded, "the upstream never received an initialize request, so this test proves nothing about the pin")
+
+	for _, version := range recorded {
+		assert.Equal(t, expectedUpstreamProtocolVersion, version,
+			"the upstream hop must stay on the legacy era until the pin is deliberately lifted (Spec 058 FR-027); "+
+				"a bare mcp.LATEST_PROTOCOL_VERSION here would have switched it to 2026-07-28 as a side effect of the library bump")
+	}
+}
+
+// Guards the constant this file asserts against: if a future library release
+// redefines the legacy constant too, the pin's meaning changes and the failure
+// should point here rather than showing up as a puzzling wire mismatch.
+func TestLegacyProtocolConstantStillNamesTheExpectedEra(t *testing.T) {
+	assert.Equal(t, expectedUpstreamProtocolVersion, mcp.LATEST_LEGACY_PROTOCOL_VERSION,
+		"mcp.LATEST_LEGACY_PROTOCOL_VERSION changed; re-read Spec 058 FR-027 before updating this expectation")
+}

--- a/internal/upstream/listtools_logging_test.go
+++ b/internal/upstream/listtools_logging_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	mcpserver "github.com/mark3labs/mcp-go/server"
+	servertest "github.com/mark3labs/mcp-go/server/servertest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -47,7 +47,7 @@ func TestListToolsFailureIsLoggedOnceAndNotAsError(t *testing.T) {
 	t.Setenv("MCPPROXY_DISABLE_OAUTH", "true")
 
 	upstream := newTestPromptUpstreamServer(t, "greeting")
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstream)
+	testServer := servertest.NewTestStreamableHTTPServer(upstream)
 
 	require.NoError(t, m.AddServerConfig("srv-a", &config.ServerConfig{
 		Name:     "server-a",
@@ -106,7 +106,7 @@ func TestListToolsFailureIsStillReported(t *testing.T) {
 	t.Setenv("MCPPROXY_DISABLE_OAUTH", "true")
 
 	upstream := newTestPromptUpstreamServer(t, "greeting")
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstream)
+	testServer := servertest.NewTestStreamableHTTPServer(upstream)
 
 	require.NoError(t, m.AddServerConfig("srv-a", &config.ServerConfig{
 		Name:     "server-a",

--- a/internal/upstream/managed/prompts_test.go
+++ b/internal/upstream/managed/prompts_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
+	servertest "github.com/mark3labs/mcp-go/server/servertest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -83,7 +84,7 @@ func TestClient_ListPrompts_NotConnected_ReturnsError(t *testing.T) {
 
 func TestClient_ListPrompts_Success(t *testing.T) {
 	upstream := newTestPromptManagedUpstream(t)
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstream)
+	testServer := servertest.NewTestStreamableHTTPServer(upstream)
 	defer testServer.Close()
 
 	mc := connectedManagedTestClient(t, testServer.URL)
@@ -102,7 +103,7 @@ func TestClient_ListPrompts_Success(t *testing.T) {
 // value down to the coreClient without requiring a reconnect.
 func TestClient_SetConfig_PropagatesExposePromptsToCoreClient(t *testing.T) {
 	upstream := newTestPromptManagedUpstream(t)
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstream)
+	testServer := servertest.NewTestStreamableHTTPServer(upstream)
 	defer testServer.Close()
 
 	mc := connectedManagedTestClient(t, testServer.URL)
@@ -123,7 +124,7 @@ func TestClient_SetConfig_PropagatesExposePromptsToCoreClient(t *testing.T) {
 
 func TestClient_ListPrompts_UpstreamError(t *testing.T) {
 	upstream := newTestPromptManagedUpstream(t)
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstream)
+	testServer := servertest.NewTestStreamableHTTPServer(upstream)
 	mc := connectedManagedTestClient(t, testServer.URL)
 
 	// Close the upstream out from under an established, "ready" client so the
@@ -146,7 +147,7 @@ func TestClient_GetPrompt_NotConnected_ReturnsError(t *testing.T) {
 
 func TestClient_GetPrompt_Success(t *testing.T) {
 	upstream := newTestPromptManagedUpstream(t)
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstream)
+	testServer := servertest.NewTestStreamableHTTPServer(upstream)
 	defer testServer.Close()
 
 	mc := connectedManagedTestClient(t, testServer.URL)
@@ -161,7 +162,7 @@ func TestClient_GetPrompt_Success(t *testing.T) {
 
 func TestClient_GetPrompt_UpstreamError(t *testing.T) {
 	upstream := newTestPromptManagedUpstream(t)
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstream)
+	testServer := servertest.NewTestStreamableHTTPServer(upstream)
 	mc := connectedManagedTestClient(t, testServer.URL)
 
 	testServer.Close()

--- a/internal/upstream/manager_prompts_test.go
+++ b/internal/upstream/manager_prompts_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
+	servertest "github.com/mark3labs/mcp-go/server/servertest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -72,7 +73,7 @@ func addConnectedTestServerWithConfig(t *testing.T, m *Manager, id string, cfg *
 	t.Setenv("MCPPROXY_DISABLE_OAUTH", "true")
 
 	upstream := newTestPromptUpstreamServer(t, promptName)
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstream)
+	testServer := servertest.NewTestStreamableHTTPServer(upstream)
 	t.Cleanup(testServer.Close)
 
 	cfg.Protocol = "streamable-http"
@@ -301,7 +302,7 @@ func TestManager_ListPrompts_PerServerCap(t *testing.T) {
 	t.Setenv("MCPPROXY_DISABLE_OAUTH", "true")
 
 	upstream := newTestPromptUpstreamServerN(t, maxPromptsPerServer+5)
-	testServer := mcpserver.NewTestStreamableHTTPServer(upstream)
+	testServer := servertest.NewTestStreamableHTTPServer(upstream)
 	t.Cleanup(testServer.Close)
 
 	require.NoError(t, m.AddServerConfig("srv-a", &config.ServerConfig{


### PR DESCRIPTION
Related #532 · Plan: #1202 (specs/058-mcp-2026-upgrade)

Spec 058 Phases 1–2. Adopts `mark3labs/mcp-go` v1.0.0 while leaving wire behaviour byte-identical in both directions, and fixes two latent defects the bump exposed.

## The bump is not the risky part; the constant it redefines is

v1.0.0 redefines `mcp.LATEST_PROTOCOL_VERSION` from `2025-11-25` to `2026-07-28`, and `client.Initialize` became modern-first. `internal/upstream/core` sent that constant, so **bumping the dependency alone would have switched every upstream hop to the new protocol era** — where `Ping` returns success without sending anything (so the Spec-074 health loop would report dead upstreams as healthy) and server-initiated requests are gone (so roots-based workspace discovery cannot work). FR-027 is amended to name both hops, and both are pinned:

- `clientFacingStreamableOptions()` pins the client-facing transports, applied at all five `NewStreamableHTTPServer` sites. It is a function rather than a package variable so it cannot be flipped at runtime or from a test, and it is shared so "pinned on four of five doors" is not expressible.
- The upstream handshake is pinned to `mcp.LATEST_LEGACY_PROTOCOL_VERSION`.

Both are asserted **on the wire** rather than by reading the constants back. The failure mode here is a constant changing underneath us, and a test comparing code to code would have passed straight through it.

## Two latent defects

**Tool-approval hashes were coupled to the library version.** Spec-032 hashes are computed over the library-*decoded* schema, because `mcp.Tool.RawInputSchema` is `json:"-"` and the upstream's bytes are discarded. v1.0.0 rewrites draft-07 `#/definitions/` refs to `#/$defs/`, so a hash stored by the old decoder could not be reproduced by the new one, and the formula-migration hatch does not absorb it — every affected tool would be reported as **changed, a rug-pull signal**, after an upgrade that changed nothing upstream. `NormalizeJSON` now canonicalizes that spelling.

The guard is deliberately narrow: it fires only when a document has a root `$defs` and no root `definitions`. `NormalizeJSON` is also applied to raw output schemas that reach the Spec-056 validator, and there a `#/definitions/` pointer is *correct* — rewriting it would aim it at a member that does not exist.

**An upstream's result envelope was replayed as mcpproxy's own.** Both forwarding paths copied `ctr.Result` wholesale, which carries `ResultType`. Since `CallToolResult` embeds `MultiRoundTripResult` separately, an upstream `input_required` reached the client stripped of the `inputRequests` and `requestState` needed to answer it — told to supply input, with no way to supply it and no way to know why. The envelope decision is now one shared `proxyResultEnvelope()`, so the two paths cannot drift.

## Verification

- Full `internal/server` suite green, **including `TestProfile_SetProfileSessionScoped` and `TestProfile_SetProfileUnknown`**, which fail on v1.0.0 unpinned. The pin alone fixes them, with no change to profile code.
- `-race` green across hash, upstream, runtime and config. Server edition green.
- 14 tool-surface golden tests pass with **no golden file regenerated**.
- `golangci-lint` v2 with the CI config: no issues. Two mcp-go deprecations are suppressed with the reason and the follow-up task named inline.
- Each new guard was mutation-tested: reverting the normalizer, either pin, or the envelope fix makes the corresponding test fail.

## What this does not do

Serving `2026-07-28` is deliberately out of scope. The stateless work (Spec 058 US3 — profile resolution, session-free attribution, and the cross-client cancellation collision in mcp-go's `inflightKey`) must land before either pin lifts; lifting first would expose that collision to real users rather than to tests.
