### PR TITLE
fix(security): scope set_profile responses to the caller's token

### DIFF
--- a/docs/features/profiles.md
+++ b/docs/features/profiles.md
@@ -68,7 +68,8 @@ The `set_profile` MCP tool switches the active profile **inside a live session**
 - The selection is keyed by the MCP session id (stable per streamable-HTTP / SSE connection) and persists for the lifetime of that session.
 - It applies to subsequent `retrieve_tools`, `call_tool_*`, `code_execution` and direct-mode (`server__tool`) calls on the base `/mcp` endpoint — `retrieve_tools` searches the profile's per-profile index directly.
 - Passing an empty string (`""`) clears the selection and returns to all servers (the result lists every configured server). A token with a [`profile_pin`](./agent-tokens.md#profile-pinning) keeps its pin — the result then lists the pinned profile's servers, since that is what the session can still reach.
-- An unknown slug is rejected: `unknown profile '<slug>' (available: research, deploy)`.
+- The `servers` list is always bounded by the caller's credential, using the same rule that scopes `retrieve_tools`: for an [agent token](./agent-tokens.md) scoped to specific servers it is the intersection of the selection (all servers, the chosen profile, or the pin) with the token's `allowed_servers`, so a token restricted to one server is never told about the others. API-key and socket callers see the full lists.
+- An unknown slug is rejected: `unknown profile '<slug>' (available: research, deploy)`. For an agent token the `available:` list names only the profiles that token may select — its pin, or the profiles overlapping its `allowed_servers` — not the whole catalogue, and a profile entirely outside the token's reach is rejected with that same error rather than confirmed as existing.
 - Session state is cleared automatically on session close.
 
 `set_profile` is available on the default `/mcp` server and the `call_tool` / `code_execution` routing-mode servers.

--- a/internal/server/profile_tool.go
+++ b/internal/server/profile_tool.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
 	"go.uber.org/zap"
 
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 )
 
@@ -75,14 +77,18 @@ func (p *MCPProxyServer) handleSetProfile(ctx context.Context, request mcp.CallT
 		// reach the resolver denies.
 		if pin != "" {
 			pinnedName, pinnedScope := p.resolveActiveProfile(ctx)
-			return setProfileResult(pinnedName, pinnedScope.AllowedServerNames())
+			return setProfileResult(pinnedName, callerVisibleServers(ctx, pinnedScope.AllowedServerNames()))
 		}
-		return setProfileResult("", allServerNames(cfg))
+		return setProfileResult("", callerVisibleServers(ctx, allServerNames(cfg)))
 	}
 
-	// Validate the slug matches a configured profile.
+	// Validate the slug names a configured profile the caller may select. The
+	// selectable set is computed BEFORE any session mutation or success log, so
+	// a profile outside the caller's reach is indistinguishable from an unknown
+	// one (FR-016b): same error, same `available:` list, no state change.
+	selectable := selectableProfileNames(ctx, cfg)
 	var match *config.ProfileConfig
-	if cfg != nil {
+	if cfg != nil && slices.Contains(selectable, slug) {
 		for i := range cfg.Profiles {
 			if cfg.Profiles[i].Name == slug {
 				match = &cfg.Profiles[i]
@@ -91,7 +97,7 @@ func (p *MCPProxyServer) handleSetProfile(ctx context.Context, request mcp.CallT
 		}
 	}
 	if match == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("unknown profile '%s' (available: %s)", slug, strings.Join(profileNames(cfg), ", "))), nil
+		return mcp.NewToolResultError(fmt.Sprintf("unknown profile '%s' (available: %s)", slug, strings.Join(selectable, ", "))), nil
 	}
 
 	p.sessionStore.SetActiveProfile(sessionID, slug)
@@ -99,7 +105,7 @@ func (p *MCPProxyServer) handleSetProfile(ctx context.Context, request mcp.CallT
 		zap.String("session_id", sessionID),
 		zap.String("profile", slug),
 	)
-	return setProfileResult(slug, match.EffectiveServers(cfg))
+	return setProfileResult(slug, callerVisibleServers(ctx, match.EffectiveServers(cfg)))
 }
 
 // setProfileResult renders the standard set_profile success payload.
