### PR TITLE
ci: re-enable the server Docker image build on stable releases

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -388,3 +388,39 @@ jobs:
           path: mcpproxy-*-darwin-${{ matrix.goarch }}-installer.dmg
           retention-days: 14
           if-no-files-found: warn
+
+  # The release workflow's `release` job now depends on `build-docker`, so a
+  # Dockerfile that no longer builds blocks a whole release at tag time. Build
+  # (never push) the server image on every PR so breakage surfaces here instead.
+  # Single-platform amd64 — it runs natively on the runner, which keeps this a
+  # couple of minutes and lets us smoke-test the entrypoint.
+  docker-image:
+    name: Build Server Docker Image
+    needs: [prepare]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4.3.0
+
+      - name: Build image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        with:
+          context: .
+          push: false
+          load: true
+          platforms: linux/amd64
+          build-args: |
+            VERSION=${{ needs.prepare.outputs.version }}
+            COMMIT=${{ github.sha }}
+          tags: mcpproxy-server:pr
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke-test the image
+        run: |
+          set -eo pipefail
+          docker run --rm --entrypoint mcpproxy mcpproxy-server:pr version | tee /tmp/version.txt
+          grep -q '(server)' /tmp/version.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1232,8 +1232,10 @@ jobs:
   build-docker:
     runs-on: ubuntu-latest
     needs: [build]
-    # Disabled until server MVP is ready — uncomment to enable
-    if: false && startsWith(github.ref, 'refs/tags/v')
+    # Stable releases only, matching `build`/`release` — release.yml fires on every
+    # `v*` tag, and an RC must never move `mcpproxy-server:latest`. prerelease.yml
+    # owns the RC channel and publishes no image.
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
     permissions:
       contents: read
       packages: write
@@ -1249,6 +1251,10 @@ jobs:
         with:
           context: .
           push: true
+          # linux/arm64 matters for Raspberry Pi / Graviton hosts, and the release
+          # already ships an arm64 Linux binary. The Dockerfile cross-compiles from
+          # $BUILDPLATFORM, so this costs a second native build, not QEMU emulation.
+          platforms: linux/amd64,linux/arm64
           build-args: |
             VERSION=${{ github.ref_name }}
             COMMIT=${{ github.sha }}
@@ -1271,7 +1277,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
 
   release:
-    needs: [build, sign-windows, generate-notes, qa-gate]  # add build-docker when server MVP is ready
+    needs: [build, build-docker, sign-windows, generate-notes, qa-gate]
     runs-on: ubuntu-latest
     environment: production
     # Explicit guard (belt-and-suspenders on top of the cascade from needs:) — RC tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1266,6 +1266,17 @@ jobs:
           tags: |
             ghcr.io/smart-mcp-proxy/mcpproxy-server:${{ github.ref_name }}
             ghcr.io/smart-mcp-proxy/mcpproxy-server:latest
+          # image.source links the GHCR package back to this repo so it inherits the
+          # repo's README and shows up under the org's packages. It does NOT make the
+          # package public: a package first created by GITHUB_TOKEN is private, and
+          # visibility has to be flipped once by hand after the first push. Until that
+          # happens an anonymous `docker pull` gets `denied`.
+          labels: |
+            org.opencontainers.image.source=https://github.com/smart-mcp-proxy/mcpproxy-go
+            org.opencontainers.image.description=MCPProxy Server Edition — headless MCP proxy with tool discovery and quarantine
+            org.opencontainers.image.licenses=MIT
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ github.ref_name }}
 
   # Spec 081: release qualification gate. Runs the server-type matrix +
   # invariants + assembled suites and produces one pass/fail verdict. The

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1231,7 +1231,11 @@ jobs:
 
   build-docker:
     runs-on: ubuntu-latest
-    needs: [build]
+    # `qa-gate` is load-bearing, not cosmetic: this job pushes to GHCR (including
+    # the `:latest` pointer), which is publishing to users. Without it in the
+    # closure a tag whose gate failed would still ship a container image — the
+    # exact hole cmd/release-gate's TestPublishJobsGatedOnQAGate exists to catch.
+    needs: [build, qa-gate]
     # Stable releases only, matching `build`/`release` — release.yml fires on every
     # `v*` tag, and an RC must never move `mcpproxy-server:latest`. prerelease.yml
     # owns the RC channel and publishes no image.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-# Build stage
-FROM golang:1.27-alpine AS builder
+# Build stage. Pinned to $BUILDPLATFORM and cross-compiled via $TARGETARCH so a
+# multi-arch build never needs QEMU emulation (the binary is CGO_ENABLED=0 and the
+# frontend is arch-independent).
+FROM --platform=$BUILDPLATFORM golang:1.27-alpine AS builder
 
 RUN apk add --no-cache git nodejs npm make
 
