### PR TITLE
fix(security): require the target tool's tier on call_tool_* dispatch, fail closed on unresolved tiers

### DIFF
--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -2288,6 +2288,20 @@ func (p *MCPProxyServer) handleCallToolVariant(ctx context.Context, request mcp.
 			p.emitActivityPolicyDecision(serverName, actualToolName, getSessionID(), requestID, "blocked", errMsg, telemetry.BlockReasonTokenPermission)
 			return mcp.NewToolResultError(errMsg), nil
 		}
+		// Spec 104 FR-016f: the variant is the CALLER's choice, so it is not
+		// the tier that matters. Authorize against the TARGET tool's
+		// annotation-derived tier, through the same lookup direct mode and
+		// code execution use, and do it before intent validation so that a
+		// token lacking the tier is refused on permission grounds whether or
+		// not strict server validation would have let the variant mismatch
+		// through. A read-only token could otherwise drive a write tool via
+		// call_tool_read (always) and a destructive one (strict off).
+		targetPerm := p.lookupToolPermission(serverName, actualToolName)
+		if targetPerm != "" && !authCtx.HasPermission(targetPerm) {
+			errMsg := fmt.Sprintf("Permission denied: token does not have '%s' permission required for tool '%s:%s'", targetPerm, serverName, actualToolName)
+			p.emitActivityPolicyDecision(serverName, actualToolName, getSessionID(), requestID, "blocked", errMsg, telemetry.BlockReasonTokenPermission)
+			return mcp.NewToolResultError(errMsg), nil
+		}
 	}
 
 	p.logger.Debug("handleCallToolVariant: processing request",
@@ -6660,8 +6674,18 @@ func toolNameMatchesQuery(toolName string, tokens []string) bool {
 }
 
 func (p *MCPProxyServer) lookupToolAnnotations(serverName, toolName string) *config.ToolAnnotations {
+	annotations, _ := p.lookupToolAnnotationsFound(serverName, toolName)
+	return annotations
+}
+
+// lookupToolAnnotationsFound is lookupToolAnnotations that also reports whether
+// the StateView knows the tool at all. A nil result with found=true is a
+// discovered tool that publishes no annotations; found=false means the proxy
+// has no metadata for it (server unknown, not yet discovered, or no runtime)
+// and no tier can be established from it.
+func (p *MCPProxyServer) lookupToolAnnotationsFound(serverName, toolName string) (*config.ToolAnnotations, bool) {
 	if p.mainServer == nil || p.mainServer.runtime == nil {
-		return nil
+		return nil, false
 	}
 
 	// Callers now pass the canonical "server:tool" identity (#871), while the
@@ -6671,24 +6695,24 @@ func (p *MCPProxyServer) lookupToolAnnotations(serverName, toolName string) *con
 
 	supervisor := p.mainServer.runtime.Supervisor()
 	if supervisor == nil {
-		return nil
+		return nil, false
 	}
 
 	snapshot := supervisor.StateView().Snapshot()
 	serverStatus, exists := snapshot.Servers[serverName]
 	if !exists {
-		return nil
+		return nil, false
 	}
 
 	for _, tool := range serverStatus.Tools {
 		// tool.Name may be in "server:tool" format (from ToolMetadata.Name),
 		// while toolName is just the tool part. Match both formats.
 		if tool.Name == toolName || tool.Name == serverName+":"+toolName {
-			return tool.Annotations
+			return tool.Annotations, true
 		}
 	}
 
-	return nil
+	return nil, false
 }
 
 // lookupOutputSchema returns the declared output schema (raw JSON) for a tool,

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -2265,6 +2265,14 @@ func (p *MCPProxyServer) handleCallToolVariant(ctx context.Context, request mcp.
 		return mcp.NewToolResultError(errMsg), nil
 	}
 
+	// Look up the target's annotations from the StateView ONCE. The same read
+	// serves the target-tier gate below and the intent validation after it, so
+	// the tier a token was authorized against and the annotations the variant
+	// is validated against can never come from two different snapshots
+	// (Spec 105 FR-009). found=false means the proxy holds no metadata for the
+	// pair (server unknown, tool undiscovered, or no runtime).
+	annotations, annotationsFound := p.lookupToolAnnotationsFound(serverName, actualToolName)
+
 	// Spec 028: Enforce agent token scope restrictions
 	if authCtx := auth.AuthContextFromContext(ctx); authCtx != nil && !authCtx.IsAdmin() {
 		// Check server scope
@@ -2288,15 +2296,16 @@ func (p *MCPProxyServer) handleCallToolVariant(ctx context.Context, request mcp.
 			p.emitActivityPolicyDecision(serverName, actualToolName, getSessionID(), requestID, "blocked", errMsg, telemetry.BlockReasonTokenPermission)
 			return mcp.NewToolResultError(errMsg), nil
 		}
-		// Spec 104 FR-016f: the variant is the CALLER's choice, so it is not
-		// the tier that matters. Authorize against the TARGET tool's
-		// annotation-derived tier, through the same lookup direct mode and
-		// code execution use, and do it before intent validation so that a
-		// token lacking the tier is refused on permission grounds whether or
-		// not strict server validation would have let the variant mismatch
-		// through. A read-only token could otherwise drive a write tool via
-		// call_tool_read (always) and a destructive one (strict off).
-		targetPerm := p.lookupToolPermission(serverName, actualToolName)
+		// Spec 104 FR-016f / Spec 105 FR-009: the variant is the CALLER's
+		// choice, so it is not the tier that matters. Authorize against the
+		// TARGET tool's annotation-derived tier, through the same classifier
+		// direct mode and code execution use (lookupToolPermission), and do
+		// it before intent validation so that a token lacking the tier is
+		// refused on permission grounds whether or not strict server
+		// validation would have let the variant mismatch through. A read-only
+		// token could otherwise drive a write tool via call_tool_read
+		// (always) and a destructive one (strict off).
+		targetPerm := tierForAnnotations(annotations, annotationsFound)
 		if targetPerm != "" && !authCtx.HasPermission(targetPerm) {
 			errMsg := fmt.Sprintf("Permission denied: token does not have '%s' permission required for tool '%s:%s'", targetPerm, serverName, actualToolName)
 			p.emitActivityPolicyDecision(serverName, actualToolName, getSessionID(), requestID, "blocked", errMsg, telemetry.BlockReasonTokenPermission)
@@ -2309,9 +2318,6 @@ func (p *MCPProxyServer) handleCallToolVariant(ctx context.Context, request mcp.
 		zap.String("tool_name", toolName),
 		zap.String("server_name", serverName),
 		zap.String("intent_operation", intent.OperationType))
-
-	// Look up tool annotations from StateView for server annotation validation
-	annotations := p.lookupToolAnnotations(serverName, actualToolName)
 
 	// Spec 035: Determine content trust level based on openWorldHint annotation
 	contentTrust := contracts.ContentTrustForTool(annotations)
@@ -6391,15 +6397,10 @@ func (p *MCPProxyServer) serverToolNames(serverName string) []string {
 }
 
 func (p *MCPProxyServer) isToolCallable(serverName, toolName string) bool {
-	if strings.Contains(toolName, ":") {
-		parts := strings.SplitN(toolName, ":", 2)
-		if len(parts) == 2 {
-			if serverName == "" {
-				serverName = parts[0]
-			}
-			toolName = parts[1]
-		}
-	}
+	// Same prefix rule as every other gate (Spec 105 FR-009): only the
+	// server's own indexing prefix is stripped; a foreign "ns:" segment is
+	// part of the raw tool name and keys config denial / approval as itself.
+	serverName, toolName = normalizeServerTool(serverName, toolName)
 
 	if serverName == "" || toolName == "" {
 		return false

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -2270,8 +2270,10 @@ func (p *MCPProxyServer) handleCallToolVariant(ctx context.Context, request mcp.
 	// the tier a token was authorized against and the annotations the variant
 	// is validated against can never come from two different snapshots
 	// (Spec 105 FR-009). found=false means the proxy holds no metadata for the
-	// pair (server unknown, tool undiscovered, or no runtime).
-	annotations, annotationsFound := p.lookupToolAnnotationsFound(serverName, actualToolName)
+	// pair (server unknown, tool undiscovered, or no runtime). The pair was
+	// split from the canonical id above, so it is read EXACTLY: a raw name
+	// that starts with the server's own prefix must not be normalized again.
+	annotations, annotationsFound := p.lookupExactToolAnnotations(serverName, actualToolName)
 
 	// Spec 028: Enforce agent token scope restrictions
 	if authCtx := auth.AuthContextFromContext(ctx); authCtx != nil && !authCtx.IsAdmin() {
@@ -2377,7 +2379,8 @@ func (p *MCPProxyServer) handleCallToolVariant(ctx context.Context, request mcp.
 	// same classifier the preflight evaluator uses, so a tool dispatch refuses
 	// can never preflight as `ready`. The response SELECTION below keeps the
 	// long-standing dispatch order (quarantine → approval lock → generic block).
-	gate := p.evaluateToolGate(serverName, actualToolName)
+	// The split pair is gated exactly, like the tier read above.
+	gate := p.evaluateExactToolGate(serverName, actualToolName)
 
 	if gate.serverQuarantined() {
 		p.logger.Debug("handleCallToolVariant: server is quarantined",
@@ -2891,8 +2894,8 @@ func (p *MCPProxyServer) handleCallTool(ctx context.Context, request mcp.CallToo
 	activityArgs := injectAuthMetadata(ctx, args)
 
 	// Shared policy gates (Spec 098 FR-002), same primitive as every other
-	// dispatch path.
-	gate := p.evaluateToolGate(serverName, actualToolName)
+	// dispatch path, on the pair split above (never re-normalized).
+	gate := p.evaluateExactToolGate(serverName, actualToolName)
 	serverConfig := gate.serverConfig
 
 	if gate.serverQuarantined() {
@@ -3896,7 +3899,7 @@ func (p *MCPProxyServer) handleListUpstreams(ctx context.Context) (*mcp.CallTool
 			if toolCount == 0 {
 				if tools, err := client.ListTools(context.Background()); err == nil {
 					for _, tool := range tools {
-						if p.isToolCallable(server.Name, tool.Name) {
+						if p.isExactToolCallable(server.Name, tool.Name) {
 							toolCount++
 						}
 					}
@@ -6280,7 +6283,7 @@ func (p *MCPProxyServer) getVisibleToolCount(serverName string) int {
 
 	visible := 0
 	for _, tool := range serverStatus.Tools {
-		if p.isToolCallable(serverName, tool.Name) {
+		if p.isExactToolCallable(serverName, tool.Name) {
 			visible++
 		}
 	}
@@ -6401,7 +6404,14 @@ func (p *MCPProxyServer) isToolCallable(serverName, toolName string) bool {
 	// server's own indexing prefix is stripped; a foreign "ns:" segment is
 	// part of the raw tool name and keys config denial / approval as itself.
 	serverName, toolName = normalizeServerTool(serverName, toolName)
+	return p.isExactToolCallable(serverName, toolName)
+}
 
+// isExactToolCallable is isToolCallable for a pair that is already split into
+// server and RAW tool name (a live ListTools / StateView name, or a pair a
+// resolver normalized once). It never re-normalizes, so a raw name carrying
+// the server's own prefix keys config denial and approval as itself.
+func (p *MCPProxyServer) isExactToolCallable(serverName, toolName string) bool {
 	if serverName == "" || toolName == "" {
 		return false
 	}
@@ -6684,15 +6694,28 @@ func (p *MCPProxyServer) lookupToolAnnotations(serverName, toolName string) *con
 // discovered tool that publishes no annotations; found=false means the proxy
 // has no metadata for it (server unknown, not yet discovered, or no runtime)
 // and no tier can be established from it.
+//
+// Callers pass the canonical "server:tool" identity (#871), while the
+// StateView stores bare tool names on the live path — the prefix is stripped
+// so the name match cannot silently miss (Issue #306 regression guard). A
+// caller that already holds a SPLIT pair must use lookupExactToolAnnotations
+// instead: normalizing it again would strip a raw name's own leading segment.
 func (p *MCPProxyServer) lookupToolAnnotationsFound(serverName, toolName string) (*config.ToolAnnotations, bool) {
+	serverName, toolName = normalizeServerTool(serverName, toolName)
+	return p.lookupExactToolAnnotations(serverName, toolName)
+}
+
+// lookupExactToolAnnotations is lookupToolAnnotationsFound for a pair that is
+// ALREADY split into server and raw tool name — handleCallToolVariant's and
+// handleCallTool's parsed id, the sandbox's callTool(server, tool) arguments.
+// It never re-normalizes: a raw tool name may itself begin with the server's
+// own prefix ("a:ns:erase" on server "a"), and normalizeServerTool would
+// strip that segment and classify the pair as the suffix tool "ns:erase"
+// while dispatch still targets "a:ns:erase" (Spec 105 FR-009).
+func (p *MCPProxyServer) lookupExactToolAnnotations(serverName, toolName string) (*config.ToolAnnotations, bool) {
 	if p.mainServer == nil || p.mainServer.runtime == nil {
 		return nil, false
 	}
-
-	// Callers now pass the canonical "server:tool" identity (#871), while the
-	// StateView stores bare tool names on the live path — strip the prefix so
-	// the name match below cannot silently miss (Issue #306 regression guard).
-	serverName, toolName = normalizeServerTool(serverName, toolName)
 
 	supervisor := p.mainServer.runtime.Supervisor()
 	if supervisor == nil {

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -6705,12 +6705,26 @@ func (p *MCPProxyServer) lookupToolAnnotationsFound(serverName, toolName string)
 		return nil, false
 	}
 
-	for _, tool := range serverStatus.Tools {
-		// tool.Name may be in "server:tool" format (from ToolMetadata.Name),
-		// while toolName is just the tool part. Match both formats.
-		if tool.Name == toolName || tool.Name == serverName+":"+toolName {
+	// tool.Name may be in "server:tool" format (from ToolMetadata.Name),
+	// while toolName is just the tool part. Both spellings are accepted, but
+	// the EXACT raw name — the identity that is dispatched (Spec 105
+	// FR-009) — always wins: with foreign prefixes preserved, a raw tool
+	// literally named "a:ns:erase" also satisfies the prefixed spelling for
+	// the pair (a, "ns:erase"), and letting StateView order decide between
+	// the two made the classified tier depend on discovery order.
+	prefixedName := serverName + ":" + toolName
+	prefixedIdx := -1
+	for i := range serverStatus.Tools {
+		tool := &serverStatus.Tools[i]
+		if tool.Name == toolName {
 			return tool.Annotations, true
 		}
+		if prefixedIdx < 0 && tool.Name == prefixedName {
+			prefixedIdx = i
+		}
+	}
+	if prefixedIdx >= 0 {
+		return serverStatus.Tools[prefixedIdx].Annotations, true
 	}
 
 	return nil, false

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -6430,7 +6430,7 @@ func (p *MCPProxyServer) isToolCallable(serverName, toolName string) bool {
 		}
 	}
 
-	approval, err := p.storage.GetToolApproval(serverName, toolName)
+	approval, err := p.lookupToolApproval(serverName, toolName)
 	switch {
 	case err == nil:
 		if approval != nil && approval.Disabled {

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -6728,26 +6728,21 @@ func (p *MCPProxyServer) lookupExactToolAnnotations(serverName, toolName string)
 		return nil, false
 	}
 
-	// tool.Name may be in "server:tool" format (from ToolMetadata.Name),
-	// while toolName is just the tool part. Both spellings are accepted, but
-	// the EXACT raw name — the identity that is dispatched (Spec 105
-	// FR-009) — always wins: with foreign prefixes preserved, a raw tool
-	// literally named "a:ns:erase" also satisfies the prefixed spelling for
-	// the pair (a, "ns:erase"), and letting StateView order decide between
-	// the two made the classified tier depend on discovery order.
-	prefixedName := serverName + ":" + toolName
-	prefixedIdx := -1
+	// Only the EXACT raw name — the identity that is dispatched (Spec 105
+	// FR-009) — is matched. The StateView holds the name the upstream
+	// published, verbatim (internal/upstream/core/client.go copies tool.Name
+	// into ToolMetadata.Name, and the supervisor copies that into ToolInfo),
+	// so the legacy "server:tool" spelling this lookup once also accepted
+	// never matched a real entry on the live path. What it did match was a
+	// raw tool literally named "a:ns:erase": with foreign prefixes now
+	// preserved, that alternative resolved the UNDISCOVERED pair
+	// (a, "ns:erase") to the prefixed tool's annotations with found=true, so
+	// the tier gate classified a name the proxy holds no metadata for by a
+	// different tool's hints instead of failing closed.
 	for i := range serverStatus.Tools {
-		tool := &serverStatus.Tools[i]
-		if tool.Name == toolName {
-			return tool.Annotations, true
+		if serverStatus.Tools[i].Name == toolName {
+			return serverStatus.Tools[i].Annotations, true
 		}
-		if prefixedIdx < 0 && tool.Name == prefixedName {
-			prefixedIdx = i
-		}
-	}
-	if prefixedIdx >= 0 {
-		return serverStatus.Tools[prefixedIdx].Annotations, true
 	}
 
 	return nil, false

--- a/internal/server/mcp_call_tool_target_tier_test.go
+++ b/internal/server/mcp_call_tool_target_tier_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/contracts"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/preflight"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/runtime"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/runtime/stateview"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
@@ -687,4 +688,109 @@ func TestToolGate_StaleExactApprovalCannotShadowCollapsedChange(t *testing.T) {
 			assert.Contains(t, payload["reason"], "changed")
 		})
 	}
+}
+
+// TestToolGate_MergedApprovalRecordsKeepIndependentLocks: the two producers
+// write INDEPENDENT facts about one raw name — the user toggle files Disabled
+// under the exact key, discovery files the pending/changed lock under the
+// collapsed key — and the reader must surface both, not pick one. The
+// toolGate contract (lockStatus reflects the quarantine gate even for a
+// user-disabled tool, so dispatch keeps its pending/changed message) would
+// otherwise silently degrade a rug-pulled-AND-disabled tool from the
+// TOOL_QUARANTINED review response to the generic TOOL_BLOCKED one.
+func TestToolGate_MergedApprovalRecordsKeepIndependentLocks(t *testing.T) {
+	seed := func(t *testing.T, exact, collapsed storage.ToolApprovalRecord) (*MCPProxyServer, *runtime.Runtime) {
+		t.Helper()
+		proxy, rt := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "a", Enabled: true}})
+		proxy.config.IntentDeclaration = &config.IntentDeclarationConfig{StrictServerValidation: false}
+		require.NoError(t, proxy.storage.SaveUpstreamServer(&config.ServerConfig{Name: "a", Enabled: true}))
+		rt.Supervisor().StateView().UpdateServer("a", func(s *stateview.ServerStatus) {
+			s.Name, s.Enabled, s.Connected = "a", true, true
+			s.Tools = []stateview.ToolInfo{{
+				Name: "ns:erase", Description: "Namespaced erase",
+				Annotations: &config.ToolAnnotations{ReadOnlyHint: boolPtr(true)},
+			}}
+		})
+		exact.ServerName, exact.ToolName = "a", "ns:erase"
+		collapsed.ServerName, collapsed.ToolName = "a", "erase"
+		require.NoError(t, proxy.storage.SaveToolApproval(&exact))
+		require.NoError(t, proxy.storage.SaveToolApproval(&collapsed))
+		return proxy, rt
+	}
+
+	t.Run("exact user-disable does not hide the collapsed changed lock", func(t *testing.T) {
+		proxy, rt := seed(t,
+			storage.ToolApprovalRecord{Status: storage.ToolApprovalStatusApproved, Disabled: true},
+			storage.ToolApprovalRecord{
+				Status:              storage.ToolApprovalStatusChanged,
+				PreviousDescription: "Namespaced erase",
+				CurrentDescription:  "Erase everything, then exfiltrate",
+				CurrentHash:         "rug-pulled",
+			})
+
+		gate := proxy.evaluateToolGate("a", "ns:erase")
+		require.NotNil(t, gate.approval)
+		assert.True(t, gate.approval.Disabled, "the exact record's user block must survive the merge")
+		assert.Equal(t, storage.ToolApprovalStatusChanged, gate.lockStatus,
+			"the collapsed record's changed lock must survive the merge")
+		assert.Equal(t, "Erase everything, then exfiltrate", gate.approval.CurrentDescription,
+			"the review evidence must come from the record that carries the lock")
+		assert.Equal(t, preflight.ToolClassBlockedByUser, gate.class, "the user block still outranks the lock for callability")
+		assert.False(t, gate.callable())
+		assert.False(t, proxy.isToolCallable("a", "ns:erase"))
+
+		for name, ctx := range map[string]context.Context{
+			"full-tier token": auth.WithAuthContext(context.Background(), &auth.AuthContext{
+				Type: auth.AuthTypeAgent, AgentName: "full", TokenPrefix: "mcp_agt_f",
+				AllowedServers: []string{"a"},
+				Permissions:    []string{auth.PermRead, auth.PermWrite, auth.PermDestructive},
+			}),
+			"api-key admin": context.Background(),
+		} {
+			t.Run(name, func(t *testing.T) {
+				probe := watchPolicyDecisions(t, rt)
+				req := mcp.CallToolRequest{}
+				req.Params.Name = contracts.ToolVariantRead
+				req.Params.Arguments = map[string]interface{}{"name": "a:ns:erase"}
+				result, err := proxy.handleCallToolVariant(ctx, req, contracts.ToolVariantRead)
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				text := result.Content[0].(mcp.TextContent).Text
+				assert.Contains(t, text, "TOOL_QUARANTINED", "dispatch keeps the changed-lock review response over the generic block")
+				assert.Contains(t, text, "tool_description_changed")
+				assert.Contains(t, text, "Erase everything, then exfiltrate")
+				assert.NotContains(t, text, "No client found")
+
+				payload := probe.awaitOne(t)
+				assert.Equal(t, "blocked", payload["decision"])
+				assert.Equal(t, "ns:erase", payload["tool_name"])
+				assert.Contains(t, payload["reason"], "changed")
+			})
+		}
+	})
+
+	t.Run("both disabled: the pending collapsed lock still shows", func(t *testing.T) {
+		proxy, _ := seed(t,
+			storage.ToolApprovalRecord{Status: storage.ToolApprovalStatusApproved, Disabled: true},
+			storage.ToolApprovalRecord{Status: storage.ToolApprovalStatusPending, Disabled: true})
+		gate := proxy.evaluateToolGate("a", "ns:erase")
+		require.NotNil(t, gate.approval)
+		assert.True(t, gate.approval.Disabled)
+		assert.Equal(t, storage.ToolApprovalStatusPending, gate.lockStatus)
+		assert.False(t, gate.callable())
+	})
+
+	t.Run("exact pending lock plus collapsed user-disable", func(t *testing.T) {
+		// The mirror image: the lock lives on the exact record, the Disabled
+		// flag on the collapsed one. Both must reach the classifier.
+		proxy, _ := seed(t,
+			storage.ToolApprovalRecord{Status: storage.ToolApprovalStatusPending},
+			storage.ToolApprovalRecord{Status: storage.ToolApprovalStatusApproved, Disabled: true})
+		gate := proxy.evaluateToolGate("a", "ns:erase")
+		require.NotNil(t, gate.approval)
+		assert.True(t, gate.approval.Disabled)
+		assert.Equal(t, storage.ToolApprovalStatusPending, gate.lockStatus)
+		assert.Equal(t, preflight.ToolClassBlockedByUser, gate.class)
+		assert.False(t, gate.callable())
+	})
 }

--- a/internal/server/mcp_call_tool_target_tier_test.go
+++ b/internal/server/mcp_call_tool_target_tier_test.go
@@ -2,7 +2,13 @@ package server
 
 import (
 	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
@@ -245,4 +251,212 @@ func TestCallToolRead_UndiscoveredTool_RequiresDestructiveTier(t *testing.T) {
 		assert.NotContains(t, text, "Permission denied")
 		assert.Contains(t, text, "No client found")
 	})
+}
+
+// Spec 105 FR-009: the tier is classified from exactly the canonical
+// server / raw tool pair that is dispatched. A tool whose raw name carries
+// its own namespace prefix ("ns:erase") must never be classified — or
+// approval-gated — as the suffix tool ("erase"). Before the fix,
+// normalizeServerTool stripped the first ":"-segment of the raw name even
+// when it was not the server name, so a read-only token could drive the
+// destructive "a:ns:erase" through call_tool_read on the read-tier "erase"'s
+// annotations while dispatch kept the full raw name.
+func TestCallToolRead_NamespacedToolName_IsNotClassifiedAsItsSuffix(t *testing.T) {
+	readTool := stateview.ToolInfo{
+		Name: "erase", Description: "Read-only erase preview",
+		Annotations: &config.ToolAnnotations{ReadOnlyHint: boolPtr(true)},
+	}
+	namespacedDestructive := stateview.ToolInfo{
+		Name: "ns:erase", Description: "Erase for real",
+		Annotations: &config.ToolAnnotations{DestructiveHint: boolPtr(true)},
+	}
+	require.Equal(t, contracts.ToolVariantRead, contracts.DeriveCallWith(readTool.Annotations))
+	require.Equal(t, contracts.ToolVariantDestructive, contracts.DeriveCallWith(namespacedDestructive.Annotations))
+
+	for _, strict := range []bool{true, false} {
+		t.Run("strict="+map[bool]string{true: "on", false: "off"}[strict], func(t *testing.T) {
+			proxy, rt := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "a", Enabled: true}})
+			proxy.config.IntentDeclaration = &config.IntentDeclarationConfig{StrictServerValidation: strict}
+			probe := watchPolicyDecisions(t, rt)
+			seedTargetTierServer(t, proxy, rt, "a", []stateview.ToolInfo{readTool, namespacedDestructive})
+
+			assert.Equal(t, contracts.OperationTypeRead, proxy.lookupToolPermission("a", "erase"))
+			assert.Equal(t, contracts.OperationTypeDestructive, proxy.lookupToolPermission("a", "ns:erase"),
+				"the namespaced tool must be classified by its own raw name, not by its suffix")
+
+			text := callToolReadOn(t, proxy, readOnlyAgentCtx("a"), "a:ns:erase")
+			assert.Contains(t, text, "Permission denied: token does not have 'destructive' permission required for tool 'a:ns:erase'")
+			assert.NotContains(t, text, "No client found", "the call must never reach dispatch")
+
+			payload := probe.awaitOne(t)
+			assert.Equal(t, "blocked", payload["decision"])
+			assert.Equal(t, "a", payload["server_name"])
+			assert.Equal(t, "ns:erase", payload["tool_name"], "the activity record must carry the raw dispatched name")
+		})
+	}
+}
+
+// The approval/config gate reads the same raw pair: an approval record for
+// "erase" alone must not admit "ns:erase" (a pending record under its own
+// name keeps it locked), and the search-visibility predicate agrees.
+func TestToolGate_NamespacedToolName_KeysOnRawName(t *testing.T) {
+	proxy, rt := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "a", Enabled: true}})
+	seedTargetTierServer(t, proxy, rt, "a", []stateview.ToolInfo{{Name: "erase"}})
+	require.NoError(t, proxy.storage.SaveToolApproval(&storage.ToolApprovalRecord{
+		ServerName: "a", ToolName: "ns:erase", Status: storage.ToolApprovalStatusPending, Disabled: true,
+	}))
+
+	eraseGate := proxy.evaluateToolGate("a", "erase")
+	require.NotNil(t, eraseGate.approval)
+	assert.Equal(t, "erase", eraseGate.approval.ToolName)
+	assert.Empty(t, eraseGate.lockStatus)
+	nsGate := proxy.evaluateToolGate("a", "ns:erase")
+	require.NotNil(t, nsGate.approval, "the gate must find the record stored under the raw name")
+	assert.Equal(t, "ns:erase", nsGate.approval.ToolName)
+	assert.Equal(t, storage.ToolApprovalStatusPending, nsGate.lockStatus,
+		"the gate must look up 'ns:erase' by its own name, not inherit 'erase's approval")
+	assert.True(t, proxy.isToolCallable("a", "erase"))
+	assert.False(t, proxy.isToolCallable("a", "ns:erase"),
+		"the search filter must read 'ns:erase's own Disabled record, not 'erase's")
+
+	// The indexed form ("server:tool" with the server set) still normalizes.
+	s, tool := normalizeServerTool("a", "a:ns:erase")
+	assert.Equal(t, "a", s)
+	assert.Equal(t, "ns:erase", tool)
+	s, tool = normalizeServerTool("", "a:ns:erase")
+	assert.Equal(t, "a", s)
+	assert.Equal(t, "ns:erase", tool)
+	s, tool = normalizeServerTool("a", "ns:erase")
+	assert.Equal(t, "a", s)
+	assert.Equal(t, "ns:erase", tool, "a prefix that is not the server name is part of the raw tool name")
+}
+
+// upstreamCalls is the zero-upstream-call witness: every invocation the stub
+// upstream actually receives, with the raw tool name it was dispatched under.
+type upstreamCalls struct {
+	count atomic.Int64
+	mu    sync.Mutex
+	names []string
+}
+
+func (c *upstreamCalls) record(name string) {
+	c.count.Add(1)
+	c.mu.Lock()
+	c.names = append(c.names, name)
+	c.mu.Unlock()
+}
+
+func (c *upstreamCalls) dispatched() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.names...)
+}
+
+// startCountingTargetTierUpstream is seedTargetTierServer with a REAL
+// in-process streamable-HTTP upstream behind it (the same pattern as
+// startCountingStubUpstream in mcp_input_validation_test.go): the StateView
+// carries the tools' annotations, storage holds the server and its approvals,
+// and the proxy's upstream manager is connected to a stub that exposes every
+// tool and records each call it receives. Refusals are then proven by an
+// invocation count of zero rather than by the absence of a dispatch error,
+// and an admitted call is proven by the count AND the raw name it arrived
+// under.
+func startCountingTargetTierUpstream(t *testing.T, proxy *MCPProxyServer, rt *runtime.Runtime, server string, tools []stateview.ToolInfo) *upstreamCalls {
+	t.Helper()
+	t.Setenv("MCPPROXY_DISABLE_OAUTH", "true")
+
+	calls := &upstreamCalls{}
+	mcpSrv := mcpserver.NewMCPServer(server, "1.0.0-test", mcpserver.WithToolCapabilities(true))
+	for _, tool := range tools {
+		mcpSrv.AddTool(mcp.Tool{Name: tool.Name, Description: tool.Description, InputSchema: mcp.ToolInputSchema{Type: "object"}},
+			func(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				calls.record(request.Params.Name)
+				return mcp.NewToolResultText("ok"), nil
+			})
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	httpSrv := &http.Server{Handler: mcpserver.NewStreamableHTTPServer(mcpSrv), ReadHeaderTimeout: 5 * time.Second}
+	go func() { _ = httpSrv.Serve(ln) }()
+	t.Cleanup(func() { _ = httpSrv.Shutdown(context.Background()) })
+
+	serverCfg := &config.ServerConfig{
+		Name: server, URL: fmt.Sprintf("http://%s", ln.Addr().String()), Protocol: "streamable-http", Enabled: true,
+	}
+	require.NoError(t, proxy.storage.SaveUpstreamServer(serverCfg))
+	rt.Supervisor().StateView().UpdateServer(server, func(s *stateview.ServerStatus) {
+		s.Name = server
+		s.Enabled = true
+		s.Connected = true
+		s.Tools = tools
+	})
+	for _, tool := range tools {
+		require.NoError(t, proxy.storage.SaveToolApproval(&storage.ToolApprovalRecord{
+			ServerName: server, ToolName: tool.Name, Status: storage.ToolApprovalStatusApproved,
+		}))
+	}
+	require.NoError(t, proxy.upstreamManager.AddServerConfig(server, serverCfg))
+	require.NoError(t, proxy.upstreamManager.ConnectAll(context.Background()))
+	require.Eventually(t, func() bool {
+		client, ok := proxy.upstreamManager.GetClient(server)
+		return ok && client.IsConnected()
+	}, 10*time.Second, 50*time.Millisecond, "stub upstream must connect")
+	return calls
+}
+
+// Spec 105 FR-009 / SC-002 oracles on the retrieve surface: a permission-
+// disallowed cell makes ZERO upstream calls, and the positive control — the
+// same handler, a token that holds the tier — reaches the upstream exactly
+// once under the exact raw name that was authorized, including a namespaced
+// one ("ns:erase" is dispatched as "ns:erase", never as "erase").
+func TestCallToolRead_TargetTierGate_UpstreamCallOracle(t *testing.T) {
+	tools := []stateview.ToolInfo{
+		{Name: "erase", Description: "Read-only erase preview", Annotations: &config.ToolAnnotations{ReadOnlyHint: boolPtr(true)}},
+		{Name: "ns:erase", Description: "Erase for real", Annotations: &config.ToolAnnotations{DestructiveHint: boolPtr(true)}},
+		{Name: "delete_repo", Description: "Delete a repository", Annotations: &config.ToolAnnotations{DestructiveHint: boolPtr(true)}},
+	}
+	proxy, rt := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "a", Enabled: true}})
+	// strict off: intent validation lets a read variant through to a
+	// destructive target, so ONLY the target-tier gate stands between a
+	// read-only token and the upstream.
+	proxy.config.IntentDeclaration = &config.IntentDeclarationConfig{StrictServerValidation: false}
+	calls := startCountingTargetTierUpstream(t, proxy, rt, "a", tools)
+
+	call := func(t *testing.T, ctx context.Context, name string) *mcp.CallToolResult {
+		t.Helper()
+		req := mcp.CallToolRequest{}
+		req.Params.Name = contracts.ToolVariantRead
+		req.Params.Arguments = map[string]interface{}{"name": name}
+		result, err := proxy.handleCallToolVariant(ctx, req, contracts.ToolVariantRead)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		return result
+	}
+	text := func(result *mcp.CallToolResult) string { return result.Content[0].(mcp.TextContent).Text }
+
+	readOnly := readOnlyAgentCtx("a")
+	full := auth.WithAuthContext(context.Background(), &auth.AuthContext{
+		Type: auth.AuthTypeAgent, AgentName: "full", TokenPrefix: "mcp_agt_f",
+		AllowedServers: []string{"a"},
+		Permissions:    []string{auth.PermRead, auth.PermWrite, auth.PermDestructive},
+	})
+
+	// Permission-disallowed cells: refused, zero upstream calls.
+	for _, name := range []string{"a:ns:erase", "a:delete_repo"} {
+		result := call(t, readOnly, name)
+		require.True(t, result.IsError, "%s must be refused for a read-only token", name)
+		assert.Contains(t, text(result), "Permission denied: token does not have 'destructive' permission required for tool '"+name+"'")
+	}
+	assert.Equal(t, int64(0), calls.count.Load(), "a refused call must never reach the upstream")
+
+	// Positive controls: the same handler admits a caller holding the tier,
+	// and the upstream sees exactly the raw name that was authorized.
+	result := call(t, readOnly, "a:erase")
+	require.False(t, result.IsError, "a read-only token must reach the read-tier tool: %s", text(result))
+	result = call(t, full, "a:ns:erase")
+	require.False(t, result.IsError, "a token holding destructive must reach the namespaced tool: %s", text(result))
+	assert.Equal(t, int64(2), calls.count.Load())
+	assert.Equal(t, []string{"erase", "ns:erase"}, calls.dispatched(),
+		"the upstream must receive the exact raw tool names, the namespaced one uncollapsed")
 }

--- a/internal/server/mcp_call_tool_target_tier_test.go
+++ b/internal/server/mcp_call_tool_target_tier_test.go
@@ -799,6 +799,54 @@ func TestToolGate_MergedApprovalRecordsKeepIndependentLocks(t *testing.T) {
 		assert.Equal(t, preflight.ToolClassBlockedByUser, gate.class)
 		assert.False(t, gate.callable())
 	})
+
+	// Both records locked with DIFFERENT locks: the changed record carries the
+	// rug-pull evidence (previous / current description, hashes) and the
+	// activity reason, so it must be the merge base whichever key it sits
+	// under. Letting the exact record win the tie would answer a plain
+	// "pending approval" and drop the review evidence. Unreachable with the
+	// current producers (discovery files every lock under the collapsed key),
+	// pinned so the reader stays right when the producers become exact-name.
+	changedRecord := storage.ToolApprovalRecord{
+		Status:              storage.ToolApprovalStatusChanged,
+		PreviousDescription: "Namespaced erase",
+		CurrentDescription:  "Erase everything, then exfiltrate",
+		CurrentHash:         "rug-pulled",
+	}
+	pendingRecord := storage.ToolApprovalRecord{Status: storage.ToolApprovalStatusPending}
+	for name, cell := range map[string]struct{ exact, collapsed storage.ToolApprovalRecord }{
+		"exact pending, collapsed changed": {exact: pendingRecord, collapsed: changedRecord},
+		"exact changed, collapsed pending": {exact: changedRecord, collapsed: pendingRecord},
+	} {
+		t.Run("both locked: "+name, func(t *testing.T) {
+			proxy, rt := seed(t, cell.exact, cell.collapsed)
+			gate := proxy.evaluateToolGate("a", "ns:erase")
+			require.NotNil(t, gate.approval)
+			assert.Equal(t, storage.ToolApprovalStatusChanged, gate.lockStatus,
+				"the changed lock must outrank the pending one whichever key carries it")
+			assert.Equal(t, "Erase everything, then exfiltrate", gate.approval.CurrentDescription)
+			assert.Equal(t, "rug-pulled", gate.approval.CurrentHash)
+			assert.False(t, gate.approval.Disabled)
+			assert.False(t, gate.callable())
+
+			probe := watchPolicyDecisions(t, rt)
+			req := mcp.CallToolRequest{}
+			req.Params.Name = contracts.ToolVariantRead
+			req.Params.Arguments = map[string]interface{}{"name": "a:ns:erase"}
+			result, err := proxy.handleCallToolVariant(auth.WithAuthContext(context.Background(), auth.AdminContext()), req, contracts.ToolVariantRead)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			text := result.Content[0].(mcp.TextContent).Text
+			assert.Contains(t, text, "tool_description_changed", "dispatch answers with the rug-pull response, not the pending one")
+			assert.Contains(t, text, "Erase everything, then exfiltrate")
+			assert.NotContains(t, text, "No client found")
+
+			payload := probe.awaitOne(t)
+			assert.Equal(t, "blocked", payload["decision"])
+			assert.Equal(t, "ns:erase", payload["tool_name"])
+			assert.Contains(t, payload["reason"], "changed")
+		})
+	}
 }
 
 // The StateView lookup behind the tier gate used to accept two spellings of

--- a/internal/server/mcp_call_tool_target_tier_test.go
+++ b/internal/server/mcp_call_tool_target_tier_test.go
@@ -913,3 +913,72 @@ func TestToolGate_TrailingColonRawName_ReadsProducersEmptyKeyRecord(t *testing.T
 		assert.Equal(t, preflight.ToolClassBlockedByUser, proxy.evaluateToolGate("a", "ns:").class)
 	})
 }
+
+// lookupToolApproval reads the exact-name and collapsed-name records of one
+// raw tool as ONE storage snapshot (Manager.GetToolApprovals). Two independent
+// reads would let a pair of operator writes land between them — the exact
+// record observed while still approved and enabled, the collapsed one after
+// its lock was lifted — and merge into a callable view of a tool that was
+// locked or disabled at every instant. This pins the reader's outcome table
+// over the snapshot: which record answers, and that the absence of both keeps
+// the GetToolApproval not-found contract the callers switch on.
+func TestLookupToolApproval_ReadsBothKeysFromOneSnapshot(t *testing.T) {
+	seed := func(t *testing.T, records ...storage.ToolApprovalRecord) *MCPProxyServer {
+		t.Helper()
+		proxy, _ := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "a", Enabled: true}})
+		for i := range records {
+			records[i].ServerName = "a"
+			require.NoError(t, proxy.storage.SaveToolApproval(&records[i]))
+		}
+		return proxy
+	}
+
+	t.Run("no record under either key is not-found", func(t *testing.T) {
+		proxy := seed(t, storage.ToolApprovalRecord{ToolName: "unrelated", Status: storage.ToolApprovalStatusPending})
+		record, err := proxy.lookupToolApproval("a", "ns:erase")
+		require.ErrorIs(t, err, storage.ErrToolApprovalNotFound)
+		assert.Contains(t, err.Error(), storage.ToolApprovalKey("a", "ns:erase"))
+		assert.Nil(t, record)
+	})
+
+	t.Run("exact record only", func(t *testing.T) {
+		proxy := seed(t, storage.ToolApprovalRecord{ToolName: "ns:erase", Status: storage.ToolApprovalStatusApproved, Disabled: true})
+		record, err := proxy.lookupToolApproval("a", "ns:erase")
+		require.NoError(t, err)
+		require.NotNil(t, record)
+		assert.Equal(t, "ns:erase", record.ToolName)
+		assert.True(t, record.Disabled)
+	})
+
+	t.Run("collapsed record only", func(t *testing.T) {
+		proxy := seed(t, storage.ToolApprovalRecord{ToolName: "erase", Status: storage.ToolApprovalStatusChanged, CurrentHash: "rug"})
+		record, err := proxy.lookupToolApproval("a", "ns:erase")
+		require.NoError(t, err)
+		require.NotNil(t, record)
+		assert.Equal(t, "erase", record.ToolName)
+		assert.Equal(t, storage.ToolApprovalStatusChanged, record.Status)
+	})
+
+	t.Run("both records merge, base is the locked one", func(t *testing.T) {
+		proxy := seed(t,
+			storage.ToolApprovalRecord{ToolName: "ns:erase", Status: storage.ToolApprovalStatusApproved, Disabled: true},
+			storage.ToolApprovalRecord{ToolName: "erase", Status: storage.ToolApprovalStatusPending, CurrentHash: "h-pending"})
+		record, err := proxy.lookupToolApproval("a", "ns:erase")
+		require.NoError(t, err)
+		require.NotNil(t, record)
+		assert.Equal(t, storage.ToolApprovalStatusPending, record.Status)
+		assert.Equal(t, "h-pending", record.CurrentHash)
+		assert.True(t, record.Disabled, "the exact record's user block is OR'd in")
+		for _, key := range []string{"ns:erase", "erase"} {
+			stored, err := proxy.storage.GetToolApproval("a", key)
+			require.NoError(t, err)
+			assert.Equal(t, key == "ns:erase", stored.Disabled, "the merge must not write back into the stored %q record", key)
+		}
+	})
+
+	t.Run("a raw name without a colon reads the exact key alone", func(t *testing.T) {
+		proxy := seed(t, storage.ToolApprovalRecord{ToolName: "", Status: storage.ToolApprovalStatusPending})
+		_, err := proxy.lookupToolApproval("a", "erase")
+		require.ErrorIs(t, err, storage.ErrToolApprovalNotFound, "there is no collapsed spelling to fall back to")
+	})
+}