@@ -140,6 +146,64 @@ func allServerNames(cfg *config.Config) []string {
 	for _, s := range cfg.Servers {
 		if s != nil {
 			names = append(names, s.Name)
+		}
+	}
+	return names
+}
+
+// callerVisibleServers filters a server list through the caller's credential.
+// set_profile's payload advertises what the session can reach, so a token
+// restricted to server A must never be told about server B — whether the list
+// is "all servers" (cleared selection), a profile's full set, or a pinned
+// profile's scope (Spec 104 FR-016b).
+//
+// The predicate is auth.CanEnumerateServer — the same CanAccessServer rule
+// serverInScope applies to retrieve_tools / describe_tool — so this surface
+// cannot disagree with visibility: admin (API-key / socket / anonymous
+// back-compat) and absent contexts pass everything through untouched; any
+// non-admin context (agent token, server-edition user) keeps only the servers
+// its AllowedServers names, "*" allows all, and an EMPTY list grants nothing.
+func callerVisibleServers(ctx context.Context, servers []string) []string {
+	if !auth.IsScopedCaller(ctx) {
+		return servers
+	}
+	out := make([]string, 0, len(servers))
+	for _, s := range servers {
+		if auth.CanEnumerateServer(ctx, s) {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// selectableProfileNames returns the profile slugs the caller may select. An
+// unrestricted caller may select any configured profile; a profile-pinned
+// token only its pin (and nothing when the pin no longer exists); a scoped
+// caller only the profiles that overlap the servers it can enumerate.
+//
+// This is both the `available:` list of the unknown-slug error and the
+// admission rule for a selection: a profile entirely outside the caller's
+// reach is treated exactly like a nonexistent one, so the error text cannot be
+// used to confirm which profiles the operator has configured (FR-016b).
+func selectableProfileNames(ctx context.Context, cfg *config.Config) []string {
+	if cfg == nil {
+		return nil
+	}
+	if pin := profilePinFromContext(ctx); pin != "" {
+		for i := range cfg.Profiles {
+			if cfg.Profiles[i].Name == pin {
+				return []string{pin}
+			}
+		}
+		return nil
+	}
+	if !auth.IsScopedCaller(ctx) {
+		return profileNames(cfg)
+	}
+	names := make([]string, 0, len(cfg.Profiles))
+	for i := range cfg.Profiles {
+		if len(callerVisibleServers(ctx, cfg.Profiles[i].EffectiveServers(cfg))) > 0 {
+			names = append(names, cfg.Profiles[i].Name)
 		}
 	}
 	return names

--- a/internal/server/profile_tool_test.go
+++ b/internal/server/profile_tool_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -15,12 +16,15 @@ import (
 )
 
 // setProfileCtx builds a request context carrying a stable session id and an
-// optional agent-token profile_pin.
+// optional agent-token profile_pin. The pinned token carries the "*" server
+// wildcard that REST minting defaults to (internal/httpapi/tokens.go) — an
+// agent token with NO allowed_servers grants nothing under CanAccessServer, so
+// a pin-only fixture would model a token that cannot see any server.
 func setProfileCtx(sessionID, pin string) context.Context {
 	helper := mcpserver.NewMCPServer("test", "1.0.0")
 	ctx := helper.WithContext(context.Background(), &fakeClientSession{id: sessionID})
 	if pin != "" {
-		ctx = auth.WithAuthContext(ctx, &auth.AuthContext{Type: auth.AuthTypeAgent, ProfilePin: pin})
+		ctx = auth.WithAuthContext(ctx, &auth.AuthContext{Type: auth.AuthTypeAgent, ProfilePin: pin, AllowedServers: []string{"*"}})
 	}
 	return ctx
 }
@@ -34,6 +38,7 @@ func newSetProfileTestServer() *MCPProxyServer {
 		Profiles: []config.ProfileConfig{
 			{Name: "research", Servers: []string{"research-srv"}},
 			{Name: "deploy", Servers: []string{"deploy-srv"}},
+			{Name: "all", Servers: []string{"research-srv", "deploy-srv"}},
 		},
 	}
 	return &MCPProxyServer{
@@ -105,4 +110,214 @@ func TestHandleSetProfile_UnpinnedUnchanged(t *testing.T) {
 	res := callSetProfileTool(t, p, ctx, "deploy")
 	require.False(t, res.IsError, "unpinned token must switch freely: %s", setProfileResultText(t, res))
 	require.Equal(t, "deploy", p.sessionStore.GetActiveProfile("sess-free"))
+}
+
+// setProfileScopedCtx builds a request context for an UNPINNED agent token
+// whose AllowedServers is restricted to the given servers (Spec 104 FR-016b).
+func setProfileScopedCtx(sessionID string, allowed ...string) context.Context {
+	helper := mcpserver.NewMCPServer("test", "1.0.0")
+	ctx := helper.WithContext(context.Background(), &fakeClientSession{id: sessionID})
+	return auth.WithAuthContext(ctx, &auth.AuthContext{Type: auth.AuthTypeAgent, AllowedServers: allowed})
+}
+
+// setProfileAdminCtx builds a request context for an API-key / socket admin.
+func setProfileAdminCtx(sessionID string) context.Context {
+	helper := mcpserver.NewMCPServer("test", "1.0.0")
+	ctx := helper.WithContext(context.Background(), &fakeClientSession{id: sessionID})
+	return auth.WithAuthContext(ctx, auth.AdminContext())
+}
+
+func setProfileScopedPayload(t *testing.T, res *mcp.CallToolResult) (string, []string) {
+	t.Helper()
+	require.False(t, res.IsError, "unexpected set_profile error: %s", setProfileResultText(t, res))
+	var payload struct {
+		ActiveProfile string   `json:"active_profile"`
+		Servers       []string `json:"servers"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(setProfileResultText(t, res)), &payload))
+	return payload.ActiveProfile, payload.Servers
+}
+
+// TestHandleSetProfile_ScopedTokenClearReportsOnlyAllowedServers: an unpinned
+// agent token restricted to one server that clears its selection must be told
+// about THAT server only — not every configured server (Spec 104 FR-016b).
+func TestHandleSetProfile_ScopedTokenClearReportsOnlyAllowedServers(t *testing.T) {
+	p := newSetProfileTestServer()
+	ctx := setProfileScopedCtx("sess-scoped-clear", "research-srv")
+
+	active, servers := setProfileScopedPayload(t, callSetProfileTool(t, p, ctx, ""))
+	require.Equal(t, "", active)
+	require.ElementsMatch(t, []string{"research-srv"}, servers,
+		"clearing the selection must not enumerate servers outside the token's AllowedServers")
+}
+
+// TestHandleSetProfile_ScopedTokenSelectIntersectsAllowedServers: selecting a
+// profile returns the profile's servers INTERSECTED with the token's
+// AllowedServers, never the profile's complete set (Spec 104 FR-016b).
+func TestHandleSetProfile_ScopedTokenSelectIntersectsAllowedServers(t *testing.T) {
+	p := newSetProfileTestServer()
+	ctx := setProfileScopedCtx("sess-scoped-select", "research-srv")
+
+	active, servers := setProfileScopedPayload(t, callSetProfileTool(t, p, ctx, "all"))
+	require.Equal(t, "all", active)
+	require.ElementsMatch(t, []string{"research-srv"}, servers,
+		"a profile's servers outside the token's AllowedServers must not be reported")
+	require.Equal(t, "all", p.sessionStore.GetActiveProfile("sess-scoped-select"))
+
+}
+
+// TestHandleSetProfile_ScopedTokenDisjointProfileIndistinguishableFromUnknown:
+// a profile entirely outside the token's reach must not be confirmable by
+// probing its name — selecting it yields the SAME error as a nonexistent slug,
+// and the session is not mutated (Spec 104 FR-016b, cross-review finding).
+func TestHandleSetProfile_ScopedTokenDisjointProfileIndistinguishableFromUnknown(t *testing.T) {
+	p := newSetProfileTestServer()
+	ctx := setProfileScopedCtx("sess-scoped-disjoint", "research-srv")
+
+	disjoint := callSetProfileTool(t, p, ctx, "deploy")
+	unknown := callSetProfileTool(t, p, ctx, "nope")
+	require.True(t, disjoint.IsError, "a disjoint profile must not be selectable")
+	require.True(t, unknown.IsError)
+	require.Equal(t,
+		strings.ReplaceAll(setProfileResultText(t, unknown), "'nope'", "'deploy'"),
+		setProfileResultText(t, disjoint),
+		"disjoint and unknown slugs must produce the same error shape")
+	require.NotContains(t, setProfileResultText(t, disjoint), "deploy-srv")
+	require.Equal(t, "", p.sessionStore.GetActiveProfile("sess-scoped-disjoint"))
+}
+
+// TestHandleSetProfile_EmptyAllowlistTokenSeesNothing: an agent token whose
+// AllowedServers is EMPTY grants nothing under CanAccessServer (the predicate
+// serverInScope applies to retrieve_tools), so set_profile must report the
+// same empty reach rather than read "empty" as "unrestricted".
+func TestHandleSetProfile_EmptyAllowlistTokenSeesNothing(t *testing.T) {
+	p := newSetProfileTestServer()
+	ctx := setProfileScopedCtx("sess-empty-allow")
+
+	_, servers := setProfileScopedPayload(t, callSetProfileTool(t, p, ctx, ""))
+	require.Empty(t, servers)
+
+	res := callSetProfileTool(t, p, ctx, "nope")
+	require.True(t, res.IsError)
+	text := setProfileResultText(t, res)
+	for _, name := range []string{"research", "deploy", "all"} {
+		require.NotContains(t, text, name)
+	}
+}
+
+// TestHandleSetProfile_ServerEditionUserScopedLikeVisibility: a server-edition
+// "user" context with a server allowlist is scoped by serverInScope exactly
+// like an agent token, so set_profile applies the same bound.
+func TestHandleSetProfile_ServerEditionUserScopedLikeVisibility(t *testing.T) {
+	p := newSetProfileTestServer()
+	helper := mcpserver.NewMCPServer("test", "1.0.0")
+	ctx := helper.WithContext(context.Background(), &fakeClientSession{id: "sess-user"})
+	ctx = auth.WithAuthContext(ctx, &auth.AuthContext{Type: auth.AuthTypeUser, AllowedServers: []string{"deploy-srv"}})
+
+	_, servers := setProfileScopedPayload(t, callSetProfileTool(t, p, ctx, ""))
+	require.ElementsMatch(t, []string{"deploy-srv"}, servers)
+}
+
+// TestHandleSetProfile_ScopedTokenUnknownSlugDoesNotEnumerateAllProfiles: the
+// invalid-selection error for an agent token names only the profiles the token
+// may select — never profiles entirely outside its reach (Spec 104 FR-016b).
+func TestHandleSetProfile_ScopedTokenUnknownSlugDoesNotEnumerateAllProfiles(t *testing.T) {
+	p := newSetProfileTestServer()
+	ctx := setProfileScopedCtx("sess-scoped-unknown", "research-srv")
+
+	res := callSetProfileTool(t, p, ctx, "nope")
+	require.True(t, res.IsError)
+	text := setProfileResultText(t, res)
+	require.Contains(t, text, "unknown profile 'nope'")
+	require.Contains(t, text, "research", "profiles overlapping the token's scope stay selectable")
+	require.NotContains(t, text, "deploy", "a profile fully outside the token's scope must not be disclosed")
+	require.Equal(t, "", p.sessionStore.GetActiveProfile("sess-scoped-unknown"))
+}
+
+// TestHandleSetProfile_StalePinUnknownSlugDisclosesNoProfiles: a token pinned
+// to a profile that has since been removed reaches the unknown-slug branch
+// (slug == pin passes the pin guard); the error must not enumerate the
+// configured profiles it can never select.
+func TestHandleSetProfile_StalePinUnknownSlugDisclosesNoProfiles(t *testing.T) {
+	p := newSetProfileTestServer()
+	ctx := setProfileCtx("sess-stale-pin", "gone")
+
+	res := callSetProfileTool(t, p, ctx, "gone")
+	require.True(t, res.IsError)
+	text := setProfileResultText(t, res)
+	require.Contains(t, text, "unknown profile 'gone'")
+	require.NotContains(t, text, "available: gone", "a removed pin is not a selectable profile")
+	for _, name := range []string{"research", "deploy", "all"} {
+		require.NotContains(t, text, name)
+	}
+	require.Equal(t, "", p.sessionStore.GetActiveProfile("sess-stale-pin"))
+}
+
+// TestHandleSetProfile_PinnedTokenClearIntersectsAllowedServers: a pinned token
+// whose AllowedServers is narrower than its pin sees the intersection.
+func TestHandleSetProfile_PinnedTokenClearIntersectsAllowedServers(t *testing.T) {
+	p := newSetProfileTestServer()
+	helper := mcpserver.NewMCPServer("test", "1.0.0")
+	ctx := helper.WithContext(context.Background(), &fakeClientSession{id: "sess-pin-narrow"})
+	ctx = auth.WithAuthContext(ctx, &auth.AuthContext{
+		Type: auth.AuthTypeAgent, ProfilePin: "all", AllowedServers: []string{"deploy-srv"},
+	})
+
+	active, servers := setProfileScopedPayload(t, callSetProfileTool(t, p, ctx, ""))
+	require.Equal(t, "all", active)
+	require.ElementsMatch(t, []string{"deploy-srv"}, servers)
+}
+
+// TestHandleSetProfile_AdminUnchanged pins the administrator (API-key / socket)
+// behaviour: full server list on clear, the profile's complete set on select,
+// and every configured profile in the unknown-slug error.
+func TestHandleSetProfile_AdminUnchanged(t *testing.T) {
+	p := newSetProfileTestServer()
+	ctx := setProfileAdminCtx("sess-admin")
+
+	_, servers := setProfileScopedPayload(t, callSetProfileTool(t, p, ctx, ""))
+	require.ElementsMatch(t, []string{"research-srv", "deploy-srv"}, servers)
+
+	active, servers := setProfileScopedPayload(t, callSetProfileTool(t, p, ctx, "all"))
+	require.Equal(t, "all", active)
+	require.ElementsMatch(t, []string{"research-srv", "deploy-srv"}, servers)
+
+	res := callSetProfileTool(t, p, ctx, "nope")
+	require.True(t, res.IsError)
+	text := setProfileResultText(t, res)
+	for _, name := range []string{"research", "deploy", "all"} {
+		require.Contains(t, text, name)
+	}
+}
+
+// TestHandleSetProfile_WildcardTokenUnchanged: an agent token with the "*"
+// wildcard is unrestricted by servers and keeps the full listings.
+func TestHandleSetProfile_WildcardTokenUnchanged(t *testing.T) {
+	p := newSetProfileTestServer()
+	ctx := setProfileScopedCtx("sess-wild", "*")
+
+	_, servers := setProfileScopedPayload(t, callSetProfileTool(t, p, ctx, ""))
+	require.ElementsMatch(t, []string{"research-srv", "deploy-srv"}, servers)
+
+	res := callSetProfileTool(t, p, ctx, "nope")
+	require.True(t, res.IsError)
+	require.Contains(t, setProfileResultText(t, res), "deploy")
+}
+
+// TestHandleSetProfile_PinnedTokenSelectsDisjointPin locks the admission
+// decision: a configured pin is always selectable by its own token (the token
+// already knows its pin exists), even when the pin's servers are disjoint from
+// the token's AllowedServers — the reach is then correctly empty.
+func TestHandleSetProfile_PinnedTokenSelectsDisjointPin(t *testing.T) {
+	p := newSetProfileTestServer()
+	helper := mcpserver.NewMCPServer("test", "1.0.0")
+	ctx := helper.WithContext(context.Background(), &fakeClientSession{id: "sess-pin-disjoint"})
+	ctx = auth.WithAuthContext(ctx, &auth.AuthContext{
+		Type: auth.AuthTypeAgent, ProfilePin: "deploy", AllowedServers: []string{"research-srv"},
+	})
+
+	active, servers := setProfileScopedPayload(t, callSetProfileTool(t, p, ctx, "deploy"))
+	require.Equal(t, "deploy", active)
+	require.Empty(t, servers)
+	require.Equal(t, "deploy", p.sessionStore.GetActiveProfile("sess-pin-disjoint"))
 }

--- a/internal/server/profile_tool_test.go
+++ b/internal/server/profile_tool_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"strings"
 	"testing"
 
@@ -38,7 +39,7 @@ func newSetProfileTestServer() *MCPProxyServer {
 		Profiles: []config.ProfileConfig{
 			{Name: "research", Servers: []string{"research-srv"}},
 			{Name: "deploy", Servers: []string{"deploy-srv"}},
-			{Name: "all", Servers: []string{"research-srv", "deploy-srv"}},
+			{Name: "mixed", Servers: []string{"research-srv", "deploy-srv"}},
 		},
 	}
 	return &MCPProxyServer{
@@ -158,11 +159,11 @@ func TestHandleSetProfile_ScopedTokenSelectIntersectsAllowedServers(t *testing.T
 	p := newSetProfileTestServer()
 	ctx := setProfileScopedCtx("sess-scoped-select", "research-srv")
 
-	active, servers := setProfileScopedPayload(t, callSetProfileTool(t, p, ctx, "all"))
-	require.Equal(t, "all", active)
+	active, servers := setProfileScopedPayload(t, callSetProfileTool(t, p, ctx, "mixed"))
+	require.Equal(t, "mixed", active)
 	require.ElementsMatch(t, []string{"research-srv"}, servers,
 		"a profile's servers outside the token's AllowedServers must not be reported")
-	require.Equal(t, "all", p.sessionStore.GetActiveProfile("sess-scoped-select"))
+	require.Equal(t, "mixed", p.sessionStore.GetActiveProfile("sess-scoped-select"))
 
 }
 
@@ -174,6 +175,11 @@ func TestHandleSetProfile_ScopedTokenDisjointProfileIndistinguishableFromUnknown
 	p := newSetProfileTestServer()
 	ctx := setProfileScopedCtx("sess-scoped-disjoint", "research-srv")
 
+	// Start from a REAL prior selection so "no state change" is not satisfied
+	// vacuously by an implementation that clears the session before refusing.
+	require.False(t, callSetProfileTool(t, p, ctx, "research").IsError)
+	require.Equal(t, "research", p.sessionStore.GetActiveProfile("sess-scoped-disjoint"))
+
 	disjoint := callSetProfileTool(t, p, ctx, "deploy")
 	unknown := callSetProfileTool(t, p, ctx, "nope")
 	require.True(t, disjoint.IsError, "a disjoint profile must not be selectable")
@@ -183,7 +189,37 @@ func TestHandleSetProfile_ScopedTokenDisjointProfileIndistinguishableFromUnknown
 		setProfileResultText(t, disjoint),
 		"disjoint and unknown slugs must produce the same error shape")
 	require.NotContains(t, setProfileResultText(t, disjoint), "deploy-srv")
-	require.Equal(t, "", p.sessionStore.GetActiveProfile("sess-scoped-disjoint"))
+	require.Equal(t, "research", p.sessionStore.GetActiveProfile("sess-scoped-disjoint"),
+		"a refused selection must leave the prior session selection untouched")
+}
+
+// TestHandleSetProfile_ScopedTokenDisjointProfilePresentVsAbsentIdentical is
+// the differential form of the non-disclosure rule: the SAME slug, requested by
+// the SAME scoped token, yields a byte-identical refusal whether the disjoint
+// profile is configured or has been removed — so probing cannot confirm the
+// operator has (or still has) a profile of that name.
+func TestHandleSetProfile_ScopedTokenDisjointProfilePresentVsAbsentIdentical(t *testing.T) {
+	withDeploy := newSetProfileTestServer()
+	withoutDeploy := newSetProfileTestServer()
+	withoutDeploy.config.Profiles = slices.DeleteFunc(slices.Clone(withoutDeploy.config.Profiles), func(pc config.ProfileConfig) bool {
+		return pc.Name == "deploy"
+	})
+	require.Len(t, withoutDeploy.config.Profiles, len(withDeploy.config.Profiles)-1)
+
+	ctx := setProfileScopedCtx("sess-scoped-differential", "research-srv")
+	for _, p := range []*MCPProxyServer{withDeploy, withoutDeploy} {
+		require.False(t, callSetProfileTool(t, p, ctx, "research").IsError)
+	}
+
+	present := callSetProfileTool(t, withDeploy, ctx, "deploy")
+	absent := callSetProfileTool(t, withoutDeploy, ctx, "deploy")
+	require.True(t, present.IsError)
+	require.True(t, absent.IsError)
+	require.Equal(t, setProfileResultText(t, absent), setProfileResultText(t, present),
+		"a configured-but-unreachable profile must be refused exactly like an absent one")
+	for _, p := range []*MCPProxyServer{withDeploy, withoutDeploy} {
+		require.Equal(t, "research", p.sessionStore.GetActiveProfile("sess-scoped-differential"))
+	}
 }
 
 // TestHandleSetProfile_EmptyAllowlistTokenSeesNothing: an agent token whose
@@ -197,10 +233,19 @@ func TestHandleSetProfile_EmptyAllowlistTokenSeesNothing(t *testing.T) {
 	_, servers := setProfileScopedPayload(t, callSetProfileTool(t, p, ctx, ""))
 	require.Empty(t, servers)
 
-	res := callSetProfileTool(t, p, ctx, "nope")
-	require.True(t, res.IsError)
-	text := setProfileResultText(t, res)
-	for _, name := range []string{"research", "deploy", "all"} {
+	// An EXISTING profile is just as unselectable as a nonexistent one for a
+	// token that can reach no server: same refusal, nothing disclosed, no
+	// session mutation.
+	existing := callSetProfileTool(t, p, ctx, "research")
+	unknown := callSetProfileTool(t, p, ctx, "nope")
+	require.True(t, existing.IsError, "an empty-allowlist token must not select any profile")
+	require.True(t, unknown.IsError)
+	require.Equal(t,
+		strings.ReplaceAll(setProfileResultText(t, unknown), "'nope'", "'research'"),
+		setProfileResultText(t, existing))
+	require.Equal(t, "", p.sessionStore.GetActiveProfile("sess-empty-allow"))
+	text := setProfileResultText(t, unknown)
+	for _, name := range []string{"research", "deploy", "mixed"} {
 		require.NotContains(t, text, name)
 	}
 }
@@ -224,6 +269,7 @@ func TestHandleSetProfile_ServerEditionUserScopedLikeVisibility(t *testing.T) {
 func TestHandleSetProfile_ScopedTokenUnknownSlugDoesNotEnumerateAllProfiles(t *testing.T) {
 	p := newSetProfileTestServer()
 	ctx := setProfileScopedCtx("sess-scoped-unknown", "research-srv")
+	require.False(t, callSetProfileTool(t, p, ctx, "mixed").IsError)
 
 	res := callSetProfileTool(t, p, ctx, "nope")
 	require.True(t, res.IsError)
@@ -231,7 +277,8 @@ func TestHandleSetProfile_ScopedTokenUnknownSlugDoesNotEnumerateAllProfiles(t *t
 	require.Contains(t, text, "unknown profile 'nope'")
 	require.Contains(t, text, "research", "profiles overlapping the token's scope stay selectable")
 	require.NotContains(t, text, "deploy", "a profile fully outside the token's scope must not be disclosed")
-	require.Equal(t, "", p.sessionStore.GetActiveProfile("sess-scoped-unknown"))
+	require.Equal(t, "mixed", p.sessionStore.GetActiveProfile("sess-scoped-unknown"),
+		"a refused selection must leave the prior session selection untouched")
 }
 
 // TestHandleSetProfile_StalePinUnknownSlugDisclosesNoProfiles: a token pinned
@@ -241,16 +288,19 @@ func TestHandleSetProfile_ScopedTokenUnknownSlugDoesNotEnumerateAllProfiles(t *t
 func TestHandleSetProfile_StalePinUnknownSlugDisclosesNoProfiles(t *testing.T) {
 	p := newSetProfileTestServer()
 	ctx := setProfileCtx("sess-stale-pin", "gone")
+	// A selection recorded before the pin went stale must survive the refusal.
+	p.sessionStore.SetActiveProfile("sess-stale-pin", "gone")
 
 	res := callSetProfileTool(t, p, ctx, "gone")
 	require.True(t, res.IsError)
 	text := setProfileResultText(t, res)
 	require.Contains(t, text, "unknown profile 'gone'")
 	require.NotContains(t, text, "available: gone", "a removed pin is not a selectable profile")
-	for _, name := range []string{"research", "deploy", "all"} {
+	for _, name := range []string{"research", "deploy", "mixed"} {
 		require.NotContains(t, text, name)
 	}
-	require.Equal(t, "", p.sessionStore.GetActiveProfile("sess-stale-pin"))
+	require.Equal(t, "gone", p.sessionStore.GetActiveProfile("sess-stale-pin"),
+		"a refused selection must leave the prior session selection untouched")
 }
 
 // TestHandleSetProfile_PinnedTokenClearIntersectsAllowedServers: a pinned token
@@ -260,11 +310,11 @@ func TestHandleSetProfile_PinnedTokenClearIntersectsAllowedServers(t *testing.T)
 	helper := mcpserver.NewMCPServer("test", "1.0.0")
 	ctx := helper.WithContext(context.Background(), &fakeClientSession{id: "sess-pin-narrow"})
 	ctx = auth.WithAuthContext(ctx, &auth.AuthContext{
-		Type: auth.AuthTypeAgent, ProfilePin: "all", AllowedServers: []string{"deploy-srv"},
+		Type: auth.AuthTypeAgent, ProfilePin: "mixed", AllowedServers: []string{"deploy-srv"},
 	})
 
 	active, servers := setProfileScopedPayload(t, callSetProfileTool(t, p, ctx, ""))
-	require.Equal(t, "all", active)
+	require.Equal(t, "mixed", active)
 	require.ElementsMatch(t, []string{"deploy-srv"}, servers)
 }
 
@@ -278,14 +328,14 @@ func TestHandleSetProfile_AdminUnchanged(t *testing.T) {
 	_, servers := setProfileScopedPayload(t, callSetProfileTool(t, p, ctx, ""))
 	require.ElementsMatch(t, []string{"research-srv", "deploy-srv"}, servers)
 
-	active, servers := setProfileScopedPayload(t, callSetProfileTool(t, p, ctx, "all"))
-	require.Equal(t, "all", active)
+	active, servers := setProfileScopedPayload(t, callSetProfileTool(t, p, ctx, "mixed"))
+	require.Equal(t, "mixed", active)
 	require.ElementsMatch(t, []string{"research-srv", "deploy-srv"}, servers)
 
 	res := callSetProfileTool(t, p, ctx, "nope")
 	require.True(t, res.IsError)
 	text := setProfileResultText(t, res)
-	for _, name := range []string{"research", "deploy", "all"} {
+	for _, name := range []string{"research", "deploy", "mixed"} {
 		require.Contains(t, text, name)
 	}
 }
@@ -320,4 +370,15 @@ func TestHandleSetProfile_PinnedTokenSelectsDisjointPin(t *testing.T) {
 	require.Equal(t, "deploy", active)
 	require.Empty(t, servers)
 	require.Equal(t, "deploy", p.sessionStore.GetActiveProfile("sess-pin-disjoint"))
+}
+
+// TestSetProfileFixtureIsLoadable guards the shared fixture against slugs that
+// config.ValidateProfiles rejects at load time (reserved names such as "all"):
+// direct handler construction bypasses validation, so without this check the
+// suite could exercise a configuration no real deployment can load.
+func TestSetProfileFixtureIsLoadable(t *testing.T) {
+	p := newSetProfileTestServer()
+	warnings, err := config.ValidateProfiles(p.config)
+	require.NoError(t, err, "the set_profile fixture must be a loadable profile configuration")
+	require.Empty(t, warnings)
 }

--- a/internal/server/profile_tool_test.go
+++ b/internal/server/profile_tool_test.go
@@ -382,3 +382,63 @@ func TestSetProfileFixtureIsLoadable(t *testing.T) {
 	require.NoError(t, err, "the set_profile fixture must be a loadable profile configuration")
 	require.Empty(t, warnings)
 }
+
+// newSetProfileTestServerWithEmptyProfiles extends the shared fixture with the
+// two ways a profile ends up with an empty effective server set: `empty`
+// declares no servers (the deny-all placeholder ValidateProfiles allows with a
+// warning) and `ghost` names only a server that is not configured, so
+// warn-and-skip leaves EffectiveServers empty. Both load in a real deployment.
+func newSetProfileTestServerWithEmptyProfiles(t *testing.T) *MCPProxyServer {
+	t.Helper()
+	p := newSetProfileTestServer()
+	p.config.Profiles = append(slices.Clone(p.config.Profiles),
+		config.ProfileConfig{Name: "empty"},
+		config.ProfileConfig{Name: "ghost", Servers: []string{"missing-srv"}},
+	)
+	warnings, err := config.ValidateProfiles(p.config)
+	require.NoError(t, err, "an empty profile is a legal (warned) configuration")
+	require.Len(t, warnings, 2)
+	return p
+}
+
+// TestHandleSetProfile_WildcardTokenRefusesEmptyProfileAdminSelectsIt locks
+// the Spec 105 "Unrestricted agent tokens" exception (1): an unpinned agent
+// token with the "*" wildcard is still a scoped caller, so a profile whose
+// effective server set is empty intersects nothing it can reach and is refused
+// exactly like an unknown slug — non-disclosing, prior selection preserved —
+// while an administrator keeps selecting it (deny-all placeholder). A shortcut
+// that admits every configured profile to wildcard tokens would fail here.
+func TestHandleSetProfile_WildcardTokenRefusesEmptyProfileAdminSelectsIt(t *testing.T) {
+	for _, slug := range []string{"empty", "ghost"} {
+		t.Run(slug, func(t *testing.T) {
+			p := newSetProfileTestServerWithEmptyProfiles(t)
+
+			agent := setProfileScopedCtx("sess-wild-"+slug, "*")
+			require.False(t, callSetProfileTool(t, p, agent, "research").IsError)
+
+			refused := callSetProfileTool(t, p, agent, slug)
+			require.True(t, refused.IsError, "a wildcard agent must not select a profile with no reachable servers")
+			unknown := callSetProfileTool(t, p, agent, "nope")
+			require.True(t, unknown.IsError)
+			require.Equal(t,
+				strings.ReplaceAll(setProfileResultText(t, unknown), "'nope'", "'"+slug+"'"),
+				setProfileResultText(t, refused),
+				"an empty profile must be refused exactly like a nonexistent one")
+			// The error echoes the caller's own slug; non-disclosure is about
+			// the `available:` list, which must name neither empty profile.
+			_, available, found := strings.Cut(setProfileResultText(t, refused), "available:")
+			require.True(t, found)
+			for _, name := range []string{"empty", "ghost"} {
+				require.NotContains(t, available, name)
+			}
+			require.Equal(t, "research", p.sessionStore.GetActiveProfile("sess-wild-"+slug),
+				"a refused selection must leave the prior session selection untouched")
+
+			admin := setProfileAdminCtx("sess-admin-" + slug)
+			active, servers := setProfileScopedPayload(t, callSetProfileTool(t, p, admin, slug))
+			require.Equal(t, slug, active)
+			require.Empty(t, servers)
+			require.Equal(t, slug, p.sessionStore.GetActiveProfile("sess-admin-"+slug))
+		})
+	}
+}


### PR DESCRIPTION
Part of Spec 105 (agent-token scope hardening) — FR-003. Lineage: Spec 104 FR-016 / FR-016b.

## Summary

**The leak.** `set_profile` answered every caller with unscoped data:

- An agent token restricted to `allowed_servers: ["research-srv"]` that cleared its selection (`""`) was handed the **complete configured server list**.
- One that selected a profile was handed that profile's **full server set**, including servers the token can never reach.
- The unknown-slug refusal listed **every configured profile**, so probing a slug confirmed whether the operator had configured it (`unknown profile 'x' (available: research, deploy, ...)`), and a profile entirely outside the token's reach was *selectable* (session mutated, success logged) even though the token could use nothing in it.

Each of these contradicts the `CanAccessServer` bound that `retrieve_tools` / `describe_tool` already enforce through `serverInScope` (Spec 028 / #1166).

**The fix.** The same predicate is threaded through `set_profile`:

- `callerVisibleServers` filters every `servers` payload — clear, select, and pinned-clear — through `auth.CanEnumerateServer`. A non-admin context (agent token, server-edition user) sees only the intersection of the selection with its `AllowedServers`; `"*"` passes everything; an **empty** allowlist grants nothing (matching `CanAccessServer`, not the "unrestricted" reading `preflight.ResolveScope` uses); admin / socket / absent contexts are passed through untouched.
- `selectableProfileNames` is both the admission rule for a slug and the `available:` list of the refusal: an unrestricted caller may select any profile; a pinned token only its still-configured pin; a scoped caller only the profiles overlapping the servers it can enumerate. It is computed **before** any session mutation, so a non-selectable profile yields byte-for-byte the same refusal as a nonexistent slug and never touches session state. No non-selectable profile is ever named.

The `set_profile` tool description is unchanged, so the frozen `tools/list` goldens under `internal/server/testdata` pass unregenerated.

## What changed

| File | Change |
|------|--------|
| `internal/server/profile_tool.go` | `callerVisibleServers` + `selectableProfileNames`; admission check + `available:` list use the selectable set; all three success payloads filtered. |
| `internal/server/profile_tool_test.go` | 11 new handler tests (see below); pinned fixture now carries `AllowedServers: ["*"]` as REST minting does, since a pin-only token models one that can see nothing. |
| `docs/features/profiles.md` | Documents the credential bound on `servers` and on the `available:` list. |

## Tests

`internal/server/profile_tool_test.go`:

- `ScopedTokenClearReportsOnlyAllowedServers` — clear reports only the token's servers.
- `ScopedTokenSelectIntersectsAllowedServers` — select returns profile ∩ allowed; selection is stored.
- `ScopedTokenDisjointProfileIndistinguishableFromUnknown` — disjoint vs nonexistent slug: identical error shape, no server names, no session mutation.
- `EmptyAllowlistTokenSeesNothing` — empty allowlist: empty `servers`, refusal names no profile.
- `ServerEditionUserScopedLikeVisibility` — `AuthTypeUser` with an allowlist is bounded the same way.
- `ScopedTokenUnknownSlugDoesNotEnumerateAllProfiles` — refusal names overlapping profiles only.
- `StalePinUnknownSlugDisclosesNoProfiles` — a removed pin discloses nothing and is not listed as available.
- `PinnedTokenClearIntersectsAllowedServers` — pin narrower than allowlist → intersection.
- `PinnedTokenSelectsDisjointPin` — a configured pin is always selectable by its own token (it already knows its pin); reach is then empty.
- `AdminUnchanged`, `WildcardTokenUnchanged` — API-key/socket and `"*"` tokens keep full listings.

Added during cross-model review (test-only commits `33486ec1d`, `6d21ce991`; no runtime code changed):

- `ScopedTokenDisjointProfilePresentVsAbsentIdentical` — same scoped token, same slug, one server with the profile configured and one with it deleted: byte-identical refusal, no session mutation on either.
- `ScopedTokenDisjointProfileIndistinguishableFromUnknown`, `ScopedTokenUnknownSlugDoesNotEnumerateAllProfiles`, `StalePinUnknownSlugDisclosesNoProfiles` now seed a real prior selection and assert it survives the refusal (a clear-before-refuse mutant fails 4 tests; the original assertions passed it).
- `EmptyAllowlistTokenSeesNothing` also attempts an existing profile and requires the unknown-slug refusal shape plus no mutation.
- `WildcardTokenRefusesEmptyProfileAdminSelectsIt` — an unpinned `"*"` agent selecting an empty (or unknown-server-only) profile is refused non-disclosingly with its prior selection preserved; an administrator selects it (`servers: []`). A mutant admitting every profile for wildcard tokens passed every earlier test.
- `SetProfileFixtureIsLoadable` — the shared fixture passes `config.ValidateProfiles` (the original fixture slug `all` is reserved and could never load).

## Verification

### Live: baseline vs branch, isolated instance

Isolated core on `127.0.0.1:18241` (own `--data-dir` per binary, own `--config`; Web UI, socket, quarantine and Docker isolation off). Two stdio fixture servers `a` and `b` (2 tools each, both `connected:true` before every run), two profiles `p1 = [a]`, `p2 = [b]`. Baseline binary built from `origin/main` (`c93f79423`); branch binary from `0cc96f141`.

Tokens minted with the CLI against the instance: `mcpproxy token create --name a-only --servers a --permissions read` (`allowed_servers: ["a"]`) and `--name wild --servers '*'` (`["*"]`). Each MCP call is a fresh session: `POST /mcp` `initialize`, then `tools/call` `set_profile` with `Authorization: Bearer <token>` (or `X-API-Key` for admin).

**Baseline (`origin/main`), `a-only` token:**

| `profile` | `content[0].text` |
|---|---|
| `""` | `{"active_profile":"","servers":["a","b"]}` — leaks `b` |
| `"p1"` | `{"active_profile":"p1","servers":["a"]}` |
| `"p2"` | `{"active_profile":"p2","servers":["b"]}` — disjoint profile selectable, leaks `b` |
| `"nonexistent"` | `unknown profile 'nonexistent' (available: p1, p2)` (isError) — enumerates every profile |

Same-session probe: `set_profile "p2"` then `retrieve_tools {"query":"echo"}` → `[]` (session silently moved into a profile the token cannot use; control with `""` → `["a:echo"]`).

**Branch (this PR), `a-only` token:**

| `profile` | `content[0].text` |
|---|---|
| `""` | `{"active_profile":"","servers":["a"]}` |
| `"p1"` | `{"active_profile":"p1","servers":["a"]}` |
| `"p2"` | `unknown profile 'p2' (available: p1)` (isError) |
| `"nonexistent"` | `unknown profile 'nonexistent' (available: p1)` (isError) |

- The two refusal bodies are byte-identical after substituting the echoed slug (`cmp`).
- No state change on refusal: `set_profile "p2"` (refused) then `retrieve_tools` in the same session → `["a:echo"]`; same for `"nonexistent"`.
- Across the whole `a-only` transcript, `b` / `p2` appear only as the caller's own echoed slug; every `servers` payload is `["a"]`; `available:` names only `p1` (the one profile intersecting the token — permitted by FR-003, which bounds naming to selectable profiles).

**Positive controls (branch):**

| caller | call | response |
|---|---|---|
| `wild` token (`["*"]`) | `"p2"` | `{"active_profile":"p2","servers":["b"]}` |
| `wild` token | `""` | `{"active_profile":"","servers":["a","b"]}` |
| `wild` token | `"nonexistent"` | `unknown profile 'nonexistent' (available: p1, p2)` — unrestricted caller keeps the full list |
| admin `X-API-Key` | `""` | `{"active_profile":"","servers":["a","b"]}` |
| admin `X-API-Key` | `"p2"` then `retrieve_tools` | `{"active_profile":"p2","servers":["b"]}` → `["b:echo"]` |

Scope of the live run: personal edition on macOS via streamable-HTTP `/mcp`. The SSE and `/mcp/p/<slug>` routing-mode surfaces and the server-edition `AuthTypeUser` path were not exercised live; the latter is covered by the unit tests only.

### Gates (at `6d21ce991`)

- `go build ./cmd/mcpproxy` and `go build -tags server -o /dev/null ./cmd/mcpproxy` — OK.
- `go test -race -skip 'E2E|Binary|MCPProtocol|TestInfoEndpoint|TestGracefulShutdownNoPanic|TestSocketInfoEndpoint' ./internal/server/...` — `ok internal/server (228.1s)`, `ok internal/server/tokens`, uncached.
- Frozen tool-surface goldens under `internal/server/testdata` pass unregenerated (`git status --short internal/server/testdata` empty).
- `/opt/homebrew/bin/golangci-lint run --config .github/.golangci.yml ./internal/server/...` — 0 issues. `go vet ./internal/server/` clean.
- Diff footprint vs `origin/main`: `internal/server/profile_tool.go`, `internal/server/profile_tool_test.go`, `docs/features/profiles.md`.

## Cross-model review

Reviewer: `opencode` CLI with `github-copilot/gpt-6-astra` (round 2 on opencode 1.18.29), briefed with the diff and the Spec 105 draft. Three rounds, each producing a verdict; two fix→re-review rounds. Every finding was verified against the diff before acting; no runtime code changed after round 0.

**Round 1 — verdict FINDINGS (5)**

| id | sev | disposition |
|---|---|---|
| F1 `set_profile` payloads ignore the `/mcp/p/<slug>` URL scope | P1 | Declined — pre-existing (`main` returned `match.EffectiveServers(cfg)` with no `ProfileScopeFromContext` either) and not a credential leak: every reported server is still inside the token's `AllowedServers`. FR-003 URL-precedence clause → follow-up. |
| F2 pinned-token admission accepts a configured pin with zero reach; deleting the pin flips the reply to a refusal | P2 | Declined — the diff narrows this (on `main` a deleted pin enumerated every profile; now it names nothing). FR-003's predicate is stated for unpinned tokens and the pin was validated at mint time (`validateProfilePin`). Contract decision for Spec 105 → follow-up. |
| F3 pinned clear reports the pin as `active_profile` rather than the stored `""` | P2 | Declined — pre-existing return that the diff only wraps; `docs/features/profiles.md` documents it. FR-003 `active_profile = stored selection` → follow-up. |
| F4 refusal tests start from an empty session, so a clear-before-refuse implementation still passes; no present-vs-absent differential | P2 | Applied (in-scope parts): prior-selection seeding in three refusal tests, `PresentVsAbsentIdentical`, existing-profile attempt in `EmptyAllowlistTokenSeesNothing`. Proven with a mutant (4 tests fail; originals passed it). URL-scope and empty-profile fixtures deferred to follow-ups. |
| F5 fixture slug `all` is in `reservedProfileSlugs` and cannot load | P3 | Applied — renamed to `mixed`, added `SetProfileFixtureIsLoadable` (watched it fail on `all`, pass on `mixed`). |

Fix commit `33486ec1d` (test-only).

**Round 2 — verdict FINDINGS (1)**

| id | sev | disposition |
|---|---|---|
| F1 no test locks the unpinned wildcard agent being refused an empty profile while an admin selects it; a mutant admitting every profile for `"*"` tokens leaves all tests green | P3 | Applied — confirmed the vacuity with that mutant (all `TestHandleSetProfile*` passed), added `WildcardTokenRefusesEmptyProfileAdminSelectsIt` (fails under the mutant, passes on real code). Runtime already behaved correctly; no runtime change. |

Fix commit `6d21ce991` (test-only). Round-1 F1/F3 re-listed by the reviewer as retained follow-ups; F2 re-listed and accepted as intended, no re-argument.

**Round 3 — verdict CLEAN.** No findings. Reviewer re-confirmed the three previously-triaged spec gaps below as retained items with no new evidence.

## Follow-ups / spec-105 gaps (not in this PR)

Reviewer-listed contract points the diff does not cover, carried as follow-ups:

- [ ] FR-003 "token restriction ∩ effective profile, with URL scope still governing where present" (and the Edge Cases URL-precedence bullet): `handleSetProfile` never consults `profile.ProfileScopeFromContext`, so on `/mcp/p/<slug>` the `servers` list reports the selected/cleared profile ∩ token instead of the URL-governed effective scope. Fix: report `ProfileScopeFromContext(ctx) ∩ token` while still storing the selection; add a URL-scoped-context test.
- [ ] FR-003 "`active_profile` reports the stored session selection": the pinned-clear path stores `""` but returns the pin name (also with a stale pin). Fix: return `""`, update `PinnedTokenClearIntersectsAllowedServers` and the `docs/features/profiles.md` line together.
- [ ] FR-003 non-selectable-refusal rule for pinned tokens: `selectableProfileNames` admits a configured pin with empty/disjoint reach (disjoint `AllowedServers`, empty grant, or empty pinned profile), mutating the session, and deleting the profile flips the same request to a refusal — disclosing current existence. `PinnedTokenSelectsDisjointPin` documents today's choice. If a configured-pin exception is intended, the contract must state it; otherwise require a non-empty intersection in the pin branch.
- [ ] Edge Cases "an empty profile is refused through set_profile" for a wildcard agent *pinned* to an empty profile: bypasses the refusal via the pin branch (same root as the item above); no dedicated test.
- [ ] FR-003 regression coverage still missing: a test with a URL scope in context.
- [ ] FR-004 (profile-URL endpoint applies the same selectable-profile predicate; identical status/body across missing / deleted / non-selectable / pin-mismatch for `/mcp/p/<slug>`, `/mcp/p`, `/mcp/p/`) — separate change.
- [ ] Live coverage of the SSE and `/mcp/p/<slug>` transports and the server-edition `AuthTypeUser` path (unit-tested only here).

## Notes

- Both `claude/eager-kirch-10f6c2` and this branch (`claude/xenodochial-lumiere-5abe75`) edit `internal/server/profile_tool.go`; whichever lands second should expect a merge conflict in `handleSetProfile` and the helper block below `allServerNames`.
- `TestGetServerLogs_MissingFileReturnsEmptyNotError` (from #1216, untouched here) failed once in an early full `-race` package run and passed in isolation, on re-run, and in every later uncached full run — test-ordering flake, not a regression from this diff.
- A macOS linker warning (`malformed LC_DYSYMTAB`) appeared while linking the test binary; toolchain noise, unrelated to the change.