@@ -17,7 +19,9 @@ RUN mkdir -p web/frontend && cp -r frontend/dist web/frontend/
 ARG VERSION=dev
 ARG COMMIT=unknown
 ARG BUILD_DATE=unknown
-RUN CGO_ENABLED=0 go build \
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build \
     -tags server \
     -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${BUILD_DATE} -X github.com/smart-mcp-proxy/mcpproxy-go/internal/httpapi.buildVersion=${VERSION} -X github.com/smart-mcp-proxy/mcpproxy-go/internal/updatecheck.buildChannel=docker -s -w" \
     -o /mcpproxy ./cmd/mcpproxy

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -324,6 +324,14 @@ docker run -d --name mcpproxy \
 
 - **Tags**: `ghcr.io/smart-mcp-proxy/mcpproxy-server:<version>` (e.g. `v0.64.0`) and `:latest`,
   which always points at the newest stable release. RC builds publish no image.
+- **State survives restarts, not replacement**: `docker restart` keeps everything. Removing and
+  re-running the container, upgrading the tag, or rescheduling the pod destroys whatever is not
+  on the volume — so mount one before you configure anything.
+- **Don't use `MCPPROXY_DATA` or a bare `--data-dir` to relocate state.** The data-dir override is
+  applied after the config file is resolved, so the config in that directory is never read and is
+  overwritten with a fresh default (rotating the API key) on every boot. Mount the volume at the
+  default `/root/.mcpproxy` path instead. (`MCPPROXY_DATA_DIR`, referenced elsewhere in the docs,
+  is not implemented at all.)
 - **Port**: the entrypoint is `mcpproxy serve --listen 0.0.0.0:8080`, so the container listens on
   `8080` inside the network namespace. The `-p 127.0.0.1:8080:8080` above keeps it reachable only
   from the host; drop the `127.0.0.1:` prefix only if you deliberately want it on the network, and

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -309,6 +309,35 @@ You can then run `mcpproxy serve` directly, or wire up your own systemd unit mod
 
 The systemd unit launches mcpproxy with `--config=/etc/mcpproxy/mcp_config.json --data-dir=/var/lib/mcpproxy` and uses `NoNewPrivileges`, `ProtectSystem=strict`, `PrivateTmp`, and friends.
 
