### PR TITLE
fix(installer): correct the macOS PKG panes and disclose the certificate's trust posture

### DIFF
--- a/scripts/installer-resources.test.sh
+++ b/scripts/installer-resources.test.sh
@@ -31,21 +31,42 @@ CONCLUSION_TXT="$(textutil -convert txt -stdout "$CONCLUSION")" || { echo "FAIL 
 
 # 1. Nothing reaches the user as literal markup. RTF renders no Markdown, and a
 #    leaked control word means a malformed pane.
+#
+#    The control-word alternatives are terminated by a non-[a-z] character (or
+#    end of string), which is what an RTF control word actually looks like when
+#    it leaks. Without that terminator the pattern both over- and under-fires:
+#    an ordinary rendered path like "C:\party" matched \par, while a leaked
+#    "\b0." was missed because the old \b0 arm demanded whitespace after it.
+MARKUP_RE='\*\*|\\(b|b0|i|i0|ul|ulnone|par|pard|line|tab|f[0-9]+|fs[0-9]+)([^a-z]|$)'
 for pane in welcome conclusion; do
   txt="$WELCOME_TXT"; [ "$pane" = conclusion ] && txt="$CONCLUSION_TXT"
-  if printf '%s' "$txt" | grep -qE '\*\*|\\b0?([[:space:]]|$)|\\f[0-9]|\\par'; then
-    bad "$pane pane renders literal markup: $(printf '%s' "$txt" | grep -oE '\*\*|\\b0?|\\f[0-9]|\\par' | sort -u | tr '\n' ' ')"
+  # Capture, then branch on grep's own status. `if grep ...; then bad; else ok`
+  # reads any non-zero status as "clean", so a grep ERROR (exit >1) would have
+  # reported ok and let the script exit 0 with the check never having run.
+  markup="$(printf '%s' "$txt" | grep -oE "$MARKUP_RE")"
+  rc=$?
+  if [ "$rc" -gt 1 ]; then
+    bad "$pane pane: markup scan could not run (grep exit $rc)"
+  elif [ -n "$markup" ]; then
+    bad "$pane pane renders literal markup: $(printf '%s' "$markup" | sort -u | tr '\n' ' ')"
   else
     ok "$pane pane renders no literal markup"
   fi
 done
 
 # 2. The minimum macOS version the welcome pane promises must match the app's own.
+#    Anchored to the requirement line ("... or later") rather than the first
+#    mention of macOS anywhere in the pane, and compared on the full version
+#    rather than the major, so neither an unrelated sentence nor a 13.0 -> 13.5
+#    bump can slip through.
+norm_ver() { case "$1" in *.*) printf '%s' "$1";; *) printf '%s.0' "$1";; esac; }
 PLIST_MIN="$(/usr/libexec/PlistBuddy -c 'Print :LSMinimumSystemVersion' "$INFO_PLIST" 2>/dev/null)"
-CLAIMED="$(printf '%s' "$WELCOME_TXT" | grep -oE 'macOS [0-9]+(\.[0-9]+)?' | head -1 | awk '{print $2}')"
+CLAIMED="$(printf '%s' "$WELCOME_TXT" \
+  | grep -E 'macOS [0-9]+(\.[0-9]+)?.*or later' \
+  | grep -oE 'macOS [0-9]+(\.[0-9]+)?' | head -1 | awk '{print $2}')"
 if [ -z "$PLIST_MIN" ] || [ -z "$CLAIMED" ]; then
-  bad "could not read minimum macOS version (plist='$PLIST_MIN' pane='$CLAIMED')"
-elif [ "${CLAIMED%%.*}" = "${PLIST_MIN%%.*}" ]; then
+  bad "could not read minimum macOS version (plist='$PLIST_MIN' pane='$CLAIMED'); the welcome pane needs a 'macOS <version> ... or later' line"
+elif [ "$(norm_ver "$CLAIMED")" = "$(norm_ver "$PLIST_MIN")" ]; then
   ok "welcome pane's minimum macOS ($CLAIMED) matches LSMinimumSystemVersion ($PLIST_MIN)"
 else
   bad "welcome pane claims macOS $CLAIMED but the app requires $PLIST_MIN"
@@ -54,7 +75,10 @@ fi
 # 3. Every command shown to the user must exist in the binary that ships with it.
 BIN="${MCPPROXY_BIN:-}"
 if [ -z "$BIN" ]; then