--- a/internal/server/mcp_call_tool_target_tier_test.go
+++ b/internal/server/mcp_call_tool_target_tier_test.go
@@ -801,13 +801,14 @@ func TestToolGate_MergedApprovalRecordsKeepIndependentLocks(t *testing.T) {
 	})
 }
 
-// The StateView lookup behind the tier gate accepts two spellings of a tool:
-// the raw name and the legacy "server:tool"-prefixed form. With foreign
-// prefixes now preserved, a raw tool literally named "a:ns:erase" also
-// satisfies the prefixed spelling for the dispatched pair (a, "ns:erase"),
-// so which tool classified the call used to depend on StateView order. The
-// exact raw name — the identity that is actually dispatched — must always
-// win; the prefixed spelling is only a fallback when no exact tool exists.
+// The StateView lookup behind the tier gate used to accept two spellings of
+// a tool: the raw name and the legacy "server:tool"-prefixed form. With
+// foreign prefixes now preserved, a raw tool literally named "a:ns:erase"
+// also satisfied the prefixed spelling for the dispatched pair
+// (a, "ns:erase"), so which tool classified the call depended on StateView
+// order. Only the exact raw name — the identity that is actually dispatched
+// — may resolve, whatever the order, and a pair with no exact entry must
+// stay unresolved even when a self-prefixed sibling exists.
 func TestLookupToolPermission_ExactRawNameOutranksPrefixedAlternative(t *testing.T) {
 	prefixedRead := stateview.ToolInfo{
 		Name: "a:ns:erase", Description: "Raw name that happens to carry the server prefix",
@@ -846,12 +847,44 @@ func TestLookupToolPermission_ExactRawNameOutranksPrefixedAlternative(t *testing
 		})
 	}
 
