### PR TITLE
fix(security): gate read_cache on the authorization that produced the entry

### DIFF
--- a/docs/features/agent-tokens.md
+++ b/docs/features/agent-tokens.md
@@ -258,6 +258,19 @@ Server scoping is enforced at three levels:
 
    Admin subscribers — the API key, the Web UI, the tray over the unix socket —
    receive every event unchanged; the stream is rendered per connection.
+4. **Cached responses** (`read_cache`) — a truncated response is parked behind
+   a cache key, and the key is a hash, not a credential. Every entry is stamped
+   with the authorization that produced it (server scope, permission tier,
+   profile pin, effective profile, caller kind). `read_cache` refuses, on every
+   page, any request whose own authorization could not have produced the entry,
+   so a narrower token sharing the same MCP session cannot page a broader
+   token's response. An unrestricted admin may read any entry; a token may read
+   its own entries and those of tokens at least as narrow as itself. Profile
+   scope is compared as a server set, so deleting or narrowing a profile after
+   the entry was produced revokes cached access as well (a stale pin resolves to
+   a deny-all scope and reads nothing). An unauthenticated `/mcp` caller ranks
+   below an authenticated admin: it cannot page an entry an API-key admin
+   produced.
 
 ## Administrative Operations Are Admin-Only
 

--- a/docs/features/routing-modes.md
+++ b/docs/features/routing-modes.md
@@ -63,7 +63,7 @@ The default mode uses BM25 full-text search to help AI agents discover relevant 
 - `call_tool_read` — Execute read-only tool calls
 - `call_tool_write` — Execute write tool calls
 - `call_tool_destructive` — Execute destructive tool calls
-- `read_cache` — Access paginated responses
+- `read_cache` — Access paginated responses. Each cached page is stamped with the authorization that produced it (agent-token server scope, permission tier, profile pin, effective profile, caller kind); a request whose own authorization could not have produced the entry is refused on every page, so a narrower token sharing an MCP session cannot read a broader token's response.
 
 **How it works:**
 1. AI agent calls `retrieve_tools` with a natural language query