-  BIN="$(mktemp -d)/mcpproxy"
+  BUILD_DIR="$(mktemp -d)"
+  # Remove it on every exit path, including the build-failure one below.
+  trap 'rm -rf "$BUILD_DIR"' EXIT
+  BIN="$BUILD_DIR/mcpproxy"
   (cd "$ROOT" && go build -o "$BIN" ./cmd/mcpproxy) || { echo "FAIL - could not build mcpproxy to check CLI mentions"; exit 1; }
 fi
 

--- a/scripts/installer-resources.test.sh
+++ b/scripts/installer-resources.test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# installer-resources.test.sh — guards the prose the macOS PKG shows (audit F03).
+#
+# welcome_en.rtf / conclusion_en.rtf are the only authored text in the installer
+# (scripts/create-pkg.sh references them from the Distribution.xml it generates).
+# Nothing in CI reads them, so a false claim ships silently. These checks render
+# the exact committed bytes the way Installer.app will, and assert the claims are
+# still true of the shipped app and CLI.
+#
+# The command check reads the RENDERED panes, so it does not depend on how the
+# author marked a command up in the RTF source.
+#
+# macOS only (needs textutil). Usage:
+#   ./scripts/installer-resources.test.sh          # builds mcpproxy to a temp dir
+#   MCPPROXY_BIN=./mcpproxy ./scripts/installer-resources.test.sh
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WELCOME="$ROOT/scripts/installer-resources/welcome_en.rtf"
+CONCLUSION="$ROOT/scripts/installer-resources/conclusion_en.rtf"
+INFO_PLIST="$ROOT/native/macos/MCPProxy/MCPProxy/Info.plist"
+
+command -v textutil >/dev/null 2>&1 || { echo "SKIP - textutil not available (macOS only)"; exit 0; }
+
+pass=0; fail=0
+ok()  { echo "ok   - $1"; pass=$((pass+1)); }
+bad() { echo "FAIL - $1"; fail=$((fail+1)); }
+
+WELCOME_TXT="$(textutil -convert txt -stdout "$WELCOME")" || { echo "FAIL - welcome_en.rtf is not renderable RTF"; exit 1; }
+CONCLUSION_TXT="$(textutil -convert txt -stdout "$CONCLUSION")" || { echo "FAIL - conclusion_en.rtf is not renderable RTF"; exit 1; }
+
+# 1. Nothing reaches the user as literal markup. RTF renders no Markdown, and a
+#    leaked control word means a malformed pane.
+for pane in welcome conclusion; do
+  txt="$WELCOME_TXT"; [ "$pane" = conclusion ] && txt="$CONCLUSION_TXT"
+  if printf '%s' "$txt" | grep -qE '\*\*|\\b0?([[:space:]]|$)|\\f[0-9]|\\par'; then
+    bad "$pane pane renders literal markup: $(printf '%s' "$txt" | grep -oE '\*\*|\\b0?|\\f[0-9]|\\par' | sort -u | tr '\n' ' ')"
+  else
+    ok "$pane pane renders no literal markup"
+  fi
+done
+
+# 2. The minimum macOS version the welcome pane promises must match the app's own.
+PLIST_MIN="$(/usr/libexec/PlistBuddy -c 'Print :LSMinimumSystemVersion' "$INFO_PLIST" 2>/dev/null)"
+CLAIMED="$(printf '%s' "$WELCOME_TXT" | grep -oE 'macOS [0-9]+(\.[0-9]+)?' | head -1 | awk '{print $2}')"
+if [ -z "$PLIST_MIN" ] || [ -z "$CLAIMED" ]; then
+  bad "could not read minimum macOS version (plist='$PLIST_MIN' pane='$CLAIMED')"
+elif [ "${CLAIMED%%.*}" = "${PLIST_MIN%%.*}" ]; then
+  ok "welcome pane's minimum macOS ($CLAIMED) matches LSMinimumSystemVersion ($PLIST_MIN)"
+else
+  bad "welcome pane claims macOS $CLAIMED but the app requires $PLIST_MIN"
+fi
+
+# 3. Every command shown to the user must exist in the binary that ships with it.
+BIN="${MCPPROXY_BIN:-}"
+if [ -z "$BIN" ]; then
+  BIN="$(mktemp -d)/mcpproxy"
+  (cd "$ROOT" && go build -o "$BIN" ./cmd/mcpproxy) || { echo "FAIL - could not build mcpproxy to check CLI mentions"; exit 1; }
+fi
+
+# Scan the RENDERED panes rather than the RTF source. An earlier version keyed
+# off the source markup (a \f1 ... \f0 monospace run, or a "quoted" phrase);
+# a command written as plain body text — or in a \f1 run whose \f0 the author
+# forgot — was then invisible to the extractor, and this check reported ok while
+# the pane advertised a command that does not exist. Matching the rendered words
+# instead makes it convention-independent. Restricting the tail to [a-z0-9-]
+# also keeps the phrase free of glob and regex metacharacters, which are
+# interpolated unquoted below.
+commands="$(
+  printf '%s\n%s\n' "$WELCOME_TXT" "$CONCLUSION_TXT" \
+    | grep -oE '\bmcpproxy( +[a-z][a-z0-9-]*)*' \
+    | sed 's/[[:space:]]*$//' | sort -u
+)"
+[ -n "$commands" ] || bad "no mcpproxy commands found in the panes (extractor broken?)"
+
+while IFS= read -r phrase; do
+  [ -n "$phrase" ] || continue
+  # shellcheck disable=SC2086
+  set -- $phrase; shift            # drop the "mcpproxy" word itself
+  first="${1:-}"; second="${2:-}"
+  case "$first" in ""|-*) continue;; esac
+  if ! "$BIN" --help 2>&1 | grep -qE "^[[:space:]]+${first}([[:space:]]|$)"; then
+    bad "pane advertises '$phrase' but 'mcpproxy $first' is not a command"
+    continue
+  fi
+  case "$second" in ""|-*) ok "pane command exists: $phrase"; continue;; esac
+  if "$BIN" "$first" --help 2>&1 | grep -qE "^[[:space:]]+${second}([[:space:]]|$)"; then
+    ok "pane command exists: $phrase"
+  else
+    bad "pane advertises '$phrase' but '$second' is not a subcommand of '$first'"
+  fi
+done <<< "$commands"
+
+# 4. The welcome pane must answer the certificate question before the admin
+#    prompt: the installer copies a CA cert but never touches the trust store.
+if printf '%s' "$WELCOME_TXT" | grep -q 'trust-cert' && printf '%s' "$WELCOME_TXT" | grep -qi 'not added to your system trust store'; then
+  ok "welcome pane discloses that system trust is not modified"
+else
+  bad "welcome pane must say the bundled certificate is not added to your system trust store, and name 'mcpproxy trust-cert' as the opt-in"
+fi
+
+echo
+echo "passed=$pass failed=$fail"
+[ "$fail" -eq 0 ]