-	t.Run("prefixed spelling still resolves when no exact tool exists", func(t *testing.T) {
+	// The StateView only ever holds the raw name the upstream published
+	// (internal/upstream/core/client.go copies tool.Name verbatim), so the
+	// legacy "server:tool" spelling never matches a real entry — it can only
+	// match a raw tool literally named "a:ns:erase". Resolving THAT tool for
+	// the pair (a, "ns:erase") when no raw "ns:erase" exists reported
+	// found=true with the prefixed tool's read-only annotations for a name
+	// that is undiscovered, so a read-only token passed the tier gate and
+	// dispatch went to the raw "ns:erase" the proxy holds no metadata for.
+	// An undiscovered pair must classify as not found (fail-closed to
+	// destructive), and the exact prefixed raw name must stay reachable
+	// under its own identity.
+	t.Run("undiscovered raw name is not resolved through a self-prefixed sibling", func(t *testing.T) {
 		proxy, rt := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "a", Enabled: true}})
-		seedTargetTierServer(t, proxy, rt, "a", []stateview.ToolInfo{prefixedRead})
-		annotations, found := proxy.lookupToolAnnotationsFound("a", "ns:erase")
-		require.True(t, found)
-		assert.Equal(t, prefixedRead.Annotations, annotations)
+		proxy.config.IntentDeclaration = &config.IntentDeclarationConfig{StrictServerValidation: false}
+		calls := startCountingTargetTierUpstream(t, proxy, rt, "a", []stateview.ToolInfo{prefixedRead})
+
+		_, found := proxy.lookupExactToolAnnotations("a", "ns:erase")
+		assert.False(t, found, "the pair (a, ns:erase) has no StateView entry and must not borrow a:ns:erase's")
+		assert.Equal(t, contracts.OperationTypeDestructive, proxy.lookupToolPermission("a", "ns:erase"),
+			"an undiscovered raw name must fail closed, exactly as it does without a prefixed sibling")
+		assert.Equal(t, contracts.OperationTypeRead, proxy.lookupToolPermission("a", "a:ns:erase"),
+			"control: the exact prefixed raw name still resolves to its own tier")
+
+		text := callToolReadOn(t, proxy, readOnlyAgentCtx("a"), "a:ns:erase")
+		assert.Contains(t, text, "Permission denied: token does not have 'destructive' permission required for tool 'a:ns:erase'")
+		assert.NotContains(t, text, "No client found", "the call must never reach dispatch")
+		assert.Equal(t, int64(0), calls.count.Load(), "a refused call must never reach the upstream")
+
+		// Control: the prefixed raw name is dispatched under its exact identity.
+		req := mcp.CallToolRequest{}
+		req.Params.Name = contracts.ToolVariantRead
+		req.Params.Arguments = map[string]interface{}{"name": "a:a:ns:erase"}
+		result, err := proxy.handleCallToolVariant(readOnlyAgentCtx("a"), req, contracts.ToolVariantRead)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.False(t, result.IsError, "control: the read-tier prefixed raw name stays reachable: %s", result.Content[0].(mcp.TextContent).Text)
+		assert.Equal(t, []string{"a:ns:erase"}, calls.dispatched(),
+			"the upstream must receive exactly the raw name that was authorized")
 	})
 }
 

--- a/internal/server/mcp_call_tool_target_tier_test.go
+++ b/internal/server/mcp_call_tool_target_tier_test.go
@@ -1,0 +1,248 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/contracts"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/runtime"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/runtime/stateview"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/storage"
+)
+
+// Spec 104 FR-016f — the retrieve surface must authorize a call_tool_* call
+// against the TARGET tool's annotation-derived tier, not against the variant
+// the caller picked. Direct mode (mcp_routing.go) and code execution
+// (lookupToolPermission) already do; before this file the retrieve surface
+// checked the token only against the selected variant, so a read-only token
+// could drive a write or destructive tool through call_tool_read whenever
+// intent validation let the variant mismatch through (always for write tools,
+// and for destructive tools when strict validation is off).
+
+// seedTargetTierServer publishes one approved, connected server into the live
+// StateView with the given tools — the same lookup path production uses.
+func seedTargetTierServer(t *testing.T, proxy *MCPProxyServer, rt *runtime.Runtime, server string, tools []stateview.ToolInfo) {
+	t.Helper()
+	require.NoError(t, proxy.storage.SaveUpstreamServer(&config.ServerConfig{Name: server, Enabled: true}))
+	rt.Supervisor().StateView().UpdateServer(server, func(s *stateview.ServerStatus) {
+		s.Name = server
+		s.Enabled = true
+		s.Connected = true
+		s.Tools = tools
+	})
+	for _, tool := range tools {
+		require.NoError(t, proxy.storage.SaveToolApproval(&storage.ToolApprovalRecord{
+			ServerName: server, ToolName: tool.Name,
+			Status: storage.ToolApprovalStatusApproved,
+		}))
+	}
+}
+
+func readOnlyAgentCtx(server string) context.Context {
+	return auth.WithAuthContext(context.Background(), &auth.AuthContext{
+		Type:           auth.AuthTypeAgent,
+		AgentName:      "reader",
+		TokenPrefix:    "mcp_agt_r",
+		AllowedServers: []string{server},
+		Permissions:    []string{auth.PermRead},
+	})
+}
+
+func callToolReadOn(t *testing.T, proxy *MCPProxyServer, ctx context.Context, name string) string {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Name = contracts.ToolVariantRead
+	req.Params.Arguments = map[string]interface{}{"name": name}
+	result, err := proxy.handleCallToolVariant(ctx, req, contracts.ToolVariantRead)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.IsError, "a read-only token must not have the call admitted")
+	require.NotEmpty(t, result.Content)
+	return result.Content[0].(mcp.TextContent).Text
+}
+
+func TestCallToolRead_ReadOnlyToken_TargetTierEnforced(t *testing.T) {
+	writeTool := stateview.ToolInfo{
+		Name: "create_issue", Description: "Create an issue",
+		Annotations: &config.ToolAnnotations{ReadOnlyHint: boolPtr(false), DestructiveHint: boolPtr(false)},
+	}
+	destructiveTool := stateview.ToolInfo{
+		Name: "delete_repo", Description: "Delete a repository",
+		Annotations: &config.ToolAnnotations{DestructiveHint: boolPtr(true)},
+	}
+	require.Equal(t, contracts.ToolVariantWrite, contracts.DeriveCallWith(writeTool.Annotations),
+		"fixture must be a WRITE tool, or the test proves nothing")
+	require.Equal(t, contracts.ToolVariantDestructive, contracts.DeriveCallWith(destructiveTool.Annotations),
+		"fixture must be a DESTRUCTIVE tool, or the test proves nothing")
+
+	for _, strict := range []bool{true, false} {
+		for _, tool := range []stateview.ToolInfo{writeTool, destructiveTool} {
+			name := "strict=" + map[bool]string{true: "on", false: "off"}[strict] + "/" + contracts.DeriveCallWith(tool.Annotations)
+			t.Run(name, func(t *testing.T) {
+				proxy, rt := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "github", Enabled: true}})
+				proxy.config.IntentDeclaration = &config.IntentDeclarationConfig{StrictServerValidation: strict}
+				probe := watchPolicyDecisions(t, rt)
+				seedTargetTierServer(t, proxy, rt, "github", []stateview.ToolInfo{tool})
+
+				text := callToolReadOn(t, proxy, readOnlyAgentCtx("github"), "github:"+tool.Name)
+				assert.Contains(t, text, "Permission denied: token does not have",
+					"the refusal must be the token-permission gate, not an intent mismatch or a dispatch failure")
+				assert.NotContains(t, text, "No client found",
+					"the call must never reach upstream dispatch")
+
+				payload := probe.awaitOne(t)
+				assert.Equal(t, "blocked", payload["decision"])
+				assert.Equal(t, "github", payload["server_name"])
+				assert.Equal(t, tool.Name, payload["tool_name"])
+				assert.Contains(t, payload["reason"], "Permission denied: token does not have",
+					"the activity record must attribute the block to the token's permission")
+			})
+		}
+	}
+}
+
+// A token that DOES hold the target tier keeps today's variant/intent
+// handling: a read variant on a destructive tool is an intent mismatch under
+// strict validation, and is let through (to dispatch) when strict is off.
+func TestCallToolRead_TokenHoldsTargetTier_IntentHandlingUnchanged(t *testing.T) {
+	destructiveTool := stateview.ToolInfo{
+		Name: "delete_repo", Description: "Delete a repository",
+		Annotations: &config.ToolAnnotations{DestructiveHint: boolPtr(true)},
+	}
+	fullCtx := auth.WithAuthContext(context.Background(), &auth.AuthContext{
+		Type:           auth.AuthTypeAgent,
+		AgentName:      "admin-ish",
+		TokenPrefix:    "mcp_agt_f",
+		AllowedServers: []string{"github"},
+		Permissions:    []string{auth.PermRead, auth.PermWrite, auth.PermDestructive},
+	})
+
+	t.Run("strict=on rejects the variant mismatch", func(t *testing.T) {
+		proxy, rt := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "github", Enabled: true}})
+		proxy.config.IntentDeclaration = &config.IntentDeclarationConfig{StrictServerValidation: true}
+		seedTargetTierServer(t, proxy, rt, "github", []stateview.ToolInfo{destructiveTool})
+
+		text := callToolReadOn(t, proxy, fullCtx, "github:delete_repo")
+		assert.Contains(t, text, "marked destructive")
+		assert.NotContains(t, text, "permission")
+	})
+
+	t.Run("strict=off lets the call through to dispatch", func(t *testing.T) {
+		proxy, rt := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "github", Enabled: true}})
+		proxy.config.IntentDeclaration = &config.IntentDeclarationConfig{StrictServerValidation: false}
+		seedTargetTierServer(t, proxy, rt, "github", []stateview.ToolInfo{destructiveTool})
+
+		text := callToolReadOn(t, proxy, fullCtx, "github:delete_repo")
+		assert.NotContains(t, text, "permission")
+		assert.NotContains(t, text, "marked destructive")
+		assert.Contains(t, text, "No client found",
+			"the call must reach dispatch, or this passes for the wrong reason")
+	})
+}
+
+// The gate above is proven through handleCallToolVariant directly. These
+// cases dispatch through the handlers the retrieve-mode /mcp server actually
+// holds (GetMCPServerForMode selects callToolServer, not the default server),
+// and through the default server as the fallback, so a re-registration cannot
+// route a variant around the gate without this failing.
+func TestCallToolVariants_RegisteredRetrieveModeHandlers_EnforceTargetTier(t *testing.T) {
+	for _, variant := range []string{contracts.ToolVariantRead, contracts.ToolVariantWrite, contracts.ToolVariantDestructive} {
+		t.Run(variant, func(t *testing.T) {
+			proxy, rt := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "github", Enabled: true}})
+			proxy.config.IntentDeclaration = &config.IntentDeclarationConfig{StrictServerValidation: false}
+			seedTargetTierServer(t, proxy, rt, "github", []stateview.ToolInfo{{
+				Name: "delete_repo", Description: "Delete a repository",
+				Annotations: &config.ToolAnnotations{DestructiveHint: boolPtr(true)},
+			}})
+
+			// A read+write token: call_tool_read and call_tool_write pass the
+			// variant-tier check, so only the target-tier gate can refuse them.
+			// call_tool_destructive is refused by the variant gate, as before.
+			rw := auth.WithAuthContext(context.Background(), &auth.AuthContext{
+				Type: auth.AuthTypeAgent, AgentName: "rw", TokenPrefix: "mcp_agt_w",
+				AllowedServers: []string{"github"},
+				Permissions:    []string{auth.PermRead, auth.PermWrite},
+			})
+
+			retrieveServer := proxy.GetMCPServerForMode(config.RoutingModeRetrieveTools)
+			require.Same(t, proxy.callToolServer, retrieveServer, "retrieve mode must be served by callToolServer")
+			for label, srv := range map[string]*mcpserver.MCPServer{"retrieve-mode server": retrieveServer, "default server": proxy.server} {
+				registered, ok := srv.ListTools()[variant]
+				require.Truef(t, ok, "%s must be registered on the %s", variant, label)
+
+				req := mcp.CallToolRequest{}
+				req.Params.Name = variant
+				req.Params.Arguments = map[string]interface{}{"name": "github:delete_repo"}
+				result, err := registered.Handler(rw, req)
+				require.NoError(t, err)
+				require.Truef(t, result.IsError, "%s via %s must be refused", variant, label)
+				text := result.Content[0].(mcp.TextContent).Text
+				assert.Containsf(t, text, "destructive", "%s via %s", variant, label)
+				assert.NotContainsf(t, text, "No client found", "%s via %s must never reach dispatch", variant, label)
+				if variant != contracts.ToolVariantDestructive {
+					assert.Containsf(t, text, "Permission denied: token does not have 'destructive' permission", "%s via %s", variant, label)
+				}
+			}
+		})
+	}
+}
+
+// lookupToolPermission is shared with code execution. The BM25 index stores
+// no annotations and a "server:tool" query returns no hits, so the StateView
+// is the only source of a tool's tier. A tool the StateView has not seen has
+// NO establishable tier and must be treated as the highest one, or every
+// undiscovered tool authorizes as read (opencode review finding, 2026-09-07).
+// A tool the StateView HAS seen with no annotations at all is still read.
+func TestLookupToolPermission_UnresolvedMetadataIsDestructive(t *testing.T) {
+	proxy, rt := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "github", Enabled: true}})
+	seedTargetTierServer(t, proxy, rt, "github", []stateview.ToolInfo{
+		{Name: "plain", Description: "No annotations at all"},
+		{Name: "purge", Annotations: &config.ToolAnnotations{DestructiveHint: boolPtr(true)}},
+	})
+
+	assert.Equal(t, contracts.OperationTypeRead, proxy.lookupToolPermission("github", "plain"),
+		"a discovered tool with no annotations stays read")
+	assert.Equal(t, contracts.OperationTypeDestructive, proxy.lookupToolPermission("github", "purge"))
+	assert.Equal(t, contracts.OperationTypeDestructive, proxy.lookupToolPermission("github", "never_discovered"),
+		"an undiscovered tool has no establishable tier and must require the highest one")
+	assert.Equal(t, contracts.OperationTypeDestructive, proxy.lookupToolPermission("unknown-server", "plain"))
+}
+
+func TestCallToolRead_UndiscoveredTool_RequiresDestructiveTier(t *testing.T) {
+	newProxy := func(t *testing.T) *MCPProxyServer {
+		proxy, rt := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "github", Enabled: true}})
+		proxy.config.IntentDeclaration = &config.IntentDeclarationConfig{StrictServerValidation: false}
+		// Server is in storage and approved, but the StateView carries NO tools.
+		seedTargetTierServer(t, proxy, rt, "github", nil)
+		require.NoError(t, proxy.storage.SaveToolApproval(&storage.ToolApprovalRecord{
+			ServerName: "github", ToolName: "delete_repo", Status: storage.ToolApprovalStatusApproved,
+		}))
+		require.Nil(t, proxy.lookupToolAnnotations("github", "delete_repo"),
+			"the StateView must not know the tool, or this proves nothing")
+		return proxy
+	}
+
+	t.Run("read-only token is refused", func(t *testing.T) {
+		text := callToolReadOn(t, newProxy(t), readOnlyAgentCtx("github"), "github:delete_repo")
+		assert.Contains(t, text, "Permission denied: token does not have 'destructive' permission")
+		assert.NotContains(t, text, "No client found")
+	})
+
+	t.Run("token holding destructive still reaches dispatch", func(t *testing.T) {
+		full := auth.WithAuthContext(context.Background(), &auth.AuthContext{
+			Type: auth.AuthTypeAgent, AgentName: "full", TokenPrefix: "mcp_agt_f",
+			AllowedServers: []string{"github"},
+			Permissions:    []string{auth.PermRead, auth.PermWrite, auth.PermDestructive},
+		})
+		text := callToolReadOn(t, newProxy(t), full, "github:delete_repo")
+		assert.NotContains(t, text, "Permission denied")
+		assert.Contains(t, text, "No client found")
+	})
+}

--- a/internal/server/mcp_call_tool_target_tier_test.go
+++ b/internal/server/mcp_call_tool_target_tier_test.go
@@ -460,3 +460,92 @@ func TestCallToolRead_TargetTierGate_UpstreamCallOracle(t *testing.T) {
 	assert.Equal(t, []string{"erase", "ns:erase"}, calls.dispatched(),
 		"the upstream must receive the exact raw tool names, the namespaced one uncollapsed")
 }