+## Docker (Server edition)
+
+The Server edition is published as a multi-arch image (`linux/amd64`, `linux/arm64`) on
+every stable release:
+
+```bash
+docker run -d --name mcpproxy \
+  -p 127.0.0.1:8080:8080 \
+  -e MCPPROXY_API_KEY="$(openssl rand -hex 32)" \
+  -v mcpproxy-data:/root/.mcpproxy \
+  ghcr.io/smart-mcp-proxy/mcpproxy-server:latest
+```
+
+- **Tags**: `ghcr.io/smart-mcp-proxy/mcpproxy-server:<version>` (e.g. `v0.64.0`) and `:latest`,
+  which always points at the newest stable release. RC builds publish no image.
+- **Port**: the entrypoint is `mcpproxy serve --listen 0.0.0.0:8080`, so the container listens on
+  `8080` inside the network namespace. The `-p 127.0.0.1:8080:8080` above keeps it reachable only
+  from the host; drop the `127.0.0.1:` prefix only if you deliberately want it on the network, and
+  read [Network exposure: localhost by default](#network-exposure-localhost-by-default) first.
+- **State**: config, the BBolt DB, and the search index live in `/root/.mcpproxy`. Mount a volume
+  there or every restart starts from an empty config.
+- **API key**: the REST API and Web UI require one. Set `MCPPROXY_API_KEY` explicitly and keep a
+  copy — the image is distroless (no shell), so reading an auto-generated key back out of the
+  container is awkward.
+- **Web UI**: `http://localhost:8080/ui/`.
+
+Note that this image ships the Server edition binary (`mcpproxy version` reports `(server)`); it is
+the headless core only, with no system tray.
+
 ## Verify Installation
 
 After installation, verify MCPProxy is working:

--- a/docs/mcp-registry-publishing.md
+++ b/docs/mcp-registry-publishing.md
@@ -98,9 +98,9 @@ mcp-publisher status --status deleted \
 ## Registry Schema Notes
 
 - `version` must be a plain semantic version string (`0.33.1`) — no `v` prefix, no ranges.
-- `packages[]` is empty because none of the supported `registryType` values (`npm`, `pypi`, `oci`, `nuget`, `mcpb`) match MCPProxy's distribution channels (Homebrew tap, GitHub release tarballs, `.deb`/`.rpm`, `go install`). The Docker server-edition image at `ghcr.io/smart-mcp-proxy/mcpproxy-server` is not yet published to releases (gated behind `if: false` in the release workflow).
+- `packages[]` is empty because none of the supported `registryType` values (`npm`, `pypi`, `oci`, `nuget`, `mcpb`) match MCPProxy's distribution channels (Homebrew tap, GitHub release tarballs, `.deb`/`.rpm`, `go install`). The Docker server-edition image at `ghcr.io/smart-mcp-proxy/mcpproxy-server` *is* published on every stable tag, but the server edition speaks Streamable HTTP rather than stdio, so it is not a drop-in `oci` package entry either.
 - `remotes[]` is intentionally **omitted**. mcpproxy runs locally (`mcpproxy serve` exposes Streamable HTTP at `http://localhost:8080/mcp`), but the registry's semantic validation **rejects localhost/private remote URLs** (`invalid-remote-url`) — `remotes[]` is reserved for publicly reachable hosted endpoints. With no public remote and no installable package type, the entry is **discovery-only**: it lists the server, description, and repository link so clients can find it and follow the repo's install instructions.
-- If a Docker image for the server edition is published in a future release, add an `oci` entry to `packages[]` pointing at `ghcr.io/smart-mcp-proxy/mcpproxy-server:{version}` with `"transport": {"type": "stdio"}` and the appropriate `runtimeArguments` for `docker run`. That would upgrade the entry from discovery-only to one-click installable.
+- Adding an `oci` entry to `packages[]` for `ghcr.io/smart-mcp-proxy/mcpproxy-server:{version}` would upgrade the entry from discovery-only to one-click installable, but it needs a transport the registry accepts for a container that serves HTTP on a published port — not `"transport": {"type": "stdio"}`. Revisit once the registry's remote/container transport story covers it.
 
 ## References
 


### PR DESCRIPTION
Closes #1171

`build-docker` has been gated behind `if: false` since the Teams work. The server edition it builds now ships, so this re-enables the job and makes `release` depend on it — a stable tag no longer publishes binaries without a matching container image.

## What changed

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | `build-docker` un-gated; `platforms: linux/amd64,linux/arm64`; `release` now `needs: build-docker` |
| `Dockerfile` | Cross-compile from `$BUILDPLATFORM` via `$TARGETOS`/`$TARGETARCH` (no QEMU) |
| `.github/workflows/pr-build.yml` | New build-only `docker-image` job + entrypoint smoke test |
| `docs/getting-started/installation.md` | New "Docker (Server edition)" section |
| `docs/mcp-registry-publishing.md` | Removed the now-false "gated behind `if: false`" note |

## Deviations from the issue's proposal

- **Guard is stable-only**, not the bare `startsWith(github.ref, 'refs/tags/v')`. release.yml fires on every `v*` tag including RCs, and the job pushes `:latest` unconditionally — an RC must not move that pointer. This matches the guard `build`/`release` already use. (Belt-and-suspenders: `build` is stable-only too, so an RC would skip-cascade anyway.)
- **Multi-arch.** The release already ships an arm64 Linux binary; an amd64-only image leaves Raspberry Pi / Graviton users building it by hand — the exact complaint in the issue. Cross-compilation keeps this a second *native* build, not emulation.
- **PR-time build job.** Now that `release` hard-depends on `build-docker`, a Dockerfile regression would first surface at tag time and block a release. The new job catches it on the PR instead.

## Verification (local)

- `docker build` — succeeds.
- `docker buildx build --platform linux/amd64,linux/arm64` — succeeds; log shows `[linux/arm64->amd64 builder]`, i.e. cross-compiled, no QEMU.
- amd64 image under `--platform linux/amd64`: `mcpproxy version` → `MCPProxy v0.0.0-multi (server) linux/amd64`; `/healthz` → 200; `/ui/` serves the real embedded Vue bundle (asset 200, 437 KB), not the fallback stub.
- API key: 401 without `X-API-Key`, 200 with; `MCPPROXY_API_KEY` env override works; state lands in `/root/.mcpproxy` (config.db, index.bleve, mcp_config.json).
- Smoke test needs `--entrypoint mcpproxy` — verified that without it, the `version` arg is swallowed by the `serve` entrypoint and the container just runs the server.
- `actionlint` finding count is byte-identical before/after on both workflows (54 and 10, all pre-existing).

## Defect caught by CI (fixed in the second commit)

The first CI run failed `cmd/release-gate`'s `TestPublishJobsGatedOnQAGate`, and it was a genuine hole in the issue's proposed change — not a flake:

> that audit **skips jobs that can never run** (`if: false`). Un-gating `build-docker` made it visible as a publisher for the first time, and its `needs: [build]` closure never reached `qa-gate`. A tag whose release-qualification gate **failed** would still have pushed an image to GHCR, `:latest` pointer included.

Fixed with `needs: [build, qa-gate]` on `build-docker`. No cycle (`release` → `build-docker` → `qa-gate`). The guard test now passes; it demonstrably bites, since it is what found this.