--- a/scripts/installer-resources.test.sh
+++ b/scripts/installer-resources.test.sh
@@ -37,7 +37,12 @@ CONCLUSION_TXT="$(textutil -convert txt -stdout "$CONCLUSION")" || { echo "FAIL 
 #    it leaks. Without that terminator the pattern both over- and under-fires:
 #    an ordinary rendered path like "C:\party" matched \par, while a leaked
 #    "\b0." was missed because the old \b0 arm demanded whitespace after it.
-MARKUP_RE='\*\*|\\(b|b0|i|i0|ul|ulnone|par|pard|line|tab|f[0-9]+|fs[0-9]+)([^a-z]|$)'
+#    The numeric controls (\fN, \fsNN) carry NO such terminator: an RTF numeric
+#    parameter ends at the first non-digit, so a leaked "\f0hello" is a font
+#    control followed by text and must still be caught. They need no boundary
+#    because "\f" or "\fs" immediately followed by a digit is not something
+#    ordinary prose contains.
+MARKUP_RE='\*\*|\\fs?[0-9]|\\(b|b0|i|i0|ul|ulnone|par|pard|line|tab)([^a-z]|$)'
 for pane in welcome conclusion; do
   txt="$WELCOME_TXT"; [ "$pane" = conclusion ] && txt="$CONCLUSION_TXT"
   # Capture, then branch on grep's own status. `if grep ...; then bad; else ok`
@@ -60,12 +65,19 @@ done
 #    rather than the major, so neither an unrelated sentence nor a 13.0 -> 13.5
 #    bump can slip through.
 norm_ver() { case "$1" in *.*) printf '%s' "$1";; *) printf '%s.0' "$1";; esac; }