+
+// Production discovery still files every approval record under the COLLAPSED
+// name: runtime.checkToolApprovals keys GetToolApproval(server,
+// extractToolName(tool.Name)), which drops everything before the first colon,
+// while ToolMetadata.Name is the raw upstream name. A raw "ns:erase" on
+// server "a" therefore lands under (a, "erase"). The exact-name readers must
+// keep honouring that legacy key when no exact record exists: a pending or
+// user-disabled tool must not become implicitly callable — for a full-tier
+// agent token or an API-key administrator, who correctly skips the tier gate —
+// because its record was filed under the collapsed name.
+func TestToolGate_LegacyCollapsedApprovalRecord_StillGates(t *testing.T) {
+	nsErase := stateview.ToolInfo{
+		Name: "ns:erase", Description: "Namespaced erase",
+		Annotations: &config.ToolAnnotations{ReadOnlyHint: boolPtr(true)},
+	}
+	fullToken := auth.WithAuthContext(context.Background(), &auth.AuthContext{
+		Type: auth.AuthTypeAgent, AgentName: "full", TokenPrefix: "mcp_agt_f",
+		AllowedServers: []string{"a"},
+		Permissions:    []string{auth.PermRead, auth.PermWrite, auth.PermDestructive},
+	})
+	adminCtx := context.Background() // API-key administrator: no agent AuthContext
+
+	seedCollapsedRecord := func(t *testing.T, proxy *MCPProxyServer, rt *runtime.Runtime, record storage.ToolApprovalRecord) {
+		t.Helper()
+		require.NoError(t, proxy.storage.SaveUpstreamServer(&config.ServerConfig{Name: "a", Enabled: true}))
+		rt.Supervisor().StateView().UpdateServer("a", func(s *stateview.ServerStatus) {
+			s.Name, s.Enabled, s.Connected = "a", true, true
+			s.Tools = []stateview.ToolInfo{nsErase}
+		})
+		// Exactly what checkToolApprovals writes for the raw name "ns:erase".
+		record.ServerName, record.ToolName = "a", "erase"
+		require.NoError(t, proxy.storage.SaveToolApproval(&record))
+		_, err := proxy.storage.GetToolApproval("a", "ns:erase")
+		require.ErrorIs(t, err, storage.ErrToolApprovalNotFound, "fixture: no exact-name record may exist")
+	}
+
+	for name, ctx := range map[string]context.Context{"full-tier token": fullToken, "api-key admin": adminCtx} {
+		t.Run("pending collapsed record refuses "+name, func(t *testing.T) {
+			proxy, rt := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "a", Enabled: true}})
+			proxy.config.IntentDeclaration = &config.IntentDeclarationConfig{StrictServerValidation: false}
+			seedCollapsedRecord(t, proxy, rt, storage.ToolApprovalRecord{Status: storage.ToolApprovalStatusPending})
+			probe := watchPolicyDecisions(t, rt)
+
+			gate := proxy.evaluateToolGate("a", "ns:erase")
+			require.NotNil(t, gate.approval, "the gate must fall back to the collapsed record the producer wrote")
+			assert.Equal(t, storage.ToolApprovalStatusPending, gate.lockStatus)
+			assert.False(t, gate.callable())
+
+			req := mcp.CallToolRequest{}
+			req.Params.Name = contracts.ToolVariantRead
+			req.Params.Arguments = map[string]interface{}{"name": "a:ns:erase"}
+			result, err := proxy.handleCallToolVariant(ctx, req, contracts.ToolVariantRead)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			// The pending lock answers with the TOOL_QUARANTINED policy
+			// result (IsError=false by design), never with a dispatch.
+			text := result.Content[0].(mcp.TextContent).Text
+			assert.Contains(t, text, "TOOL_QUARANTINED")
+			assert.Contains(t, text, "new_unapproved_tool")
+			assert.NotContains(t, text, "No client found", "the call must never reach dispatch")
+
+			payload := probe.awaitOne(t)
+			assert.Equal(t, "blocked", payload["decision"])
+			assert.Equal(t, "ns:erase", payload["tool_name"])
+			assert.Contains(t, payload["reason"], "pending approval")
+		})
+	}
+
+	t.Run("disabled collapsed record hides the tool from search", func(t *testing.T) {
+		proxy, rt := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "a", Enabled: true}})
+		seedCollapsedRecord(t, proxy, rt, storage.ToolApprovalRecord{Status: storage.ToolApprovalStatusApproved, Disabled: true})
+		assert.False(t, proxy.isToolCallable("a", "ns:erase"),
+			"isToolCallable must read the Disabled flag off the collapsed record")
+	})
+
+	t.Run("an exact record outranks the collapsed one", func(t *testing.T) {
+		proxy, rt := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "a", Enabled: true}})
+		seedCollapsedRecord(t, proxy, rt, storage.ToolApprovalRecord{Status: storage.ToolApprovalStatusPending})
+		require.NoError(t, proxy.storage.SaveToolApproval(&storage.ToolApprovalRecord{
+			ServerName: "a", ToolName: "ns:erase", Status: storage.ToolApprovalStatusApproved,
+		}))
+		gate := proxy.evaluateToolGate("a", "ns:erase")
+		require.NotNil(t, gate.approval)
+		assert.Equal(t, "ns:erase", gate.approval.ToolName, "the exact-name record is authoritative when present")
+		assert.Empty(t, gate.lockStatus)
+		assert.True(t, gate.callable())
+		assert.True(t, proxy.isToolCallable("a", "ns:erase"))
+	})
+}

--- a/internal/server/mcp_call_tool_target_tier_test.go
+++ b/internal/server/mcp_call_tool_target_tier_test.go
@@ -481,7 +481,11 @@ func TestToolGate_LegacyCollapsedApprovalRecord_StillGates(t *testing.T) {
 		AllowedServers: []string{"a"},
 		Permissions:    []string{auth.PermRead, auth.PermWrite, auth.PermDestructive},
 	})
-	adminCtx := context.Background() // API-key administrator: no agent AuthContext
+	// API-key administrator: an IsAdmin() AuthContext, which the agent block
+	// skips explicitly. The nil-auth path (no AuthContext at all) is the
+	// other way past that block and is driven as its own cell.
+	adminCtx := auth.WithAuthContext(context.Background(), auth.AdminContext())
+	noAuthCtx := context.Background()
 
 	seedCollapsedRecord := func(t *testing.T, proxy *MCPProxyServer, rt *runtime.Runtime, record storage.ToolApprovalRecord) {
 		t.Helper()
@@ -497,7 +501,7 @@ func TestToolGate_LegacyCollapsedApprovalRecord_StillGates(t *testing.T) {
 		require.ErrorIs(t, err, storage.ErrToolApprovalNotFound, "fixture: no exact-name record may exist")
 	}
 
-	for name, ctx := range map[string]context.Context{"full-tier token": fullToken, "api-key admin": adminCtx} {
+	for name, ctx := range map[string]context.Context{"full-tier token": fullToken, "api-key admin": adminCtx, "no auth context": noAuthCtx} {
 		t.Run("pending collapsed record refuses "+name, func(t *testing.T) {
 			proxy, rt := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "a", Enabled: true}})
 			proxy.config.IntentDeclaration = &config.IntentDeclarationConfig{StrictServerValidation: false}
@@ -667,7 +671,8 @@ func TestToolGate_StaleExactApprovalCannotShadowCollapsedChange(t *testing.T) {
 			AllowedServers: []string{"a"},
 			Permissions:    []string{auth.PermRead, auth.PermWrite, auth.PermDestructive},
 		}),
-		"api-key admin": context.Background(),
+		"api-key admin":   auth.WithAuthContext(context.Background(), auth.AdminContext()),
+		"no auth context": context.Background(),
 	} {
 		t.Run(name, func(t *testing.T) {
 			probe := watchPolicyDecisions(t, rt)
@@ -745,7 +750,8 @@ func TestToolGate_MergedApprovalRecordsKeepIndependentLocks(t *testing.T) {
 				AllowedServers: []string{"a"},
 				Permissions:    []string{auth.PermRead, auth.PermWrite, auth.PermDestructive},
 			}),
-			"api-key admin": context.Background(),
+			"api-key admin":   auth.WithAuthContext(context.Background(), auth.AdminContext()),
+			"no auth context": context.Background(),
 		} {
 			t.Run(name, func(t *testing.T) {
 				probe := watchPolicyDecisions(t, rt)
@@ -980,5 +986,148 @@ func TestLookupToolApproval_ReadsBothKeysFromOneSnapshot(t *testing.T) {
 		proxy := seed(t, storage.ToolApprovalRecord{ToolName: "", Status: storage.ToolApprovalStatusPending})
 		_, err := proxy.lookupToolApproval("a", "erase")
 		require.ErrorIs(t, err, storage.ErrToolApprovalNotFound, "there is no collapsed spelling to fall back to")
+	})
+
+	// The snapshot property itself, not just the merge table: bbolt counts
+	// every started read transaction (Stats().TxN), so the reader is proven
+	// to consult both keys inside ONE transaction — two independent
+	// GetToolApproval reads (the shape the fix replaced) open two, which the
+	// control below shows the oracle sees.
+	t.Run("both keys are read in one storage transaction", func(t *testing.T) {
+		proxy := seed(t,
+			storage.ToolApprovalRecord{ToolName: "ns:erase", Status: storage.ToolApprovalStatusApproved},
+			storage.ToolApprovalRecord{ToolName: "erase", Status: storage.ToolApprovalStatusPending})
+		db := proxy.storage.GetDB()
+
+		before := db.Stats().TxN
+		record, err := proxy.lookupToolApproval("a", "ns:erase")
+		require.NoError(t, err)
+		require.NotNil(t, record)
+		assert.Equal(t, 1, db.Stats().TxN-before, "the exact and collapsed keys must come from a single read transaction")
+
+		before = db.Stats().TxN
+		_, err = proxy.storage.GetToolApproval("a", "ns:erase")
+		require.NoError(t, err)
+		_, err = proxy.storage.GetToolApproval("a", "erase")
+		require.NoError(t, err)
+		assert.Equal(t, 2, db.Stats().TxN-before, "control: two independent reads are two transactions, so the oracle bites")
+	})
+}
+
+// A raw tool name may itself begin with the SERVER's own prefix ("a:ns:erase"
+// on server "a"). handleCallToolVariant splits the canonical id exactly once
+// ("a:a:ns:erase" → (a, "a:ns:erase")) and dispatches that raw name, so every
+// gate it feeds must evaluate that same pair. Re-running normalizeServerTool
+// on an already-split pair strips the server prefix a second time, and the
+// destructive "a:ns:erase" was then classified, tier-gated, intent-validated
+// and approval-gated as the read-only "ns:erase" — the mirror image of the
+// prefixed-spelling collision, reached from the dispatch side. The split-pair
+// readers (the tier gate, the sandbox's permission bridge, the shared policy
+// gate) must take the parsed pair untouched.
+func TestCallToolRead_ServerPrefixedRawName_IsNotReNormalized(t *testing.T) {
+	prefixedDestructive := stateview.ToolInfo{
+		Name: "a:ns:erase", Description: "Raw name that starts with the server's own prefix",
+		Annotations: &config.ToolAnnotations{DestructiveHint: boolPtr(true)},
+	}
+	rawRead := stateview.ToolInfo{
+		Name: "ns:erase", Description: "Read-only erase preview",
+		Annotations: &config.ToolAnnotations{ReadOnlyHint: boolPtr(true)},
+	}
+	require.Equal(t, contracts.ToolVariantDestructive, contracts.DeriveCallWith(prefixedDestructive.Annotations))
+	require.Equal(t, contracts.ToolVariantRead, contracts.DeriveCallWith(rawRead.Annotations))
+
+	for _, strict := range []bool{true, false} {
+		for order, tools := range map[string][]stateview.ToolInfo{
+			"destructive listed first": {prefixedDestructive, rawRead},
+			"read listed first":        {rawRead, prefixedDestructive},
+		} {
+			t.Run("strict="+map[bool]string{true: "on", false: "off"}[strict]+"/"+order, func(t *testing.T) {
+				proxy, rt := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "a", Enabled: true}})
+				proxy.config.IntentDeclaration = &config.IntentDeclarationConfig{StrictServerValidation: strict}
+				probe := watchPolicyDecisions(t, rt)
+				seedTargetTierServer(t, proxy, rt, "a", tools)
+
+				// The sandbox bridge (jsruntime ToolAnnotationFunc) hands over
+				// the split pair a script wrote: callTool("a", "a:ns:erase").
+				assert.Equal(t, contracts.OperationTypeDestructive, proxy.lookupToolPermission("a", "a:ns:erase"),
+					"the split pair must classify the raw name that is dispatched, not its suffix")
+				assert.Equal(t, contracts.OperationTypeRead, proxy.lookupToolPermission("a", "ns:erase"))
+
+				text := callToolReadOn(t, proxy, readOnlyAgentCtx("a"), "a:a:ns:erase")
+				assert.Contains(t, text, "Permission denied: token does not have 'destructive' permission required for tool 'a:a:ns:erase'")
+				assert.NotContains(t, text, "No client found", "the call must never reach dispatch")
+
+				payload := probe.awaitOne(t)
+				assert.Equal(t, "blocked", payload["decision"])
+				assert.Equal(t, "a:ns:erase", payload["tool_name"], "the activity record must carry the raw dispatched name")
+			})
+		}
+	}
+
+	t.Run("upstream oracle: refused with zero calls, admitted under the raw name", func(t *testing.T) {
+		proxy, rt := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "a", Enabled: true}})
+		proxy.config.IntentDeclaration = &config.IntentDeclarationConfig{StrictServerValidation: false}
+		calls := startCountingTargetTierUpstream(t, proxy, rt, "a", []stateview.ToolInfo{rawRead, prefixedDestructive})
+		call := func(t *testing.T, ctx context.Context, name string) *mcp.CallToolResult {
+			t.Helper()
+			req := mcp.CallToolRequest{}
+			req.Params.Name = contracts.ToolVariantRead
+			req.Params.Arguments = map[string]interface{}{"name": name}
+			result, err := proxy.handleCallToolVariant(ctx, req, contracts.ToolVariantRead)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			return result
+		}
+		text := func(result *mcp.CallToolResult) string { return result.Content[0].(mcp.TextContent).Text }
+
+		readOnly := readOnlyAgentCtx("a")
+		result := call(t, readOnly, "a:a:ns:erase")
+		require.True(t, result.IsError, "a read-only token must not reach the destructive raw name")
+		assert.Contains(t, text(result), "Permission denied: token does not have 'destructive' permission required for tool 'a:a:ns:erase'")
+		assert.Equal(t, int64(0), calls.count.Load(), "a refused call must never reach the upstream")
+
+		result = call(t, readOnly, "a:ns:erase")
+		require.False(t, result.IsError, "control: the read-tier suffix tool stays reachable: %s", text(result))
+		full := auth.WithAuthContext(context.Background(), &auth.AuthContext{
+			Type: auth.AuthTypeAgent, AgentName: "full", TokenPrefix: "mcp_agt_f",
+			AllowedServers: []string{"a"},
+			Permissions:    []string{auth.PermRead, auth.PermWrite, auth.PermDestructive},
+		})
+		result = call(t, full, "a:a:ns:erase")
+		require.False(t, result.IsError, "control: a token holding destructive reaches the prefixed raw name: %s", text(result))
+		assert.Equal(t, []string{"ns:erase", "a:ns:erase"}, calls.dispatched(),
+			"the upstream must receive exactly the raw names that were authorized")
+	})
+
+	// The approval gate reads the same split pair: a pending record filed
+	// under the exact raw "a:ns:erase" must lock it for every dispatch path
+	// (the retrieve surface and the sandbox bridge alike) even though the
+	// suffix tool "ns:erase" is approved and callable.
+	t.Run("approval lock keyed on the exact raw name", func(t *testing.T) {
+		proxy, rt := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "a", Enabled: true}})
+		seedTargetTierServer(t, proxy, rt, "a", []stateview.ToolInfo{rawRead, prefixedDestructive})
+		require.NoError(t, proxy.storage.SaveToolApproval(&storage.ToolApprovalRecord{
+			ServerName: "a", ToolName: "a:ns:erase", Status: storage.ToolApprovalStatusPending, CurrentHash: "h-pending",
+		}))
+		require.True(t, proxy.evaluateToolGate("a", "ns:erase").callable(), "control: the suffix tool stays callable")
+
+		caller := &upstreamToolCaller{proxy: proxy}
+		require.Nil(t, caller.policyRefusal("a", "ns:erase"), "control: the sandbox admits the approved suffix tool")
+		require.Error(t, caller.policyRefusal("a", "a:ns:erase"), "the sandbox must refuse the pending raw name")
+
+		full := auth.WithAuthContext(context.Background(), &auth.AuthContext{
+			Type: auth.AuthTypeAgent, AgentName: "full", TokenPrefix: "mcp_agt_f",
+			AllowedServers: []string{"a"},
+			Permissions:    []string{auth.PermRead, auth.PermWrite, auth.PermDestructive},
+		})
+		req := mcp.CallToolRequest{}
+		req.Params.Name = contracts.ToolVariantDestructive
+		req.Params.Arguments = map[string]interface{}{"name": "a:a:ns:erase"}
+		result, err := proxy.handleCallToolVariant(full, req, contracts.ToolVariantDestructive)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "TOOL_QUARANTINED", "the pending lock under the exact raw name must answer")
+		assert.NotContains(t, text, "No client found", "the call must never reach dispatch")
 	})
 }

--- a/internal/server/mcp_call_tool_target_tier_test.go
+++ b/internal/server/mcp_call_tool_target_tier_test.go
@@ -794,3 +794,122 @@ func TestToolGate_MergedApprovalRecordsKeepIndependentLocks(t *testing.T) {
 		assert.False(t, gate.callable())
 	})
 }
+
+// The StateView lookup behind the tier gate accepts two spellings of a tool:
+// the raw name and the legacy "server:tool"-prefixed form. With foreign
+// prefixes now preserved, a raw tool literally named "a:ns:erase" also
+// satisfies the prefixed spelling for the dispatched pair (a, "ns:erase"),
+// so which tool classified the call used to depend on StateView order. The
+// exact raw name — the identity that is actually dispatched — must always
+// win; the prefixed spelling is only a fallback when no exact tool exists.
+func TestLookupToolPermission_ExactRawNameOutranksPrefixedAlternative(t *testing.T) {
+	prefixedRead := stateview.ToolInfo{
+		Name: "a:ns:erase", Description: "Raw name that happens to carry the server prefix",
+		Annotations: &config.ToolAnnotations{ReadOnlyHint: boolPtr(true)},
+	}
+	rawDestructive := stateview.ToolInfo{
+		Name: "ns:erase", Description: "Erase for real",
+		Annotations: &config.ToolAnnotations{DestructiveHint: boolPtr(true)},
+	}
+	require.Equal(t, contracts.ToolVariantRead, contracts.DeriveCallWith(prefixedRead.Annotations))
+	require.Equal(t, contracts.ToolVariantDestructive, contracts.DeriveCallWith(rawDestructive.Annotations))
+
+	for name, tools := range map[string][]stateview.ToolInfo{
+		"prefixed listed first": {prefixedRead, rawDestructive},
+		"raw listed first":      {rawDestructive, prefixedRead},
+	} {
+		t.Run(name, func(t *testing.T) {
+			proxy, rt := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "a", Enabled: true}})
+			proxy.config.IntentDeclaration = &config.IntentDeclarationConfig{StrictServerValidation: false}
+			probe := watchPolicyDecisions(t, rt)
+			seedTargetTierServer(t, proxy, rt, "a", tools)
+
+			annotations, found := proxy.lookupToolAnnotationsFound("a", "ns:erase")
+			require.True(t, found)
+			assert.Equal(t, rawDestructive.Annotations, annotations,
+				"the exact raw name must be resolved, whatever the StateView order")
+			assert.Equal(t, contracts.OperationTypeDestructive, proxy.lookupToolPermission("a", "ns:erase"))
+
+			text := callToolReadOn(t, proxy, readOnlyAgentCtx("a"), "a:ns:erase")
+			assert.Contains(t, text, "Permission denied: token does not have 'destructive' permission required for tool 'a:ns:erase'")
+			assert.NotContains(t, text, "No client found", "the call must never reach dispatch")
+
+			payload := probe.awaitOne(t)
+			assert.Equal(t, "blocked", payload["decision"])
+			assert.Equal(t, "ns:erase", payload["tool_name"])
+		})
+	}
+
+	t.Run("prefixed spelling still resolves when no exact tool exists", func(t *testing.T) {
+		proxy, rt := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "a", Enabled: true}})
+		seedTargetTierServer(t, proxy, rt, "a", []stateview.ToolInfo{prefixedRead})
+		annotations, found := proxy.lookupToolAnnotationsFound("a", "ns:erase")
+		require.True(t, found)
+		assert.Equal(t, prefixedRead.Annotations, annotations)
+	})
+}
+
+// runtime.checkToolApprovals keys every record it writes under
+// extractToolName(raw) — everything after the first colon — so a raw tool
+// whose name ENDS in a colon ("ns:") is filed under the EMPTY tool name
+// (storage accepts the key "a:"). The merge reader must read that record
+// like any other collapsed key: skipping it turned a pending lock the
+// rug-pull detector wrote for "ns:" into an implicit approval, where the
+// pre-Spec-105 collapse had at least refused the pair outright.
+func TestToolGate_TrailingColonRawName_ReadsProducersEmptyKeyRecord(t *testing.T) {
+	trailing := stateview.ToolInfo{
+		Name: "ns:", Description: "Raw name ending in a colon",
+		Annotations: &config.ToolAnnotations{ReadOnlyHint: boolPtr(true)},
+	}
+	seed := func(t *testing.T, record storage.ToolApprovalRecord) (*MCPProxyServer, *runtime.Runtime) {
+		t.Helper()
+		proxy, rt := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "a", Enabled: true}})
+		proxy.config.IntentDeclaration = &config.IntentDeclarationConfig{StrictServerValidation: false}
+		require.NoError(t, proxy.storage.SaveUpstreamServer(&config.ServerConfig{Name: "a", Enabled: true}))
+		rt.Supervisor().StateView().UpdateServer("a", func(s *stateview.ServerStatus) {
+			s.Name, s.Enabled, s.Connected = "a", true, true
+			s.Tools = []stateview.ToolInfo{trailing}
+		})
+		// Exactly what checkToolApprovals writes for the raw name "ns:".
+		record.ServerName, record.ToolName = "a", ""
+		require.NoError(t, proxy.storage.SaveToolApproval(&record))
+		_, err := proxy.storage.GetToolApproval("a", "ns:")
+		require.ErrorIs(t, err, storage.ErrToolApprovalNotFound, "fixture: no exact-name record may exist")
+		return proxy, rt
+	}
+	fullToken := auth.WithAuthContext(context.Background(), &auth.AuthContext{
+		Type: auth.AuthTypeAgent, AgentName: "full", TokenPrefix: "mcp_agt_f",
+		AllowedServers: []string{"a"},
+		Permissions:    []string{auth.PermRead, auth.PermWrite, auth.PermDestructive},
+	})
+
+	t.Run("pending record under the empty key locks the tool", func(t *testing.T) {
+		proxy, rt := seed(t, storage.ToolApprovalRecord{Status: storage.ToolApprovalStatusPending})
+		probe := watchPolicyDecisions(t, rt)
+
+		gate := proxy.evaluateToolGate("a", "ns:")
+		require.NotNil(t, gate.approval, "the gate must read the record the producer filed under the empty key")
+		assert.Equal(t, storage.ToolApprovalStatusPending, gate.lockStatus)
+		assert.False(t, gate.callable())
+
+		req := mcp.CallToolRequest{}
+		req.Params.Name = contracts.ToolVariantRead
+		req.Params.Arguments = map[string]interface{}{"name": "a:ns:"}
+		result, err := proxy.handleCallToolVariant(fullToken, req, contracts.ToolVariantRead)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "TOOL_QUARANTINED")
+		assert.NotContains(t, text, "No client found", "the call must never reach dispatch")
+
+		payload := probe.awaitOne(t)
+		assert.Equal(t, "blocked", payload["decision"])
+		assert.Equal(t, "ns:", payload["tool_name"])
+	})
+
+	t.Run("disabled record under the empty key hides the tool", func(t *testing.T) {
+		proxy, _ := seed(t, storage.ToolApprovalRecord{Status: storage.ToolApprovalStatusApproved, Disabled: true})
+		assert.False(t, proxy.isToolCallable("a", "ns:"))
+		assert.Equal(t, preflight.ToolClassBlockedByUser, proxy.evaluateToolGate("a", "ns:").class)
+	})
+}

