### PR TITLE
fix(db): make the compaction lock token unique independent of the clock

### DIFF
--- a/cmd/mcpproxy/db_cmd.go
+++ b/cmd/mcpproxy/db_cmd.go
@@ -292,6 +292,11 @@ func runDBStats(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
+// compactLockNow is a seam so tests can freeze the clock. A frozen clock is
+// exactly the Windows condition this token guards against, which is what lets
+// the lock tests reproduce it on every platform instead of by luck.
+var compactLockNow = time.Now
+
 // compactDatabase rewrites srcPath in place via a temp file + atomic rename.
 //
 // The rename is what makes this safe to interrupt: until it succeeds the
@@ -339,7 +344,7 @@ func acquireCompactLock(dir string) (release func(), err error) {
 		return nil, fmt.Errorf("failed to generate compaction lock token: %w", errors.Join(rerr, cerr))
 	}
 	token := fmt.Sprintf("pid=%d\nstarted=%s\nnonce=%x\n",
-		os.Getpid(), time.Now().UTC().Format(time.RFC3339Nano), nonce)
+		os.Getpid(), compactLockNow().UTC().Format(time.RFC3339Nano), nonce)
 	_, writeErr := f.WriteString(token)
 	closeErr := f.Close()
 	if writeErr != nil || closeErr != nil {

--- a/cmd/mcpproxy/db_cmd.go
+++ b/cmd/mcpproxy/db_cmd.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"os"
@@ -325,7 +326,20 @@ func acquireCompactLock(dir string) (release func(), err error) {
 	// a successor's. Without it: someone deletes A's stale-looking lock, B
 	// creates a fresh one, A finishes and removes the pathname — which is now
 	// B's lock — and a third compaction starts alongside B.
-	token := fmt.Sprintf("pid=%d\nstarted=%s\n", os.Getpid(), time.Now().UTC().Format(time.RFC3339Nano))
+	//
+	// The nonce, not pid+timestamp, is what makes the token unique. Windows'
+	// system clock is coarse (~0.5-15ms), so two acquisitions in one process
+	// can share a timestamp and therefore a whole token. pid and started stay
+	// because they are what a human reads out of a stale lock file.
+	var nonce [16]byte
+	if _, rerr := rand.Read(nonce[:]); rerr != nil {
+		// Close before removing: Windows refuses to delete an open file.
+		cerr := f.Close()
+		os.Remove(lockPath)
+		return nil, fmt.Errorf("failed to generate compaction lock token: %w", errors.Join(rerr, cerr))
+	}
+	token := fmt.Sprintf("pid=%d\nstarted=%s\nnonce=%x\n",
+		os.Getpid(), time.Now().UTC().Format(time.RFC3339Nano), nonce)
 	_, writeErr := f.WriteString(token)
 	closeErr := f.Close()
 	if writeErr != nil || closeErr != nil {

--- a/cmd/mcpproxy/db_cmd_test.go
+++ b/cmd/mcpproxy/db_cmd_test.go
@@ -501,7 +501,15 @@ func TestCopyFileReplacesTheDestinationInsteadOfTruncatingIt(t *testing.T) {
 // path. A review found the sequence: someone deletes A's stale-looking lock, B
 // creates a fresh one, A finishes and removes the pathname — which is now B's —
 // and a third compaction starts alongside B.
+//
+// The clock is frozen so both acquisitions share a timestamp. That is the
+// Windows condition — a ~0.5-15ms granularity with these calls back-to-back —
+// which made this test fail intermittently on windows-latest while passing on
+// nanosecond-resolution platforms. Frozen, it exercises the collision
+// everywhere instead of by luck.
 func TestCompactLockReleaseDoesNotRemoveSomeoneElsesLock(t *testing.T) {
+	freezeCompactLockClock(t)
+
 	dir := t.TempDir()
 	lockPath := filepath.Join(dir, dbFileName+".compact.lock")
 
@@ -538,9 +546,10 @@ func TestCompactLockReleaseDoesNotRemoveSomeoneElsesLock(t *testing.T) {
 // and A's release then deletes B's lock.
 //
 // Asserting "the two files differ" would pass vacuously on a nanosecond clock,
-// so this strips the clock-derived line and requires what remains to still
-// differ — the same thing Windows sees.
+// so the clock is frozen — what Windows does by accident, this does on purpose.
 func TestCompactLockTokenIsUniqueWithinOneClockTick(t *testing.T) {
+	freezeCompactLockClock(t)
+
 	dir := t.TempDir()
 	lockPath := filepath.Join(dir, dbFileName+".compact.lock")
 
@@ -550,14 +559,7 @@ func TestCompactLockTokenIsUniqueWithinOneClockTick(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read lock: %v", err)
 		}
-		var kept []string
-		for _, line := range strings.Split(string(b), "\n") {
-			if line == "" || strings.HasPrefix(line, "started=") {
-				continue // clock-derived: assume it collides
-			}
-			kept = append(kept, line)
-		}
-		return strings.Join(kept, "\n")
+		return string(b)
 	}
 
 	releaseA, err := acquireCompactLock(dir)
@@ -575,7 +577,17 @@ func TestCompactLockTokenIsUniqueWithinOneClockTick(t *testing.T) {
 	tokenB := readToken()
 
 	if tokenA == tokenB {
-		t.Fatalf("two acquisitions produced the same clock-independent token %q; "+
+		t.Fatalf("two acquisitions produced the same token %q; "+
 			"on a coarse clock A's release would delete B's lock", tokenA)
 	}
+}
+
+// freezeCompactLockClock pins compactLockNow so every acquisition in a test
+// reads the same instant, reproducing Windows' coarse clock on any platform.
+func freezeCompactLockClock(t *testing.T) {
+	t.Helper()
+	frozen := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	restore := compactLockNow
+	compactLockNow = func() time.Time { return frozen }
+	t.Cleanup(func() { compactLockNow = restore })
 }

--- a/cmd/mcpproxy/db_cmd_test.go
+++ b/cmd/mcpproxy/db_cmd_test.go
@@ -530,3 +530,52 @@ func TestCompactLockReleaseDoesNotRemoveSomeoneElsesLock(t *testing.T) {
 		t.Error("B's own release must remove B's lock")
 	}
 }
+
+// The token is what separates "my lock" from "a successor's lock", so it must
+// be unique even when the clock cannot tell two acquisitions apart. Windows'
+// system clock is coarse (~0.5-15ms), and two back-to-back acquisitions in one
+// process land in the same tick: same pid + same timestamp = identical tokens,
+// and A's release then deletes B's lock.
+//
+// Asserting "the two files differ" would pass vacuously on a nanosecond clock,
+// so this strips the clock-derived line and requires what remains to still
+// differ — the same thing Windows sees.
+func TestCompactLockTokenIsUniqueWithinOneClockTick(t *testing.T) {
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, dbFileName+".compact.lock")
+
+	readToken := func() string {
+		t.Helper()
+		b, err := os.ReadFile(lockPath)
+		if err != nil {
+			t.Fatalf("read lock: %v", err)
+		}
+		var kept []string
+		for _, line := range strings.Split(string(b), "\n") {
+			if line == "" || strings.HasPrefix(line, "started=") {
+				continue // clock-derived: assume it collides
+			}
+			kept = append(kept, line)
+		}
+		return strings.Join(kept, "\n")
+	}
+
+	releaseA, err := acquireCompactLock(dir)
+	if err != nil {
+		t.Fatalf("acquire A: %v", err)
+	}
+	tokenA := readToken()
+	releaseA()
+
+	releaseB, err := acquireCompactLock(dir)
+	if err != nil {
+		t.Fatalf("acquire B: %v", err)
+	}
+	defer releaseB()
+	tokenB := readToken()
+
+	if tokenA == tokenB {
+		t.Fatalf("two acquisitions produced the same clock-independent token %q; "+
+			"on a coarse clock A's release would delete B's lock", tokenA)
+	}
+}


### PR DESCRIPTION
## Problem

`TestCompactLockReleaseDoesNotRemoveSomeoneElsesLock` fails on the `windows-latest` **Build Binaries** job of **PR Build**, blocking every PR. It is pre-existing and unrelated to any branch: introduced by f95fc1428 (#1214), and [#1215](https://github.com/smart-mcp-proxy/mcpproxy-go/pull/1215) — which touches only `.github/RELEASE_NOTICE.md` — failed with the byte-identical message (run 33946755580, job 101259930963).

## Root cause

`acquireCompactLock` stamped the lock file with

```go
token := fmt.Sprintf("pid=%d\nstarted=%s\n", os.Getpid(), time.Now().UTC().Format(time.RFC3339Nano))
```

and release compares `string(current) != token` to decide whether the lock is still ours.

On Linux/macOS `time.Now()` has nanosecond resolution, so two acquisitions in one process always differ. Windows' system clock is coarse (~0.5–15 ms); the test acquires A, removes the file, and acquires B back-to-back with no work between them, so both land in the same tick. Same PID + same timestamp = identical token, A's release believes B's lock is its own, and deletes it. The test running in 0.00s matches.

This is a real bug, not just a flaky test: the token is the only thing standing between a stale-lock cleanup and two concurrent compactions on the same BBolt database, and on Windows it can genuinely collide.

## Fix

Add a 16-byte `crypto/rand` nonce to the token. `pid` and `started` stay — they are what a human reads out of a stale lock file. The lock protocol and the compaction flow are untouched.

## Test

`TestCompactLockTokenIsUniqueWithinOneClockTick` acquires, releases, re-acquires, and compares the two lock files **with the clock-derived `started=` line stripped** — so it reproduces what Windows sees and bites on a nanosecond clock too, instead of passing vacuously everywhere but Windows.

Verified failing before the fix:

```
db_cmd_test.go:578: two acquisitions produced the same clock-independent token "pid=45729";
on a coarse clock A's release would delete B's lock
```

and passing after, alongside the original test. `go test ./cmd/mcpproxy/` green, `-race` green, `GOOS=windows go test -c` builds, `golangci-lint run --config .github/.golangci.yml ./cmd/mcpproxy/...` reports 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)