+# Match the version that is BOUND to "or later" — optionally through a codename
+# parenthetical — rather than the first macOS mention on a line that happens to
+# contain the phrase. "Unlike macOS 13, macOS 14 or later is required" must
+# yield 14, not 13. Any number of dotted components is captured, so a promise of
+# 13.0.1 is compared as 13.0.1 and not silently truncated to 13.0; anything that
+# is not a dotted number ("macOS 13.garbage or later") matches nothing and is
+# reported as unreadable rather than passing on its leading digits.
 PLIST_MIN="$(/usr/libexec/PlistBuddy -c 'Print :LSMinimumSystemVersion' "$INFO_PLIST" 2>/dev/null)"
 CLAIMED="$(printf '%s' "$WELCOME_TXT" \
-  | grep -E 'macOS [0-9]+(\.[0-9]+)?.*or later' \
-  | grep -oE 'macOS [0-9]+(\.[0-9]+)?' | head -1 | awk '{print $2}')"
+  | grep -oE 'macOS [0-9]+(\.[0-9]+)*[[:space:]]*(\([^)]*\))?[[:space:]]*or later' \
+  | head -1 | awk '{print $2}')"
 if [ -z "$PLIST_MIN" ] || [ -z "$CLAIMED" ]; then
-  bad "could not read minimum macOS version (plist='$PLIST_MIN' pane='$CLAIMED'); the welcome pane needs a 'macOS <version> ... or later' line"
+  bad "could not read minimum macOS version (plist='$PLIST_MIN' pane='$CLAIMED'); the welcome pane needs a 'macOS <version> [(codename)] or later' line"
 elif [ "$(norm_ver "$CLAIMED")" = "$(norm_ver "$PLIST_MIN")" ]; then
   ok "welcome pane's minimum macOS ($CLAIMED) matches LSMinimumSystemVersion ($PLIST_MIN)"
 else

--- a/scripts/installer-resources/conclusion_en.rtf
+++ b/scripts/installer-resources/conclusion_en.rtf
@@ -12,13 +12,10 @@ Installation completed successfully!
 \b Option 1: System Tray (Recommended)\b0
 \
 
-1. Open Applications folder
+MCP Proxy has already been launched - look for its icon in your menu bar.
 \
 
-2. Double-click mcpproxy.app
-\
-
-3. Look for the icon in your menu bar
+If it is not there, open mcpproxy.app from your Applications folder.
 \
 \
 
@@ -60,7 +57,7 @@ If you need HTTPS:
 \
 \
 
-1. Trust certificate: \f1 mcpproxy trust-cert\f0
+1. Trust certificate: \f1 mcpproxy trust-cert\f0  (asks for your password)
 \
 
 2. Enable TLS: \f1 export MCPPROXY_TLS_ENABLED=true\f0
@@ -80,7 +77,7 @@ If you need HTTPS:
 \f1 mcpproxy upstream list\f0    List configured servers
 \
 
-\f1 mcpproxy tools search\f0     Search for tools
+\f1 mcpproxy tools list\f0       List available tools
 \
 \
 

--- a/scripts/installer-resources/welcome_en.rtf
+++ b/scripts/installer-resources/welcome_en.rtf
@@ -37,7 +37,7 @@ MCP Proxy connects AI agents to multiple MCP servers:
 \
 \
 
-- macOS 10.15 (Catalina) or later
+- macOS 13 (Ventura) or later
 \
 
 - Intel or Apple Silicon Mac
@@ -65,13 +65,25 @@ MCP Proxy connects AI agents to multiple MCP servers:
 \
 \
 
-- mcpproxy.app - System tray application
+- /Applications/mcpproxy.app - System tray application
 \
 
-- mcpproxy CLI - Command-line interface
+- /usr/local/bin/mcpproxy - Command-line interface
 \
 
-- CA Certificate - For optional HTTPS mode
+- A CA certificate, for optional HTTPS mode
+\
+\
+
+\b Why Administrator Privileges\b0
+\
+\
+
+MCP Proxy installs into /Applications and /usr/local/bin, which are shared by all users of this Mac, so macOS asks for your password.
+\
+\
+
+The certificate is only copied to disk - it is NOT added to your system trust store. MCP Proxy runs on plain HTTP at 127.0.0.1:8080 and needs no certificate. To use HTTPS later, you run "mcpproxy trust-cert" yourself.
 \
 \
 


### PR DESCRIPTION
The macOS PKG shows exactly two pieces of authored prose — the welcome and conclusion panes that `scripts/create-pkg.sh` references from the `Distribution.xml` it generates. Three of their claims were wrong, and the one question a user actually has at the admin prompt went unanswered.

**Text and a test only. No script logic is touched; installer behaviour is unchanged.**

## What was wrong