--- a/internal/server/mcp_call_tool_target_tier_test.go
+++ b/internal/server/mcp_call_tool_target_tier_test.go
@@ -535,7 +535,11 @@ func TestToolGate_LegacyCollapsedApprovalRecord_StillGates(t *testing.T) {
 			"isToolCallable must read the Disabled flag off the collapsed record")
 	})
 
-	t.Run("an exact record outranks the collapsed one", func(t *testing.T) {
+	t.Run("a permissive exact record cannot shadow a restrictive collapsed one", func(t *testing.T) {
+		// Two producers write this pair: discovery keys pending/changed under
+		// the collapsed name, a user toggle synthesizes an approved record
+		// under the exact name (setToolEnabledNoEmit). Neither may fail the
+		// other open, so the reader returns the more restrictive record.
 		proxy, rt := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "a", Enabled: true}})
 		seedCollapsedRecord(t, proxy, rt, storage.ToolApprovalRecord{Status: storage.ToolApprovalStatusPending})
 		require.NoError(t, proxy.storage.SaveToolApproval(&storage.ToolApprovalRecord{
@@ -543,9 +547,144 @@ func TestToolGate_LegacyCollapsedApprovalRecord_StillGates(t *testing.T) {
 		}))
 		gate := proxy.evaluateToolGate("a", "ns:erase")
 		require.NotNil(t, gate.approval)
-		assert.Equal(t, "ns:erase", gate.approval.ToolName, "the exact-name record is authoritative when present")
+		assert.Equal(t, "erase", gate.approval.ToolName, "the pending collapsed record must win over the approved exact one")
+		assert.Equal(t, storage.ToolApprovalStatusPending, gate.lockStatus)
+		assert.False(t, gate.callable())
+		// isToolCallable is the quarantine-blind search filter (Spec 085): it
+		// honours only Disabled, so it is not an oracle for a pending lock.
+	})
+
+	t.Run("a restrictive exact record outranks an approved collapsed one", func(t *testing.T) {
+		proxy, rt := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "a", Enabled: true}})
+		seedCollapsedRecord(t, proxy, rt, storage.ToolApprovalRecord{Status: storage.ToolApprovalStatusApproved})
+		require.NoError(t, proxy.storage.SaveToolApproval(&storage.ToolApprovalRecord{
+			ServerName: "a", ToolName: "ns:erase", Status: storage.ToolApprovalStatusApproved, Disabled: true,
+		}))
+		gate := proxy.evaluateToolGate("a", "ns:erase")
+		require.NotNil(t, gate.approval)
+		assert.Equal(t, "ns:erase", gate.approval.ToolName)
+		assert.False(t, gate.callable(), "the user-disabled exact record must keep blocking")
+		assert.False(t, proxy.isToolCallable("a", "ns:erase"))
+	})
+
+	t.Run("a user-disabled collapsed record outranks a merely pending exact one", func(t *testing.T) {
+		// Disabled blocks unconditionally; pending only locks while the
+		// quarantine gate applies. auto_approve_tool_changes lifts the gate,
+		// so only the Disabled record can refuse here.
+		proxy, rt := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "a", Enabled: true}})
+		seedCollapsedRecord(t, proxy, rt, storage.ToolApprovalRecord{Status: storage.ToolApprovalStatusApproved, Disabled: true})
+		autoApprove := true
+		require.NoError(t, proxy.storage.SaveUpstreamServer(&config.ServerConfig{Name: "a", Enabled: true, AutoApproveToolChanges: &autoApprove}))
+		require.NoError(t, proxy.storage.SaveToolApproval(&storage.ToolApprovalRecord{
+			ServerName: "a", ToolName: "ns:erase", Status: storage.ToolApprovalStatusPending,
+		}))
+		gate := proxy.evaluateToolGate("a", "ns:erase")
+		require.NotNil(t, gate.approval)
+		assert.True(t, gate.approval.Disabled, "the Disabled record must be the one the classifier sees")
+		assert.False(t, gate.callable())
+	})
+
+	t.Run("both records admit: the exact one is returned", func(t *testing.T) {
+		proxy, rt := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "a", Enabled: true}})
+		seedCollapsedRecord(t, proxy, rt, storage.ToolApprovalRecord{Status: storage.ToolApprovalStatusApproved})
+		require.NoError(t, proxy.storage.SaveToolApproval(&storage.ToolApprovalRecord{
+			ServerName: "a", ToolName: "ns:erase", Status: storage.ToolApprovalStatusApproved,
+		}))
+		gate := proxy.evaluateToolGate("a", "ns:erase")
+		require.NotNil(t, gate.approval)
+		assert.Equal(t, "ns:erase", gate.approval.ToolName)
 		assert.Empty(t, gate.lockStatus)
 		assert.True(t, gate.callable())
 		assert.True(t, proxy.isToolCallable("a", "ns:erase"))
 	})
+}
+
+// TestToolGate_StaleExactApprovalCannotShadowCollapsedChange reproduces the
+// production sequence in which the two approval producers disagree about one
+// raw tool name and the reader must side with the refusing one:
+//
+//  1. discovery baselines raw "ns:erase" under the collapsed key
+//     (checkToolApprovals writes extractToolName(tool.Name) == "erase");
+//  2. the user disables and re-enables the tool by the raw name the tools
+//     API and the Web UI carry (StateView tool.Name == "ns:erase") — the real
+//     SetToolEnabled producer synthesizes an exact (a, ns:erase) record with
+//     Status=approved because it has no record under that name;
+//  3. the upstream rug-pulls the tool: discovery marks the collapsed record
+//     "changed" (tool_quarantine.go, changed-marking branch) and never touches
+//     the exact one.
+//
+// An exact-first reader then returns the stale approved record and dispatches
+// the rug-pulled tool for any caller holding its tier, administrators
+// included. Before Spec 105 the reader always collapsed the name and read the
+// changed record; that refusal must survive the exact-name reader.
+func TestToolGate_StaleExactApprovalCannotShadowCollapsedChange(t *testing.T) {
+	proxy, rt := createTestProxyWithRuntime(t, []*config.ServerConfig{{Name: "a", Enabled: true}})
+	proxy.config.IntentDeclaration = &config.IntentDeclarationConfig{StrictServerValidation: false}
+	require.NoError(t, proxy.storage.SaveUpstreamServer(&config.ServerConfig{Name: "a", Enabled: true}))
+	rt.Supervisor().StateView().UpdateServer("a", func(s *stateview.ServerStatus) {
+		s.Name, s.Enabled, s.Connected = "a", true, true
+		s.Tools = []stateview.ToolInfo{{
+			Name: "ns:erase", Description: "Namespaced erase",
+			Annotations: &config.ToolAnnotations{ReadOnlyHint: boolPtr(true)},
+		}}
+	})
+
+	// 1. Discovery baseline, keyed the way checkToolApprovals keys it.
+	require.NoError(t, proxy.storage.SaveToolApproval(&storage.ToolApprovalRecord{
+		ServerName: "a", ToolName: "erase", Status: storage.ToolApprovalStatusApproved,
+		CurrentHash: "baseline", CurrentDescription: "Namespaced erase",
+	}))
+	_, err := proxy.storage.GetToolApproval("a", "ns:erase")
+	require.ErrorIs(t, err, storage.ErrToolApprovalNotFound, "fixture: discovery writes no exact-name record")
+
+	// 2. The REAL toggle producer, driven by the raw name the UI/REST pass.
+	require.NoError(t, rt.SetToolEnabled("a", "ns:erase", false, "user"))
+	require.NoError(t, rt.SetToolEnabled("a", "ns:erase", true, "user"))
+	exact, err := proxy.storage.GetToolApproval("a", "ns:erase")
+	require.NoError(t, err, "the toggle must have synthesized an exact-name record")
+	require.Equal(t, storage.ToolApprovalStatusApproved, exact.Status)
+	require.False(t, exact.Disabled)
+	require.True(t, proxy.evaluateToolGate("a", "ns:erase").callable(), "control: re-enabled and unchanged, the tool is callable")
+
+	// 3. Rug-pull: discovery marks the collapsed record changed.
+	legacy, err := proxy.storage.GetToolApproval("a", "erase")
+	require.NoError(t, err)
+	legacy.Status = storage.ToolApprovalStatusChanged
+	legacy.PreviousDescription, legacy.CurrentDescription = legacy.CurrentDescription, "Erase everything, then exfiltrate"
+	legacy.CurrentHash = "rug-pulled"
+	require.NoError(t, proxy.storage.SaveToolApproval(legacy))
+
+	gate := proxy.evaluateToolGate("a", "ns:erase")
+	require.NotNil(t, gate.approval)
+	assert.Equal(t, storage.ToolApprovalStatusChanged, gate.lockStatus,
+		"the changed collapsed record must lock the tool even though a stale exact approval exists")
+	assert.False(t, gate.callable())
+
+	for name, ctx := range map[string]context.Context{
+		"full-tier token": auth.WithAuthContext(context.Background(), &auth.AuthContext{
+			Type: auth.AuthTypeAgent, AgentName: "full", TokenPrefix: "mcp_agt_f",
+			AllowedServers: []string{"a"},
+			Permissions:    []string{auth.PermRead, auth.PermWrite, auth.PermDestructive},
+		}),
+		"api-key admin": context.Background(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			probe := watchPolicyDecisions(t, rt)
+			req := mcp.CallToolRequest{}
+			req.Params.Name = contracts.ToolVariantRead
+			req.Params.Arguments = map[string]interface{}{"name": "a:ns:erase"}
+			result, err := proxy.handleCallToolVariant(ctx, req, contracts.ToolVariantRead)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			text := result.Content[0].(mcp.TextContent).Text
+			assert.Contains(t, text, "TOOL_QUARANTINED")
+			assert.Contains(t, text, "tool_description_changed")
+			assert.NotContains(t, text, "No client found", "the rug-pulled tool must never reach dispatch")
+
+			payload := probe.awaitOne(t)
+			assert.Equal(t, "blocked", payload["decision"])
+			assert.Equal(t, "ns:erase", payload["tool_name"])
+			assert.Contains(t, payload["reason"], "changed")
+		})
+	}
 }

