### PR TITLE
fix(db): make the compaction lock token unique independent of the clock

### DIFF
--- a/cmd/mcpproxy/db_cmd.go
+++ b/cmd/mcpproxy/db_cmd.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -291,6 +293,10 @@ func runDBStats(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
+// compactLockNow is a seam so tests can freeze the clock and prove the token
+// stays unique when the timestamp cannot distinguish two acquisitions.
+var compactLockNow = time.Now
+
 // compactDatabase rewrites srcPath in place via a temp file + atomic rename.
 //
 // The rename is what makes this safe to interrupt: until it succeeds the
@@ -325,7 +331,18 @@ func acquireCompactLock(dir string) (release func(), err error) {
 	// a successor's. Without it: someone deletes A's stale-looking lock, B
 	// creates a fresh one, A finishes and removes the pathname — which is now
 	// B's lock — and a third compaction starts alongside B.
-	token := fmt.Sprintf("pid=%d\nstarted=%s\n", os.Getpid(), time.Now().UTC().Format(time.RFC3339Nano))
+	//
+	// The nonce is what actually makes the token unique. pid+timestamp does not:
+	// Windows' clock granularity is coarse (~0.5-15ms), so two acquisitions in
+	// one process can share an instant and therefore a token. pid and started
+	// stay for the human reading a stale lock file.
+	nonce := make([]byte, 16)
+	if _, rerr := rand.Read(nonce); rerr != nil {
+		os.Remove(lockPath)
+		return nil, fmt.Errorf("failed to generate compaction lock token: %w", rerr)
+	}
+	token := fmt.Sprintf("pid=%d\nstarted=%s\nnonce=%s\n",
+		os.Getpid(), compactLockNow().UTC().Format(time.RFC3339Nano), hex.EncodeToString(nonce))
 	_, writeErr := f.WriteString(token)
 	closeErr := f.Close()
 	if writeErr != nil || closeErr != nil {

--- a/cmd/mcpproxy/db_cmd_test.go
+++ b/cmd/mcpproxy/db_cmd_test.go
@@ -501,7 +501,18 @@ func TestCopyFileReplacesTheDestinationInsteadOfTruncatingIt(t *testing.T) {
 // path. A review found the sequence: someone deletes A's stale-looking lock, B
 // creates a fresh one, A finishes and removes the pathname — which is now B's —
 // and a third compaction starts alongside B.
+//
+// The clock is frozen so the two acquisitions share a timestamp. That is the
+// Windows condition — its clock granularity is ~0.5-15ms and these calls are
+// back-to-back — which made this test fail intermittently there while passing
+// on nanosecond-resolution platforms. Frozen, it exercises the collision on
+// every platform instead of by luck.
 func TestCompactLockReleaseDoesNotRemoveSomeoneElsesLock(t *testing.T) {
+	frozen := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	restore := compactLockNow
+	compactLockNow = func() time.Time { return frozen }
+	t.Cleanup(func() { compactLockNow = restore })
+
 	dir := t.TempDir()
 	lockPath := filepath.Join(dir, dbFileName+".compact.lock")
 
@@ -528,5 +539,45 @@ func TestCompactLockReleaseDoesNotRemoveSomeoneElsesLock(t *testing.T) {
 	releaseB()
 	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
 		t.Error("B's own release must remove B's lock")
+	}
+}
+
+// The lock token is what tells OUR lock from a successor's, so two acquisitions
+// in the same process must never produce the same one. Before the nonce the
+// token was pid+timestamp: on Windows the clock granularity is coarse (~0.5-15ms)
+// and two back-to-back acquisitions could land on the same instant, making A's
+// release delete B's lock. Freezing the clock reproduces that collision window
+// deterministically on every platform.
+func TestCompactLockTokenIsUniqueWithoutClockAdvance(t *testing.T) {
+	frozen := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	restore := compactLockNow
+	compactLockNow = func() time.Time { return frozen }
+	t.Cleanup(func() { compactLockNow = restore })
+
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, dbFileName+".compact.lock")
+
+	releaseA, err := acquireCompactLock(dir)
+	if err != nil {
+		t.Fatalf("acquire A: %v", err)
+	}
+	tokenA, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	releaseA()
+
+	releaseB, err := acquireCompactLock(dir)
+	if err != nil {
+		t.Fatalf("acquire B: %v", err)
+	}
+	defer releaseB()
+	tokenB, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(tokenA) == string(tokenB) {
+		t.Fatalf("two acquisitions produced the same lock token %q; one run's release would delete the other's lock", tokenA)
 	}
 }


### PR DESCRIPTION
## Problem

`TestCompactLockReleaseDoesNotRemoveSomeoneElsesLock` fails intermittently on the `windows-latest` "Build Binaries" job. It is not branch-specific — it failed on [#1215](https://github.com/smart-mcp-proxy/mcpproxy-go/pull/1215) (a docs-only change) and on [#1216](https://github.com/smart-mcp-proxy/mcpproxy-go/pull/1216), then passed on the next run of the same branch.

It is also a real correctness bug, not just a flaky test.

`acquireCompactLock` stamps the lock file with:

```go
token := fmt.Sprintf("pid=%d\nstarted=%s\n", os.Getpid(), time.Now().UTC().Format(time.RFC3339Nano))
```

and release compares `string(current) != token` to decide whether the lock is still its own. On Windows the system clock granularity is coarse (~0.5-15ms), so two acquisitions in the same process with no work between them can read the *same* `time.Now()`. Same pid + same timestamp = identical token, so A's release believes B's lock is its own and deletes it — freeing the pathname for a third compaction to run alongside B on the same BBolt database. Whether the two calls straddle a clock tick is what made it intermittent; the observed failures run in 0.00s.

## Fix

Add 16 `crypto/rand` bytes, hex-encoded, to the token. `pid` and `started` stay for whoever has to diagnose a stale lock file. The lock protocol and the compaction flow are unchanged.

## Testing

`compactLockNow` is a seam so tests can freeze the clock — which *is* the Windows condition, made deterministic.

- The existing `TestCompactLockReleaseDoesNotRemoveSomeoneElsesLock` now freezes the clock, so it exercises the collision on every platform instead of by luck. With the nonce reverted it reproduces the byte-identical windows-latest failure on macOS: `A's release removed B's lock, so a third compaction could start: stat …config.db.compact.lock: no such file or directory`.
- New `TestCompactLockTokenIsUniqueWithoutClockAdvance` asserts the token property directly (acquire → read file → release → re-acquire → read file → compare).

Both fail without the nonce and pass with it. Verified: `go test -count=5 ./cmd/mcpproxy/` (green), `go test -race` (green), `GOOS=windows go build ./...` and `GOOS=windows go test -c` (both build), `golangci-lint run --config .github/.golangci.yml ./cmd/mcpproxy/...` → 0 issues.

Windows CI on this PR is the remaining confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)