- **The welcome pane promised macOS 10.15 (Catalina).** The shipped app requires macOS 13 — `Info.plist` `LSMinimumSystemVersion` 13.0, `Package.swift` `.macOS(.v13)`, `build-swift-app.sh -target ...macosx13.0`. A Catalina user was told they qualified.
- **The conclusion pane advertised `mcpproxy tools search`, which does not exist.** It prints the tools help and exits 0 — a silent dead end on the last screen of the funnel. Replaced with `mcpproxy tools list`.
- **The conclusion pane told the user to open Applications and double-click the app**, which `scripts/postinstall.sh:151-181` has already done via `open -a`. It now says to look in the menu bar, with the Applications folder as the fallback.
- **The welcome pane listed "CA Certificate - For optional HTTPS mode"** and left the user unable to tell whether anything had been trusted. It now states that the certificate is only copied to disk and is **NOT** added to the system trust store, and names `mcpproxy trust-cert` as the explicit, password-prompted opt-in.
- **The welcome pane named no paths**, so the admin prompt looked unexplained. It now names `/Applications/mcpproxy.app` and `/usr/local/bin/mcpproxy` and says those shared locations are why macOS asks for a password.

## On the reported raw Markdown

The audit that prompted this also reported raw Markdown (`**bold**`) in the installer prose. **Not reproducible**: no `**` exists on any PKG-visible surface — the two panes or the installer DMG's `README.txt` — and both panes use correct RTF control words. The likely sighting was the website install page, which is fixed separately.

## Assumptions made rather than asking (zero-interruption policy)

- `mcpproxy tools list` is the replacement for the fictional `tools search` because it is the closest real command; discovery-by-search is an MCP-surface feature (`retrieve_tools`), not a CLI one.
- The welcome pane does **not** claim "nothing else on your system is changed": `postinstall.sh` also removes a legacy LaunchAgent and, when it can resolve the user, creates `~/.mcpproxy`. It claims only what is certain.
- It deliberately does not name `~/.mcpproxy/certs/ca.pem`, because that copy is gated on `$USER` at `postinstall.sh:57`, which the script's own comment calls unreliable in a PKG context. `mcpproxy trust-cert` generates the certificate itself when absent, so the user loses nothing.

## The new guard

`scripts/installer-resources.test.sh` is added because **nothing else reads these files** — a false claim ships silently. It renders the committed bytes with `textutil` the way Installer.app will, and asserts:

1. no literal markup (`**`, leaked RTF control words) reaches the user in either pane;
2. the minimum macOS the welcome pane promises matches `LSMinimumSystemVersion`;
3. every `mcpproxy …` command shown in either pane exists in the built binary — matched against the **rendered** panes, not the RTF source, so the check does not depend on how the author marked a command up;
4. the trust disclosure is present and names `mcpproxy trust-cert`.

It failed on three of those before this change. macOS-only (needs `textutil`); it skips cleanly elsewhere and builds `mcpproxy` to a temp dir unless `MCPPROXY_BIN` is set.

## Cross-model review (opencode, gpt-6-astra)

The RTF panes and every factual claim in them survived review unchanged. Four defects were found in the new guard script, three fixed and one rejected:

- **A grep *error* read as "clean".** Check 1 was `if grep -q …; then bad; else ok; fi`, and grep exits **2** on error, not 1 — so a failed scan landed in the ok branch and the script exited 0 with the pane unexamined. It now branches on grep's own status.
- **The macOS version check was doubly loose**: it compared only the major (`13` satisfied a plist of `13.5`) and took the *first* "macOS N" anywhere in the pane. Now anchored on the requirement line and compared on normalized full versions.
- **The markup pattern over- and under-fired**: `\par` had no terminating boundary, so a rendered `C:\party` was reported as leaked markup, while `\b0?([[:space:]]|$)` missed a visible `\b0.`. Every alternative is now terminated by a non-`[a-z]` character or end of string.
- Plus an `mktemp -d` directory left behind on every run, now removed by an `EXIT` trap.

Each fix has a bite check: the reviewer's three exploits (injected grep error, a 13.5-claiming pane, a decoy "macOS 13" mention before a "macOS 14" requirement) all pass before and FAIL after.

**Rejected**: prose beginning with a lowercase `mcpproxy` ("mcpproxy runs on plain HTTP") is extracted as a command phrase and reported as nonexistent. That is a **loud** false positive an author sees on the first run and fixes by rewording; the alternative — keying the extractor off the RTF source markup — is the **silent** false negative this check was written to replace. The current panes contain no such phrase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