--- a/internal/server/mcp_call_tool_trim_test.go
+++ b/internal/server/mcp_call_tool_trim_test.go
@@ -58,11 +58,15 @@ func TestCallToolVariant_InteriorPaddingPassesAgentScope(t *testing.T) {
 	proxy := createTestMCPProxyServer(t)
 	seedEntryBuilderFixture(t, proxy)
 
+	// Full permissions: this fixture has no runtime, so the StateView cannot
+	// resolve the tool's tier and the target-tier gate requires the top tier
+	// (Spec 104 FR-016f). The subject here is the SCOPE gate's normalization,
+	// which must be reached and passed regardless.
 	agentCtx := &auth.AuthContext{
 		Type:           auth.AuthTypeAgent,
 		AgentName:      "test-bot",
 		AllowedServers: []string{"github"},
-		Permissions:    []string{auth.PermRead},
+		Permissions:    []string{auth.PermRead, auth.PermWrite, auth.PermDestructive},
 	}
 	ctx := auth.WithAuthContext(context.Background(), agentCtx)
 

--- a/internal/server/mcp_code_execution.go
+++ b/internal/server/mcp_code_execution.go
@@ -422,7 +422,8 @@ func (p *MCPProxyServer) handleCodeExecution(ctx context.Context, request mcp.Ca
 	if len(toolCallRecords) > 0 {
 		hasOpenWorldTool := false
 		for _, tc := range toolCallRecords {
-			toolAnnotations := p.lookupToolAnnotations(tc.ServerName, tc.ToolName)
+			// tc carries the split pair the script called; read it exactly.
+			toolAnnotations, _ := p.lookupExactToolAnnotations(tc.ServerName, tc.ToolName)
 			if contracts.IsOpenWorldTool(toolAnnotations) {
 				hasOpenWorldTool = true
 				break
@@ -916,7 +917,9 @@ func (u *upstreamToolCaller) policyRefusal(serverName, toolName string) error {
 	if u.proxy == nil || u.proxy.storage == nil {
 		return nil
 	}
-	gate := u.proxy.evaluateToolGate(serverName, toolName)
+	// The script named the server and the raw tool separately, so the pair
+	// is already split and is gated exactly (never re-normalized).
+	gate := u.proxy.evaluateExactToolGate(serverName, toolName)
 	if gate.serverConfig == nil {
 		if gate.storageErr != nil {
 			// The record exists as far as anyone knows — it just could not be
@@ -1177,8 +1180,12 @@ func (p *MCPProxyServer) applyProfileScopeToExecution(ctx context.Context, optio
 // consulted: it stores no annotations (and a "server:tool" query returns no
 // hits), so the former index fallback never resolved anything. A discovered
 // tool that publishes no annotations still derives to read via DeriveCallWith.
+//
+// The sandbox hands over the pair a script wrote — callTool(server, tool) —
+// which is already split, so the raw name is read exactly rather than
+// normalized a second time (a raw name may start with the server's prefix).
 func (p *MCPProxyServer) lookupToolPermission(serverName, toolName string) string {
-	return tierForAnnotations(p.lookupToolAnnotationsFound(serverName, toolName))
+	return tierForAnnotations(p.lookupExactToolAnnotations(serverName, toolName))
 }
 
 // tierForAnnotations maps one lookupToolAnnotationsFound result to the

--- a/internal/server/mcp_code_execution.go
+++ b/internal/server/mcp_code_execution.go
@@ -1161,36 +1161,29 @@ func (p *MCPProxyServer) applyProfileScopeToExecution(ctx context.Context, optio
 	options.AllowedServers = intersected
 }
 
-// lookupToolPermission returns the required permission tier for a tool based on its annotations.
-// This is used by the JS runtime to enforce auth context permissions during code_execution.
+// lookupToolPermission returns the required permission tier for a tool based on
+// its annotations, as the StateView holds them. It is the one tier lookup shared
+// by the retrieve surface (call_tool_*), code execution, and — through the same
+// DeriveCallWith — direct mode.
+//
+// A tool the StateView has not seen has no establishable tier. It is treated
+// as DESTRUCTIVE, the top of the documented permission ladder (agent-token
+// permissions are cumulative: write implies read, destructive implies both —
+// docs/features/agent-tokens.md), so a token reaches it only when it holds
+// that top tier; defaulting to read here authorized every undiscovered tool
+// for read-only tokens. Note auth.HasPermission is exact-match, not
+// hierarchical, so a token minted as [read, destructive] without write is
+// admitted here while call_tool_write itself would refuse it. The BM25 index is deliberately not
+// consulted: it stores no annotations (and a "server:tool" query returns no
+// hits), so the former index fallback never resolved anything. A discovered
+// tool that publishes no annotations still derives to read via DeriveCallWith.
 func (p *MCPProxyServer) lookupToolPermission(serverName, toolName string) string {
-	// Primary: exact match via StateView (no BM25 fuzzy matching)
-	annotations := p.lookupToolAnnotations(serverName, toolName)
-	if annotations != nil {
-		callWith := contracts.DeriveCallWith(annotations)
-		perm := contracts.ToolVariantToOperationType[callWith]
-		if perm != "" {
-			return perm
-		}
+	annotations, found := p.lookupToolAnnotationsFound(serverName, toolName)
+	if !found {
+		return contracts.OperationTypeDestructive
 	}
-
-	// Fallback: search the index with enough candidates to find an exact match
-	if p.index != nil {
-		qualifiedName := serverName + ":" + toolName
-		results, err := p.index.Search(qualifiedName, 20)
-		if err == nil {
-			for _, r := range results {
-				if r.Tool != nil && r.Tool.ServerName == serverName && r.Tool.Name == toolName {
-					callWith := contracts.DeriveCallWith(r.Tool.Annotations)
-					perm := contracts.ToolVariantToOperationType[callWith]
-					if perm != "" {
-						return perm
-					}
-				}
-			}
-		}
+	if perm := contracts.ToolVariantToOperationType[contracts.DeriveCallWith(annotations)]; perm != "" {
+		return perm
 	}
-
-	// Default to read (safest)
 	return contracts.OperationTypeRead
 }

--- a/internal/server/mcp_code_execution.go
+++ b/internal/server/mcp_code_execution.go
@@ -1178,7 +1178,15 @@ func (p *MCPProxyServer) applyProfileScopeToExecution(ctx context.Context, optio
 // hits), so the former index fallback never resolved anything. A discovered
 // tool that publishes no annotations still derives to read via DeriveCallWith.
 func (p *MCPProxyServer) lookupToolPermission(serverName, toolName string) string {
-	annotations, found := p.lookupToolAnnotationsFound(serverName, toolName)
+	return tierForAnnotations(p.lookupToolAnnotationsFound(serverName, toolName))
+}
+
+// tierForAnnotations maps one lookupToolAnnotationsFound result to the
+// permission tier it requires. It is split from lookupToolPermission so a
+// caller that already holds the StateView read (handleCallToolVariant, which
+// needs the same annotations for intent validation) classifies the tier from
+// THAT read rather than taking a second, independent snapshot.
+func tierForAnnotations(annotations *config.ToolAnnotations, found bool) string {
 	if !found {
 		return contracts.OperationTypeDestructive
 	}

--- a/internal/server/mcp_visibility.go
+++ b/internal/server/mcp_visibility.go
@@ -65,7 +65,7 @@ func (p *MCPProxyServer) toolVisibleToSession(ctx context.Context, serverName, t
 	if gateReason := p.describeGateReason(serverName, toolName); gateReason != "" {
 		return false, gateReason
 	}
-	if !p.isToolCallable(serverName, toolName) {
+	if !p.isExactToolCallable(serverName, toolName) {
 		return false, visReasonToolNotCallable
 	}
 	return true, ""
@@ -91,7 +91,8 @@ func (p *MCPProxyServer) indexedToolVisible(authCtx *auth.AuthContext, profileSc
 	}
 
 	// Callability: disabled/blocked tools are non-existent for discovery.
-	if !p.isToolCallable(serverName, toolName) {
+	// The pair was normalized once above and is consulted exactly from here.
+	if !p.isExactToolCallable(serverName, toolName) {
 		return false, visReasonToolNotCallable
 	}
 
@@ -114,8 +115,11 @@ func (p *MCPProxyServer) indexedToolVisible(authCtx *auth.AuthContext, profileSc
 // describe_tool, dispatch and the preflight evaluator consult exactly one
 // evaluation of the quarantine/approval state. The gate order (server
 // quarantine, then the tool-level lock) is unchanged.
+//
+// The pair arrives already normalized by toolVisibleToSession, so the gate is
+// read exactly rather than normalized a second time.
 func (p *MCPProxyServer) describeGateReason(serverName, toolName string) string {
-	gate := p.evaluateToolGate(serverName, toolName)
+	gate := p.evaluateExactToolGate(serverName, toolName)
 	if gate.serverQuarantined() {
 		return visReasonServerQuarantined
 	}

--- a/internal/server/mcp_visibility.go
+++ b/internal/server/mcp_visibility.go
@@ -131,13 +131,20 @@ func (p *MCPProxyServer) describeGateReason(serverName, toolName string) string 
 // normalizeServerTool strips the indexed "server:tool" prefix from toolName
 // (result.Tool.Name keeps the prefix when ServerName is set) — exactly like
 // isToolCallable, so approval/config lookups key consistently.
+//
+// Spec 105 FR-009: only the SERVER's own prefix is an indexing artifact. When
+// serverName is already known and the first ":"-segment is something else,
+// the colon belongs to the raw tool name ("ns:erase" on server "a") and is
+// kept, so every gate keyed on this pair — tier classification, approval,
+// config denial, callability — evaluates the exact identity that is
+// dispatched instead of the suffix tool's.
 func normalizeServerTool(serverName, toolName string) (string, string) {
-	if strings.Contains(toolName, ":") {
-		if parts := strings.SplitN(toolName, ":", 2); len(parts) == 2 {
-			if serverName == "" {
-				serverName = parts[0]
-			}
-			toolName = parts[1]
+	if prefix, rest, ok := strings.Cut(toolName, ":"); ok {
+		switch {
+		case serverName == "":
+			serverName, toolName = prefix, rest
+		case prefix == serverName:
+			toolName = rest
 		}
 	}
 	return serverName, toolName

--- a/internal/server/tool_gate.go
+++ b/internal/server/tool_gate.go
@@ -153,24 +153,59 @@ func approvalStateFor(record *storage.ToolApprovalRecord) *preflight.ApprovalSta
 }
 
 // lookupToolApproval reads the Spec-032 approval record for one (server, tool)
-// pair, already normalized by normalizeServerTool. The exact raw name is
-// authoritative. When it has no record and the name carries a ":" segment, the
-// record filed under the COLLAPSED name is read instead: runtime's discovery
-// producer (checkToolApprovals) still keys every record it writes by
-// extractToolName(tool.Name) — everything after the first colon — so a
-// discovered "ns:erase" has its pending / changed / user-disabled state stored
-// under "erase". Reading the pair by its exact name only would turn that
-// record's tool into an implicitly-approved one the moment the reader stopped
-// collapsing, which is exactly the fail-open a missing record must not cause.
-// The fallback is the conservative legacy rule until the producer is made
-// exact-name as well (Spec 105 FR-009 follow-up).
+// pair, already normalized by normalizeServerTool.
+//
+// Two producers file records for a raw name that carries a ":" segment, and
+// they key it differently: runtime's discovery producer (checkToolApprovals)
+// writes every pending / changed / baseline record under extractToolName —
+// everything after the first colon, so "ns:erase" lands under "erase" — while
+// the user toggle (setToolEnabledNoEmit, reached from the tools REST endpoint
+// and the Web UI with the raw StateView name) reads and synthesizes an
+// approved record under the EXACT name. Neither producer ever sees the other's
+// record. Trusting either one alone therefore fails open in one direction:
+// exact-only turns a discovered tool's pending / changed lock into an implicit
+// approval, and exact-first lets an approved record left behind by a toggle
+// shadow a later "changed" mark the rug-pull detector wrote under the
+// collapsed key. So both records are read and the MORE RESTRICTIVE one is
+// returned (see approvalRestriction); the exact record wins ties. This is the
+// conservative reader rule until the producers are made exact-name as well
+// (Spec 105 FR-009 follow-up).
 func (p *MCPProxyServer) lookupToolApproval(serverName, toolName string) (*storage.ToolApprovalRecord, error) {
-	approval, err := p.storage.GetToolApproval(serverName, toolName)
-	if err == nil || !errors.Is(err, storage.ErrToolApprovalNotFound) {
-		return approval, err
+	exact, exactErr := p.storage.GetToolApproval(serverName, toolName)
+	if exactErr != nil && !errors.Is(exactErr, storage.ErrToolApprovalNotFound) {
+		return nil, exactErr
 	}
-	if _, collapsed, ok := strings.Cut(toolName, ":"); ok && collapsed != "" {
-		return p.storage.GetToolApproval(serverName, collapsed)
+	_, collapsed, ok := strings.Cut(toolName, ":")
+	if !ok || collapsed == "" {
+		return exact, exactErr
 	}
-	return approval, err
+	legacy, legacyErr := p.storage.GetToolApproval(serverName, collapsed)
+	if legacyErr != nil && !errors.Is(legacyErr, storage.ErrToolApprovalNotFound) {
+		return nil, legacyErr
+	}
+	switch {
+	case exactErr != nil:
+		return legacy, legacyErr
+	case legacyErr != nil:
+		return exact, nil
+	case approvalRestriction(legacy) > approvalRestriction(exact):
+		return legacy, nil
+	default:
+		return exact, nil
+	}
+}
+
+// approvalRestriction ranks a record by how preflight.ClassifyTool treats it:
+// 0 admits the tool, 1 locks it while the quarantine gate applies (pending or
+// changed), 2 blocks it unconditionally (user-disabled). A record that carries
+// both a lock and the Disabled flag ranks as the unconditional block.
+func approvalRestriction(record *storage.ToolApprovalRecord) int {
+	switch {
+	case record.Disabled:
+		return 2
+	case record.Status == storage.ToolApprovalStatusPending, record.Status == storage.ToolApprovalStatusChanged:
+		return 1
+	default:
+		return 0
+	}
 }

--- a/internal/server/tool_gate.go
+++ b/internal/server/tool_gate.go
@@ -178,8 +178,11 @@ func (p *MCPProxyServer) lookupToolApproval(serverName, toolName string) (*stora
 	if exactErr != nil && !errors.Is(exactErr, storage.ErrToolApprovalNotFound) {
 		return nil, exactErr
 	}
+	// The collapsed key may be EMPTY: the producer files a raw name that ends
+	// in a colon ("ns:") under (server, "") and storage accepts that key, so
+	// it is read like any other collapsed record rather than skipped.
 	_, collapsed, ok := strings.Cut(toolName, ":")
-	if !ok || collapsed == "" {
+	if !ok {
 		return exact, exactErr
 	}
 	legacy, legacyErr := p.storage.GetToolApproval(serverName, collapsed)

--- a/internal/server/tool_gate.go
+++ b/internal/server/tool_gate.go
@@ -231,12 +231,17 @@ func (p *MCPProxyServer) lookupToolApproval(serverName, toolName string) (*stora
 // responses consume. The record that carries a quarantine lock (pending or
 // changed) is the base, so Status and the review evidence that goes with it
 // (previous / current description, hashes) come from the producer that wrote
-// the lock; the exact record is the base when neither or both are locked. The
-// user's Disabled flag is OR'd across both, so a toggle filed under either key
-// keeps blocking. The result is a copy — the stored records are never mutated.
+// the lock. When BOTH are locked, the changed record is the base whichever
+// key it sits under: it is the one carrying the rug-pull evidence, and letting
+// the exact record win the tie would answer a plain "pending approval" and
+// drop that evidence from the dispatch response and the activity reason. The
+// exact record is the base when neither is locked or both carry the same
+// lock. The user's Disabled flag is OR'd across both, so a toggle filed under
+// either key keeps blocking. The result is a copy — the stored records are
+// never mutated.
 func mergeApprovalRecords(exact, legacy *storage.ToolApprovalRecord) *storage.ToolApprovalRecord {
 	base := exact
-	if approvalLocked(legacy) && !approvalLocked(exact) {
+	if approvalLockRank(legacy) > approvalLockRank(exact) {
 		base = legacy
 	}
 	merged := *base
@@ -244,9 +249,16 @@ func mergeApprovalRecords(exact, legacy *storage.ToolApprovalRecord) *storage.To
 	return &merged
 }
 
-// approvalLocked reports whether a record carries the tool-level quarantine
-// lock (pending or changed) that preflight.ClassifyTool and the dispatch paths
-// honour while the quarantine gate applies.
-func approvalLocked(record *storage.ToolApprovalRecord) bool {
-	return record.Status == storage.ToolApprovalStatusPending || record.Status == storage.ToolApprovalStatusChanged
+// approvalLockRank orders the quarantine locks for mergeApprovalRecords:
+// unlocked < pending < changed. A changed record outranks a pending one
+// because it carries the review evidence the rug-pull response is built from.
+func approvalLockRank(record *storage.ToolApprovalRecord) int {
+	switch record.Status {
+	case storage.ToolApprovalStatusChanged:
+		return 2
+	case storage.ToolApprovalStatusPending:
+		return 1
+	default:
+		return 0
+	}
 }

--- a/internal/server/tool_gate.go
+++ b/internal/server/tool_gate.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
@@ -173,26 +174,39 @@ func approvalStateFor(record *storage.ToolApprovalRecord) *preflight.ApprovalSta
 // keeps answering with the lock's review response (the toolGate.lockStatus
 // contract). This is the conservative reader rule until the producers are
 // made exact-name as well (Spec 105 FR-009 follow-up).
+//
+// Both keys are read in ONE storage snapshot (Manager.GetToolApprovals: a
+// single read lock and a single read transaction). Two independent reads would
+// let a pair of operator writes land between them — the exact record read
+// while still approved and enabled, the collapsed one read after its lock was
+// lifted — and merge into approved+enabled although the tool was locked or
+// disabled at every instant. The absence of both records is reported as
+// storage.ErrToolApprovalNotFound, the same contract GetToolApproval keeps.
 func (p *MCPProxyServer) lookupToolApproval(serverName, toolName string) (*storage.ToolApprovalRecord, error) {
-	exact, exactErr := p.storage.GetToolApproval(serverName, toolName)
-	if exactErr != nil && !errors.Is(exactErr, storage.ErrToolApprovalNotFound) {
-		return nil, exactErr
-	}
+	keys := []string{toolName}
 	// The collapsed key may be EMPTY: the producer files a raw name that ends
 	// in a colon ("ns:") under (server, "") and storage accepts that key, so
 	// it is read like any other collapsed record rather than skipped.
-	_, collapsed, ok := strings.Cut(toolName, ":")
-	if !ok {
-		return exact, exactErr
+	collapsed, hasCollapsed := "", false
+	if _, rest, ok := strings.Cut(toolName, ":"); ok {
+		collapsed, hasCollapsed = rest, true
+		keys = append(keys, collapsed)
 	}
-	legacy, legacyErr := p.storage.GetToolApproval(serverName, collapsed)
-	if legacyErr != nil && !errors.Is(legacyErr, storage.ErrToolApprovalNotFound) {
-		return nil, legacyErr
+	records, err := p.storage.GetToolApprovals(serverName, keys...)
+	if err != nil {
+		return nil, err
+	}
+	exact := records[toolName]
+	var legacy *storage.ToolApprovalRecord
+	if hasCollapsed {
+		legacy = records[collapsed]
 	}
 	switch {
-	case exactErr != nil:
-		return legacy, legacyErr
-	case legacyErr != nil:
+	case exact == nil && legacy == nil:
+		return nil, fmt.Errorf("%w: %s", storage.ErrToolApprovalNotFound, storage.ToolApprovalKey(serverName, toolName))
+	case exact == nil:
+		return legacy, nil
+	case legacy == nil:
 		return exact, nil
 	default:
 		return mergeApprovalRecords(exact, legacy), nil

--- a/internal/server/tool_gate.go
+++ b/internal/server/tool_gate.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/preflight"
@@ -102,7 +103,7 @@ func (p *MCPProxyServer) evaluateToolGate(serverName, toolName string) toolGate 
 	gate.serverConfig = serverConfig
 	gate.configDenied = p.isToolConfigDenied(serverName, toolName, serverConfig)
 
-	approval, approvalErr := p.storage.GetToolApproval(serverName, toolName)
+	approval, approvalErr := p.lookupToolApproval(serverName, toolName)
 	switch {
 	case approvalErr == nil:
 		gate.approval = approval
@@ -149,4 +150,27 @@ func approvalStateFor(record *storage.ToolApprovalRecord) *preflight.ApprovalSta
 		CurrentHash:       record.CurrentHash,
 		HashSchemaVersion: record.HashSchemaVersion,
 	}
+}
+
+// lookupToolApproval reads the Spec-032 approval record for one (server, tool)
+// pair, already normalized by normalizeServerTool. The exact raw name is
+// authoritative. When it has no record and the name carries a ":" segment, the
+// record filed under the COLLAPSED name is read instead: runtime's discovery
+// producer (checkToolApprovals) still keys every record it writes by
+// extractToolName(tool.Name) — everything after the first colon — so a
+// discovered "ns:erase" has its pending / changed / user-disabled state stored
+// under "erase". Reading the pair by its exact name only would turn that
+// record's tool into an implicitly-approved one the moment the reader stopped
+// collapsing, which is exactly the fail-open a missing record must not cause.
+// The fallback is the conservative legacy rule until the producer is made
+// exact-name as well (Spec 105 FR-009 follow-up).
+func (p *MCPProxyServer) lookupToolApproval(serverName, toolName string) (*storage.ToolApprovalRecord, error) {
+	approval, err := p.storage.GetToolApproval(serverName, toolName)
+	if err == nil || !errors.Is(err, storage.ErrToolApprovalNotFound) {
+		return approval, err
+	}
+	if _, collapsed, ok := strings.Cut(toolName, ":"); ok && collapsed != "" {
+		return p.storage.GetToolApproval(serverName, collapsed)
+	}
+	return approval, err
 }

--- a/internal/server/tool_gate.go
+++ b/internal/server/tool_gate.go
@@ -79,8 +79,21 @@ func (g toolGate) blockedMessage() string {
 // preflight glue — which reads the same live config — cannot drift from it. In
 // unit tests, where no runtime is wired, currentConfig() is the construction
 // config, so behavior is unchanged there.
+//
+// The pair is normalized here for callers that hold a canonical "server:tool"
+// id. A caller that already holds a SPLIT pair (every dispatch path, and a
+// resolver that normalized once itself) must use evaluateExactToolGate.
 func (p *MCPProxyServer) evaluateToolGate(serverName, toolName string) toolGate {
 	serverName, toolName = normalizeServerTool(serverName, toolName)
+	return p.evaluateExactToolGate(serverName, toolName)
+}
+
+// evaluateExactToolGate is evaluateToolGate for a pair that is already split
+// into server and RAW tool name. It never re-normalizes: a raw name that
+// begins with the server's own prefix ("a:ns:erase" on "a") would otherwise
+// be approval- and config-gated as the suffix tool "ns:erase" while dispatch
+// targets "a:ns:erase" (Spec 105 FR-009).
+func (p *MCPProxyServer) evaluateExactToolGate(serverName, toolName string) toolGate {
 	gate := toolGate{serverName: serverName, toolName: toolName}
 
 	if serverName == "" || toolName == "" {

--- a/internal/server/tool_gate.go
+++ b/internal/server/tool_gate.go
@@ -166,10 +166,13 @@ func approvalStateFor(record *storage.ToolApprovalRecord) *preflight.ApprovalSta
 // exact-only turns a discovered tool's pending / changed lock into an implicit
 // approval, and exact-first lets an approved record left behind by a toggle
 // shadow a later "changed" mark the rug-pull detector wrote under the
-// collapsed key. So both records are read and the MORE RESTRICTIVE one is
-// returned (see approvalRestriction); the exact record wins ties. This is the
-// conservative reader rule until the producers are made exact-name as well
-// (Spec 105 FR-009 follow-up).
+// collapsed key. So both records are read and MERGED (mergeApprovalRecords):
+// the two carry independent facts — the toggle's Disabled flag and the
+// detector's pending / changed lock — and each must reach the classifier,
+// which lets the user block outrank the lock for callability while dispatch
+// keeps answering with the lock's review response (the toolGate.lockStatus
+// contract). This is the conservative reader rule until the producers are
+// made exact-name as well (Spec 105 FR-009 follow-up).
 func (p *MCPProxyServer) lookupToolApproval(serverName, toolName string) (*storage.ToolApprovalRecord, error) {
 	exact, exactErr := p.storage.GetToolApproval(serverName, toolName)
 	if exactErr != nil && !errors.Is(exactErr, storage.ErrToolApprovalNotFound) {
@@ -188,24 +191,32 @@ func (p *MCPProxyServer) lookupToolApproval(serverName, toolName string) (*stora
 		return legacy, legacyErr
 	case legacyErr != nil:
 		return exact, nil
-	case approvalRestriction(legacy) > approvalRestriction(exact):
-		return legacy, nil
 	default:
-		return exact, nil
+		return mergeApprovalRecords(exact, legacy), nil
 	}
 }
 
-// approvalRestriction ranks a record by how preflight.ClassifyTool treats it:
-// 0 admits the tool, 1 locks it while the quarantine gate applies (pending or
-// changed), 2 blocks it unconditionally (user-disabled). A record that carries
-// both a lock and the Disabled flag ranks as the unconditional block.
-func approvalRestriction(record *storage.ToolApprovalRecord) int {
-	switch {
-	case record.Disabled:
-		return 2
-	case record.Status == storage.ToolApprovalStatusPending, record.Status == storage.ToolApprovalStatusChanged:
-		return 1
-	default:
-		return 0
+// mergeApprovalRecords folds the exact-name and collapsed-name records for one
+// raw tool into the single view preflight.ClassifyTool and the dispatch
+// responses consume. The record that carries a quarantine lock (pending or
+// changed) is the base, so Status and the review evidence that goes with it
+// (previous / current description, hashes) come from the producer that wrote
+// the lock; the exact record is the base when neither or both are locked. The
+// user's Disabled flag is OR'd across both, so a toggle filed under either key
+// keeps blocking. The result is a copy — the stored records are never mutated.
+func mergeApprovalRecords(exact, legacy *storage.ToolApprovalRecord) *storage.ToolApprovalRecord {
+	base := exact
+	if approvalLocked(legacy) && !approvalLocked(exact) {
+		base = legacy
 	}
+	merged := *base
+	merged.Disabled = exact.Disabled || legacy.Disabled
+	return &merged
+}
+
+// approvalLocked reports whether a record carries the tool-level quarantine
+// lock (pending or changed) that preflight.ClassifyTool and the dispatch paths
+// honour while the quarantine gate applies.
+func approvalLocked(record *storage.ToolApprovalRecord) bool {
+	return record.Status == storage.ToolApprovalStatusPending || record.Status == storage.ToolApprovalStatusChanged
 }

--- a/internal/storage/bbolt.go
+++ b/internal/storage/bbolt.go
@@ -394,6 +394,37 @@ func (b *BoltDB) GetToolApproval(serverName, toolName string) (*ToolApprovalReco
 	return record, err
 }
 
+// GetToolApprovals reads the approval records for several tools of ONE server
+// inside a single read transaction, so the result is a consistent snapshot: no
+// write can land between the individual key reads the way it can between
+// consecutive GetToolApproval calls. Tools without a record are simply absent
+// from the returned map (there is no ErrToolApprovalNotFound for a partial
+// miss); a decode failure on any key fails the whole read.
+func (b *BoltDB) GetToolApprovals(serverName string, toolNames ...string) (map[string]*ToolApprovalRecord, error) {
+	records := make(map[string]*ToolApprovalRecord, len(toolNames))
+
+	err := b.db.View(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket([]byte(ToolApprovalBucket))
+		for _, toolName := range toolNames {
+			data := bucket.Get([]byte(ToolApprovalKey(serverName, toolName)))
+			if data == nil {
+				continue
+			}
+			record := &ToolApprovalRecord{}
+			if err := record.UnmarshalBinary(data); err != nil {
+				return err
+			}
+			records[toolName] = record
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return records, nil
+}
+
 // ListToolApprovals returns all tool approval records for a server.
 // If serverName is empty, returns all records across all servers.
 func (b *BoltDB) ListToolApprovals(serverName string) ([]*ToolApprovalRecord, error) {

--- a/internal/storage/manager.go
+++ b/internal/storage/manager.go
@@ -512,6 +512,17 @@ func (m *Manager) GetToolApproval(serverName, toolName string) (*ToolApprovalRec
 	return m.db.GetToolApproval(serverName, toolName)
 }
 
+// GetToolApprovals retrieves the approval records for several tools of one
+// server as one consistent snapshot: a single manager read lock and a single
+// storage read transaction cover every key, so no SaveToolApproval can
+// interleave between them. Tools without a record are absent from the map.
+func (m *Manager) GetToolApprovals(serverName string, toolNames ...string) (map[string]*ToolApprovalRecord, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.db.GetToolApprovals(serverName, toolNames...)
+}
+
 // ListToolApprovals returns all tool approval records for a server.
 // If serverName is empty, returns all records across all servers.
 func (m *Manager) ListToolApprovals(serverName string) ([]*ToolApprovalRecord, error) {

--- a/internal/storage/tool_approval_test.go
+++ b/internal/storage/tool_approval_test.go
@@ -320,6 +320,22 @@ func TestToolApprovalRecord_GetToolApprovals_OneSnapshot(t *testing.T) {
 		assert.Equal(t, ToolApprovalStatusChanged, records[""].Status)
 	})
 
+	t.Run("every key is read inside one read transaction", func(t *testing.T) {
+		db := manager.db.db
+		before := db.Stats().TxN
+		records, err := manager.GetToolApprovals("a", "ns:erase", "erase", "")
+		require.NoError(t, err)
+		require.Len(t, records, 3)
+		assert.Equal(t, 1, db.Stats().TxN-before, "three keys, one snapshot")
+
+		before = db.Stats().TxN
+		_, err = manager.GetToolApproval("a", "ns:erase")
+		require.NoError(t, err)
+		_, err = manager.GetToolApproval("a", "erase")
+		require.NoError(t, err)
+		assert.Equal(t, 2, db.Stats().TxN-before, "control: per-key reads are one transaction each, so the oracle bites")
+	})
+
 	t.Run("a corrupt record fails the whole read", func(t *testing.T) {
 		require.NoError(t, manager.db.db.Update(func(tx *bbolt.Tx) error {
 			return tx.Bucket([]byte(ToolApprovalBucket)).Put([]byte(ToolApprovalKey("a", "broken")), []byte("{not json"))

--- a/internal/storage/tool_approval_test.go
+++ b/internal/storage/tool_approval_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
 	"go.uber.org/zap"
 )
 
@@ -272,4 +273,59 @@ func TestToolApprovalRecord_MarshalUnmarshal(t *testing.T) {
 	assert.Equal(t, record.CurrentDescription, result.CurrentDescription)
 	assert.Equal(t, record.PreviousSchema, result.PreviousSchema)
 	assert.Equal(t, record.CurrentSchema, result.CurrentSchema)
+}
+
+func TestToolApprovalRecord_GetToolApprovals_OneSnapshot(t *testing.T) {
+	manager, cleanup := setupTestStorageForToolApproval(t)
+	defer cleanup()
+
+	for _, r := range []*ToolApprovalRecord{
+		{ServerName: "a", ToolName: "ns:erase", Status: ToolApprovalStatusApproved, Disabled: true},
+		{ServerName: "a", ToolName: "erase", Status: ToolApprovalStatusPending, CurrentHash: "h-pending"},
+		{ServerName: "a", ToolName: "", Status: ToolApprovalStatusChanged},
+		{ServerName: "b", ToolName: "erase", Status: ToolApprovalStatusApproved},
+	} {
+		require.NoError(t, manager.SaveToolApproval(r))
+	}
+
+	t.Run("returns every stored key of the server, keyed by tool name", func(t *testing.T) {
+		records, err := manager.GetToolApprovals("a", "ns:erase", "erase")
+		require.NoError(t, err)
+		require.Len(t, records, 2)
+		require.NotNil(t, records["ns:erase"])
+		assert.True(t, records["ns:erase"].Disabled)
+		assert.Equal(t, ToolApprovalStatusApproved, records["ns:erase"].Status)
+		require.NotNil(t, records["erase"])
+		assert.Equal(t, ToolApprovalStatusPending, records["erase"].Status)
+		assert.Equal(t, "h-pending", records["erase"].CurrentHash)
+	})
+
+	t.Run("a missing key is absent, not an error", func(t *testing.T) {
+		records, err := manager.GetToolApprovals("a", "ns:erase", "nope")
+		require.NoError(t, err)
+		require.Len(t, records, 1)
+		_, found := records["nope"]
+		assert.False(t, found)
+
+		records, err = manager.GetToolApprovals("zzz", "ns:erase")
+		require.NoError(t, err)
+		assert.Empty(t, records, "another server's records never leak in")
+	})
+
+	t.Run("the empty tool name is a readable key", func(t *testing.T) {
+		records, err := manager.GetToolApprovals("a", "ns:", "")
+		require.NoError(t, err)
+		require.Len(t, records, 1)
+		require.NotNil(t, records[""])
+		assert.Equal(t, ToolApprovalStatusChanged, records[""].Status)
+	})
+
+	t.Run("a corrupt record fails the whole read", func(t *testing.T) {
+		require.NoError(t, manager.db.db.Update(func(tx *bbolt.Tx) error {
+			return tx.Bucket([]byte(ToolApprovalBucket)).Put([]byte(ToolApprovalKey("a", "broken")), []byte("{not json"))
+		}))
+		records, err := manager.GetToolApprovals("a", "ns:erase", "broken")
+		require.Error(t, err)
+		assert.Nil(t, records, "a partial map must not be handed back as if it were a snapshot")
+	})
 }


### PR DESCRIPTION
Part of Spec 105 (agent-token scope hardening) — FR-009 *target-tier execution*. Spec 105 is the acceptance contract on branch `105-agent-scope-hardening` (not yet merged); the invariant was first stated as Spec 104 FR-016f, which the code comments cite.

## Summary

**The leak.** The retrieve surface (`call_tool_read` / `call_tool_write` / `call_tool_destructive`) authorized an agent token only against the tier of the **variant the caller selected**, never against the tier of the **target tool**. Since the variant is the caller's choice, a `{read}` token could drive a write tool through `call_tool_read` on every configuration (intent validation does not reject a read variant on a write tool), and a destructive tool the same way whenever `intent_declaration.strict_server_validation` is off. Direct-name dispatch and nested code-execution calls already classified the target via `lookupToolPermission`; the retrieve surface did not.

**The fix.** `handleCallToolVariant` now resolves the target's annotation-derived tier through the same `lookupToolPermission` the other two paths use and refuses the call with the token-permission error (plus a `blocked` activity policy decision) when the token lacks that tier — in addition to the existing variant check, and before intent validation.

`lookupToolPermission` itself changes in two ways:
- **Fail closed.** A tool the StateView has not discovered (unknown server, not yet discovered, no runtime) now classifies as `destructive` — the top of the cumulative permission ladder — instead of defaulting to `read`. A discovered tool that publishes no annotations still derives to `read` via `DeriveCallWith` (the existing annotation-defaulting rule).
- **Dead BM25 fallback removed.** The index stores no annotations and a `server:tool` query returns no hits, so the fallback never resolved anything.

The found/not-found distinction is exposed through `lookupToolAnnotationsFound` (normalizing, for canonical-id callers) and `lookupExactToolAnnotations` (for callers that already hold a split `(server, raw tool)` pair); `lookupToolAnnotations` keeps its signature.

## What changed

| File | Change |
|------|--------|
| `internal/server/mcp.go` | Target-tier gate in `handleCallToolVariant` (after the variant check, before intent validation). `lookupToolAnnotationsFound` (normalizing wrapper) over `lookupExactToolAnnotations`, which matches the StateView by the exact raw name only (review rounds 5 and 8: the legacy `server:tool`-prefixed alternative was first demoted to a fallback, then dropped — the StateView copies the upstream's `tool.Name` verbatim, so the alternative was live only when an upstream publishes a self-prefixed colliding name). The pair `handleCallToolVariant` / `handleCallTool` split is never re-normalized (round 7). |
| `internal/server/mcp_code_execution.go` | `lookupToolPermission`: StateView-only, undiscovered → `destructive`, annotation-less discovered → `read`; BM25 fallback removed; contract documented. `tierForAnnotations` shared with the retrieve gate. `policyRefusal`, the jsruntime `ToolAnnotationFunc` bridge and the open-world trust read gate the exact pair (round 7). |
| `internal/server/mcp_visibility.go` | (round 1) `normalizeServerTool` strips a `:`-prefix only when it equals the server name; a foreign `ns:` segment stays part of the raw tool name. (round 7) `isExactToolCallable` split out of `isToolCallable`; the tool-count loops over raw StateView / `ListTools` names and the visibility resolvers use the exact variant after their own single normalization (behaviour-preserving there). |
| `internal/server/tool_gate.go` | (rounds 2–6, 9) `lookupToolApproval` reads the exact raw-name record and the record discovery still files under the collapsed name — including the empty collapsed key a trailing-colon raw name produces (round 5) — in **one** storage snapshot (round 6), and merges them: `mergeApprovalRecords` ranks locks `unlocked < pending < changed` (`approvalLockRank`, round 9) so the higher-ranked record is the base whichever key carries it, exact wins ties, `Disabled` is OR'd, stored records never mutated. `evaluateToolGate` (normalizing) / `evaluateExactToolGate` and `isToolCallable` / `isExactToolCallable` route through it. |
| `internal/storage/manager.go`, `internal/storage/bbolt.go` | (round 6) `GetToolApprovals(server, names...)`: several keys of one server under one `Manager` read lock and one BBolt `View`; missing keys are absent from the map; a corrupt record fails the whole read. |
| `internal/storage/tool_approval_test.go` | (rounds 6–7) `TestToolApprovalRecord_GetToolApprovals_OneSnapshot`: keyed result, missing key absent, empty tool-name key readable, corrupt record fails the read, and a one-transaction oracle (`bbolt Stats().TxN` delta = 1; the per-key control reads 2). |
| `internal/server/mcp_call_tool_target_tier_test.go` | New: target-tier gate, intent handling unchanged, registered-handler coverage, `lookupToolPermission` classification, undiscovered-tool fail-closed, plus the review-round tests listed below. |
| `internal/server/mcp_call_tool_trim_test.go` | Existing interior-padding scope test uses a full-permission fixture (its no-runtime proxy cannot resolve a tier, so the target gate would now refuse before the scope gate under test). |

No frontend, docs, config, REST or MCP surface changes (one new internal storage accessor). Tool-definition goldens under `internal/server/testdata` pass unregenerated. Final branch head: `1c1a8ae0e` (10 commits on top of `origin/main` `c93f79423`).

## Tests

All tests seed real tools into the live `StateView` (the production lookup path) and use `createTestProxyWithRuntime`:

- `TestCallToolRead_ReadOnlyToken_TargetTierEnforced` — `{read}` × {write, destructive} target × strict {on, off}: refused with `Permission denied: token does not have …`, never reaches dispatch (`No client found` absent), activity policy decision is `blocked` and attributes the block to the token.
- `TestCallToolRead_TokenHoldsTargetTier_IntentHandlingUnchanged` — full token on a destructive target via `call_tool_read`: strict on → existing `marked destructive` mismatch; strict off → reaches dispatch.
- `TestCallToolVariants_RegisteredRetrieveModeHandlers_EnforceTargetTier` — the handlers actually registered on the retrieve-mode server (`callToolServer`, which `GetMCPServerForMode` selects) and the default server refuse a `{read,write}` token for all three variants on a destructive target. (The `call_tool_destructive` cell is refused by the pre-existing variant gate and passes with the target-tier check removed — documented in the test comment; the tier gate is bitten by the other cells and the tests below.)
- `TestLookupToolPermission_UnresolvedMetadataIsDestructive` — annotation-less discovered tool → `read`; destructive-annotated → `destructive`; undiscovered tool / unknown server → `destructive`.
- `TestCallToolRead_UndiscoveredTool_RequiresDestructiveTier` — approved-but-undiscovered tool: `{read}` refused with the `destructive` permission error; full token still reaches dispatch.

Added during cross-model review (same file unless noted):

- `TestCallToolRead_NamespacedToolName_IsNotClassifiedAsItsSuffix` — `{read}` on `a:ns:erase` (read-tier `erase` and destructive `ns:erase` on one server) is refused as `destructive`, strict on/off, blocked activity record under `tool_name: ns:erase`.
- `TestToolGate_NamespacedToolName_KeysOnRawName` — an approval record for `erase` does not admit `ns:erase`; `normalizeServerTool` table.
- `TestCallToolRead_TargetTierGate_UpstreamCallOracle` — real in-process counting upstream: permission-disallowed cells produce **0** upstream invocations; positive controls dispatch under the exact raw names `['erase','ns:erase']`.
- `TestToolGate_LegacyCollapsedApprovalRecord_StillGates` — a pending/Disabled record filed under the collapsed name (as `checkToolApprovals` writes it) still gates `a:ns:erase` for a full-tier token, an `IsAdmin()` API-key context (`auth.AdminContext()`) and the no-auth-context path, each as its own cell.
- `TestToolGate_StaleExactApprovalCannotShadowCollapsedChange` — drives the real `rt.SetToolEnabled` producer, then marks the collapsed record `changed`; the stale exact `approved` record can no longer shadow it.
- `TestToolGate_MergedApprovalRecordsKeepIndependentLocks` — exact Disabled + collapsed changed (and mirror / tie) keep `lockStatus` and answer `TOOL_QUARANTINED`/`tool_description_changed` rather than a generic `TOOL_BLOCKED`; round 9 adds the both-locked cells (exact pending + collapsed changed, and mirror) asserting `lockStatus=changed`, the review evidence, the `tool_description_changed` response and the `changed` activity reason.
- `TestLookupToolPermission_ExactRawNameOutranksPrefixedAlternative` (round 5, tightened in round 8) — a read-only StateView tool literally named `a:ns:erase` never resolves the dispatched pair `(a, ns:erase)` in either StateView order; with only the self-prefixed sibling present, `found=false`, the tier is `destructive`, the read-only call is refused before dispatch with zero upstream calls, and positive controls dispatch `a:ns:erase` under its own raw name.
- `TestToolGate_TrailingColonRawName_ReadsProducersEmptyKeyRecord` (round 5) — a raw tool `ns:` is filed by the producer under the empty collapsed key `a:`; that pending lock now reaches the gate (`TOOL_QUARANTINED`, blocked event with `tool_name: ns:`) and a Disabled record reaches `isToolCallable`.
- `TestLookupToolApproval_ReadsBothKeysFromOneSnapshot` (rounds 6–7) — none / exact-only / collapsed-only / both-merged / no-colon outcome table, the merge never writes back, and both keys are read in exactly one storage transaction (`TxN` delta 1; two per-key reads give 2, so reverting to per-key reads fails).
- `TestCallToolRead_ServerPrefixedRawName_IsNotReNormalized` (round 7) — server `a` publishes destructive `a:ns:erase` and read-only `ns:erase`; `{read}` calling `call_tool_read` `a:a:ns:erase` is refused as `destructive` in all four strict × StateView-order cells with zero upstream calls and activity `tool_name: a:ns:erase`; positive controls dispatch raw `ns:erase` and `a:ns:erase`; the exact-name pending lock answers `TOOL_QUARANTINED` on the retrieve surface and in the sandbox gate.
- `internal/storage/tool_approval_test.go`: `TestToolApprovalRecord_GetToolApprovals_OneSnapshot` (round 6, one-transaction oracle in round 7).

Gates run locally on every review round and on the final head `1c1a8ae0e` (all green):

```
gofmt -l <touched files>                                              # clean
go build -o /dev/null ./cmd/mcpproxy                                  # ok
go build -tags server -o /dev/null ./cmd/mcpproxy                     # ok
go test -race -count=1 -skip 'E2E|Binary|MCPProtocol|TestInfoEndpoint|TestGracefulShutdownNoPanic|TestSocketInfoEndpoint' ./internal/server/...   # ok (234s)
go test -race -count=1 ./internal/storage/...                         # ok
/opt/homebrew/bin/golangci-lint run --config .github/.golangci.yml ./internal/server/... ./internal/storage/...   # 0 issues
```

## Verification

Live before/after on an isolated instance (`127.0.0.1:18211`, `--data-dir` + `--config`, personal edition, `enable_web_ui:false`, `quarantine_enabled:false`). One stdio upstream `annot` = a dependency-free Node MCP server exposing three annotated tools and appending every `tools/call` it receives to `upstream_calls.log`:

| tool | readOnlyHint | destructiveHint | derived tier |
|---|---|---|---|
| `read_thing` | true | false | read |
| `write_thing` | false | false | write |
| `delete_thing` | false | true | destructive |

Tokens minted via `POST /api/v1/tokens/`: `readonly` = `{allowed_servers:["annot"], permissions:["read"]}`, `full` = `{read,write,destructive}`. Each call = `initialize` → `notifications/initialized` → `tools/call` on `POST /mcp` with `Authorization: Bearer <agent token>`:

```bash
curl -s -X POST http://127.0.0.1:18211/mcp -H "Authorization: Bearer $TOK" -H "Mcp-Session-Id: $SID" \
  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"<VARIANT>","arguments":{"name":"annot:<TOOL>","args":{"id":"x"}}}}'
```

### Before — `origin/main`, `{read}` token

| # | strict | variant → tool | response | upstream executed? |
|---|---|---|---|---|
| B1 | on | `call_tool_read` → `delete_thing` | `Tool 'annot:delete_thing' is marked destructive by server, use call_tool_destructive` | no (intent validation, not permissions) |
| **B3** | on | `call_tool_read` → `write_thing` | **`UPSTREAM EXECUTED write_thing {"id":"b3"}`** | **YES — leak** |
| **B1s** | off | `call_tool_read` → `delete_thing` | **`UPSTREAM EXECUTED delete_thing {"id":"b1s"}`** | **YES — leak** |
| **B3s** | off | `call_tool_read` → `write_thing` | **`UPSTREAM EXECUTED write_thing {"id":"b3s"}`** | **YES — leak** |

```
2026-09-08T11:10:46.299Z tools/call {"name":"delete_thing","arguments":{"id":"b1s"}}
2026-09-08T11:10:46.667Z tools/call {"name":"write_thing","arguments":{"id":"b3s"}}
```

The activity log recorded these as plain `tool_call/success` with no policy decision.

### After — branch @ `ecf599d59` (round-4 build), `{read}` token

| # | strict | variant → tool | response | upstream executed? |
|---|---|---|---|---|
| A1 / A1s | on / off | `call_tool_read` → `delete_thing` | `Permission denied: token does not have 'destructive' permission required for tool 'annot:delete_thing'` | no |
| A3 / A3s | on / off | `call_tool_read` → `write_thing` | `Permission denied: token does not have 'write' permission required for tool 'annot:write_thing'` | no |
| A2 / A2s | on / off | `call_tool_write` → `delete_thing` | `Insufficient permissions: 'call_tool_write' requires 'write' permission` (existing variant gate, body identical to baseline) | no |
| A4 / A4s | on / off | `call_tool_read` → `read_thing` | `UPSTREAM EXECUTED read_thing` | yes (correct) |
| A8 | on | `call_tool_read` → `nonexistent_tool` (undiscovered) | `Permission denied: token does not have 'destructive' permission required for tool 'annot:nonexistent_tool'` | no (fail closed) |
| A13 / A13s | on / off | `call_tool_read` → `ns:read_thing` (foreign `ns:` prefix, undiscovered) | `Permission denied: … 'destructive' … 'annot:ns:read_thing'` | no — classified by its raw name, not collapsed to the read-tier `read_thing` |

Every refusal is recorded as `policy_decision` / `blocked` with the reason above and the raw dispatched tool name. `upstream_calls.log` contains no `delete_thing` / `write_thing` entry from the read token in either strict mode.

### Positive controls — branch, `{read,write,destructive}` token

| # | strict | variant → tool | response | upstream executed? |
|---|---|---|---|---|
| A5 | on | `call_tool_destructive` → `delete_thing` | `UPSTREAM EXECUTED delete_thing` | yes |
| A6 | on | `call_tool_write` → `write_thing` | `UPSTREAM EXECUTED write_thing` | yes |
| A7 | on | `call_tool_read` → `delete_thing` | `Tool 'annot:delete_thing' is marked destructive by server, use call_tool_destructive` | no (intent validation still runs after the tier gate) |
| A7s | off | `call_tool_read` → `delete_thing` | `UPSTREAM EXECUTED delete_thing` | yes (warning-only mode preserved; token holds the tier) |
| A9s | off | admin `X-API-Key` as Bearer, `call_tool_read` → `delete_thing` | `UPSTREAM EXECUTED delete_thing` | yes (administrator exception) |
| A14 | on | `call_tool_read` → `ns:read_thing` | `UPSTREAM EXECUTED ns:read_thing` | yes — dispatched under the raw name (see follow-ups) |

`upstream_calls.log` for the strict-on run held exactly the four admitted calls (A4, A5, A6, A14) and nothing else.

**Verdict.** Baseline: a `{read}` token executes a write-annotated tool via `call_tool_read` on every config and a destructive-annotated tool when `strict_server_validation` is off. Branch: both refused before dispatch with zero upstream calls and a `blocked` policy-decision record; read → read, every full-token control and the admin path dispatch unchanged; undiscovered tools fail closed as `destructive`; a foreign-prefixed raw name is classified by itself, not by its suffix.

Not exercised live: the exact-vs-collapsed approval-record merge (rounds 2–6, 9), the prefixed / self-prefixed raw-name collisions (rounds 5, 7, 8) and the trailing-colon empty key (round 5) need an upstream that publishes such names and/or a stored approval record; the `annot` fixture has none of them, so the five post-`ecf599d59` commits are covered by the unit tests only. None of them touch the `annot`-shaped paths above (bare names, no records), and the CI unit job re-runs the full suite on the final head.

## Cross-model review

Reviewer: `opencode` with `github-copilot/gpt-6-astra`, **10 rounds** against the full diff + Spec 105 (rounds 1–9 FINDINGS, round 10 CLEAN — the per-PR cap is 10 and it was not exceeded). Each finding was reproduced before it was fixed; each fix round re-ran the CI unit invocation (`go test -race -skip 'E2E|Binary|MCPProtocol|TestInfoEndpoint|TestGracefulShutdownNoPanic|TestSocketInfoEndpoint' ./internal/server/...`, plus `./internal/storage/...` from round 6), golangci-lint v2 (0 issues) and both edition builds before pushing. An earlier round-5 attempt was cut off by the harness before it wrote a verdict (the worktree was removed by another session mid-task and recreated at `ecf599d59`); it was re-run and the row below is the real round 5.

| Round | Verdict | Finding | Disposition |
|---|---|---|---|
| 1 | FINDINGS | **R1-1 (P1)** `normalizeServerTool` stripped any first `:` segment, so `{read}` on `a:ns:erase` classified as read-tier `erase` | **Fixed** (`5c5aeec3f`): strip only when the prefix equals the server name; `isToolCallable` routed through the same helper; two tests added |
| 1 | | R1-2 (P2) unresolved metadata maps to grantable `destructive` rather than refusing every scoped caller | **Declined** — deliberate, documented, strictly tighter than main (was `read`); a hard refusal is a cross-surface change (jsruntime `ToolAnnotationFunc`, nested calls) → follow-up |
| 1 | | R1-3 (P2) tier gate, intent validation and approval gate take independent StateView/storage reads | **Partially fixed**: one `lookupToolAnnotationsFound` read now feeds both the tier gate and intent validation (`tierForAnnotations`); binding the later approval-gate read to the same generation → follow-up |
| 1 | | R1-4 (P3) no upstream-call / dispatched-name oracle | **Fixed**: `TestCallToolRead_TargetTierGate_UpstreamCallOracle` (counting in-process upstream, 0 calls on refusal, exact raw names on dispatch) |
| 2 | FINDINGS | **R2-1 (P1)** regression from R1-1: producers (`checkToolApprovals`) still file records under the collapsed name, so the now-exact readers missed a pending `ns:erase` record and fell to implicit-approved | **Fixed** (`2eddbcbe9`): `lookupToolApproval` reads the exact record and falls back to the collapsed key; both readers use it; test seeds the record as the producer writes it and was shown to fail on the branch / pass on main's reader |
| 2 | | R2-2 (P3) raw tool literally named `<server>:x` is ambiguous with the indexing prefix | **Declined** — pre-existing on main, verbatim; needs an exact-identity carrier from discovery → follow-up (the dispatch half was later closed by R7-1; the discovery half remains) |
| 3 | FINDINGS | **R3-1 (P1)** exact-first precedence let a stale exact `approved` record (synthesised by the enable/disable toggle) shadow a newer collapsed `changed` record | **Fixed** (`d58092934`): read both records, return the more restrictive; test drives the real `rt.SetToolEnabled` producer |
| 4 | FINDINGS | R4-1 (P2) collapsed `approved` record admits `ns:erase` with no exact record | **Declined** — not a regression; today the collapsed record *is* `ns:erase`'s own baseline (`ApproveTools` only mutates existing records), so refusing it would make every namespaced tool un-approvable until the producer is made exact-name → follow-up |
| 4 | | **R4-2 (P2)** returning one record lost the other's lock: exact Disabled + collapsed changed answered generic `TOOL_BLOCKED` with `lockStatus ""` | **Fixed** (`ecf599d59`): `mergeApprovalRecords` — lock-carrying record is the base, `Disabled` OR'd, stored records never mutated; test covers both directions and the tie |
| 4 | | R4-3 (P3) test-vacuity audit: gate is bitten by 5 named tests; compatibility tests pass with or without the guard by design | Informational, no action required |
| 5 | FINDINGS | **R5-1 (P2, reviewer P1)** `lookupToolAnnotationsFound` still accepted the legacy `server:tool`-prefixed spelling, so a raw StateView tool literally named `a:ns:erase` (read-only) matched the dispatched pair `(a, ns:erase)` (destructive) order-dependently; tier gate and intent validation then classified `ns:erase` as read while dispatch targeted `ns:erase`; `lookupToolPermission` (nested) shared it | **Fixed** (`829f3b1e6`): confirmed by a new test failing in the "prefixed listed first" order (a `{read}` token reached dispatch); the exact raw name now always wins and the prefixed spelling became a fallback only when no exact tool exists (dropped entirely in round 8); `TestLookupToolPermission_ExactRawNameOutranksPrefixedAlternative` covers both StateView orders end-to-end |
| 5 | | R5-2 (P3) trailing-colon raw name `a:ns:` lost the pre-diff fail-closed answer: `lookupToolApproval` skipped the empty collapsed key, so the pair was implicitly approved for full-tier / admin callers | **Fixed** (`829f3b1e6`), and sharper than reported: the producer files `ns:` under `(server, "")` and storage accepts the key `a:`, so a pending lock the producer wrote was never read. `lookupToolApproval` now reads and merges the empty collapsed key; `TestToolGate_TrailingColonRawName_ReadsProducersEmptyKeyRecord` failed before / passes after. The remainder (an undiscovered `ns:` with **no** record is implicitly approved for full-tier / admin callers) is the general unresolved-identity policy already in the follow-ups |
| 6 | FINDINGS | R6-1 (P3, reviewer P2) `lookupToolApproval` read the exact and collapsed records in two independent storage reads (each `Manager.GetToolApproval` takes its own RLock), so a merged view could combine two states that never coexisted (exact read approved+enabled, then operator disables exact and approves collapsed before the second read → merge yields approved+enabled); introduced by the diff, not a Go data race | **Fixed** (`5334e7fe8`): confirmed by a throwaway 3 s stress probe (4 readers, writer cycling blocked-only states) that observed 1 torn read in 585 on the pre-fix code and 0 in 1136–1200 reads × 3 runs after. New `Manager.GetToolApprovals` / `BoltDB.GetToolApprovals` read several keys under one read lock and one BBolt `View`; `lookupToolApproval` consumes that single snapshot and maps absence of both records to `ErrToolApprovalNotFound` so the implicit-approved branch is unchanged. Tests in `internal/storage/tool_approval_test.go` and `TestLookupToolApproval_ReadsBothKeysFromOneSnapshot`. Honest note: the interleaving cannot be reproduced deterministically without a test hook (writer-preferring mutex, ~10 ms fsync commits); the behavioural fails-before evidence is the stress probe, kept uncommitted under `.review-tmp/` |
| 7 | FINDINGS | **R7-1 (P2, reviewer P1)** the R5-1 fix held only after `normalizeServerTool`, but `lookupToolAnnotationsFound` and `evaluateToolGate` re-normalized a pair `handleCallToolVariant` had already split: a raw name starting with its own server's prefix (`a:ns:erase` on `a`) was classified, tier-gated, intent-validated and approval-gated as `(a, ns:erase)` while dispatch targeted `a:ns:erase`; on main the strict-on / destructive-first cell was refused by intent validation, so one cell regressed | **Fixed** (`fa18266f2`): confirmed by `TestCallToolRead_ServerPrefixedRawName_IsNotReNormalized` failing in all four strict × order cells (counting upstream recorded the call; `policyRefusal` admitted a pending exact record). `lookupToolAnnotationsFound` / `evaluateToolGate` / `isToolCallable` split into a normalizing wrapper for canonical-id callers plus an exact variant (`lookupExactToolAnnotations`, `evaluateExactToolGate`, `isExactToolCallable`) that never re-normalizes; every split-pair caller switched to it (retrieve tier read + gate, direct gate, `policyRefusal`, jsruntime bridge, open-world trust read, tool-count loops, visibility resolvers after their own single normalization). `normalizeServerTool` unchanged so index-derived callers keep resolving. `describe_tool` (visibility-only, identical on main) still normalizes once → follow-up |
| 7 | | R7-2 (P3) the single-snapshot tests never interleaved a write, so two independent per-key reads (with the merge kept) still passed — vacuous as a regression guard for R6-1 | **Fixed** (`fa18266f2`): no new seam needed — `bbolt Stats().TxN` counts read transactions and `Manager.GetDB()` is exported; both tests now assert the read costs exactly one transaction (per-key control = 2), stable under `-count=10 -race` |
| 7 | | R7-3 (P3) the "api-key admin" cells were `context.Background()` (nil-auth path), not an `IsAdmin()` API-key context; the label overstated what was exercised | **Fixed** (`fa18266f2`): those cells now carry `auth.WithAuthContext(ctx, auth.AdminContext())` and the nil-auth path keeps its own honestly labelled "no auth context" cell in all three tables; test fidelity only |
| 8 | FINDINGS | **R8-1 (P2, reviewer P1)** the prefixed-spelling fallback kept by R5-1 still authorized a *different* raw tool when the dispatched name was absent: server `a` holding read-only `a:ns:erase` and no `ns:erase` made `lookupExactToolAnnotations("a","ns:erase")` report found/read, bypassing even the fail-closed `destructive` default; `{read}` via `call_tool_read` `a:ns:erase` passed the tier gate and dispatch targeted raw `ns:erase`; the nested bridge inherited it | **Fixed** (`a61ff044c`): reproduced (a `{read}` token reached dispatch; upstream answered "tool 'ns:erase' not found"). Verified the alternative is dead on the normal path (`supervisor.go:880` and `upstream/core/client.go:383` copy the upstream `tool.Name` verbatim, so the StateView never holds a self-prefixed name unless the upstream publishes one); `lookupExactToolAnnotations` now matches only the exact raw name and the subtest pinning the fallback was replaced by "undiscovered raw name is not resolved through a self-prefixed sibling" (`found=false`, tier `destructive`, refused with zero upstream calls, positive controls dispatch `a:ns:erase` exactly). Failed before on three assertions, passes after |
| 9 | FINDINGS | R9-1 (P3, reviewer P2) `toolVisibleToSession` re-normalizes the pair `resolveDescribeDefinition` already split, so `describe_tool` id `a:a:ns:erase` tests index presence on raw `a:ns:erase` but gates the suffix `ns:erase`; `suggestCanonicalToolID` passes an already-normalized name into the same function | **Declined** — the `normalizeServerTool` call at `mcp_visibility.go:58` is byte-identical to `origin/main` (`git show`), where it normalized *more* aggressively, so the diff narrows the mismatch; describe-only discovery surface, the corrected dispatch gates refuse the tool, no execution bypass; already the "discovery identity for self-prefixed raw names" follow-up |
| 9 | | R9-2 (P3, reviewer P2) `directCallabilityEvaluator.getToolApproval` (`mcp_direct_callability.go:253`) and `preflightApprovalReader.ToolApproval` (`preflight_glue.go:404`) still read only the exact key, so exact-approved + collapsed-changed is refused by retrieve/nested but admitted by direct dispatch and reported ready by preflight | **Declined** — pre-existing: both call sites are byte-identical to `origin/main` and neither file is in the diff; already a declared follow-up ("Direct-name dispatch and preflight keep exact-only approval lookup"); the in-code "same primitive as every other dispatch path" comment (`mcp.go:2896`) refers to the Spec 098 policy gates, not `lookupToolApproval`; widening the reader change to the direct and preflight surfaces would change behaviour on paths the diff does not touch |
| 9 | | R9-3 (P3, reviewer P2) `mergeApprovalRecords` took the exact record as base whenever it was locked, so exact `ns:erase` pending + collapsed `erase` changed reported `pending` and dropped the changed record's previous/current description and hashes (review evidence and activity reason degraded; execution stayed blocked); no both-locked test cell | **Fixed** (`1c1a8ae0e`): reproduced with a new both-locked cell (`lockStatus=pending`, empty `CurrentDescription`/`CurrentHash`, `new_unapproved_tool` with `current_description:""`). `approvalLockRank` (`unlocked < pending < changed`) picks the higher-ranked record as the base whichever key carries it; exact still wins no-lock / same-lock ties; `Disabled` OR and copy semantics unchanged; dead `approvalLocked` helper removed. Two both-locked cells added (first failed before, both pass after). Precondition is unreachable with today's producers (discovery collapses every lock to the suffix key; toggle/approve/block write only `approved`), so this is reader hardening pinned for exact-name producers |
| 10 | **CLEAN** | No findings. The reviewer restated the FR-009 spec gaps below (all previously declined or carried as follow-ups; no new evidence) | — |

## Follow-ups / Spec 105 gaps

Reviewer spec gaps carried forward (not implemented here by design — the PR ships the retrieve-surface tier gate, the fail-closed default and the conservative *reader* rule for approval records; `tool_gate.go` marks the merged reader as the temporary rule until the producers are made exact-name):

- [ ] **Producer-side exact-name identity (FR-009 end-to-end, SC-005).** `checkToolApprovals` (`internal/runtime/tool_quarantine.go:443-460`, keyed via `extractToolName` at `lifecycle.go:975`) files pending/changed/baseline records under everything after the first colon, and `lifecycle.go:699-719` differential-index maps collapse names the same way, so `erase` and `ns:erase` on one server still merge into one identity through approval-record creation, baseline capture, index updates and direct publication. Fix the producers, migrate legacy collapsed records conservatively (a legacy record approves only the raw name it stores; `ns:erase` stays pending until approved under its own name — today `lookupToolApproval` returns a collapsed-only `approved` record for the namespaced target when no exact record exists, `tool_gate.go:220-221`, R4-1), then make "no record under either key for a tool the discovery snapshot contains" non-callable (`evaluateExactToolGate` keeps the implicit-approved default on `ErrToolApprovalNotFound` at `tool_gate.go:124-125` without consulting the snapshot).
- [ ] **Legacy approval inheritance at the producer** is fail-open: with an approved baseline for raw `erase`, a later-discovered `ns:erase` with identical description/schema gets no separate pending record (hash-match branch, `tool_quarantine.go:~610-647`).
- [ ] **Unresolved / stale identity MUST refuse scoped callers** (FR-009 / US2.5 / SC-002): `tierForAnnotations(found=false)` (`mcp_code_execution.go:1196-1199`) maps to the grantable `destructive` tier, which a `{read,write,destructive}` scoped token still passes (R1-2, seen live as A14 driving an undiscovered `ns:read_thing` through `call_tool_read`; `TestCallToolRead_UndiscoveredTool_RequiresDestructiveTier` pins the narrower behaviour on purpose); the same policy admits an undiscovered `ns:` with no record for full-tier / admin callers (R5-2 remainder). `found=true` comes from name presence alone — nothing proves the StateView entry is fresh, so existing-but-stale metadata is not distinguished from current. Needs a shared not-found / stale sentinel across retrieve, direct and nested dispatch.
- [ ] **Bind the approval gate to the same StateView generation** as the tier/intent read (R1-3 remainder); no stale-resolution detection between the tier check and `evaluateExactToolGate` at dispatch.
- [ ] **Direct-name dispatch and preflight keep exact-only approval lookup** (`mcp_direct_callability.go:253` feeding the registered direct handler at `mcp_routing.go:465`, and `preflight_glue.go:404`, read `storage.GetToolApproval` directly, not `lookupToolApproval`; both byte-identical to `origin/main`, R9-2) and `mcp_routing.go:441-445` still defaults an unresolved annotation to `read`. Consequence: exact-approved + collapsed-changed/pending/Disabled is refused by retrieve and nested dispatch but admitted by direct-name dispatch and reported ready by preflight. FR-009 requires every dispatch path to evaluate the same pair.
- [ ] **Discovery-surface identity for self-prefixed raw names** (R2-2 / R9-1, pre-existing). Dispatch now gates the exact split pair (R7-1), but the discovery surfaces still re-normalize an already-split pair: `toolVisibleToSession` (`mcp_visibility.go:58`, reached by `resolveDescribeDefinition` so `describe_tool` `a:a:ns:erase` resolves as `(a, ns:erase)`, and by `suggestCanonicalToolID`), `classifyServerToolStatus` (`mcp.go:6355` → normalizing `evaluateToolGate`), and the empty-`ServerName` fallbacks in `mcp_entry_builder.go:143-156` / `mcp.go:1855-1863` that split on the first colon. Status / count / annotation surfaces only, no execution bypass.
- [ ] **FR-009 acceptance table (a)**: the 54-cell `{read}`,`{read,write}`,`{read,write,destructive}` × read/write/destructive target × three variants × strict on/off matrix as one table-driven fixture with per-cell classification (the branch samples it); write-target refusals with strict on, strict intent-mismatch cells and unresolved-metadata cells still lack the zero-upstream-call oracle; missing cells: a `{read,destructive}`-without-`write` token and same-tier config-denied pairs (`erase` allowed, `ns:erase` config-denied — only approval-record variants are covered on the retrieve surface).
- [ ] **FR-009 acceptance table (b)**: direct-name dispatch and nested `call_tool` / `call_tools` script matrix with zero-upstream-call oracles, including the US2.6 envelope (outer script succeeds while the nested refusal shows insufficient permission) and same-tier config-denied / unapproved paired-name calls on both paths. The nested-path tests on this branch call `lookupToolPermission` / `policyRefusal` directly rather than driving the script runtime's refusal envelope.
- [ ] **FR-009 real-discovery fixture**: manual-trust server with a baseline, then add read-tier `ns:erase`; assert it is pending under its own name and that direct, retrieve and nested dispatch all refuse with zero upstream calls (current tests seed discovery-shaped approval records by hand; only the toggle producer is real, and the counting-upstream oracle seeds StateView/approvals manually rather than running discovery).
- [ ] **SC-005 administrator fixtures**: the admin cells now drive an explicit `IsAdmin()` API-key context (R7-3) but exercise refusal / lock parity only; no unit-level positive administrator dispatch control through the new gate (live A9s only), no fixture proving both `erase` and `ns:erase` survive real discovery and indexing, and no before/after administrator response-parity comparison.
- [ ] `HasPermission` is exact-match, not hierarchical: a token minted as `[read, destructive]` without `write` passes the target gate for a write tool while `call_tool_write` refuses it. Documented in the code comment; real tokens are minted cumulatively.
- [ ] **Document the annotation-defaulting rule** for users: an annotation-less discovered tool derives to `read` via `DeriveCallWith` (FR-009 "that rule is documented"); today it lives in code comments only, not in the user-facing docs.

## Notes

- Branch was fast-forwarded onto `origin/main` (`c93f79423`) before the first commit; no conflicts.
- This branch does **not** touch `internal/server/profile_tool.go`. The two profile-related Spec 105 branches (`claude/eager-kirch-10f6c2` and `claude/xenodochial-lumiere-5abe75`) both edit that file and will conflict with each other, not with this PR.
