### PR TITLE
fix(test): size TestDetectionScansUntruncatedResponse for the race detector

### DIFF
--- a/internal/runtime/activity_response_truncation_test.go
+++ b/internal/runtime/activity_response_truncation_test.go
@@ -253,16 +253,25 @@ func TestSetMaxResponseSizeIgnoresNonPositive(t *testing.T) {
 //
 // Each case puts the key AFTER the storage cut, so it is absent from the
 // persisted response and can only be found via the pre-truncation string.
+//
+// The cap is set explicitly rather than left at the 64KB default, which keeps
+// the payload small. Detector.Scan costs roughly 5.5us/byte, and the race
+// detector multiplies that by ~23x: a payload sized to clear the default cap
+// took 9.5s to scan under -race against waitForDetectionMetadata's 5s poll
+// deadline, so the test failed in CI (which runs -race everywhere) while
+// passing locally without it. A 1KB cap exercises the identical seam.
 func TestDetectionScansUntruncatedResponse(t *testing.T) {
 	const awsKey = "AKIA1234567890ABCDEF"
-	// Comfortably past the 64KB default cap, well inside the detector's 1024KB.
-	padding := strings.Repeat("x", storage.DefaultMaxResponseSize+10_000)
+	const storageCap = 1024
+	// Past the storage cut, well inside the detector's own 1024KB window.
+	padding := strings.Repeat("x", storageCap*4)
 
 	t.Run("tool_call", func(t *testing.T) {
 		store, cleanup := setupTestStorage(t)
 		defer cleanup()
 
 		svc := NewActivityService(store, zap.NewNop())
+		svc.SetMaxResponseSize(storageCap)
 		svc.SetDetector(security.NewDetector(config.DefaultSensitiveDataDetectionConfig()))
 
 		svc.handleEvent(Event{
@@ -291,6 +300,7 @@ func TestDetectionScansUntruncatedResponse(t *testing.T) {
 		defer cleanup()
 
 		svc := NewActivityService(store, zap.NewNop())
+		svc.SetMaxResponseSize(storageCap)
 		svc.SetDetector(security.NewDetector(config.DefaultSensitiveDataDetectionConfig()))
 
 		svc.handleEvent(Event{


### PR DESCRIPTION
# Pull Request

Follow-up to #1174. Related #1173

## Description

`TestDetectionScansUntruncatedResponse`, added in #1174, fails in both `Unit Tests` and `End-to-End Tests`. The defect is the test's payload sizing, not the behaviour it guards — the production change in #1174 is correct and unmodified here.

To put a secret past the storage cut, the test padded the response to `storage.DefaultMaxResponseSize+10_000` (~75KB) so it could rely on the 64KB default cap. `security.Detector.Scan` costs ~5.5 µs/byte, and the race detector multiplies that by **~24x** (measured 114–137 µs/byte across 1K–75K payloads). The scan therefore took **~9.5s** against the **5s** poll deadline in `waitForDetectionMetadata`.

Two things made this read as a logic failure rather than a slow one:

- `runAsyncDetection` writes metadata **only when something is detected**, so an over-budget scan and a scan of the wrong (truncated) text produce the identical symptom: `timed out waiting for detection metadata`.
- CI runs `-race` in both workflows; a plain local `go test` does not. Without `-race` the same test passes in 0.48s.

### What this changes

Test-only, three hunks in one file:

- `svc.SetMaxResponseSize(1024)` in both subtests, instead of leaning on the 64KB default
- padding `4096` bytes instead of `DefaultMaxResponseSize+10_000`
- a comment recording why, so nobody restores the large payload

The seam is identical. The AWS key sits at bytes `[4113, 4133)`, i.e. **3089 bytes past** the 1024-byte cut, and `truncateResponse` honours any positive `maxSize` with no minimum floor. Runtime drops from ~9.5s to ~0.5s per subtest.

`TestDefaultResponseCapAppliesWithoutConfig` still covers the 64KB default separately, so no coverage is lost.

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests that prove my fix is effective or my feature works
- [x] All existing tests pass

- **5/5 runs** under `-race`: 0.45–0.50s per subtest against the 5s deadline
- **Negative control** — moving the `detectionSource` capture back to *after* `truncateForStorage` in both handlers still fails the test at the smaller payload (10.07s, both subtests, same timeout message). It is not passing vacuously.
- **Second control** — stubbing `truncateForStorage` to `return response, false` fails the `NotContains` assertion, proving the key really is past the cut and the assertion is live.
- Whole `internal/runtime` package green under plain `-race`, under the `unit-tests.yml` invocation, and under the `e2e-tests.yml` `-short` invocation. No data races.
- **Headroom measured, not assumed**: under graded CPU oversubscription the test still passes at an **8x** slowdown (2.96–3.76s) and breaks only around **10.8x**. `GOMAXPROCS=1` changes nothing (0.47s vs 0.46s) — the scan is single-goroutine CPU-bound, so only single-core speed matters.

### Noted for later, not fixed here

`internal/security/mask_test.go:TestMaskTextStaysCheapOnAPayloadFullOfSecrets` builds a 64KB payload under a hard `2 * time.Second` wall-clock assertion. It is safe today — `MaskText` costs ~3.8 µs/byte under `-race`, ~36x cheaper per byte than `Scan`, leaving ~8x headroom — but it is the same fragile shape, and it converts into this failure immediately if anyone ever routes masking through `Scan`.