--- a/internal/cache/authorization.go
+++ b/internal/cache/authorization.go
@@ -1,0 +1,149 @@
+package cache
+
+import "errors"
+
+// Caller kinds recorded on a cache entry. They mirror the auth context types
+// the MCP layer hands out; the cache package keeps its own copy so it does not
+// depend on internal/auth.
+const (
+	CallerKindAdmin     = "admin"      // API-key admin: unrestricted
+	CallerKindAdminUser = "admin_user" // OAuth admin (server edition): unrestricted
+	CallerKindAnonymous = "anonymous"  // unauthenticated /mcp caller (back-compat admin): unrestricted
+	CallerKindAgent     = "agent"      // agent token: bounded by AllowedServers/Permissions/ProfilePin
+	CallerKindUser      = "user"       // OAuth user (server edition): bounded to its own identity
+)
+
+// ErrUnauthorizedRead is returned when a reader's authorization could not have
+// produced the entry it asks for (Spec 104 FR-016a).
+var ErrUnauthorizedRead = errors.New("cache entry was produced under an authorization this request does not hold")
+
+// Authorization is the authorization a cache entry was produced under, and the
+// authorization a read_cache request presents. A cache key is a hash, not a
+// credential: without this record a narrower token on the same MCP session
+// could page a payload a broader token generated.
+type Authorization struct {
+	CallerKind string `json:"caller_kind"`
+	// Principal identifies the caller within its kind: agent name for agent
+	// tokens, user id for OAuth users. Empty for unrestricted kinds.
+	Principal string `json:"principal,omitempty"`
+	// AllowedServers is the agent token's server scope ("*" = every server).
+	// nil means unrestricted (admin kinds).
+	AllowedServers []string `json:"allowed_servers,omitempty"`
+	// Permissions is the agent token's permission tier list. nil means
+	// unrestricted (admin kinds).
+	Permissions []string `json:"permissions,omitempty"`
+	// ProfilePin is the agent token's pinned profile ("" = unpinned).
+	ProfilePin string `json:"profile_pin,omitempty"`
+	// Profile is the effective profile the request was bounded to (token pin >
+	// URL profile > session set_profile), "" when unscoped.
+	Profile string `json:"profile,omitempty"`
+	// ProfileScoped is true when a profile bounded the request. It is kept
+	// separate from ProfileServers because a deny-all scope (an empty profile,
+	// or the scope a stale pin resolves to) is scoped with NO servers, which
+	// omitempty could not tell apart from unscoped.
+	ProfileScoped bool `json:"profile_scoped,omitempty"`
+	// ProfileServers is the effective server set of that profile at the time
+	// of the request. The read gate compares server sets, not names: deleting
+	// or narrowing a profile must revoke cached access, and a stale pin keeps
+	// its name while resolving to deny-all.
+	ProfileServers []string `json:"profile_servers,omitempty"`
+}
+
+// Unrestricted reports whether the caller kind carries no server/permission
+// bound of its own.
+func (a Authorization) Unrestricted() bool {
+	switch a.CallerKind {
+	case CallerKindAdmin, CallerKindAdminUser, CallerKindAnonymous:
+		return true
+	}
+	return false
+}
+
+// CouldHaveProduced reports whether reader is at least as broad as the
+// producing authorization a in every dimension — i.e. whether the reader could
+// have generated the entry itself. That is the read gate for read_cache: a
+// reader never sees a payload it could not have obtained by calling the tool.
+//
+// Profile scope is compared first and for every kind: a request bounded to a
+// profile (by pin, URL or set_profile) is narrower than an unscoped one, and a
+// scoped reader must currently cover every server the producer's profile
+// exposed — compared as server sets, so a profile that was deleted (stale pin:
+// same name, deny-all scope) or narrowed since the entry was produced no
+// longer reads it.
+//
+// The anonymous kind is unrestricted for tool calls but is not an identity
+// (auth.AnonymousContext), so it ranks below an authenticated admin: it may
+// read anonymous, agent and user entries, never an authenticated admin's.
+func (a Authorization) CouldHaveProduced(reader Authorization) bool {
+	if reader.ProfileScoped {
+		// A deny-all scope (empty profile, or a stale pin) can call no tool,
+		// so it could not have produced ANY entry — including one that was
+		// stamped deny-all because the profile vanished while the upstream
+		// call was in flight.
+		if len(reader.ProfileServers) == 0 {
+			return false
+		}
+		if !a.ProfileScoped || !coversAll(reader.ProfileServers, a.ProfileServers) {
+			return false
+		}
+	}
+	if reader.Unrestricted() {
+		if reader.CallerKind == CallerKindAnonymous {
+			return a.CallerKind != CallerKindAdmin && a.CallerKind != CallerKindAdminUser
+		}
+		return true
+	}
+	if a.Unrestricted() {
+		return false
+	}
+	if reader.CallerKind != a.CallerKind {
+		return false
+	}
+	switch a.CallerKind {
+	case CallerKindUser:
+		return reader.Principal != "" && reader.Principal == a.Principal
+	case CallerKindAgent:
+		if reader.ProfilePin != "" && reader.ProfilePin != a.ProfilePin {
+			return false
+		}
+		return coversServers(reader.AllowedServers, a.AllowedServers) &&
+			coversAll(reader.Permissions, a.Permissions)
+	}
+	return false
+}
+
+// coversServers reports whether the reader's server scope includes every
+// server in the producer's scope. A "*" wildcard covers everything; only a
+// wildcard covers a wildcard.
+func coversServers(reader, producer []string) bool {
+	readerAll := false
+	for _, s := range reader {
+		if s == "*" {
+			readerAll = true
+			break
+		}
+	}
+	if readerAll {
+		return true
+	}
+	for _, s := range producer {
+		if s == "*" {
+			return false
+		}
+	}
+	return coversAll(reader, producer)
+}
+
+// coversAll reports whether every element of want is present in have.
+func coversAll(have, want []string) bool {
+	set := make(map[string]struct{}, len(have))
+	for _, s := range have {
+		set[s] = struct{}{}
+	}
+	for _, s := range want {
+		if _, ok := set[s]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cache/authorization_test.go
+++ b/internal/cache/authorization_test.go
@@ -1,0 +1,186 @@
+package cache
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// CouldHaveProduced is the read gate: a reader may see an entry only when its
+// own authorization is at least as broad as the one the entry was produced
+// under, in every dimension. "Broader" is the direction that matters — an
+// unrestricted admin could have produced anything, a weather-only token could
+// not have produced a github listing.
+func TestAuthorization_CouldHaveProduced(t *testing.T) {
+	admin := Authorization{CallerKind: CallerKindAdmin}
+	anonymous := Authorization{CallerKind: CallerKindAnonymous}
+	broad := Authorization{CallerKind: CallerKindAgent, Principal: "broad",
+		AllowedServers: []string{"github", "weather"}, Permissions: []string{"read", "write"}}
+	narrow := Authorization{CallerKind: CallerKindAgent, Principal: "narrow",
+		AllowedServers: []string{"weather"}, Permissions: []string{"read"}}
+	wildcard := Authorization{CallerKind: CallerKindAgent, Principal: "star",
+		AllowedServers: []string{"*"}, Permissions: []string{"read", "write", "destructive"}}
+	pinned := Authorization{CallerKind: CallerKindAgent, Principal: "pinned",
+		AllowedServers: []string{"github", "weather"}, Permissions: []string{"read", "write"},
+		ProfilePin: "research", Profile: "research", ProfileScoped: true, ProfileServers: []string{"github"}}
+	otherPin := pinned
+	otherPin.ProfilePin, otherPin.Profile, otherPin.ProfileServers = "deploy", "deploy", []string{"weather"}
+	stalePin := pinned
+	stalePin.ProfileServers = []string{} // the pinned profile was deleted: deny-all scope, same name
+	adminInProfile := Authorization{CallerKind: CallerKindAdmin, Profile: "research",
+		ProfileScoped: true, ProfileServers: []string{"github"}}
+	adminInWiderProfile := Authorization{CallerKind: CallerKindAdmin, Profile: "everything",
+		ProfileScoped: true, ProfileServers: []string{"github", "weather"}}
+	adminInDenyAll := Authorization{CallerKind: CallerKindAdmin, Profile: "research",
+		ProfileScoped: true, ProfileServers: []string{}}
+	alice := Authorization{CallerKind: CallerKindUser, Principal: "user-alice"}
+	bob := Authorization{CallerKind: CallerKindUser, Principal: "user-bob"}
+
+	cases := []struct {
+		name     string
+		producer Authorization
+		reader   Authorization
+		want     bool
+	}{
+		{"same agent token", broad, broad, true},
+		{"narrower server scope", broad, narrow, false},
+		{"narrower permission tier", broad, Authorization{CallerKind: CallerKindAgent,
+			AllowedServers: []string{"github", "weather"}, Permissions: []string{"read"}}, false},
+		{"broader agent may read narrower", narrow, broad, true},
+		{"wildcard server scope covers everything", broad, wildcard, true},
+		{"explicit list does not cover wildcard", wildcard, broad, false},
+		{"admin reads agent entry", broad, admin, true},
+		{"agent cannot read admin entry", admin, broad, false},
+		{"agent cannot read wildcard-less anonymous entry", anonymous, wildcard, false},
+		{"anonymous cannot read an authenticated admin entry", admin, anonymous, false},
+		{"admin reads anonymous", anonymous, admin, true},
+		{"anonymous reads anonymous", anonymous, anonymous, true},
+		{"anonymous reads agent entry", broad, anonymous, true},
+		{"same profile pin", pinned, pinned, true},
+		{"different profile pin", pinned, otherPin, false},
+		{"unpinned reader is broader than pinned producer", pinned, broad, true},
+		{"pinned reader is narrower than unpinned producer", broad, pinned, false},
+		{"admin bound to a URL profile cannot read an unscoped admin entry", admin, adminInProfile, false},
+		{"unscoped admin reads profile-bound admin entry", adminInProfile, admin, true},
+		{"profile whose servers cover the producer's profile", adminInProfile, adminInWiderProfile, true},
+		{"profile whose servers do not cover the producer's profile", adminInWiderProfile, adminInProfile, false},
+		{"deleted profile: same name, deny-all scope, cannot read", adminInProfile, adminInDenyAll, false},
+		{"stale pin (profile deleted) cannot read its own earlier entry", pinned, stalePin, false},
+		{"deny-all reader matches nothing, not even a deny-all-stamped entry", stalePin, stalePin, false},
+		{"deny-all admin reader matches nothing", adminInDenyAll, adminInDenyAll, false},
+		{"anonymous reads a user's entry", alice, anonymous, true},
+		{"anonymous cannot read an admin_user entry", Authorization{CallerKind: CallerKindAdminUser, Principal: "u9"}, anonymous, false},
+		{"same user", alice, alice, true},
+		{"different user", alice, bob, false},
+		{"agent cannot read a user's entry", alice, wildcard, false},
+		{"admin reads a user's entry", alice, admin, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.producer.CouldHaveProduced(tc.reader); got != tc.want {
+				t.Fatalf("producer=%+v reader=%+v: got %v want %v", tc.producer, tc.reader, got, tc.want)
+			}
+		})
+	}
+}
+
+// Entries persisted before producer stamping existed carry no authorization.
+// They are treated as produced by an unrestricted caller with no identity:
+// any unrestricted reader (anonymous /mcp included) may page them, no agent
+// or user may.
+func TestGetRecordsAs_LegacyEntryWithoutProducer(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	m, err := NewManager(db, zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+
+	if err := m.Store("legacy", "github:list", nil, `{"items":[1,2,3]}`, "items", 3); err != nil {
+		t.Fatal(err)
+	}
+	agent := Authorization{CallerKind: CallerKindAgent, AllowedServers: []string{"*"}, Permissions: []string{"read"}}
+	if _, err := m.GetRecordsAs("legacy", 0, 10, agent); !errors.Is(err, ErrUnauthorizedRead) {
+		t.Fatalf("agent reading a legacy entry: got %v, want ErrUnauthorizedRead", err)
+	}
+	if _, err := m.GetRecordsAs("legacy", 0, 10, Authorization{CallerKind: CallerKindAdmin}); err != nil {
+		t.Fatalf("admin reading a legacy entry: %v", err)
+	}
+	if _, err := m.GetRecordsAs("legacy", 0, 10, Authorization{CallerKind: CallerKindAnonymous}); err != nil {
+		t.Fatalf("anonymous reading a legacy entry: %v", err)
+	}
+	user := Authorization{CallerKind: CallerKindUser, Principal: "u1"}
+	if _, err := m.GetRecordsAs("legacy", 0, 10, user); !errors.Is(err, ErrUnauthorizedRead) {
+		t.Fatalf("user reading a legacy entry: got %v, want ErrUnauthorizedRead", err)
+	}
+}
+
+// A refused read must not count as a hit or bump the entry's access stats —
+// otherwise the refusal is visible as "someone read this" in the stats.
+func TestGetRecordsAs_RefusedReadLeavesStatsUntouched(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	m, err := NewManager(db, zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+
+	admin := Authorization{CallerKind: CallerKindAdmin}
+	if err := m.StoreAs("k", "github:list", nil, `{"items":[1,2,3]}`, "items", 3, admin); err != nil {
+		t.Fatal(err)
+	}
+	before := *m.GetStats()
+	agent := Authorization{CallerKind: CallerKindAgent, AllowedServers: []string{"github"}, Permissions: []string{"read"}}
+	if _, err := m.GetRecordsAs("k", 0, 10, agent); !errors.Is(err, ErrUnauthorizedRead) {
+		t.Fatalf("got %v, want ErrUnauthorizedRead", err)
+	}
+	after := *m.GetStats()
+	if before != after {
+		t.Fatalf("refused read changed stats: before=%+v after=%+v", before, after)
+	}
+	rec, ok := m.Peek("k")
+	if !ok || rec.AccessCount != 0 {
+		t.Fatalf("refused read bumped access count: %+v", rec)
+	}
+	if rec.Producer == nil || rec.Producer.CallerKind != CallerKindAdmin {
+		t.Fatalf("producer authorization not persisted with the entry: %+v", rec.Producer)
+	}
+}
+
+// The gate must not change what an authorized reader gets back: the
+// gated page is byte-identical to the ungated one.
+func TestGetRecordsAs_SameAuthorizationIsByteIdentical(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	m, err := NewManager(db, zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+
+	agent := Authorization{CallerKind: CallerKindAgent, Principal: "bot",
+		AllowedServers: []string{"github"}, Permissions: []string{"read"}}
+	content := `{"tools":[{"name":"a","x":1},{"name":"b","x":2},{"name":"c","x":3}]}`
+	if err := m.StoreAs("k", "retrieve_tools", map[string]interface{}{"query": "q"}, content, "tools", 3, agent); err != nil {
+		t.Fatal(err)
+	}
+	for _, offset := range []int{0, 1, 2, 3} {
+		ungated, err := m.GetRecords("k", offset, 2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		gated, err := m.GetRecordsAs("k", offset, 2, agent)
+		if err != nil {
+			t.Fatalf("offset %d: %v", offset, err)
+		}
+		want, _ := json.Marshal(ungated)
+		got, _ := json.Marshal(gated)
+		if string(want) != string(got) {
+			t.Fatalf("offset %d: gated page differs from ungated\n want %s\n got  %s", offset, want, got)
+		}
+	}
+}

--- a/internal/cache/manager.go
+++ b/internal/cache/manager.go
@@ -105,9 +105,22 @@ func NextUniqueTimestamp() time.Time {
 
 var lastKeyNano atomic.Int64
 
-// Store saves a tool response to cache
+// Store saves a tool response to cache with no producer authorization. Such an
+// entry is readable only by unrestricted callers; production callers stamp the
+// producer via StoreAs.
 func (m *Manager) Store(key, toolName string, args map[string]interface{}, content, recordPath string, totalRecords int) error {
+	return m.storeRecord(key, toolName, args, content, recordPath, totalRecords, nil)
+}
+
+// StoreAs saves a tool response to cache stamped with the authorization it was
+// produced under. GetRecordsAs refuses readers that could not have produced it.
+func (m *Manager) StoreAs(key, toolName string, args map[string]interface{}, content, recordPath string, totalRecords int, producer Authorization) error {
+	return m.storeRecord(key, toolName, args, content, recordPath, totalRecords, &producer)
+}
+
+func (m *Manager) storeRecord(key, toolName string, args map[string]interface{}, content, recordPath string, totalRecords int, producer *Authorization) error {
 	record := &Record{
+		Producer:     producer,
 		Key:          key,
 		ToolName:     toolName,
 		Args:         args,
@@ -143,6 +156,13 @@ func (m *Manager) Store(key, toolName string, args map[string]interface{}, conte
 
 // Get retrieves a cached tool response
 func (m *Manager) Get(key string) (*Record, error) {
+	return m.getGuarded(key, nil)
+}
+
+// getGuarded is Get with an optional read gate. The gate runs after the
+// expiry check and BEFORE the access-stats update, so a refused read neither
+// counts as a hit nor marks the entry as accessed.
+func (m *Manager) getGuarded(key string, guard func(*Record) error) (*Record, error) {
 	var record *Record
 
 	err := m.db.Update(func(tx *bbolt.Tx) error {
@@ -169,6 +189,13 @@ func (m *Manager) Get(key string) (*Record, error) {
 			return fmt.Errorf("cache key expired")
 		}
 
+		if guard != nil {
+			if err := guard(record); err != nil {
+				record = nil
+				return err
+			}
+		}
+
 		// Update access stats
 		record.AccessCount++
 		record.LastAccessed = time.Now()
@@ -189,9 +216,33 @@ func (m *Manager) Get(key string) (*Record, error) {
 	return record, err
 }
 
-// GetRecords retrieves paginated records from a cached response
+// GetRecords retrieves paginated records from a cached response without a
+// read gate. Callers serving a credentialed request use GetRecordsAs.
 func (m *Manager) GetRecords(key string, offset, limit int) (*ReadCacheResponse, error) {
-	record, err := m.Get(key)
+	return m.getRecords(key, offset, limit, nil)
+}
+
+// GetRecordsAs retrieves paginated records from a cached response, refusing
+// with ErrUnauthorizedRead when reader could not have produced the entry
+// (Spec 104 FR-016a). The gate runs on every page. An entry with no recorded
+// producer (persisted before stamping existed, or written through Store by an
+// internal caller) is treated as produced by an unrestricted caller with no
+// identity — readable by any unrestricted kind, never by an agent or user.
+func (m *Manager) GetRecordsAs(key string, offset, limit int, reader Authorization) (*ReadCacheResponse, error) {
+	return m.getRecords(key, offset, limit, func(r *Record) error {
+		producer := Authorization{CallerKind: CallerKindAnonymous}
+		if r.Producer != nil {
+			producer = *r.Producer
+		}
+		if !producer.CouldHaveProduced(reader) {
+			return ErrUnauthorizedRead
+		}
+		return nil
+	})
+}
+
+func (m *Manager) getRecords(key string, offset, limit int, guard func(*Record) error) (*ReadCacheResponse, error) {
+	record, err := m.getGuarded(key, guard)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cache/models.go
+++ b/internal/cache/models.go
@@ -19,6 +19,11 @@ type Record struct {
 	AccessCount  int                    `json:"access_count"`
 	LastAccessed time.Time              `json:"last_accessed"`
 	CreatedAt    time.Time              `json:"created_at"`
+	// Producer is the authorization the entry was produced under (Spec 104
+	// FR-016a). nil on entries persisted before stamping existed or written
+	// through Store by internal callers; those are readable only by
+	// unrestricted callers.
+	Producer *Authorization `json:"producer,omitempty"`
 }
 
 // Stats represents cache statistics

--- a/internal/server/cache_authz.go
+++ b/internal/server/cache_authz.go
@@ -1,0 +1,86 @@
+package server
+
+import (
+	"context"
+	"sort"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/cache"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/profile"
+)
+
+// cacheAuthorization derives the authorization a request acts under, in the
+// shape the cache stamps on entries and checks on reads (Spec 104 FR-016a):
+// caller kind, principal, agent server scope, permission tier, profile pin and
+// the effective profile (token pin > URL > session set_profile).
+//
+// A request with no auth context at all is the unauthenticated /mcp path,
+// which the auth middleware would otherwise have handed an anonymous admin
+// context — so it is recorded as such rather than as an agent with nothing.
+func (p *MCPProxyServer) cacheAuthorization(ctx context.Context) cache.Authorization {
+	name, scope := p.resolveActiveProfile(ctx)
+	return p.cacheAuthorizationWith(ctx, name, scope)
+}
+
+// cacheAuthorizationWith is cacheAuthorization for a handler that has already
+// resolved the request's effective profile — the same (name, scope) pair it
+// authorized the call against. Handlers capture the producer stamp HERE, before
+// the upstream call, not when the response comes back to be truncated: a
+// profile deleted or narrowed while the call is in flight must not re-stamp a
+// response that was authorized under the wider scope.
+func (p *MCPProxyServer) cacheAuthorizationWith(ctx context.Context, profileName string, scope *profile.ProfileScope) cache.Authorization {
+	a := cache.Authorization{CallerKind: cache.CallerKindAnonymous}
+	if ac := auth.AuthContextFromContext(ctx); ac != nil {
+		switch {
+		case ac.Anonymous:
+			a.CallerKind = cache.CallerKindAnonymous
+		case ac.Type == auth.AuthTypeAgent:
+			a.CallerKind = cache.CallerKindAgent
+			a.Principal = ac.AgentName
+			a.AllowedServers = append([]string(nil), ac.AllowedServers...)
+			a.Permissions = append([]string(nil), ac.Permissions...)
+			a.ProfilePin = ac.ProfilePin
+		case ac.Type == auth.AuthTypeUser:
+			a.CallerKind = cache.CallerKindUser
+			a.Principal = ac.UserID
+		case ac.Type == auth.AuthTypeAdminUser:
+			a.CallerKind = cache.CallerKindAdminUser
+			a.Principal = ac.UserID
+		default:
+			a.CallerKind = cache.CallerKindAdmin
+		}
+	}
+	a.Profile = profileName
+	if scope != nil {
+		a.ProfileScoped = true
+		a.ProfileServers = scope.AllowedServerNames()
+		sort.Strings(a.ProfileServers)
+	}
+	return a
+}
+
+// producerCacheStore is the CacheStore the truncation helpers write through.
+// It carries the producing request's authorization so every entry lands
+// stamped, without the helpers (which have no ctx) needing to know about auth.
+type producerCacheStore struct {
+	store    *cache.Manager
+	producer cache.Authorization
+}
+
+func (s producerCacheStore) Store(key, toolName string, args map[string]interface{}, content, recordPath string, totalRecords int) error {
+	return s.store.StoreAs(key, toolName, args, content, recordPath, totalRecords, s.producer)
+}
+
+// cacheStoreAs returns the CacheStore a handler must write truncated payloads
+// through, stamping every entry with producer — the authorization the handler
+// captured when it authorized the call (never re-sampled at truncation time:
+// read_cache gates the read and re-caches an oversize page, and a concurrent
+// set_profile or profile deletion must not stamp the page under a different
+// scope than the one that passed the gate). Returns an untyped nil when there
+// is no cache manager so the helpers' `cacheStore != nil` short-circuit holds.
+func (p *MCPProxyServer) cacheStoreAs(producer cache.Authorization) CacheStore {
+	if p.cacheManager == nil {
+		return nil
+	}
+	return producerCacheStore{store: p.cacheManager, producer: producer}
+}

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -1705,6 +1705,9 @@ func (p *MCPProxyServer) handleRetrieveToolsWithMode(ctx context.Context, reques
 	// profile that may no longer exist. The post-filter below returns the same
 	// empty result set from the shared index.
 	profileName, profileScope := p.resolveActiveProfile(ctx)
+	// Spec 104 FR-016a: the cache stamp is the authorization THIS search runs
+	// under, captured now rather than re-resolved when the response is cut.
+	producer := p.cacheAuthorizationWith(ctx, profileName, profileScope)
 	searchIndex := p.index
 	if profileName != "" && !profileScope.DeniesAll() {
 		if pIdx, perr := p.index.ForProfile(profileName); perr == nil && pIdx != nil {
@@ -2074,7 +2077,7 @@ func (p *MCPProxyServer) handleRetrieveToolsWithMode(ctx context.Context, reques
 			len(mcpTools),
 			"tools",
 			p.currentTruncator(),
-			p.cacheManager,
+			p.cacheStoreAs(producer),
 			p.logger,
 		)
 	}
@@ -2259,7 +2262,13 @@ func (p *MCPProxyServer) handleCallToolVariant(ctx context.Context, request mcp.
 	// Spec 057 / Profiles v2: profile filter — runs independently of agent-scope
 	// so that unauthenticated /mcp/p/<slug> connections (AdminContext) are still
 	// filtered, and so a base /mcp session that ran set_profile is bounded too.
-	if _, profileScope := p.resolveActiveProfile(ctx); profileScope != nil && !profileScope.Allows(serverName) {
+	// The same resolution is the read_cache producer stamp (Spec 104
+	// FR-016a), captured here — at authorization time, before the upstream
+	// call — so a profile deleted or narrowed while the call is in flight
+	// cannot re-stamp a response that was authorized under the wider scope.
+	profileSlug, profileScope := p.resolveActiveProfile(ctx)
+	producer := p.cacheAuthorizationWith(ctx, profileSlug, profileScope)
+	if profileScope != nil && !profileScope.Allows(serverName) {
 		errMsg := fmt.Sprintf("server '%s' is not in profile '%s'", serverName, profileScope.Name)
 		p.emitActivityPolicyDecision(serverName, actualToolName, getSessionID(), requestID, "blocked", errMsg, telemetry.BlockReasonProfileScope)
 		return mcp.NewToolResultError(errMsg), nil
@@ -2342,10 +2351,9 @@ func (p *MCPProxyServer) handleCallToolVariant(ctx context.Context, request mcp.
 	// requestID was minted above the first policy gate, near the top of this
 	// handler — every activity event below shares that one value.
 
-	// Spec 057 FR-011 / Profiles v2: effective profile slug (token pin > URL >
-	// session set_profile) tagged on every activity record (success AND error
-	// paths) at top-level metadata["profile"].
-	profileSlug, _ := p.resolveActiveProfile(ctx)
+	// Spec 057 FR-011 / Profiles v2: profileSlug (resolved above with the
+	// profile filter; token pin > URL > session set_profile) is tagged on every
+	// activity record (success AND error paths) at top-level metadata["profile"].
 
 	// Spec 028: Inject auth identity into a separate copy for activity logging only.
 	// The original args must not be mutated — upstream servers reject unknown fields
@@ -2679,7 +2687,7 @@ func (p *MCPProxyServer) handleCallToolVariant(ctx context.Context, request mcp.
 		toonDetectionText, toonDecisions = p.encodeToonBlocks(serverName, actualToolName, contentTrust, args, ctr)
 	}
 
-	forwarded, response, wasTruncated := forwardContentResult(result, p.currentTruncator(), p.cacheManager, p.logger, toolName, args)
+	forwarded, response, wasTruncated := forwardContentResult(result, p.currentTruncator(), p.cacheStoreAs(producer), p.logger, toolName, args)
 
 	// Spec 056: output-schema validation. Strict mode blocks a violating result
 	// (returns an error); warn mode forwards unchanged after recording a
@@ -2906,6 +2914,10 @@ func (p *MCPProxyServer) handleCallTool(ctx context.Context, request mcp.CallToo
 		return mcp.NewToolResultError(errMsg), nil
 	}
 
+	// Spec 104 FR-016a: read_cache producer stamp, captured before the
+	// upstream call (see handleCallToolVariant for why not at truncation time).
+	producer := p.cacheAuthorization(ctx)
+
 	// Check connection status before attempting tool call to prevent hanging
 	if client, exists := p.upstreamManager.GetClient(serverName); exists {
 		p.logger.Debug("handleCallTool: client found",
@@ -3121,7 +3133,7 @@ func (p *MCPProxyServer) handleCallTool(ctx context.Context, request mcp.CallToo
 	legacyResponseBytes := rawByteSize(result)
 	legacyRequestBytes := rawByteSize(activityArgs)
 
-	forwarded, response, wasTruncated := forwardContentResult(result, p.currentTruncator(), p.cacheManager, p.logger, toolName, args)
+	forwarded, response, wasTruncated := forwardContentResult(result, p.currentTruncator(), p.cacheStoreAs(producer), p.logger, toolName, args)
 
 	// Spec 056: output-schema validation. Strict mode blocks a violating result
 	// (returns an error); warn mode forwards unchanged after recording a
@@ -5603,28 +5615,39 @@ func (p *MCPProxyServer) handleReadCache(ctx context.Context, request mcp.CallTo
 		"offset": offset,
 		"limit":  limit,
 	}
+	// Spec 028: auth identity on the activity record only (never in the
+	// cache-key derivation input, which stays `args`).
+	activityArgs := injectAuthMetadata(ctx, args)
 
 	// Validate parameters
 	if offset < 0 {
-		p.emitActivityInternalToolCall("read_cache", "", "", "", sessionID, requestID, "error", "Offset must be non-negative", time.Since(startTime).Milliseconds(), args, nil, nil, "")
+		p.emitActivityInternalToolCall("read_cache", "", "", "", sessionID, requestID, "error", "Offset must be non-negative", time.Since(startTime).Milliseconds(), activityArgs, nil, nil, "")
 		return mcp.NewToolResultError("Offset must be non-negative"), nil
 	}
 	if limit <= 0 || limit > 1000 {
-		p.emitActivityInternalToolCall("read_cache", "", "", "", sessionID, requestID, "error", "Limit must be between 1 and 1000", time.Since(startTime).Milliseconds(), args, nil, nil, "")
+		p.emitActivityInternalToolCall("read_cache", "", "", "", sessionID, requestID, "error", "Limit must be between 1 and 1000", time.Since(startTime).Milliseconds(), activityArgs, nil, nil, "")
 		return mcp.NewToolResultError("Limit must be between 1 and 1000"), nil
 	}
 
-	// Retrieve cached data
-	response, err := p.cacheManager.GetRecords(key, offset, limit)
+	// Retrieve cached data. The read is gated on the authorization the entry
+	// was produced under (Spec 104 FR-016a): a cache key is a hash, not a
+	// credential, and the MCP session is shared by whichever tokens present
+	// on it, so a narrower token must not page a payload a broader one
+	// generated. The gate runs here, on every page.
+	reader := p.cacheAuthorization(ctx)
+	response, err := p.cacheManager.GetRecordsAs(key, offset, limit, reader)
 	if err != nil {
-		p.emitActivityInternalToolCall("read_cache", "", "", "", sessionID, requestID, "error", err.Error(), time.Since(startTime).Milliseconds(), args, nil, nil, "")
+		p.emitActivityInternalToolCall("read_cache", "", "", "", sessionID, requestID, "error", err.Error(), time.Since(startTime).Milliseconds(), activityArgs, nil, nil, "")
+		if errors.Is(err, cache.ErrUnauthorizedRead) {
+			return mcp.NewToolResultError("Cache entry is not readable with this credential: it was produced under a broader authorization (server scope, permission tier or profile) than this request holds. Re-run the original tool call with this credential to obtain your own cache key."), nil
+		}
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to retrieve cached data: %v", err)), nil
 	}
 
 	// Serialize response
 	jsonResult, err := json.Marshal(response)
 	if err != nil {
-		p.emitActivityInternalToolCall("read_cache", "", "", "", sessionID, requestID, "error", err.Error(), time.Since(startTime).Milliseconds(), args, nil, nil, "")
+		p.emitActivityInternalToolCall("read_cache", "", "", "", sessionID, requestID, "error", err.Error(), time.Since(startTime).Milliseconds(), activityArgs, nil, nil, "")
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to serialize response: %v", err)), nil
 	}
 
@@ -5641,7 +5664,7 @@ func (p *MCPProxyServer) handleReadCache(ctx context.Context, request mcp.CallTo
 		args,
 		len(response.Records),
 		p.currentTruncator(),
-		p.cacheManager,
+		p.cacheStoreAs(reader),
 		p.logger,
 	)
 
@@ -5661,7 +5684,7 @@ func (p *MCPProxyServer) handleReadCache(ctx context.Context, request mcp.CallTo
 	}
 
 	// Spec 024: Emit success event with args and response
-	p.emitActivityInternalToolCall("read_cache", "", "", "", sessionID, requestID, "success", "", time.Since(startTime).Milliseconds(), args, response, nil, "")
+	p.emitActivityInternalToolCall("read_cache", "", "", "", sessionID, requestID, "success", "", time.Since(startTime).Milliseconds(), activityArgs, response, nil, "")
 
 	return mcp.NewToolResultText(text), nil
 }

--- a/internal/server/mcp_read_cache_authz_test.go
+++ b/internal/server/mcp_read_cache_authz_test.go
@@ -1,0 +1,202 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+)
+
+// A read_cache key is minted for whoever produced the truncated response. The
+// key is a hash, not a credential: nothing about it says which authorization
+// generated the payload behind it. Spec 104 FR-016a: a cache entry must carry
+// the authorization it was produced under, and read_cache must refuse any
+// request whose own authorization could not have produced that entry — on
+// every page, not just the first.
+//
+// Scenario: a broad agent token (github + weather) truncates a retrieve_tools
+// response that lists github tools. A narrower token (weather only) on the SAME
+// MCP session then asks read_cache for the key. Before the fix it got the
+// github tools it could never have discovered itself.
+
+func readCacheAs(t *testing.T, proxy *MCPProxyServer, ctx context.Context, key string, offset int) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{
+		"key": key, "offset": float64(offset), "limit": float64(1),
+	}
+	result, err := proxy.handleReadCache(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	return result
+}
+
+func TestReadCache_NarrowerTokenOnSameSessionCannotReadBroaderEntry(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+	seedEntryBuilderFixture(t, proxy)
+
+	helper := mcpserver.NewMCPServer("test", "1.0.0")
+	session := helper.WithContext(context.Background(), &fakeClientSession{id: "shared-session"})
+
+	broad := auth.WithAuthContext(session, &auth.AuthContext{
+		Type: auth.AuthTypeAgent, AgentName: "broad", TokenPrefix: "mcp_agt_broad",
+		AllowedServers: []string{"github", "weather"},
+		Permissions:    []string{auth.PermRead, auth.PermWrite},
+	})
+	narrow := auth.WithAuthContext(session, &auth.AuthContext{
+		Type: auth.AuthTypeAgent, AgentName: "narrow", TokenPrefix: "mcp_agt_narro",
+		AllowedServers: []string{"weather"},
+		Permissions:    []string{auth.PermRead},
+	})
+
+	args := map[string]interface{}{"query": "manage", "limit": float64(10)}
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+
+	full, err := proxy.handleRetrieveTools(broad, req)
+	require.NoError(t, err)
+	require.False(t, full.IsError)
+	var fullResp retrieveToolsResponse
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, full)), &fullResp))
+	require.GreaterOrEqual(t, len(fullResp.Tools), 2, "fixture must yield at least two pages of one record")
+	require.Contains(t, resultText(t, full), "github:", "premise: the broad response lists a github tool the narrow token cannot see")
+
+	setTruncateLimit(proxy, len(resultText(t, full))/2)
+	truncated, err := proxy.handleRetrieveTools(broad, req)
+	require.NoError(t, err)
+	match := cacheKeyRE.FindStringSubmatch(resultText(t, truncated))
+	require.Len(t, match, 2, "truncated response must carry a read_cache key")
+	key := match[1]
+	setTruncateLimit(proxy, 1_000_000)
+
+	// Every page, not only the first: an attacker who is refused page 0 just
+	// asks for page 1. The refusal must be THE authorization refusal — a
+	// key-not-found or any other error would pass a vacuous "IsError" check.
+	for offset := range fullResp.Tools {
+		result := readCacheAs(t, proxy, narrow, key, offset)
+		assert.True(t, result.IsError, "offset %d: a narrower token must not read a broader token's cache entry", offset)
+		assert.Contains(t, resultText(t, result), "not readable with this credential",
+			"offset %d: refusal must be the authorization gate, not an unrelated failure", offset)
+		assert.NotContains(t, resultText(t, result), "github:",
+			"offset %d: refused read must not leak the out-of-scope payload", offset)
+		assert.NotContains(t, resultText(t, result), `"records"`,
+			"offset %d: refused read must not return a page at all", offset)
+	}
+
+	// Same authorization keeps reading exactly as before.
+	for offset := range fullResp.Tools {
+		result := readCacheAs(t, proxy, broad, key, offset)
+		require.False(t, result.IsError, "offset %d: the producing authorization must still read its own entry", offset)
+		var page struct {
+			Records []map[string]interface{} `json:"records"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(resultText(t, result)), &page))
+		require.Len(t, page.Records, 1)
+		assert.Equal(t, fullResp.Tools[offset]["name"], page.Records[0]["name"])
+	}
+
+	// The narrow token is not blanket-refused: it reads its OWN entries.
+	setTruncateLimit(proxy, 1_000_000)
+	ownFull, err := proxy.handleRetrieveTools(narrow, req)
+	require.NoError(t, err)
+	setTruncateLimit(proxy, len(resultText(t, ownFull))/2)
+	ownTrunc, err := proxy.handleRetrieveTools(narrow, req)
+	require.NoError(t, err)
+	ownMatch := cacheKeyRE.FindStringSubmatch(resultText(t, ownTrunc))
+	require.Len(t, ownMatch, 2, "the narrow token's own oversize response must mint a key")
+	setTruncateLimit(proxy, 1_000_000)
+	own := readCacheAs(t, proxy, narrow, ownMatch[1], 0)
+	require.False(t, own.IsError, "a token must be able to page the entry it produced itself: %s", resultText(t, own))
+	assert.NotContains(t, resultText(t, own), "github:")
+}
+
+// Deleting (or narrowing) a pinned profile after the entry was produced must
+// revoke cached access too: a stale pin resolves to a deny-all scope under the
+// SAME profile name, so a name-only comparison would keep the payload readable
+// for the cache TTL after the operator removed the profile.
+func TestReadCache_DeletedPinnedProfileRevokesCachedAccess(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+	seedEntryBuilderFixture(t, proxy)
+	// EffectiveServers only keeps servers the config knows about.
+	proxy.config.Servers = []*config.ServerConfig{{Name: "github", Enabled: true}, {Name: "weather", Enabled: true}}
+	proxy.config.Profiles = []config.ProfileConfig{{Name: "research", Servers: []string{"github", "weather"}}}
+	// Mimic the production profile-index sync (Profiles v2): the per-profile
+	// index physically holds the profile's servers' tools.
+	pIdx, err := proxy.index.ForProfile("research")
+	require.NoError(t, err)
+	for _, name := range []string{"github:create_issue", "github:list_issues", "github:get_repo", "weather:get_forecast", "weather:search_city"} {
+		require.NoError(t, pIdx.IndexTool(&config.ToolMetadata{
+			Name: name, ServerName: name[:strings.Index(name, ":")],
+			Description: "manage things with " + name, ParamsJSON: `{"type":"object","properties":{"a":{"type":"string"},"b":{"type":"string"}}}`,
+			Hash: "hash-" + name,
+		}))
+	}
+
+	pinned := auth.WithAuthContext(context.Background(), &auth.AuthContext{
+		Type: auth.AuthTypeAgent, AgentName: "pinned", TokenPrefix: "mcp_agt_pinne",
+		AllowedServers: []string{"*"}, Permissions: []string{auth.PermRead},
+		ProfilePin: "research",
+	})
+
+	args := map[string]interface{}{"query": "manage", "limit": float64(10)}
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+	full, err := proxy.handleRetrieveTools(pinned, req)
+	require.NoError(t, err)
+	require.Contains(t, resultText(t, full), "github:", "premise: the pinned profile exposes github")
+	require.GreaterOrEqual(t, len(resultText(t, full)), 800, "premise: the response must be large enough to truncate into a keyed page")
+	setTruncateLimit(proxy, len(resultText(t, full))/2)
+	truncated, err := proxy.handleRetrieveTools(pinned, req)
+	require.NoError(t, err)
+	match := cacheKeyRE.FindStringSubmatch(resultText(t, truncated))
+	require.Len(t, match, 2)
+	setTruncateLimit(proxy, 1_000_000)
+
+	before := readCacheAs(t, proxy, pinned, match[1], 0)
+	require.False(t, before.IsError, "while the profile exists the producing token reads its entry")
+
+	// Operator deletes the profile. The pin now resolves to deny-all.
+	proxy.config.Profiles = nil
+
+	after := readCacheAs(t, proxy, pinned, match[1], 0)
+	assert.True(t, after.IsError, "a deleted pinned profile must revoke cached access")
+	assert.Contains(t, resultText(t, after), "not readable with this credential")
+	assert.NotContains(t, resultText(t, after), "github:")
+}
+
+// The reverse direction stays open: an admin (unrestricted) reader could have
+// produced anything an agent token produced.
+func TestReadCache_BroaderReaderMayReadNarrowerEntry(t *testing.T) {
+	proxy := createTestMCPProxyServer(t)
+	seedEntryBuilderFixture(t, proxy)
+
+	agent := auth.WithAuthContext(context.Background(), &auth.AuthContext{
+		Type: auth.AuthTypeAgent, AgentName: "narrow", TokenPrefix: "mcp_agt_narro",
+		AllowedServers: []string{"github", "weather"},
+		Permissions:    []string{auth.PermRead},
+	})
+
+	args := map[string]interface{}{"query": "manage", "limit": float64(10)}
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+	full, err := proxy.handleRetrieveTools(agent, req)
+	require.NoError(t, err)
+	setTruncateLimit(proxy, len(resultText(t, full))/2)
+	truncated, err := proxy.handleRetrieveTools(agent, req)
+	require.NoError(t, err)
+	match := cacheKeyRE.FindStringSubmatch(resultText(t, truncated))
+	require.Len(t, match, 2)
+	setTruncateLimit(proxy, 1_000_000)
+
+	admin := auth.WithAuthContext(context.Background(), auth.AdminContext())
+	result := readCacheAs(t, proxy, admin, match[1], 0)
+	assert.False(t, result.IsError, "an unrestricted admin could have produced the entry, so it may read it")
+}


### PR DESCRIPTION
Part of Spec 105 (agent-token scope hardening) — FR-001 / FR-002. Spec 105 is the acceptance contract on branch `105-agent-scope-hardening` (not yet merged); this fix was built against the Spec 104 FR-016a lineage that requirement descends from.

## Summary

**The leak.** A `read_cache` key is a hash of the truncated response, not a credential. `handleReadCache` resolved the key without looking at who was asking, so any credential that could present a key on the shared MCP session — or on another session, or through the REST direct-call path (`/api/v1/tools/call` routes `read_cache` to the same handler) — could page the full payload a broader credential had produced. Concretely: an agent token scoped to `github,weather` runs `retrieve_tools`, the response is truncated and parked behind a key; a `weather`-only token on the same session calls `read_cache` with that key and receives the github tools it can never discover itself, on every page.

**The fix.** Every cache entry now carries the authorization it was produced under (`cache.Authorization`: caller kind, principal, agent server scope, permission tier, profile pin, and the effective profile as a **server set**). `read_cache` reads through `Manager.GetRecordsAs`, which refuses — on every page — any reader that could not have produced the entry. The order is caller kind first: an admin (API key / OAuth admin) reads anything; an agent token never reads an admin's entry; between agents the server set, permission set and profile scope of the reader must each cover the snapshot's; an OAuth user reads only its own entries; the unauthenticated `/mcp` back-compat caller ranks below an authenticated admin. Profile scope is compared as a server set, so deleting or narrowing a profile after the entry was written revokes cached access (a stale pin resolves to deny-all, and a deny-all reader matches nothing). The stamp is captured when the handler authorizes the call — before the upstream round-trip — so a `set_profile` or profile deletion in flight cannot re-stamp the response under a scope that never passed the gate. A refused read touches neither the access stats nor the record; a same-authorization read is byte-identical to the previous ungated page.

## What changed

| File | Change |
|---|---|
| `internal/cache/authorization.go` | New: `Authorization` snapshot type, caller-kind constants, `ErrUnauthorizedRead`, `CouldHaveProduced` superset rule (kind → profile server set → server scope / permission tier / pin). |
| `internal/cache/models.go` | `Record.Producer *Authorization` (`json:"producer,omitempty"`), persisted with the entry. |
| `internal/cache/manager.go` | `StoreAs` (stamped write), `GetRecordsAs` (gated read, gate runs after expiry and before the access-stats bump); `Store`/`GetRecords` keep their old unstamped/ungated behaviour for internal callers. |
| `internal/server/cache_authz.go` | New: `cacheAuthorization` / `cacheAuthorizationWith` derive the snapshot from the auth context + resolved profile; `producerCacheStore` / `cacheStoreAs` adapt the `CacheStore` seam so the truncation helpers write stamped entries without knowing about auth. |
| `internal/server/mcp.go` | `handleRetrieveToolsWithMode`, `handleCallToolVariant`, `handleCallTool` capture the producer stamp at authorization time and truncate through `cacheStoreAs(producer)`; `handleReadCache` reads through `GetRecordsAs(reader)`, maps `ErrUnauthorizedRead` to a tool error, re-caches an oversize page under the reader's stamp, and now tags the Spec 028 auth identity onto its activity records. |
| `internal/cache/authorization_test.go` | Superset table + legacy-entry, untouched-stats and byte-identical-page tests. |
| `internal/server/mcp_read_cache_authz_test.go` | Handler-level tests: narrower token on the same session refused on every page (and still reads its own entries), deleted pinned profile revokes access, admin reads an agent entry. |
| `docs/features/agent-tokens.md`, `docs/features/routing-modes.md` | Document the cache stamp as the fourth enforcement level. |

No new dependencies. Tool-surface goldens under `internal/server/testdata` are untouched and pass unregenerated.

## Tests

- `TestAuthorization_CouldHaveProduced` (31 cases): same/narrower/broader agent scope, wildcard vs explicit lists, permission tiers, admin vs agent vs anonymous vs user kinds, profile pin match/mismatch, profile server-set coverage, stale (deleted) pin, deny-all readers.
- `TestGetRecordsAs_LegacyEntryWithoutProducer`: unstamped entry is refused for agent and user readers, readable by admin/anonymous.
- `TestGetRecordsAs_RefusedReadLeavesStatsUntouched`: refusal bumps neither stats nor `AccessCount`; producer persists with the record.
- `TestGetRecordsAs_SameAuthorizationIsByteIdentical`: gated page == ungated page at every offset.
- `TestReadCache_NarrowerTokenOnSameSessionCannotReadBroaderEntry`: end-to-end through `handleRetrieveTools` → truncation → `handleReadCache`; every page refused with the authorization message (not a key-not-found), no `github:` or `records` in the refusal; the producing token still reads every page; the narrow token reads its own entry.
- `TestReadCache_DeletedPinnedProfileRevokesCachedAccess`: pinned token reads its entry, operator deletes the profile, the same token is refused.
- `TestReadCache_BroaderReaderMayReadNarrowerEntry`: admin reads an agent-produced entry.

Gates (run on the merged branch):

```
gofmt -l <touched files>                                   -> clean
go build -o ./mcpproxy ./cmd/mcpproxy                      -> ok
go build -tags server -o /dev/null ./cmd/mcpproxy          -> ok
go test -race -skip 'E2E|Binary|MCPProtocol|TestInfoEndpoint|TestGracefulShutdownNoPanic|TestSocketInfoEndpoint' ./internal/server/... ./internal/cache/...
    ok  internal/server         263.7s
    ok  internal/server/tokens    6.1s
    ok  internal/cache            3.8s
/opt/homebrew/bin/golangci-lint run --config .github/.golangci.yml ./internal/server/... ./internal/cache/...
    0 issues
```

## Verification

Live, isolated instance on `127.0.0.1:18231` (scratch `--data-dir` and `--config`; `~/.mcpproxy` and the port-8080 core untouched). Two stdio servers `a` and `b` (a local echo fixture), `tool_response_limit: 500`, quarantine off. Same script run against an `origin/main` build (baseline) and this branch (fresh data dir each). Tokens minted over REST: `wildcard` (`allowed_servers: ["*"]`, read+write) and `a-only` (`allowed_servers: ["a"]`, read). MCP calls via `POST /mcp` with `Authorization: Bearer <token>` (`X-API-Key` for admin), `initialize` → `notifications/initialized` → `tools/call`, `Mcp-Session-Id` carried from the initialize response.

**The request.** `wildcard` calls `b:echo` with 40 records (1690 chars > 500) → truncated and parked behind a key, identical on both builds:

```
tools/call call_tool_read {"name":"b:echo","args":{"items":["SECRET-B-RECORD-0-…", … 40 items]}}
→ "… [truncated by mcpproxy] Response truncated (limit: 500 chars, actual: 1690 chars, records: 40)
   Use read_cache tool: key=\"<KEY>\", offset=0, limit=50 …"
```

Control on both builds: `a-only` calling `b:echo` directly → `Server 'b' is not in scope for this agent token` (isError).

**Baseline leak (`origin/main`).** `a-only` redeems the wildcard's key and receives the `b` payload through all three doors:

```
# same MCP session as the producer
read_cache {"key":"<KEY>","offset":0,"limit":3}
→ {"records":["SECRET-B-RECORD-0-…","SECRET-B-RECORD-1-…","SECRET-B-RECORD-2-…"],"meta":{"total_records":40,…,"record_path":"echo.items"}}
# new MCP session (a-only initialize)           → identical records payload
# REST: POST /api/v1/tools/call {"tool_name":"read_cache",…} with Bearer <a-only>
→ {"success":true,"data":[{"type":"text","text":"{\"records\":[\"SECRET-B-RECORD-0-…"}]}
```

**Branch refusal.** Same three doors, every page, and the recursive child key:

```
# same session
→ {"content":[{"type":"text","text":"Cache entry is not readable with this credential: it was produced under a broader authorization (server scope, permission tier or profile) than this request holds. Re-run the original tool call with this credential to obtain your own cache key."}],"isError":true}
# new session                                → byte-identical refusal
# page 2 (offset 10)                         → byte-identical refusal
# REST /api/v1/tools/call read_cache branch  → {"success":false,"error":"Failed to call tool: tool call failed: Cache entry is not readable with this credential: …"}
# recursive child (wildcard paged limit=50 → oversize page re-cached under a child key): a-only read_cache → byte-identical refusal
grep -l SECRET-B-RECORD <all branch refusal captures>  → no matches
```

**Positive controls (branch).** `wildcard` reads its key on a new session; admin reads it over MCP and over REST; `wildcard` reads the recursive child; `a-only` calls `a:echo` (40 records), gets its own key and pages it on the same and on a new session; `wildcard` (superset) reads `a-only`'s key. All return the records payload.

**Upgrade fixture.** Branch binary started on the baseline's data dir (legacy unstamped entry written by `origin/main`): admin reads it (twice — not invalidated); `wildcard` and `a-only` are refused over MCP and REST.

Gates on the PR head, `-count=1`: `go test -race -skip 'E2E|Binary|MCPProtocol|TestInfoEndpoint|TestGracefulShutdownNoPanic|TestSocketInfoEndpoint' ./internal/server/... ./internal/cache/...` → `ok internal/server 230.2s · ok internal/server/tokens 5.7s · ok internal/cache 3.5s`; `golangci-lint` v2 with `.github/.golangci.yml` on the same packages → 0 issues; `git diff origin/main --name-only -- internal/server/testdata` → empty (goldens unregenerated, green).

Not exercised live (unit-tested only): profile-pin scenarios (pinned token vs unpinned entry, deleted pin) and the in-flight profile-narrowing snapshot. Observed outside the diff: `POST /api/v1/tokens` with a misspelled or missing `allowed_servers` silently mints a `["*"]` token — pre-existing REST behaviour, worth a separate fail-closed look.

## Cross-model review

Reviewer: `opencode` with `github-copilot/gpt-6-astra`, one round, verdict FINDINGS (4). Each was checked against the code; none is a defect introduced by the diff — all four are Spec 105 acceptance points already listed under Follow-ups, so no code changed and nothing was pushed. Gates re-run on the PR head after the round: both editions build, `go test -race` on `./internal/cache/...` and the skip-filtered `./internal/server/...` green, lint 0 issues, goldens untouched.

| # | Sev | Finding | Disposition |
|---|---|---|---|
| R1-F1 | P1 | Unstamped entries (legacy, registry, guesser) stay readable by admin/anonymous and are never invalidated on refusal (FR-002/SC-004). | Declined — follow-up. On `main` every entry was readable by every caller; the diff strictly narrows that. Admin reading anything is the spec's own FR-001 rule; the anonymous `/mcp` caller is out of scope per the spec's Scope Boundary. Universal refusal + durable invalidation is FR-002 work. |
| R1-F2 | P2 | Profile server-set coverage is checked before caller kind, so an admin bound to a session/URL profile is refused entries it could read before (FR-001 kind-first, SC-005 parity). | Declined — follow-up. Deliberate: the profile filter in `handleCallToolVariant` also blocks admin sessions, so a profiled admin cannot obtain that payload by calling the tool either; the ordering enforces exactly "never a payload you could not have obtained". Over-refusal in the safe direction, self-imposed and liftable via `set_profile`. |
| R1-F3 | P2 | Authorization refusal is distinguishable from key-not-found on MCP and REST (existence oracle). | Declined — follow-up. Keys are `sha256(tool:args:UnixNano)` and cannot be guessed, so a caller can only probe a key it already holds; the message carries no server names, content or producer identity. Not-found was already distinguishable from expired/parse errors on `main`. |
| R1-F4 | P2 | Recursive child pages are stamped with the reader's snapshot rather than the parent's (FR-001 monotonicity). | Declined — follow-up. Re-cache happens only after `GetRecordsAs(reader)` passed, so reader ⊇ parent and any child reader must be ⊇ reader ⊇ parent: nobody who could not read the parent can read the child. Only effect is stricter redemption of the child; carrying the parent's stamp needs `Producer` plumbed through `ReadCacheResponse` (Spec 105). |

## Follow-ups / Spec 105 gaps

This PR ships the read gate and the provenance stamp. Spec 105 contract points it does not cover (reviewer-confirmed list), to be picked up separately:

- [ ] **FR-002 universal refusal + durable invalidation**: entries with absent/legacy/unrecognised provenance are readable by admin and anonymous readers (nil producer treated as anonymous-produced) and are never deleted on first refused redemption; no upgrade fixture asserts content-free refusal, absence after restart and empty store (SC-004).
- [ ] **FR-002 internal-entry isolation**: registry (`internal/runtime/runtime.go` `registry-servers`) and guesser (`internal/experiments/guesser.go`) writers still use the unstamped `Store`, which the gate treats as redeemable by unrestricted callers via `read_cache`; SC-005's freshly-generated internal-entry fixture is absent.
- [ ] **FR-001 caller-kind-first ordering / administrator compatibility**: profile coverage is evaluated before caller kind, so a profile-bound (URL/session) administrator is refused entries it could previously read, contrary to "an administrator qualifies for any snapshot" and SC-005 admin parity.
- [ ] **FR-001 recursive provenance monotonicity**: a re-cached `read_cache` child carries the redeemer's snapshot (possibly broader than the parent's) instead of the parent's snapshot or the narrower of the two.
- [ ] **FR-001 non-disclosing refusal**: on MCP and on the REST `/api/v1/tools/call` `read_cache` branch, an unauthorized live key and a nonexistent key return distinguishable bodies.
- [ ] **FR-001 required fixtures**: held-upstream-call tests where the session selection and, separately, the profile definition are narrowed to `{a}` before the response completes (the deleted-profile test only mutates config after production); cross-session redemption test; upstream-content-block producer test; recursive-child authorization test (admin with session profile `{a}` → child requested by wildcard agent pinned to `{a}`, on MCP and REST); pinned-token REST fixture comparing direct dispatch with cache redemption on `/api/v1/tools/call`.

## Notes

- This branch does not touch `internal/server/profile_tool.go`; the two profile branches (`claude/eager-kirch-10f6c2`, `claude/xenodochial-lumiere-5abe75`) both edit that file and are expected to conflict with each other, not with this one. If either of them also edits `internal/server/mcp.go` (`handleCallToolVariant` profile-resolution block or `handleReadCache`), expect a small hunk-adjacent conflict there.
- `origin/main` was merged into the branch (merge, not rebase) with no conflicts.

