### PR TITLE
fix(test): restore the registry SSRF allow-policy after loopback fixtures

### DIFF
--- a/internal/server/consistency_official_test.go
+++ b/internal/server/consistency_official_test.go
@@ -57,6 +57,9 @@ func startOfficialTestRegistry(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
+	// Restore the default catalog and SSRF allow-policy (MCP-1076).
+	t.Cleanup(func() { registries.SetRegistriesFromConfig(nil) })
+
 	registries.SetRegistriesFromConfig(&config.Config{
 		// Loopback httptest registry; opt past the SSRF guard (MCP-1076).
 		AllowPrivateRegistryFetch: true,

--- a/internal/server/mcp_add_from_registry_test.go
+++ b/internal/server/mcp_add_from_registry_test.go
@@ -46,8 +46,11 @@ func newAddFromRegistryTestServer(t *testing.T) *MCPProxyServer {
 
 // startTestRegistry registers an in-memory registry (id="testreg") whose server
 // list is served by a local httptest server, so add_from_registry can resolve a
-// registry reference without touching the network. SetRegistriesFromConfig
-// replaces the global catalog; tests run sequentially so the last writer wins.
+// registry reference without touching the network.
+//
+// SetRegistriesFromConfig writes process-global state: the registry catalog and,
+// through AllowPrivateRegistryFetch, the SSRF allow-policy. Both are restored on
+// cleanup so later tests that read the policy without setting it are unaffected.
 func startTestRegistry(t *testing.T, servers []map[string]interface{}) {
 	t.Helper()
 
@@ -57,6 +60,10 @@ func startTestRegistry(t *testing.T, servers []map[string]interface{}) {
 		_ = json.NewEncoder(w).Encode(payload)
 	}))
 	t.Cleanup(srv.Close)
+
+	// Restore the default catalog and SSRF allow-policy (MCP-1076). Registered
+	// before the write so LIFO cleanup runs it while srv is still serving.
+	t.Cleanup(func() { registries.SetRegistriesFromConfig(nil) })
 
 	registries.SetRegistriesFromConfig(&config.Config{
 		// The registry is served on loopback (httptest); opt past the SSRF guard

--- a/internal/server/registry_fixture_isolation_test.go
+++ b/internal/server/registry_fixture_isolation_test.go
@@ -1,0 +1,43 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/registries"
+)
+
+// TestRegistryFixturesRestoreSSRFPolicy verifies that the registry test fixtures
+// restore the SSRF allow-policy (MCP-1076) they opt out of.
+//
+// The policy is process-global in internal/registries. A fixture that leaves it
+// disabled suppresses every later SSRF assertion in this test binary, including
+// the five in TestBuildRegistrySourceEntry_RejectsSSRFLiteralIP.
+//
+// Each case resets the policy to its default before running one fixture in a
+// nested subtest, so the result does not depend on test order. t.Run returns
+// only after the subtest's cleanups have run, so the assertion below observes
+// the restored value rather than the fixture's.
+func TestRegistryFixturesRestoreSSRFPolicy(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		setup func(*testing.T)
+	}{
+		{"startTestRegistry", func(t *testing.T) { startTestRegistry(t, nil) }},
+		{"startOfficialTestRegistry", startOfficialTestRegistry},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// A nil config yields the default catalog and an enabled guard.
+			registries.SetRegistriesFromConfig(nil)
+			t.Cleanup(func() { registries.SetRegistriesFromConfig(nil) })
+
+			t.Run("fixture", tc.setup)
+
+			_, err := buildRegistrySourceEntry("https://169.254.169.254/v0.1/servers", "", "", "")
+			require.Errorf(t, err, "%s did not restore the SSRF allow-policy: the cloud-metadata endpoint was accepted", tc.name)
+			assert.ErrorIs(t, err, ErrInvalidRegistryURL)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Test-only change. No production code is modified and no runtime behaviour changes.

`TestBuildRegistrySourceEntry_RejectsSSRFLiteralIP` — the MCP-1076 / CWE-918 regression test — can pass without exercising the guard it covers. Reproduction on `main` (3.9s, two tests):

```console
$ go test ./internal/server/ -count=2 \
    -run 'TestBuildRegistrySourceEntry_RejectsSSRFLiteralIP|TestHandleUpstreamServers_AddFromRegistry_HappyPath'
--- FAIL: TestBuildRegistrySourceEntry_RejectsSSRFLiteralIP (0.00s)
    Error Trace: internal/server/add_registry_source_test.go:52
    Error:       An error is expected but got nil.
    Messages:    must reject SSRF target "https://169.254.169.254/v0.1/servers"
```

`buildRegistrySourceEntry` accepts the cloud-metadata endpoint. The same command at `-count=1` passes.

## Root cause

The allow-policy is process-global (`internal/registries/ssrf.go:42`):

```go
var registryAllowPrivateFetch atomic.Bool
```

Its only writer is `SetAllowPrivateRegistryFetch`, reached through `SetRegistriesFromConfig` (`registry_data.go:66`). Two fixtures disable the policy so they can serve a loopback `httptest` registry, and neither restores it:

- `internal/server/mcp_add_from_registry_test.go` — `startTestRegistry`
- `internal/server/consistency_official_test.go` — `startOfficialTestRegistry`

Both register `t.Cleanup(srv.Close)` for the httptest server, but nothing for the global. Every later test in the binary then runs with the policy disabled, so all five assertions in `add_registry_source_test.go:43` (metadata endpoint, loopback, two RFC1918 ranges, IPv6 loopback) succeed without reaching the guard.

`startTestRegistry`'s doc comment records the assumption behind this — *"tests run sequentially so the last writer wins."* That holds only for tests that write the policy; tests that read it observe whatever the last fixture left. The comment is corrected here.

## Why the suite passes today

At `-count=1`, Go runs tests in file order, and `add_registry_source_test.go` sorts ahead of both `consistency_official_test.go` and `mcp_add_from_registry_test.go`, so the assertion runs before either fixture. `-shuffle` is not used in `.github/workflows/`, so no lane exercises a different order.

The order is incidental, not a property anything enforces. On unfixed `main`, running the victim alongside the two fixtures under `-shuffle` fails on 2 of 5 seeds at `-count=1`:

```console
seed=1 -> ok
seed=2 -> ok
seed=3 -> --- FAIL: TestBuildRegistrySourceEntry_RejectsSSRFLiteralIP
seed=4 -> ok
seed=5 -> --- FAIL: TestBuildRegistrySourceEntry_RejectsSSRFLiteralIP
```

`-count>1` also fails it, as does adopting `t.Parallel()`, or adding another policy-disabling fixture in a file sorting ahead of `add_registry_source_test.go`. With this change, all five seeds pass.

## Production behaviour

Unaffected. `add_registry_source.go:139`, `remove_registry_source.go:63` and `edit_registry_source.go:103` each do `updatedConfig := *currentConfig`, a struct copy that carries `AllowPrivateRegistryFetch` forward, so the CRUD paths propagate the operator's setting rather than resetting it. The defect is confined to the test binary.

The scope is therefore test reliability, on a CWE-918 guard: a future change that broke `isBlockedIP` would not be caught by the test written to catch it.

## Fix

`t.Cleanup(func() { registries.SetRegistriesFromConfig(nil) })` in both fixtures. A `nil` config restores the default catalog and re-enables the policy in one exported call, which also clears the second value leaked from the same line: the `testreg` / `officialreg` entry pointing at a closed `httptest` URL. `TestSetRegistriesFromConfig_NilConfigUsesDefaults` already pins those semantics.

This follows `withGuardActive` in `internal/registries/ssrf_test.go:21-31`, which does save-and-restore for the same flag within its own package.

`TestRegistryFixturesRestoreSSRFPolicy` is the regression test. It resets the policy itself before running each fixture in a nested subtest, so it detects the leak independently of test order and without `-shuffle`.

**Verified failing before the fix** (both fixtures, `t.Cleanup` lines removed):

```console
--- FAIL: TestRegistryFixturesRestoreSSRFPolicy/startTestRegistry
    Messages: startTestRegistry did not restore the SSRF allow-policy: the cloud-metadata endpoint was accepted
--- FAIL: TestRegistryFixturesRestoreSSRFPolicy/startOfficialTestRegistry
    Messages: startOfficialTestRegistry did not restore the SSRF allow-policy: the cloud-metadata endpoint was accepted
```

## Not included

`-shuffle=on` in a CI lane. It would prevent this class from recurring, but it may surface unrelated order dependencies elsewhere in the tree, which should not be resolved as part of this fix. Happy to open it separately.

### Pre-existing, not addressed here

`TestGetServerLogs_MissingFileReturnsEmptyNotError` also fails under `-race -count=2`, and it is unrelated to this change: the same command on unmodified `main` at `4e304ba0` reproduces both failures.

```console
# clean main
--- FAIL: TestBuildRegistrySourceEntry_RejectsSSRFLiteralIP     (fixed by this PR)
--- FAIL: TestGetServerLogs_MissingFileReturnsEmptyNotError     (pre-existing)
```

`newLogsTestServer` registers a server with `AddServerConfig` only, while `NewServer` starts config-as-source-of-truth reconciliation in the background; the server is absent from the config, so the reconciler removes it and `GetServerLogs` can observe "server not found". It passes 30/30 in isolation under `-race`, so it needs full-package timing to surface. Same class as this PR, different subsystem — happy to file it separately.

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests that prove my fix is effective
- [x] All existing tests pass

| Check | Result |
|---|---|
| `TestRegistryFixturesRestoreSSRFPolicy` | fails on unfixed code (both subtests), passes with the fix |
| Minimal repro above, `-count=2` | `FAIL` → `ok` |
| Same three tests, `-shuffle=` seeds 1-5, `-count=1` | 2/5 fail on `main`; 5/5 pass here |
| `go test -race -count=2 ./internal/server/...`, CI's skip set | `TestBuildRegistrySourceEntry_RejectsSSRFLiteralIP` no longer fails; 0 data races. One unrelated pre-existing failure — see below |
| `./scripts/test-api-e2e.sh` | 65/65 passed, 0 failed |
| `go vet ./internal/server/` | clean |
| `gofmt` | clean |
| `golangci-lint` v2.13.2, `.github/.golangci.yml` | 5 issues in `./internal/server/...`, byte-identical to clean `main` at `4e304ba0` (1 `govet` inline hint, 4 `SA1019` deprecated-field uses in existing test files). None in the three files changed here. |
