### PR TITLE
fix(security): authorize aggregated prompts by canonical owner and stop profile enumeration on a deleted pin

### DIFF
--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -595,15 +595,25 @@ func NewMCPProxyServer(
 	// Register proxy tools for the default (retrieve_tools) server
 	proxy.registerTools(debugSearch)
 
+	// Attach the aggregated-prompt auth filter to the default retrieve_tools
+	// server. It closes over `proxy` (needed by resolveActiveProfile), which
+	// did not exist when mcpServer was constructed above; ServerOption is
+	// just func(*MCPServer), so invoking it here is identical to having
+	// passed it to NewMCPServer. Enforced on prompts/list AND prompts/get
+	// (PR #973 review, finding F1).
+	//
+	// Bound UNCONDITIONALLY, not under EnablePrompts: RefreshPrompts publishes
+	// from the LIVE config snapshot on every servers.changed / config.reloaded
+	// / prompts-changed event, and mcp-go registers the prompts capability
+	// implicitly on the first SetPrompts. A server built with prompts off and
+	// enabled at runtime would otherwise serve every upstream prompt with no
+	// scope filter and with the internal owner stamp on the wire (Spec 105
+	// FR-006, cross-review round 2). With no prompts registered the filter is
+	// never invoked, so binding it early changes nothing while prompts are off.
+	mcpserver.WithPromptFilter(proxy.filterAggregatedPromptsForAuth)(mcpServer)
+
 	// Register prompts if enabled
 	if config.EnablePrompts {
-		// Attach the aggregated-prompt auth filter to the default retrieve_tools
-		// server. It closes over `proxy` (needed by resolveActiveProfile), which
-		// did not exist when mcpServer was constructed above; ServerOption is
-		// just func(*MCPServer), so invoking it here is identical to having
-		// passed it to NewMCPServer. Enforced on prompts/list AND prompts/get
-		// (PR #973 review, finding F1).
-		mcpserver.WithPromptFilter(proxy.filterAggregatedPromptsForAuth)(mcpServer)
 		proxy.registerPrompts()
 	}
 

--- a/internal/server/mcp_block_tools_test.go
+++ b/internal/server/mcp_block_tools_test.go
@@ -27,6 +27,14 @@ import (
 // runtime so tests can seed/verify approval records directly.
 func createTestProxyWithRuntime(t *testing.T, servers []*config.ServerConfig) (*MCPProxyServer, *runtime.Runtime) {
 	t.Helper()
+	return createTestProxyWithRuntimeCfg(t, servers, nil)
+}
+
+// createTestProxyWithRuntimeCfg is createTestProxyWithRuntime with a hook to
+// edit the config BEFORE the proxy is constructed, for tests that must observe
+// construction-time gating (e.g. EnablePrompts false at boot, flipped live).
+func createTestProxyWithRuntimeCfg(t *testing.T, servers []*config.ServerConfig, configure func(*config.Config)) (*MCPProxyServer, *runtime.Runtime) {
+	t.Helper()
 
 	logger := zap.NewNop()
 
@@ -35,6 +43,9 @@ func createTestProxyWithRuntime(t *testing.T, servers []*config.ServerConfig) (*
 	cfg.Listen = "127.0.0.1:0"
 	cfg.ToolsLimit = 20
 	cfg.Servers = servers
+	if configure != nil {
+		configure(cfg)
+	}
 
 	rt, err := runtime.New(cfg, "", logger)
 	require.NoError(t, err)

--- a/internal/server/mcp_direct_scope.go
+++ b/internal/server/mcp_direct_scope.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"go.uber.org/zap"
 
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
@@ -152,20 +154,25 @@ var builtinPromptNames = map[string]struct{}{
 
 // filterAggregatedPromptsForAuth filters prompts/list AND prompts/get for scoped
 // agent tokens and for any request with an active profile. It is the prompt
-// analogue of filterDirectModeToolsForAuth and the ONLY access check on the
-// aggregated-prompt get path: buildAggregatedServerPrompts wires each prompt
-// handler straight to Manager.GetPrompt with zero auth checks, so without this
-// filter a scoped agent token could fetch any upstream server's prompt over
-// prompts/get even when the tool filters hid that server (PR #973 review,
-// finding F1). mcp-go enforces this on both list and get (server.go
-// filteredPrompts / passesPromptFilters, v0.57.0), so a prompt dropped here is
-// neither discoverable nor retrievable.
+// analogue of filterDirectModeToolsForAuth and the list-side half of the
+// aggregated-prompt gate (the handler-side half is
+// authorizeAggregatedPromptServer): without it a scoped agent token could
+// discover any upstream server's prompt even when the tool filters hid that
+// server (PR #973 review, finding F1). mcp-go enforces this on both list and
+// get (server.go filteredPrompts / passesPromptFilters, v1.0.0), so a prompt
+// dropped here is neither discoverable nor retrievable.
 //
-// Built-in prompts are always kept. A display name that does not parse into
-// server__prompt is also kept rather than dropped: the reverse mapping is
-// best-effort (a server or prompt name that itself contains "__" can mis-split;
-// that pre-existing ambiguity is out of scope for F1) and must never panic or
-// blackhole a prompt whose owner cannot be identified.
+// Built-in prompts are always kept. The owning server of an upstream prompt is
+// the canonical name stamped into the registered prompt's _meta at publication
+// (Spec 104 FR-016g) — the same server its handler dispatches to, read from
+// the same snapshot mcp-go is filtering. It is NOT re-parsed from the display
+// name: "a__b__c" splits on the first "__" into owner "a", while the handler
+// dispatches to "a__b", so a token scoped to "a" alone could list and fetch
+// "a__b"'s prompt. An upstream prompt with no stamp cannot have come from
+// buildAggregatedServerPrompts and is dropped for scoped callers (fail closed).
+//
+// The internal stamp is stripped from every prompt returned, for every caller,
+// so the client-visible _meta is exactly what the upstream sent.
 //
 // Unlike the tool filter there is no permission-tier check: prompts have no
 // read/write/destructive variant, so server scope (CanAccessServer) plus profile
@@ -178,9 +185,8 @@ func (p *MCPProxyServer) filterAggregatedPromptsForAuth(ctx context.Context, pro
 	authCtx := auth.AuthContextFromContext(ctx)
 	_, profileScope := p.resolveActiveProfile(ctx)
 	isScopedAgent := authCtx != nil && authCtx.Type == auth.AuthTypeAgent
-	if !isScopedAgent && profileScope == nil {
-		return prompts
-	}
+	enforce := isScopedAgent || profileScope != nil
+	allowed := promptServerAllowed(authCtx, profileScope)
 
 	filtered := make([]mcp.Prompt, 0, len(prompts))
 	for _, prompt := range prompts {
@@ -189,25 +195,78 @@ func (p *MCPProxyServer) filterAggregatedPromptsForAuth(ctx context.Context, pro
 			continue
 		}
 
-		serverName, _, ok := ParseDirectToolName(prompt.Name)
-		if !ok {
-			// Unidentifiable owner — keep rather than break (see doc comment).
-			filtered = append(filtered, prompt)
-			continue
+		serverName, stamped := aggregatedPromptServer(prompt)
+		if enforce {
+			if !stamped {
+				if p.logger != nil {
+					p.logger.Warn("dropping aggregated prompt with no canonical-owner stamp for scoped caller",
+						zap.String("prompt", prompt.Name))
+				}
+				continue
+			}
+			if !allowed(serverName) {
+				continue
+			}
 		}
 
-		// profileScope.Allows tolerates a nil receiver (returns true), so the
-		// scoped-agent-without-profile case falls through correctly.
-		if !profileScope.Allows(serverName) {
-			continue
-		}
-
-		if isScopedAgent && !authCtx.CanAccessServer(serverName) {
-			continue
-		}
-
-		filtered = append(filtered, prompt)
+		filtered = append(filtered, stripAggregatedPromptServer(prompt))
 	}
 
 	return filtered
 }
+
+// promptServerAllowed returns the per-server access predicate for one caller:
+// profile scope (Allows) plus, for scoped agent tokens, server scope
+// (CanAccessServer). profileScope.Allows tolerates a nil receiver (returns
+// true), so the scoped-agent-without-profile case falls through correctly.
+// It is the ONE definition of "may this caller touch prompts on server X",
+// shared by the list/get filter and by every aggregated prompt handler.
+func promptServerAllowed(authCtx *auth.AuthContext, profileScope *profile.ProfileScope) func(serverName string) bool {
+	isScopedAgent := authCtx != nil && authCtx.Type == auth.AuthTypeAgent
+	return func(serverName string) bool {
+		if !profileScope.Allows(serverName) {
+			return false
+		}
+		return !isScopedAgent || authCtx.CanAccessServer(serverName)
+	}
+}
+
+// authorizeAggregatedPromptServer is the handler-side gate every aggregated
+// prompt handler runs against its OWN canonical server before dispatching
+// (Spec 104 FR-016g, cross-review P1). The list/get filter authorizes against
+// the owner record; that record and the registered handlers are published in
+// two steps, and a display-name collision winner can differ between refreshes
+// (upstream ListPrompts iterates a map), so a filter-only design has a window
+// in which a caller allowed for the RECORDED owner invokes a handler that
+// dispatches to a different server. Binding the check to the handler closure,
+// which knows its server by construction, closes that window regardless of
+// what the record says.
+//
+// Reachability: the list/get filter reads the owner from the SAME registered
+// prompt (see filterAggregatedPromptsForAuth), so an owner mismatch can no
+// longer get past the filter. What CAN reach this gate is a scope change
+// between the two checks of one request — an administrator deleting the
+// caller's pinned profile, or dropping this server from it, in that
+// millisecond window — because scope is resolved per check, not per request.
+// Dispatch is still blocked. The residual is cosmetic: mcp-go maps a handler
+// error to INTERNAL_ERROR, and that code is not controllable from a handler,
+// so a probe timed inside such a window could tell "registered but hidden"
+// from "absent" by the error code even though the message is identical.
+func (p *MCPProxyServer) authorizeAggregatedPromptServer(ctx context.Context, serverName string) error {
+	authCtx := auth.AuthContextFromContext(ctx)
+	_, profileScope := p.resolveActiveProfile(ctx)
+	if promptServerAllowed(authCtx, profileScope)(serverName) {
+		return nil
+	}
+	if p.logger != nil {
+		p.logger.Warn("aggregated prompt handler denied: caller not authorized for the prompt's canonical server",
+			zap.String("server", serverName))
+	}
+	return errPromptNotFound
+}
+
+// errPromptNotFound is the sentinel an aggregated prompt handler returns for a
+// caller that may not reach its server. The handler wraps it in the exact
+// message mcp-go uses for an unregistered name ("prompt '<name>' not found:
+// prompt not found"), so the message cannot separate "hidden" from "absent".
+var errPromptNotFound = mcpserver.ErrPromptNotFound

--- a/internal/server/mcp_prompt_scope_test.go
+++ b/internal/server/mcp_prompt_scope_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
 	servertest "github.com/mark3labs/mcp-go/server/servertest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -309,4 +310,98 @@ func TestAggregatedPrompt_ScopeUsesCanonicalOwner(t *testing.T) {
 		assert.NotContains(t, entry, "_meta", "owner stamp must be stripped for admins too: %v", entry)
 	}
 	assert.Subset(t, adminNames, []string{"a__greeting", "a__b__greeting"})
+}
+
+// TestAggregatedPrompt_LateEnableStillFiltered (Spec 105 FR-006, cross-review
+// round 2): the prompt filter used to be installed only when enable_prompts
+// was true at CONSTRUCTION, while RefreshPrompts publishes from the LIVE
+// snapshot on every servers.changed / config.reloaded / prompts-changed event.
+// Boot with prompts off, flip enable_prompts + aggregate_upstream_prompts at
+// runtime, and every routing-mode server received the upstream prompts with
+// no scope filter at all — and, since the filter is also what strips the
+// internal owner stamp, the wire carried `"_meta":{"app.mcpproxy/server":{}}`
+// for every caller. The filter must be bound to every server unconditionally
+// so late-published prompts are scoped and stamp-free exactly like boot-time
+// ones.
+func TestAggregatedPrompt_LateEnableStillFiltered(t *testing.T) {
+	t.Setenv("MCPPROXY_DISABLE_OAUTH", "true")
+
+	proxy, _ := createTestProxyWithRuntimeCfg(t, nil, func(cfg *config.Config) {
+		cfg.EnablePrompts = false
+		cfg.AggregateUpstreamPrompts = false
+	})
+	require.Empty(t, proxy.server.ListPrompts(), "precondition: nothing registered while prompts are disabled")
+
+	// Hot-reload: both flags flip in the live snapshot the refresh reads.
+	proxy.config.EnablePrompts = true
+	proxy.config.AggregateUpstreamPrompts = true
+	qOff := false
+	proxy.config.QuarantineEnabled = &qOff
+
+	um := upstream.NewManager(zap.NewNop(), proxy.config, nil, secret.NewResolver(), nil)
+	t.Cleanup(func() { um.DisconnectAll() })
+	for _, name := range []string{"a", "hidden"} {
+		testServer := servertest.NewTestStreamableHTTPServer(newTestRefreshPromptsUpstream(t))
+		t.Cleanup(testServer.Close)
+		require.NoError(t, um.AddServerConfig(name, &config.ServerConfig{
+			Name: name, Protocol: "streamable-http", URL: testServer.URL, Enabled: true,
+		}))
+		client, ok := um.GetClient(name)
+		require.True(t, ok)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		require.NoError(t, client.Connect(ctx))
+		cancel()
+	}
+	proxy.upstreamManager = um
+	proxy.RefreshPrompts()
+	require.Contains(t, proxy.server.ListPrompts(), "hidden__greeting", "precondition: the late-enabled prompts were published")
+
+	scoped := auth.WithAuthContext(context.Background(), &auth.AuthContext{
+		Type:           auth.AuthTypeAgent,
+		AgentName:      "a-only",
+		AllowedServers: []string{"a"},
+		Permissions:    []string{auth.PermRead},
+	})
+	admin := auth.WithAuthContext(context.Background(), auth.AdminContext())
+
+	servers := map[string]*mcpserver.MCPServer{
+		"retrieve":  proxy.server,
+		"direct":    proxy.directServer,
+		"code-exec": proxy.codeExecServer,
+		"call-tool": proxy.callToolServer,
+	}
+	for label, srv := range servers {
+		require.NotNil(t, srv, label)
+		t.Run(label, func(t *testing.T) {
+			list := func(ctx context.Context) []map[string]interface{} {
+				t.Helper()
+				require.NotNil(t, srv.HandleMessage(ctx, []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"t","version":"0"}}}`)))
+				encoded, err := json.Marshal(srv.HandleMessage(ctx, []byte(`{"jsonrpc":"2.0","id":2,"method":"prompts/list","params":{}}`)))
+				require.NoError(t, err)
+				var envelope map[string]interface{}
+				require.NoError(t, json.Unmarshal(encoded, &envelope))
+				require.Nil(t, envelope["error"], "prompts/list must succeed: %v", envelope)
+				var entries []map[string]interface{}
+				for _, pr := range envelope["result"].(map[string]interface{})["prompts"].([]interface{}) {
+					entries = append(entries, pr.(map[string]interface{}))
+				}
+				return entries
+			}
+
+			var scopedNames []string
+			for _, entry := range list(scoped) {
+				scopedNames = append(scopedNames, entry["name"].(string))
+				assert.NotContains(t, entry, "_meta", "owner stamp must not reach the wire: %v", entry)
+			}
+			assert.Contains(t, scopedNames, "a__greeting")
+			assert.NotContains(t, scopedNames, "hidden__greeting", "a token scoped to 'a' must not see 'hidden' after a late enable")
+
+			var adminNames []string
+			for _, entry := range list(admin) {
+				adminNames = append(adminNames, entry["name"].(string))
+				assert.NotContains(t, entry, "_meta", "owner stamp must be stripped for admins too: %v", entry)
+			}
+			assert.Subset(t, adminNames, []string{"a__greeting", "hidden__greeting"})
+		})
+	}
 }

--- a/internal/server/mcp_prompt_scope_test.go
+++ b/internal/server/mcp_prompt_scope_test.go
@@ -2,13 +2,22 @@ package server
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	servertest "github.com/mark3labs/mcp-go/server/servertest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/auth"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/profile"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/secret"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/upstream"
 )
 
 func promptNamesForTest(prompts []mcp.Prompt) []string {
@@ -31,13 +40,15 @@ func TestFilterAggregatedPromptsForAuth(t *testing.T) {
 	githubPrompt := FormatDirectPromptName("github", "pr_review")
 	gitlabPrompt := FormatDirectPromptName("gitlab", "mr_review")
 
-	// Full aggregated set every case starts from: 2 built-ins + 2 upstream.
+	// Full aggregated set every case starts from: 2 built-ins + 2 upstream,
+	// the upstream ones stamped exactly as buildAggregatedServerPrompts
+	// publishes them.
 	base := func() []mcp.Prompt {
 		return []mcp.Prompt{
 			{Name: builtinSetup},
 			{Name: builtinTrbl},
-			{Name: githubPrompt},
-			{Name: gitlabPrompt},
+			aggregatedPromptForTest("github", "pr_review"),
+			aggregatedPromptForTest("gitlab", "mr_review"),
 		}
 	}
 
@@ -98,24 +109,150 @@ func TestFilterAggregatedPromptsForAuth(t *testing.T) {
 			proxy := &MCPProxyServer{}
 			got := proxy.filterAggregatedPromptsForAuth(tc.ctx, base())
 			assert.ElementsMatch(t, tc.want, promptNamesForTest(got))
+			for _, pr := range got {
+				_, stamped := aggregatedPromptServer(pr)
+				assert.False(t, stamped, "internal owner stamp must be stripped from %q for every caller", pr.Name)
+			}
 		})
 	}
 }
 
-// TestFilterAggregatedPromptsForAuth_KeepsUnparseableName verifies a display
-// name that cannot be parsed into server__prompt is kept, never dropped or
-// panicked on (F1: the filter must not break on the pre-existing __ collision).
-func TestFilterAggregatedPromptsForAuth_KeepsUnparseableName(t *testing.T) {
+// aggregatedPromptForTest builds an upstream prompt exactly as
+// buildAggregatedServerPrompts publishes it: "__" display name plus the
+// canonical-owner _meta stamp.
+func aggregatedPromptForTest(server, prompt string) mcp.Prompt {
+	return mcp.Prompt{
+		Name: FormatDirectPromptName(server, prompt),
+		Meta: stampAggregatedPromptServer(nil, server),
+	}
+}
+
+// TestFilterAggregatedPromptsForAuth_UnstampedFailsClosed (Spec 104 FR-016g):
+// an upstream prompt with no canonical-owner stamp cannot have come from
+// buildAggregatedServerPrompts, so the filter must not guess its owner from the
+// display name (that re-parse is the original leak). It is dropped for scoped
+// callers and left alone for unscoped ones.
+func TestFilterAggregatedPromptsForAuth_UnstampedFailsClosed(t *testing.T) {
 	proxy := &MCPProxyServer{}
-	weird := "noseparator" // no "__", not a built-in
-	got := proxy.filterAggregatedPromptsForAuth(
-		auth.WithAuthContext(context.Background(), &auth.AuthContext{
-			Type:           auth.AuthTypeAgent,
-			AgentName:      "scoped-bot",
-			AllowedServers: []string{"github"},
-			Permissions:    []string{auth.PermRead},
-		}),
-		[]mcp.Prompt{{Name: weird}, {Name: FormatDirectPromptName("github", "x")}},
-	)
-	assert.ElementsMatch(t, []string{FormatDirectPromptName("github", "x"), weird}, promptNamesForTest(got))
+	unstamped := mcp.Prompt{Name: FormatDirectPromptName("github", "looks_in_scope")}
+	stamped := aggregatedPromptForTest("github", "x")
+	scoped := auth.WithAuthContext(context.Background(), &auth.AuthContext{
+		Type:           auth.AuthTypeAgent,
+		AgentName:      "scoped-bot",
+		AllowedServers: []string{"github"},
+		Permissions:    []string{auth.PermRead},
+	})
+
+	got := proxy.filterAggregatedPromptsForAuth(scoped, []mcp.Prompt{unstamped, stamped})
+	assert.ElementsMatch(t, []string{stamped.Name}, promptNamesForTest(got), "unstamped upstream prompt is dropped for a scoped caller")
+
+	got = proxy.filterAggregatedPromptsForAuth(context.Background(), []mcp.Prompt{unstamped, stamped})
+	assert.ElementsMatch(t, []string{unstamped.Name, stamped.Name}, promptNamesForTest(got), "unscoped callers are not filtered")
+}
+
+// TestStripAggregatedPromptServer_PreservesUpstreamMeta verifies the stamp is
+// removed without disturbing upstream-supplied _meta and without mutating the
+// registered prompt (mcp-go hands filters a shared Meta pointer).
+func TestStripAggregatedPromptServer_PreservesUpstreamMeta(t *testing.T) {
+	upstream := &mcp.Meta{AdditionalFields: map[string]any{"vendor/x": "keep"}}
+	registered := mcp.Prompt{Name: "srv__p", Meta: stampAggregatedPromptServer(upstream, "srv")}
+
+	owner, ok := aggregatedPromptServer(registered)
+	require.True(t, ok)
+	assert.Equal(t, "srv", owner)
+
+	stripped := stripAggregatedPromptServer(registered)
+	require.NotNil(t, stripped.Meta)
+	assert.Equal(t, map[string]any{"vendor/x": "keep"}, stripped.Meta.AdditionalFields)
+	_, stillStamped := aggregatedPromptServer(registered)
+	assert.True(t, stillStamped, "the registered prompt must not be mutated by stripping a copy")
+
+	bare := stripAggregatedPromptServer(mcp.Prompt{Name: "srv__q", Meta: stampAggregatedPromptServer(nil, "srv")})
+	assert.Nil(t, bare.Meta, "a stamp-only _meta is removed entirely")
+}
+
+// TestAggregatedPrompt_ScopeUsesCanonicalOwner is the Spec 104 FR-016g
+// regression (cross-model review): with servers "a" and "a__b" both serving a
+// prompt, "a__b"'s prompt is published as "a__b__greeting". Re-parsing that
+// display name on the first "__" yields owner "a", so an agent token scoped to
+// "a" alone could LIST and GET a prompt the handler dispatches to "a__b". The
+// filter must authorize against the canonical owner recorded at publication —
+// the same one the handler dispatches to — so both list and get are denied.
+func TestAggregatedPrompt_ScopeUsesCanonicalOwner(t *testing.T) {
+	t.Setenv("MCPPROXY_DISABLE_OAUTH", "true")
+
+	proxy, _ := createTestProxyWithRuntime(t, nil)
+	proxy.config.EnablePrompts = true
+	proxy.config.AggregateUpstreamPrompts = true
+	qOff := false
+	proxy.config.QuarantineEnabled = &qOff
+
+	um := upstream.NewManager(zap.NewNop(), proxy.config, nil, secret.NewResolver(), nil)
+	t.Cleanup(func() { um.DisconnectAll() })
+	for _, name := range []string{"a", "a__b"} {
+		testServer := servertest.NewTestStreamableHTTPServer(newTestRefreshPromptsUpstream(t))
+		t.Cleanup(testServer.Close)
+		require.NoError(t, um.AddServerConfig(name, &config.ServerConfig{
+			Name: name, Protocol: "streamable-http", URL: testServer.URL, Enabled: true,
+		}))
+		client, ok := um.GetClient(name)
+		require.True(t, ok)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		require.NoError(t, client.Connect(ctx))
+		cancel()
+	}
+	proxy.upstreamManager = um
+	proxy.RefreshPrompts()
+
+	registered := proxy.server.ListPrompts()
+	require.Contains(t, registered, "a__greeting")
+	require.Contains(t, registered, "a__b__greeting", "precondition: the collision-prone prompt is published")
+
+	ctx := auth.WithAuthContext(context.Background(), &auth.AuthContext{
+		Type:           auth.AuthTypeAgent,
+		AgentName:      "a-only",
+		AllowedServers: []string{"a"},
+		Permissions:    []string{auth.PermRead},
+	})
+	handle := func(id int, method, params string) map[string]interface{} {
+		t.Helper()
+		raw := []byte(`{"jsonrpc":"2.0","id":` + fmt.Sprint(id) + `,"method":"` + method + `","params":` + params + `}`)
+		encoded, err := json.Marshal(proxy.server.HandleMessage(ctx, raw))
+		require.NoError(t, err)
+		var envelope map[string]interface{}
+		require.NoError(t, json.Unmarshal(encoded, &envelope))
+		return envelope
+	}
+	require.NotNil(t, proxy.server.HandleMessage(ctx, []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"t","version":"0"}}}`)))
+
+	// prompts/list: only server "a"'s prompt (plus built-ins) is visible, and
+	// the internal owner stamp never reaches the wire.
+	list := handle(2, "prompts/list", `{}`)
+	require.Nil(t, list["error"], "prompts/list must succeed: %v", list)
+	var listed []string
+	for _, pr := range list["result"].(map[string]interface{})["prompts"].([]interface{}) {
+		entry := pr.(map[string]interface{})
+		listed = append(listed, entry["name"].(string))
+		assert.NotContains(t, entry, "_meta", "owner stamp must be stripped from prompts/list output: %v", entry)
+	}
+	assert.Contains(t, listed, "a__greeting")
+	assert.NotContains(t, listed, "a__b__greeting", "a token scoped to server 'a' must not see a__b's prompt")
+
+	// prompts/get: in-scope works, out-of-scope is denied.
+	okGet := handle(3, "prompts/get", `{"name":"a__greeting"}`)
+	assert.Nil(t, okGet["error"], "in-scope prompts/get must succeed: %v", okGet)
+	denied := handle(4, "prompts/get", `{"name":"a__b__greeting"}`)
+	assert.NotNil(t, denied["error"], "a token scoped to server 'a' must not fetch a__b's prompt: %v", denied)
+
+	// The same session as an admin sees everything, with no stamp on the wire.
+	ctx = auth.WithAuthContext(context.Background(), auth.AdminContext())
+	adminList := handle(5, "prompts/list", `{}`)
+	require.Nil(t, adminList["error"])
+	var adminNames []string
+	for _, pr := range adminList["result"].(map[string]interface{})["prompts"].([]interface{}) {
+		entry := pr.(map[string]interface{})
+		adminNames = append(adminNames, entry["name"].(string))
+		assert.NotContains(t, entry, "_meta", "owner stamp must be stripped for admins too: %v", entry)
+	}
+	assert.Subset(t, adminNames, []string{"a__greeting", "a__b__greeting"})
 }

--- a/internal/server/mcp_prompt_scope_test.go
+++ b/internal/server/mcp_prompt_scope_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -152,23 +153,50 @@ func TestFilterAggregatedPromptsForAuth_UnstampedFailsClosed(t *testing.T) {
 
 // TestStripAggregatedPromptServer_PreservesUpstreamMeta verifies the stamp is
 // removed without disturbing upstream-supplied _meta and without mutating the
-// registered prompt (mcp-go hands filters a shared Meta pointer).
+// registered prompt (mcp-go hands filters a shared Meta pointer), and that the
+// client-visible _meta is byte-identical to what the upstream sent — nil stays
+// absent, an empty `{}` stays `{}`, a progress token survives, and even an
+// upstream value under our own key comes back (Spec 105 SC-005: administrator
+// output must not change for prompts the feature does not withhold).
 func TestStripAggregatedPromptServer_PreservesUpstreamMeta(t *testing.T) {
-	upstream := &mcp.Meta{AdditionalFields: map[string]any{"vendor/x": "keep"}}
-	registered := mcp.Prompt{Name: "srv__p", Meta: stampAggregatedPromptServer(upstream, "srv")}
+	wire := func(pr mcp.Prompt) string {
+		t.Helper()
+		b, err := json.Marshal(pr)
+		require.NoError(t, err)
+		return string(b)
+	}
 
-	owner, ok := aggregatedPromptServer(registered)
-	require.True(t, ok)
-	assert.Equal(t, "srv", owner)
+	cases := map[string]*mcp.Meta{
+		"nil":            nil,
+		"empty":          {AdditionalFields: map[string]any{}},
+		"fields":         {AdditionalFields: map[string]any{"vendor/x": "keep"}},
+		"progress token": {ProgressToken: "tok-1", AdditionalFields: map[string]any{}},
+		"our key":        {AdditionalFields: map[string]any{aggregatedPromptServerMetaKey: "upstream-claims-this"}},
+	}
+	for name, upstream := range cases {
+		t.Run(name, func(t *testing.T) {
+			asSent := mcp.Prompt{Name: "srv__p", Meta: upstream}
+			registered := mcp.Prompt{Name: "srv__p", Meta: stampAggregatedPromptServer(upstream, "srv")}
 
-	stripped := stripAggregatedPromptServer(registered)
-	require.NotNil(t, stripped.Meta)
-	assert.Equal(t, map[string]any{"vendor/x": "keep"}, stripped.Meta.AdditionalFields)
-	_, stillStamped := aggregatedPromptServer(registered)
-	assert.True(t, stillStamped, "the registered prompt must not be mutated by stripping a copy")
+			owner, ok := aggregatedPromptServer(registered)
+			require.True(t, ok)
+			assert.Equal(t, "srv", owner, "the owner is what mcpproxy dispatches to, never an upstream claim")
 
-	bare := stripAggregatedPromptServer(mcp.Prompt{Name: "srv__q", Meta: stampAggregatedPromptServer(nil, "srv")})
-	assert.Nil(t, bare.Meta, "a stamp-only _meta is removed entirely")
+			stripped := stripAggregatedPromptServer(registered)
+			assert.Equal(t, wire(asSent), wire(stripped), "client-visible _meta must be exactly what the upstream sent")
+			_, stillStamped := aggregatedPromptServer(registered)
+			assert.True(t, stillStamped, "the registered prompt must not be mutated by stripping a copy")
+			_, leaked := aggregatedPromptServer(stripped)
+			assert.False(t, leaked)
+		})
+	}
+
+	// An upstream that sends a bare string under our key is not a stamp: the
+	// filter must not trust it as an owner.
+	forged := mcp.Prompt{Name: "srv__p", Meta: &mcp.Meta{AdditionalFields: map[string]any{aggregatedPromptServerMetaKey: "srv"}}}
+	_, ok := aggregatedPromptServer(forged)
+	assert.False(t, ok, "an upstream-supplied string under the stamp key is not a registration identity")
+	assert.Equal(t, forged, stripAggregatedPromptServer(forged), "an unstamped prompt is returned untouched")
 }
 
 // TestAggregatedPrompt_ScopeUsesCanonicalOwner is the Spec 104 FR-016g
@@ -242,7 +270,33 @@ func TestAggregatedPrompt_ScopeUsesCanonicalOwner(t *testing.T) {
 	okGet := handle(3, "prompts/get", `{"name":"a__greeting"}`)
 	assert.Nil(t, okGet["error"], "in-scope prompts/get must succeed: %v", okGet)
 	denied := handle(4, "prompts/get", `{"name":"a__b__greeting"}`)
-	assert.NotNil(t, denied["error"], "a token scoped to server 'a' must not fetch a__b's prompt: %v", denied)
+	require.NotNil(t, denied["error"], "a token scoped to server 'a' must not fetch a__b's prompt: %v", denied)
+
+	// Non-disclosing refusal (FR-010): the hidden prompt's error must have the
+	// same code and the same message (modulo the caller's own echoed name) as
+	// a prompt that does not exist at all.
+	absent := handle(6, "prompts/get", `{"name":"a__nonexistent"}`)
+	require.NotNil(t, absent["error"], "precondition: %v", absent)
+	deniedErr := denied["error"].(map[string]interface{})
+	absentErr := absent["error"].(map[string]interface{})
+	assert.Equal(t, absentErr["code"], deniedErr["code"], "hidden vs absent must share the JSON-RPC error code")
+	assert.Equal(t,
+		strings.ReplaceAll(absentErr["message"].(string), "a__nonexistent", "<name>"),
+		strings.ReplaceAll(deniedErr["message"].(string), "a__b__greeting", "<name>"),
+		"hidden vs absent must share the error message")
+
+	// The handler-side gate is wired in production, not only in the unit test
+	// with a fake hook: invoking the REGISTERED handler directly (bypassing
+	// mcp-go's filter) still refuses the scoped caller with the not-found
+	// sentinel and never contacts the upstream, while an admin gets through.
+	hiddenHandler := registered["a__b__greeting"].Handler
+	_, err := hiddenHandler(ctx, mcp.GetPromptRequest{Params: mcp.GetPromptParams{Name: "a__b__greeting"}})
+	require.ErrorIs(t, err, errPromptNotFound, "production RefreshPrompts must wire authorizeAggregatedPromptServer into every upstream handler")
+	assert.Equal(t, "prompt 'a__b__greeting' not found: prompt not found", err.Error())
+	res, err := hiddenHandler(auth.WithAuthContext(context.Background(), auth.AdminContext()),
+		mcp.GetPromptRequest{Params: mcp.GetPromptParams{Name: "a__b__greeting"}})
+	require.NoError(t, err)
+	require.NotNil(t, res)
 
 	// The same session as an admin sees everything, with no stamp on the wire.
 	ctx = auth.WithAuthContext(context.Background(), auth.AdminContext())

--- a/internal/server/mcp_routing.go
+++ b/internal/server/mcp_routing.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -1241,14 +1243,40 @@ func (p *MCPProxyServer) RefreshCodeExecutionAvailability() {
 // client-facing "__" name is needed since the handler closure already knows
 // which server it came from. Upstream prompts with a malformed (unqualified)
 // name are skipped.
+//
+// Each published upstream prompt carries its canonical owning server — the
+// server its handler dispatches to — in the registered Prompt's _meta under
+// aggregatedPromptServerMetaKey (see stampAggregatedPromptServer).
+// filterAggregatedPromptsForAuth authorizes against THAT stamp, never against
+// a re-parse of the display name: "a__b__c" re-parsed on the first "__" claims
+// owner "a", while its handler dispatches to "a__b" (Spec 104 FR-016g).
+// Riding inside the registered prompt means the owner and the prompt are
+// published in ONE SetPrompts step and filtered from ONE snapshot, so a
+// refresh that changes a collision winner can never pair an old prompt with a
+// new owner. The stamp is stripped from client-visible output by the filter.
+//
+// authorize, when non-nil, is invoked by every upstream prompt handler with the
+// prompt's canonical server BEFORE getPrompt; a non-nil error is returned to
+// the caller and the upstream is never contacted. It is the handler-side half
+// of the FR-016g gate (see authorizeAggregatedPromptServer) and must not be
+// nil in production.
 func buildAggregatedServerPrompts(
 	builtins []mcpserver.ServerPrompt,
 	upstreamPrompts []mcp.Prompt,
 	getPrompt func(ctx context.Context, name string, args map[string]string) (*mcp.GetPromptResult, error),
+	authorize func(ctx context.Context, serverName string) error,
 	logger *zap.Logger,
 ) []mcpserver.ServerPrompt {
 	all := make([]mcpserver.ServerPrompt, 0, len(builtins)+len(upstreamPrompts))
 	all = append(all, builtins...)
+
+	// Upstream ListPrompts iterates a map, so its order — and therefore the
+	// collision winner below — would otherwise change from refresh to refresh.
+	// Sort by qualified name so the same (server,prompt) wins every time.
+	upstreamPrompts = slices.Clone(upstreamPrompts)
+	slices.SortStableFunc(upstreamPrompts, func(x, y mcp.Prompt) int {
+		return strings.Compare(x.Name, y.Name)
+	})
 
 	// F7: two distinct (server,prompt) pairs can flatten to the same "__" display
 	// name (server "a__b"+prompt "c" and "a"+prompt "b__c" both -> "a__b__c").
@@ -1285,16 +1313,73 @@ func buildAggregatedServerPrompts(
 		qualifiedName := qualified.Name
 		display := qualified
 		display.Name = displayName
+		display.Meta = stampAggregatedPromptServer(display.Meta, serverName)
 
 		all = append(all, mcpserver.ServerPrompt{
 			Prompt: display,
 			Handler: func(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+				if authorize != nil {
+					if err := authorize(ctx, serverName); err != nil {
+						// Same wording mcp-go emits for an unregistered name.
+						return nil, fmt.Errorf("prompt '%s' not found: %w", request.Params.Name, err)
+					}
+				}
 				return getPrompt(ctx, qualifiedName, request.Params.Arguments)
 			},
 		})
 	}
 
 	return all
+}
+
+// aggregatedPromptServerMetaKey is the _meta key under which a published
+// upstream prompt records its canonical owning server. Namespaced per the MCP
+// _meta convention (reverse-DNS prefix) so it cannot collide with protocol or
+// upstream keys. It is internal: the auth filter strips it before the prompt
+// reaches a client.
+const aggregatedPromptServerMetaKey = "app.mcpproxy/server"
+
+// stampAggregatedPromptServer returns a fresh Meta carrying serverName under
+// aggregatedPromptServerMetaKey. Upstream-supplied additional fields are
+// preserved, but an upstream that itself sent our key is overwritten — the
+// owner is what mcpproxy dispatches to, never what the upstream claims.
+func stampAggregatedPromptServer(upstream *mcp.Meta, serverName string) *mcp.Meta {
+	meta := &mcp.Meta{AdditionalFields: map[string]any{}}
+	if upstream != nil {
+		meta.ProgressToken = upstream.ProgressToken
+		maps.Copy(meta.AdditionalFields, upstream.AdditionalFields)
+	}
+	meta.AdditionalFields[aggregatedPromptServerMetaKey] = serverName
+	return meta
+}
+
+// aggregatedPromptServer reads the canonical owner stamped by
+// stampAggregatedPromptServer. ok is false for a prompt that carries no stamp
+// (a built-in, or anything not published by buildAggregatedServerPrompts).
+func aggregatedPromptServer(prompt mcp.Prompt) (serverName string, ok bool) {
+	if prompt.Meta == nil {
+		return "", false
+	}
+	serverName, ok = prompt.Meta.AdditionalFields[aggregatedPromptServerMetaKey].(string)
+	return serverName, ok && serverName != ""
+}
+
+// stripAggregatedPromptServer returns prompt with the internal owner stamp
+// removed, leaving every other _meta field intact. The registered prompt is
+// never mutated: mcp-go hands filters the stored value and a shared Meta
+// pointer, so the Meta is copied before the key is dropped.
+func stripAggregatedPromptServer(prompt mcp.Prompt) mcp.Prompt {
+	if _, ok := aggregatedPromptServer(prompt); !ok {
+		return prompt
+	}
+	fields := maps.Clone(prompt.Meta.AdditionalFields)
+	delete(fields, aggregatedPromptServerMetaKey)
+	if len(fields) == 0 && prompt.Meta.ProgressToken == nil {
+		prompt.Meta = nil
+		return prompt
+	}
+	prompt.Meta = &mcp.Meta{ProgressToken: prompt.Meta.ProgressToken, AdditionalFields: fields}
+	return prompt
 }
 
 // RefreshPrompts rebuilds every routing-mode server's prompt set: the built-in
@@ -1342,7 +1427,7 @@ func (p *MCPProxyServer) RefreshPrompts() {
 		// prompts/get natively; there is no runtime get-time gate.
 		approval := p.checkPromptApprovals(upstreamPrompts)
 		upstreamPrompts = filterBlockedPrompts(upstreamPrompts, approval.blocked)
-		all = buildAggregatedServerPrompts(builtins, upstreamPrompts, p.getPromptAggregated, p.logger)
+		all = buildAggregatedServerPrompts(builtins, upstreamPrompts, p.getPromptAggregated, p.authorizeAggregatedPromptServer, p.logger)
 		p.logger.Info("refreshed prompts",
 			zap.Int("upstream_prompt_count", len(upstreamPrompts)),
 			zap.Int("total_prompt_count", len(all)),
@@ -1351,7 +1436,7 @@ func (p *MCPProxyServer) RefreshPrompts() {
 	} else {
 		// nil upstreamPrompts: the aggregation loop never runs, so the nil
 		// getPrompt is never invoked.
-		all = buildAggregatedServerPrompts(builtins, nil, nil, p.logger)
+		all = buildAggregatedServerPrompts(builtins, nil, nil, nil, p.logger)
 		p.logger.Debug("refreshed prompts (upstream aggregation disabled, built-ins only)",
 			zap.Int("total_prompt_count", len(all)))
 	}

--- a/internal/server/mcp_routing.go
+++ b/internal/server/mcp_routing.go
@@ -953,14 +953,21 @@ func (p *MCPProxyServer) initRoutingModeServers() {
 	// unreachable over Streamable HTTP (PR #973 review, P1).
 	if p.config.EnablePrompts {
 		opts = append(opts, mcpserver.WithPromptCapabilities(true))
-		// Enforce agent-token + profile scope on aggregated prompts across every
-		// routing-mode server. mcp-go applies this on BOTH prompts/list and
-		// prompts/get (passesPromptFilters), closing the F1 get-time auth bypass.
-		// Added to the shared opts (before directOpts copies it) so directServer,
-		// codeExecServer and callToolServer all inherit it; p.server gets the
-		// same filter in NewMCPProxyServer, where proxy exists.
-		opts = append(opts, mcpserver.WithPromptFilter(p.filterAggregatedPromptsForAuth))
 	}
+	// Enforce agent-token + profile scope on aggregated prompts across every
+	// routing-mode server. mcp-go applies this on BOTH prompts/list and
+	// prompts/get (passesPromptFilters), closing the F1 get-time auth bypass.
+	// Added to the shared opts (before directOpts copies it) so directServer,
+	// codeExecServer and callToolServer all inherit it; p.server gets the
+	// same filter in NewMCPProxyServer, where proxy exists.
+	//
+	// Bound regardless of EnablePrompts: RefreshPrompts publishes from the LIVE
+	// snapshot, so a server built with prompts off can still receive upstream
+	// prompts after a runtime enable, and mcp-go then serves prompts/list from
+	// the implicitly-registered capability. Only the filter makes that listing
+	// scoped and stamp-free (Spec 105 FR-006, cross-review round 2). It is a
+	// no-op while no prompts are registered.
+	opts = append(opts, mcpserver.WithPromptFilter(p.filterAggregatedPromptsForAuth))
 
 	// Create direct mode server. Both direct-mode tool filters are agent-scoped
 	// discovery filters and belong only on the direct server (not the shared
@@ -1250,10 +1257,14 @@ func (p *MCPProxyServer) RefreshCodeExecutionAvailability() {
 // filterAggregatedPromptsForAuth authorizes against THAT stamp, never against
 // a re-parse of the display name: "a__b__c" re-parsed on the first "__" claims
 // owner "a", while its handler dispatches to "a__b" (Spec 104 FR-016g).
-// Riding inside the registered prompt means the owner and the prompt are
-// published in ONE SetPrompts step and filtered from ONE snapshot, so a
-// refresh that changes a collision winner can never pair an old prompt with a
-// new owner. The stamp is stripped from client-visible output by the filter.
+// Riding inside the registered mcp.Prompt binds the owner PER PROMPT rather
+// than in a side table: mcp-go's SetPrompts is not atomic as a whole (it
+// clears the maps, unlocks, then AddPrompts re-locks per batch, so a
+// concurrent list can observe an empty or partially repopulated set, and
+// overlapping refreshes can interleave), but every prompt a list does observe
+// carries the owner its own handler dispatches to, so a refresh that changes
+// a collision winner can never pair an old prompt with a new owner. The stamp
+// is stripped from client-visible output by the filter.
 //
 // authorize, when non-nil, is invoked by every upstream prompt handler with the
 // prompt's canonical server BEFORE getPrompt; a non-nil error is returned to

--- a/internal/server/mcp_routing.go
+++ b/internal/server/mcp_routing.go
@@ -1339,46 +1339,64 @@ func buildAggregatedServerPrompts(
 // reaches a client.
 const aggregatedPromptServerMetaKey = "app.mcpproxy/server"
 
+// aggregatedPromptStamp is the value stored under aggregatedPromptServerMetaKey.
+// It is a private struct rather than a bare string so an upstream that itself
+// sends our key (a string) can never be mistaken for a stamp, and so the
+// upstream's own _meta — nil, `{}`, a progress token, or even its own value
+// for our key — travels with the registered prompt and is handed back
+// verbatim by stripAggregatedPromptServer. Marshalling it (which only an
+// unfiltered path could do) yields `{}`: the fields are unexported.
+type aggregatedPromptStamp struct {
+	server   string
+	upstream *mcp.Meta
+}
+
 // stampAggregatedPromptServer returns a fresh Meta carrying serverName under
-// aggregatedPromptServerMetaKey. Upstream-supplied additional fields are
-// preserved, but an upstream that itself sent our key is overwritten — the
-// owner is what mcpproxy dispatches to, never what the upstream claims.
+// aggregatedPromptServerMetaKey. Upstream-supplied fields are mirrored into it
+// (so an unfiltered reader still sees them), while the upstream Meta itself is
+// kept inside the stamp so the strip can restore exactly what the upstream
+// sent. An upstream value under our key never wins — the owner is what
+// mcpproxy dispatches to, never what the upstream claims — but it is restored
+// on the client-visible copy along with the rest of the upstream _meta.
 func stampAggregatedPromptServer(upstream *mcp.Meta, serverName string) *mcp.Meta {
 	meta := &mcp.Meta{AdditionalFields: map[string]any{}}
 	if upstream != nil {
 		meta.ProgressToken = upstream.ProgressToken
 		maps.Copy(meta.AdditionalFields, upstream.AdditionalFields)
 	}
-	meta.AdditionalFields[aggregatedPromptServerMetaKey] = serverName
+	meta.AdditionalFields[aggregatedPromptServerMetaKey] = aggregatedPromptStamp{server: serverName, upstream: upstream}
 	return meta
 }
 
 // aggregatedPromptServer reads the canonical owner stamped by
 // stampAggregatedPromptServer. ok is false for a prompt that carries no stamp
-// (a built-in, or anything not published by buildAggregatedServerPrompts).
+// (a built-in, anything not published by buildAggregatedServerPrompts, or an
+// upstream-supplied string under our key).
 func aggregatedPromptServer(prompt mcp.Prompt) (serverName string, ok bool) {
+	stamp, ok := aggregatedPromptStampOf(prompt)
+	return stamp.server, ok && stamp.server != ""
+}
+
+func aggregatedPromptStampOf(prompt mcp.Prompt) (aggregatedPromptStamp, bool) {
 	if prompt.Meta == nil {
-		return "", false
+		return aggregatedPromptStamp{}, false
 	}
-	serverName, ok = prompt.Meta.AdditionalFields[aggregatedPromptServerMetaKey].(string)
-	return serverName, ok && serverName != ""
+	stamp, ok := prompt.Meta.AdditionalFields[aggregatedPromptServerMetaKey].(aggregatedPromptStamp)
+	return stamp, ok
 }
 
 // stripAggregatedPromptServer returns prompt with the internal owner stamp
-// removed, leaving every other _meta field intact. The registered prompt is
-// never mutated: mcp-go hands filters the stored value and a shared Meta
-// pointer, so the Meta is copied before the key is dropped.
+// removed and its _meta restored to exactly the value the upstream sent —
+// nil stays nil, an empty `{}` stays `{}` — so administrator-visible output is
+// byte-identical to the pre-stamp wire format (Spec 105 SC-005). The
+// registered prompt is never mutated: mcp-go hands filters the stored value
+// and a shared Meta pointer, and only the copy's Meta pointer is replaced.
 func stripAggregatedPromptServer(prompt mcp.Prompt) mcp.Prompt {
-	if _, ok := aggregatedPromptServer(prompt); !ok {
+	stamp, ok := aggregatedPromptStampOf(prompt)
+	if !ok {
 		return prompt
 	}
-	fields := maps.Clone(prompt.Meta.AdditionalFields)
-	delete(fields, aggregatedPromptServerMetaKey)
-	if len(fields) == 0 && prompt.Meta.ProgressToken == nil {
-		prompt.Meta = nil
-		return prompt
-	}
-	prompt.Meta = &mcp.Meta{ProgressToken: prompt.Meta.ProgressToken, AdditionalFields: fields}
+	prompt.Meta = stamp.upstream
 	return prompt
 }
 

--- a/internal/server/mcp_routing_test.go
+++ b/internal/server/mcp_routing_test.go
@@ -182,9 +182,14 @@ func TestBuildAggregatedServerPrompts(t *testing.T) {
 		return &mcp.GetPromptResult{Description: "from upstream"}, nil
 	}
 
-	all := buildAggregatedServerPrompts([]mcpserver.ServerPrompt{builtin}, upstreamPrompts, fakeGetPrompt, zap.NewNop())
+	all := buildAggregatedServerPrompts([]mcpserver.ServerPrompt{builtin}, upstreamPrompts, fakeGetPrompt, nil, zap.NewNop())
 
 	require.Len(t, all, 2)
+	_, builtinStamped := aggregatedPromptServer(all[0].Prompt)
+	assert.False(t, builtinStamped, "built-ins carry no owner stamp")
+	owner, stamped := aggregatedPromptServer(all[1].Prompt)
+	require.True(t, stamped, "published upstream prompt carries its canonical owner")
+	assert.Equal(t, "server-a", owner)
 	assert.Equal(t, "setup-new-mcp-server", all[0].Prompt.Name)
 	assert.Equal(t, "server-a__greeting", all[1].Prompt.Name)
 	assert.Equal(t, "hi", all[1].Prompt.Description)
@@ -202,7 +207,7 @@ func TestBuildAggregatedServerPrompts(t *testing.T) {
 
 func TestBuildAggregatedServerPrompts_SkipsMalformedNames(t *testing.T) {
 	upstreamPrompts := []mcp.Prompt{{Name: "no-colon-here"}}
-	all := buildAggregatedServerPrompts(nil, upstreamPrompts, nil, zap.NewNop())
+	all := buildAggregatedServerPrompts(nil, upstreamPrompts, nil, nil, zap.NewNop())
 	assert.Empty(t, all)
 }
 
@@ -1187,7 +1192,10 @@ func TestBuildAggregatedServerPrompts_CollisionKeepsFirst(t *testing.T) {
 		return &mcp.GetPromptResult{}, nil
 	}
 
-	all := buildAggregatedServerPrompts(nil, upstreamPrompts, fakeGetPrompt, logger)
+	all := buildAggregatedServerPrompts(nil, upstreamPrompts, fakeGetPrompt, nil, logger)
+	require.Len(t, all, 1)
+	owner, _ := aggregatedPromptServer(all[0].Prompt)
+	assert.Equal(t, "gh", owner, "the kept (first) writer owns the display name")
 
 	names := make([]string, len(all))
 	for i, p := range all {
@@ -1287,4 +1295,39 @@ func TestDirectDeferralLegend_ExplainsTheMarkers(t *testing.T) {
 	assert.Contains(t, directDeferralLegend, "~")
 	assert.Contains(t, directDeferralLegend, "describe_tool")
 	assert.Contains(t, directDeferralLegend, "placeholder")
+}
+
+// TestBuildAggregatedServerPrompts_HandlerAuthorizesCanonicalServer (Spec 104
+// FR-016g, cross-review P1): every upstream prompt handler must consult the
+// authorize hook with its OWN canonical server before contacting the upstream,
+// so a stale owner record or a mid-refresh window can never turn a filter
+// pass into an unauthorized fetch.
+func TestBuildAggregatedServerPrompts_HandlerAuthorizesCanonicalServer(t *testing.T) {
+	var fetched []string
+	fakeGetPrompt := func(_ context.Context, name string, _ map[string]string) (*mcp.GetPromptResult, error) {
+		fetched = append(fetched, name)
+		return &mcp.GetPromptResult{}, nil
+	}
+	var asked []string
+	authorize := func(_ context.Context, serverName string) error {
+		asked = append(asked, serverName)
+		if serverName == "a__b" {
+			return errPromptNotFound
+		}
+		return nil
+	}
+
+	all := buildAggregatedServerPrompts(nil, []mcp.Prompt{{Name: "a:greeting"}, {Name: "a__b:greeting"}}, fakeGetPrompt, authorize, zap.NewNop())
+	byName := map[string]mcpserver.ServerPrompt{}
+	for _, sp := range all {
+		byName[sp.Prompt.Name] = sp
+	}
+
+	_, err := byName["a__b__greeting"].Handler(context.Background(), mcp.GetPromptRequest{})
+	require.ErrorIs(t, err, errPromptNotFound)
+	_, err = byName["a__greeting"].Handler(context.Background(), mcp.GetPromptRequest{})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"a__b", "a"}, asked, "each handler asks about its canonical server, not a re-parse of the display name")
+	assert.Equal(t, []string{"a:greeting"}, fetched, "a denied handler never contacts the upstream")
 }

--- a/internal/server/mcp_routing_test.go
+++ b/internal/server/mcp_routing_test.go
@@ -1177,32 +1177,42 @@ func TestRefreshPrompts_PopulatesRoutingModeServers(t *testing.T) {
 // TestBuildAggregatedServerPrompts_CollisionKeepsFirst covers Finding F7: two
 // distinct (server,prompt) pairs that flatten to the same "server__prompt"
 // display name must be resolved deterministically (first-writer-wins), not
-// silently overwritten, and the drop must be logged.
+// silently overwritten, and the drop must be logged. The winner must be the
+// same whichever order the upstream manager hands the prompts over in —
+// ListPrompts iterates a map — so both input orders are exercised (Spec 105
+// FR-006 "collisions in both input orders").
 func TestBuildAggregatedServerPrompts_CollisionKeepsFirst(t *testing.T) {
-	core, logs := observer.New(zap.WarnLevel)
-	logger := zap.New(core)
-
 	// "gh" + "issue__create" and "gh__issue" + "create" both flatten to
 	// "gh__issue__create".
-	upstreamPrompts := []mcp.Prompt{
-		{Name: "gh:issue__create", Description: "first"},
-		{Name: "gh__issue:create", Description: "second (collides)"},
-	}
+	first := mcp.Prompt{Name: "gh:issue__create", Description: "first"}
+	second := mcp.Prompt{Name: "gh__issue:create", Description: "second (collides)"}
 	fakeGetPrompt := func(_ context.Context, _ string, _ map[string]string) (*mcp.GetPromptResult, error) {
 		return &mcp.GetPromptResult{}, nil
 	}
 
-	all := buildAggregatedServerPrompts(nil, upstreamPrompts, fakeGetPrompt, nil, logger)
-	require.Len(t, all, 1)
-	owner, _ := aggregatedPromptServer(all[0].Prompt)
-	assert.Equal(t, "gh", owner, "the kept (first) writer owns the display name")
+	for name, upstreamPrompts := range map[string][]mcp.Prompt{
+		"sorted order":   {first, second},
+		"reversed order": {second, first},
+	} {
+		t.Run(name, func(t *testing.T) {
+			core, logs := observer.New(zap.WarnLevel)
+			logger := zap.New(core)
 
-	names := make([]string, len(all))
-	for i, p := range all {
-		names[i] = p.Prompt.Name
+			all := buildAggregatedServerPrompts(nil, upstreamPrompts, fakeGetPrompt, nil, logger)
+			require.Len(t, all, 1)
+			owner, _ := aggregatedPromptServer(all[0].Prompt)
+			assert.Equal(t, "gh", owner, "the lexically-first qualified name owns the display name regardless of input order")
+			assert.Equal(t, "gh__issue__create", all[0].Prompt.Name, "colliding display name must appear once (first kept)")
+			assert.Equal(t, "first", all[0].Prompt.Description)
+
+			entries := logs.FilterMessage("dropping upstream prompt: display-name collision (kept first)").All()
+			require.Len(t, entries, 1, "the dropped collision must be logged exactly once")
+			fields := entries[0].ContextMap()
+			assert.Equal(t, "gh__issue", fields["server"])
+			assert.Equal(t, "create", fields["prompt"])
+			assert.Equal(t, "gh__issue__create", fields["display_name"])
+		})
 	}
-	assert.Equal(t, []string{"gh__issue__create"}, names, "colliding display name must appear once (first kept)")
-	require.Equal(t, 1, logs.FilterMessage("dropping upstream prompt: display-name collision (kept first)").Len())
 }
 
 // Spec 102 FR-007 / D11 / D16 (T034): the direct server carries instructions on

--- a/internal/server/profile_integration_test.go
+++ b/internal/server/profile_integration_test.go
@@ -765,3 +765,49 @@ func TestProfile_EndpointReachability(t *testing.T) {
 			"profile endpoint %s must be reachable; got %d", url, resp.StatusCode)
 	}
 }
+
+// TestProfile_DeletedPinDoesNotEnumerateProfiles is the Spec 104 FR-016b
+// regression (cross-model review): after the profile an agent token is pinned
+// to is deleted, a request to /mcp/p/<pin> passes the pin check and fell into
+// the generic "unknown profile" branch, whose "available" list enumerated
+// every remaining profile — profiles the token may never select (the resolver
+// treats a deleted pin as deny-all). The error must not list them.
+func TestProfile_DeletedPinDoesNotEnumerateProfiles(t *testing.T) {
+	env := newProfileTestEnv(t)
+	rawToken := env.mintPinnedToken("pinned-research", "research")
+
+	// Delete the pinned profile; "deploy" remains configured.
+	old := env.proxyServer.runtime.Config()
+	cfgCopy := *old
+	cfg := &cfgCopy
+	cfg.Profiles = []config.ProfileConfig{{Name: "deploy", Servers: []string{"deploy-srv"}}}
+	env.proxyServer.runtime.UpdateConfig(cfg, "")
+
+	baseURL := strings.TrimSuffix(env.proxyAddr, "/mcp")
+	const initBody = `{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/mcp/p/research", strings.NewReader(initBody))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+rawToken)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "unknown profile 'research'", body["error"])
+	_, enumerated := body["available"]
+	assert.False(t, enumerated, "a pinned agent token must not be told which other profiles exist: %v", body)
+
+	// Administrator behaviour is unchanged: an unauthenticated (admin-context)
+	// caller on an unknown slug still gets the list.
+	adminResp, err := http.Post(baseURL+"/mcp/p/research", "application/json", strings.NewReader(initBody))
+	require.NoError(t, err)
+	defer adminResp.Body.Close()
+	require.Equal(t, http.StatusNotFound, adminResp.StatusCode)
+	var adminBody map[string]interface{}
+	require.NoError(t, json.NewDecoder(adminResp.Body).Decode(&adminBody))
+	available, _ := adminBody["available"].([]interface{})
+	assert.Equal(t, []interface{}{"deploy"}, available, "admin still sees the available list")
+}

--- a/internal/server/profile_tool.go
+++ b/internal/server/profile_tool.go
@@ -91,6 +91,13 @@ func (p *MCPProxyServer) handleSetProfile(ctx context.Context, request mcp.CallT
 		}
 	}
 	if match == nil {
+		// A pinned token only gets here when its own pinned profile has been
+		// deleted; the resolver treats that pin as deny-all, so the remaining
+		// profiles are not selectable by it and must not be enumerated
+		// (Spec 104 FR-016b). Unpinned callers keep the discovery list.
+		if pin != "" {
+			return mcp.NewToolResultError(fmt.Sprintf("unknown profile '%s'", slug)), nil
+		}
 		return mcp.NewToolResultError(fmt.Sprintf("unknown profile '%s' (available: %s)", slug, strings.Join(profileNames(cfg), ", "))), nil
 	}
 

--- a/internal/server/profile_tool_test.go
+++ b/internal/server/profile_tool_test.go
@@ -123,8 +123,22 @@ func TestHandleSetProfile_DeletedPinDoesNotEnumerateProfiles(t *testing.T) {
 	require.Contains(t, text, "unknown profile 'research'")
 	require.NotContains(t, text, "deploy", "a pinned token must not learn the other profiles' names: %s", text)
 
-	// Unpinned callers keep the discovery affordance.
-	res = callSetProfileTool(t, p, setProfileCtx("sess-unpinned", ""), "research")
+	// Unpinned callers keep the discovery affordance — proven with an actual
+	// unpinned AGENT identity (ProfilePin ""), not merely the absence of an
+	// auth context, which is administrator-shaped and would leave the agent
+	// contract unproven (cross-review round 2).
+	unpinnedAgent := auth.WithAuthContext(setProfileCtx("sess-unpinned", ""), &auth.AuthContext{
+		Type:           auth.AuthTypeAgent,
+		AgentName:      "unpinned-bot",
+		AllowedServers: []string{"*"},
+		Permissions:    []string{auth.PermRead},
+	})
+	res = callSetProfileTool(t, p, unpinnedAgent, "research")
+	require.True(t, res.IsError)
+	require.Contains(t, setProfileResultText(t, res), "available: deploy")
+
+	// And an administrator-shaped caller (no auth context) likewise.
+	res = callSetProfileTool(t, p, setProfileCtx("sess-admin", ""), "research")
 	require.True(t, res.IsError)
 	require.Contains(t, setProfileResultText(t, res), "available: deploy")
 }

--- a/internal/server/profile_tool_test.go
+++ b/internal/server/profile_tool_test.go
@@ -106,3 +106,25 @@ func TestHandleSetProfile_UnpinnedUnchanged(t *testing.T) {
 	require.False(t, res.IsError, "unpinned token must switch freely: %s", setProfileResultText(t, res))
 	require.Equal(t, "deploy", p.sessionStore.GetActiveProfile("sess-free"))
 }
+
+// TestHandleSetProfile_DeletedPinDoesNotEnumerateProfiles is the Spec 104
+// FR-016b regression on the MCP surface (cross-review finding): a token pinned
+// to a profile that has since been deleted passes the pin check for its own
+// slug and fell into the "unknown profile (available: ...)" error, which listed
+// every remaining profile — profiles the pin makes unselectable. The error must
+// not enumerate them; an unpinned caller still gets the list.
+func TestHandleSetProfile_DeletedPinDoesNotEnumerateProfiles(t *testing.T) {
+	p := newSetProfileTestServer()
+	p.config.Profiles = []config.ProfileConfig{{Name: "deploy", Servers: []string{"deploy-srv"}}}
+
+	res := callSetProfileTool(t, p, setProfileCtx("sess-deleted-pin", "research"), "research")
+	require.True(t, res.IsError)
+	text := setProfileResultText(t, res)
+	require.Contains(t, text, "unknown profile 'research'")
+	require.NotContains(t, text, "deploy", "a pinned token must not learn the other profiles' names: %s", text)
+
+	// Unpinned callers keep the discovery affordance.
+	res = callSetProfileTool(t, p, setProfileCtx("sess-unpinned", ""), "research")
+	require.True(t, res.IsError)
+	require.Contains(t, setProfileResultText(t, res), "available: deploy")
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2303,6 +2303,12 @@ func withHSTS(next http.Handler) http.Handler {
 // 404 responses:
 //   - No profiles configured at all → {"error":"no profiles configured"}
 //   - Slug not found               → {"error":"unknown profile '<slug>'","available":[...]}
+//
+// "available" is an administrator affordance. A profile-pinned agent token
+// reaches this branch only when its pinned profile has been deleted, and the
+// resolver treats that pin as deny-all (resolveActiveProfile) — so the error
+// omits the list rather than enumerate profiles the token may never select
+// (Spec 104 FR-016b).
 func (s *Server) profileMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		cfg := s.runtime.Config()
@@ -2346,16 +2352,19 @@ func (s *Server) profileMiddleware(next http.Handler) http.Handler {
 
 		// FR-009: slug not found.
 		if found == nil {
-			available := make([]string, 0, len(cfg.Profiles))
-			for _, p := range cfg.Profiles {
-				available = append(available, p.Name)
+			body := map[string]interface{}{
+				"error": fmt.Sprintf("unknown profile '%s'", slug),
+			}
+			if profilePinFromContext(r.Context()) == "" {
+				available := make([]string, 0, len(cfg.Profiles))
+				for _, p := range cfg.Profiles {
+					available = append(available, p.Name)
+				}
+				body["available"] = available
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusNotFound)
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{
-				"error":     fmt.Sprintf("unknown profile '%s'", slug),
-				"available": available,
-			})
+			_ = json.NewEncoder(w).Encode(body)
 			return
 		}
 


### PR DESCRIPTION
Part of Spec 105 (agent-token scope hardening).

## Summary

Two agent-token scope leaks on the HTTP MCP surfaces, both fail-closed now.

**Aggregated prompts (Spec 105 FR-006).** `filterAggregatedPromptsForAuth` re-parsed each published `server__prompt` display name on its *first* `__` to find the owner, while the registered handler dispatched to the server captured at publication. With servers `a` and `a__b` both serving `greeting`, `a__b`'s prompt is published as `a__b__greeting`; the re-parse claims owner `a`, so an agent token scoped to `a` alone could **list and fetch** a prompt that dispatches to `a__b`. The fix:

- `buildAggregatedServerPrompts` stamps the canonical owner into the registered prompt's `_meta` (`app.mcpproxy/server`). The stamp is a private struct carrying the owner **and** the upstream's original `_meta` pointer, so an upstream-supplied string under that key is never accepted as a stamp. The filter authorizes list **and** get against that stamp, read from the same registered prompt mcp-go hands it, so owner and prompt cannot skew across a refresh. The stamp is stripped from every prompt returned (admins included) by restoring the upstream `_meta` verbatim (`nil` → `nil`, `{}` → `{}`, progress token and foreign keys untouched), so client-visible `_meta` is exactly what the upstream sent.
- An upstream prompt with no stamp is dropped for scoped callers — the display-name guess is gone (fail closed).
- Every aggregated prompt handler runs `authorizeAggregatedPromptServer` against its **own** server before `getPrompt`, returning mcp-go's exact unregistered-name wording (`prompt '<name>' not found: prompt not found`), so a scope change between the filter and the handler inside one request still cannot dispatch.
- Upstream prompts are sorted by qualified name before collision resolution, so the display-name winner no longer depends on map iteration order.
- The prompt filter is bound to all four routing-mode servers **unconditionally**, not only under construction-time `enable_prompts`. `RefreshPrompts` publishes from the live config snapshot on every `servers.changed` / `config.reloaded` / prompts-changed event and mcp-go registers the prompts capability implicitly on the first `SetPrompts`, so a core started with prompts off and hot-reloaded to on would otherwise serve every upstream prompt unfiltered, with the internal stamp on the wire (cross-review round 2).

**Profile enumeration on a deleted pin (Spec 105 FR-004).** When the profile an agent token is pinned to has been deleted, both the profile-URL middleware (`/mcp/p/<slug>` 404 with `"available": [...]`) and the `set_profile` tool (`unknown profile 'x' (available: ...)`) fell into the generic unknown-slug branch and enumerated every remaining profile — profiles the resolver treats as unselectable for that token (a deleted pin is deny-all). Both now omit the list for pinned callers; unpinned callers and administrators are unchanged.

## What changed

| File | Change |
|---|---|
| `internal/server/mcp_routing.go` | `buildAggregatedServerPrompts` gains an `authorize` hook consulted by every upstream prompt handler before dispatch; stamps the canonical owner into `_meta` as a private `aggregatedPromptStamp{server, upstream}`; sorts upstream prompts by qualified name (`slices.SortStableFunc`) before collision resolution. Helpers `stampAggregatedPromptServer` / `aggregatedPromptStampOf` / `aggregatedPromptServer` / `stripAggregatedPromptServer` (strip restores the upstream `_meta` pointer verbatim). `RefreshPrompts` wires `p.authorizeAggregatedPromptServer`; `initRoutingModeServers` binds `WithPromptFilter` on the direct / code / call servers regardless of `EnablePrompts`. |
| `internal/server/mcp.go` | `NewMCPProxyServer` binds `WithPromptFilter(filterAggregatedPromptsForAuth)` on the default server unconditionally (was inside `if config.EnablePrompts`); `registerPrompts` stays gated. |
| `internal/server/mcp_direct_scope.go` | `filterAggregatedPromptsForAuth` authorizes against the `_meta` stamp instead of re-parsing the display name; unstamped upstream prompts dropped for scoped callers; stamp stripped from all output. New `promptServerAllowed` (single predicate shared by filter and handler gate), `authorizeAggregatedPromptServer`, `errPromptNotFound` (= `mcpserver.ErrPromptNotFound`). |
| `internal/server/server.go` | `profileMiddleware` unknown-slug 404 omits `available` when the request carries a profile pin. |
| `internal/server/profile_tool.go` | `handleSetProfile` unknown-slug error omits `(available: ...)` when the caller is pinned. |
| `internal/server/mcp_prompt_scope_test.go` | Base fixtures now stamped like production; new `TestAggregatedPrompt_ScopeUsesCanonicalOwner` (with refusal-shape parity + direct handler invocation), `TestAggregatedPrompt_LateEnableStillFiltered`, `TestFilterAggregatedPromptsForAuth_UnstampedFailsClosed`, table-driven `TestStripAggregatedPromptServer_PreservesUpstreamMeta`; removed `..._KeepsUnparseableName` (it encoded the leak). |
| `internal/server/mcp_routing_test.go` | Signature update; owner-stamp assertions; new `TestBuildAggregatedServerPrompts_HandlerAuthorizesCanonicalServer`; `_CollisionKeepsFirst` runs both input orders. |
| `internal/server/mcp_block_tools_test.go` | `createTestProxyWithRuntimeCfg` — `createTestProxyWithRuntime` with a pre-construction config hook (used by the late-enable test). |
| `internal/server/profile_integration_test.go` | New `TestProfile_DeletedPinDoesNotEnumerateProfiles` (HTTP: pinned token gets no list, admin still does). |
| `internal/server/profile_tool_test.go` | New `TestHandleSetProfile_DeletedPinDoesNotEnumerateProfiles` (pinned: no list; unpinned agent token **and** no-auth admin: list unchanged). |

No config, API-surface, or tool-definition golden changes.

## Tests

- `TestAggregatedPrompt_ScopeUsesCanonicalOwner` — real `a` and `a__b` upstreams (streamable-http test servers), `prompts/list` + `prompts/get` through `HandleMessage` as an `a`-only token: `a__greeting` visible/fetchable, `a__b__greeting` hidden and denied; admin sees both; no `_meta` stamp on the wire for either caller. Asserts JSON-RPC code + message parity (modulo the echoed name) between the hidden `a__b__greeting` get and a nonexistent `a__nonexistent` get, and invokes the **registered** handler directly (bypassing mcp-go's filter) requiring `errPromptNotFound` for the `a`-only context while the admin context is served.
- `TestAggregatedPrompt_LateEnableStillFiltered` — proxy built with `enable_prompts=false`, both prompt flags flipped in the live snapshot, `RefreshPrompts`, then `prompts/list` as an `a`-only agent on all four servers: hidden prompt absent, no `_meta` stamp on any entry.
- `TestBuildAggregatedServerPrompts_HandlerAuthorizesCanonicalServer` — each handler asks about its canonical server (`a__b`, not `a`); a denied handler never calls `getPrompt`.
- `TestBuildAggregatedServerPrompts_CollisionKeepsFirst` — both input orders yield the same winner/owner/description and the same dropped-collision log fields.
- `TestStripAggregatedPromptServer_PreservesUpstreamMeta` — table: `nil` / `{}` / fields / progress token / upstream value under our key, each comparing `json.Marshal` of stripped vs as-sent; plus a forged-string stamp case.
- `TestFilterAggregatedPromptsForAuth_UnstampedFailsClosed`, stamp assertions in `TestBuildAggregatedServerPrompts`.
- `TestProfile_DeletedPinDoesNotEnumerateProfiles`, `TestHandleSetProfile_DeletedPinDoesNotEnumerateProfiles`.

Bite checks (each restored afterwards): PR-head `stripAggregatedPromptServer` → strip `empty` and `our_key` subtests fail; `SortStableFunc` removed → collision `reversed_order` fails; `authorize` passed as `nil` in `RefreshPrompts` → integration wiring assertion fails; filter bound only under `EnablePrompts` → `LateEnableStillFiltered` fails on all four servers; a guard hiding the profile list from every agent → `profile_tool_test.go:138` fails.

Gates run locally (CI invocation), green on every commit:

```
go build ./cmd/mcpproxy && go build -tags server -o /dev/null ./cmd/mcpproxy
go test -race -count=1 -skip 'E2E|Binary|MCPProtocol|TestInfoEndpoint|TestGracefulShutdownNoPanic|TestSocketInfoEndpoint' ./internal/server/...
/opt/homebrew/bin/golangci-lint run --config .github/.golangci.yml ./internal/server/...   # 0 issues
```

Frozen tool-surface goldens under `internal/server/testdata` pass unregenerated.

## Verification

Live verification on an isolated personal-edition instance (`127.0.0.1:18201`, fresh `--data-dir` + scratch `--config`, socket and Web UI disabled). Branch `da05678f` (the original fix commit; the two review commits below change the `_meta` restore and the filter binding, neither of which alters the probes shown) vs baseline `origin/main c93f79423`, same config on both binaries.

**Rig.** Upstreams `a` and `a__b` are both `npx -y @modelcontextprotocol/server-everything` (stdio; 4 prompts each: `args-prompt`, `completable-prompt`, `resource-prompt`, `simple-prompt`). Profiles `p-doomed` → `["a"]`, `p-other` → `["a__b"]`. `enable_prompts: true`, `aggregate_upstream_prompts: true`, `quarantine_enabled: false`, both servers `quarantined: false`, both `connected: true` before any probe. Tokens minted via `POST /api/v1/tokens` (X-API-Key): `tok-a-only` (`allowed_servers: ["a"]`, read), `tok-wild` (`["*"]`), `tok-pinned` (`["*"]`, `profile_pin: "p-doomed"`).

**Request shape** — `initialize` (`protocolVersion 2025-03-26`) → capture `Mcp-Session-Id` → second `POST` with the probe method:

```
curl -s -D hdrs -X POST http://127.0.0.1:18201/mcp -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' -H "Authorization: Bearer $TOKEN" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"verify","version":"1"}}}'
curl -s -X POST http://127.0.0.1:18201/mcp … -H "Mcp-Session-Id: $SID" \
  -d '{"jsonrpc":"2.0","id":2,"method":"prompts/get","params":{"name":"a__b__args-prompt","arguments":{"city":"Vilnius"}}}'
```

### Scenario 1 — `a`-only agent token vs prompts owned by `a__b`

| probe | baseline (`origin/main`) | branch (#1227) |
|---|---|---|
| `tok-a-only` `prompts/list` | **leak** — all 10 names, incl. `a__b__args-prompt`, `a__b__completable-prompt`, `a__b__resource-prompt`, `a__b__simple-prompt` | `a__args-prompt`, `a__completable-prompt`, `a__resource-prompt`, `a__simple-prompt`, `setup-new-mcp-server`, `troubleshoot-mcp-server` — no `a__b__*`, no `_meta` |
| `tok-a-only` `prompts/get a__b__args-prompt` | **leak** — `result.messages[0].content.text = "What's weather in Vilnius?"` (upstream `a__b` was contacted) | `{"error":{"code":-32602,"message":"prompt 'a__b__args-prompt' not found: prompt not found"}}` |
| `tok-a-only` `prompts/get totally-unknown-prompt` (reference) | `-32602 "prompt 'totally-unknown-prompt' not found: prompt not found"` | same |
| `tok-a-only` `prompts/get a__args-prompt` (own server) | 1 message | 1 message, `"What's weather in Vilnius?"` |
| `tok-wild` `prompts/get a__b__args-prompt` (positive control) | 1 message | 1 message, `"What's weather in Vilnius?"` |
| `tok-wild` / admin `prompts/list` (positive control) | 10 names | 10 names, no `_meta` on any prompt |

Refusal-shape parity on the branch (request `id` stripped, caller-supplied name placeholdered):

```
diff <(jq -c 'del(.id)|.error.message|=sub("a__b__args-prompt";"<NAME>")' branch-aonly-get-ab.json) \
     <(jq -c 'del(.id)|.error.message|=sub("totally-unknown-prompt";"<NAME>")' branch-aonly-get-unknown.json)
→ identical: {"jsonrpc":"2.0","error":{"code":-32602,"message":"prompt '<NAME>' not found: prompt not found"}}
```

An `a__b` prompt is indistinguishable from an unregistered name to the `a`-only caller; the only name in the refusal is the one the caller itself sent.

### Scenario 2 — pinned token whose pinned profile was deleted

Deletion = remove `p-doomed` from `profiles[]` in the scratch config; the watcher hot-reloaded within 2 s (`GET /api/v1/profiles` → `["p-other"]`) on both binaries.

| probe (`tok-pinned`, pin `p-doomed`) | baseline | branch |
|---|---|---|
| `initialize` via `/mcp/p/p-doomed` after deletion | HTTP 404 **`{"available":["p-other"],"error":"unknown profile 'p-doomed'"}`** — leak | HTTP 404 `{"error":"unknown profile 'p-doomed'"}` |
| `tools/call set_profile {"profile":"p-doomed"}` on `/mcp` | isError **`"unknown profile 'p-doomed' (available: p-other)"`** — leak | isError `"unknown profile 'p-doomed'"` |
| `set_profile {"profile":"nope-nope"}` | `"agent token is pinned to profile 'p-doomed' and cannot switch to 'nope-nope'"` (pin-mismatch check fires first on both) | same |
| `set_profile {"profile":""}` | — | `{"active_profile":"p-doomed","servers":[]}` — deny-all, no server names |
| `/mcp/p/p-other` (foreign profile) | — | HTTP 403 `"agent token is pinned to profile 'p-doomed' and cannot access profile 'p-other'"` |
| `/mcp/p/p-doomed` before deletion (positive control) | — | 200; `prompts/list` = `a__*` ×4 + built-ins |

Unpinned admin references are unchanged by design on both binaries: `/mcp/p/nope-nope` → 404 with `available: ["p-other"]`; `set_profile nope-nope` → `"unknown profile 'nope-nope' (available: p-other)"`; `set_profile p-other` → `{"active_profile":"p-other","servers":["a__b"]}`. `grep -c -E 'p-other|available|a__b'` over every branch pinned-token body → 0.

Caveats from the run:

- The branch `prompts/get` refusal does name the requested prompt, but only by echoing the caller's own input; it is byte-identical in shape to the refusal for a never-registered name. Read "without naming it" as "without confirming it exists".
- The baseline `set_profile` enumeration is only reachable when the pinned token names its **own** deleted slug; a foreign bad name is short-circuited by the pin-mismatch check on both binaries. The own-slug path is the one shown closed above.
- `./cmd/mcpfixture` exposes no prompts, so both upstreams are `server-everything` — identical prompt names on both servers, which is exactly the first-`__` parse trap.
- Unscoped admin / API-key callers still receive every aggregated prompt and the `available` list (Spec 105 admin-withholding point, listed under follow-ups).
- Live-instance verification only; unit tests and lint were run separately (see Tests above and the review record below). Both instances were killed by pattern, port 18201 confirmed free, no orphaned `server-everything` children; `8080` / `~/.mcpproxy` untouched.

## Cross-model review

Reviewer: opencode 1.18.29, model `github-copilot/gpt-6-astra`. Rounds run: 3 (one attempt each, every round returned a verdict of FINDINGS). Fix rounds: 2 (round 1 → `8466860ec`, round 2 → `b1a4864b5`, both pushed); round 3 produced no genuine defect in the diff, so nothing was pushed and the PR stands at `b1a4864b5`. Every finding was verified against the code before being applied or declined. The reviewer was given Spec 105 (staged under the worktree's uncommitted `.review-tmp/`) as the acceptance contract.

### Round 1 — 6 findings (all P3); fixed in `8466860ec`

| id | file | claim | disposition |
|---|---|---|---|
| R1-1 | `mcp_routing.go` | `stripAggregatedPromptServer` changed admin-visible upstream `_meta`: an upstream `_meta: {}` (non-nil empty map) went absent on the wire, and an upstream value under `app.mcpproxy/server` was overwritten at stamp time and deleted at strip time — contradicting the "exactly what the upstream sent" claim. | **Applied.** Confirmed (`mcp.Meta.MarshalJSON` emits `{}` for a non-nil empty map). Stamp is now a private `aggregatedPromptStamp{server, upstream *mcp.Meta}`; strip restores `stamp.upstream` verbatim (exact pre-PR pointer parity); an upstream string under our key is no longer accepted as a stamp. `TestStripAggregatedPromptServer_PreservesUpstreamMeta` rewritten table-driven; `empty` and `our_key` subtests fail on the PR-head strip. |
| R1-2 | `mcp_direct_scope.go` | Unstamped non-built-in prompts are dropped only when `enforce` is true; admin / API-key callers still list and fetch them; FR-006 + SC-005 require withholding from everyone. | **Declined.** Unreachable in production — every upstream prompt registered by `buildAggregatedServerPrompts` is stamped by construction and the only unstamped prompts are built-ins. Admin withholding is the FR-006/SC-005 contract point already listed as a follow-up; the test at `mcp_prompt_scope_test.go:150` documents current behaviour for that follow-up to flip. |
| R1-3 | `mcp_routing.go` | `strings.Cut("a:", ":")` succeeds, so an empty upstream prompt name is stamped with owner `a` and registered as `a__`; FR-006/SC-005 require withholding it from everyone. | **Declined.** The `!ok` gate on `strings.Cut` and the manager's `name + ":" + prompt` qualification predate the PR; the diff only stamps the (correct) owner onto what the gate admits. An `a`-authorized caller listing `a__` is not a scope leak; withholding empty-name registrations is the first FR-006 follow-up. |
| R1-4 | `mcp_direct_scope.go` | Handler-side denial surfaces as `-32603` (INTERNAL_ERROR) while the unregistered-name / filter-hidden paths return `-32602` (INVALID_PARAMS); message identical. | **Declined.** Verified against mcp-go v1.0.0 `handleGetPrompt`: any `finalHandler` error is unconditionally wrapped as `INTERNAL_ERROR` — no handler-controllable code. Reachable only via a scope change inside one request; already documented as a residual in the code and under follow-ups. The reachable path is now pinned to `-32602` + identical message by the new parity assertion. |
| R1-5 | `mcp_prompt_scope_test.go`, `mcp_routing_test.go`, `profile_tool_test.go` | Test-strength gaps: (a) `UnstampedFailsClosed` is vacuous for the explicit `!stamped` branch; (b) `CollisionKeepsFirst` is vacuous for the new `SortStableFunc` (input already lexically ordered); (c) the "unpinned" comparison in `HandleSetProfile_DeletedPin…` runs with a nil auth context; (d) `ScopeUsesCanonicalOwner` asserts only `NotNil(denied["error"])` and passes with the authorize hook removed. | **(b), (d) applied.** Collision test runs both input orders (removing `SortStableFunc` fails `reversed_order`); `ScopeUsesCanonicalOwner` asserts code + message parity vs a nonexistent name and invokes the registered handler directly with the `a`-only context (passing `nil` for `authorize` fails). **(a) declined:** `auth.CanAccessServer("")` and `ProfileScope.Allows("")` both return false for every enforcing caller, so the `!stamped` branch is redundant defence in depth and no fixture can make it deciding; the test still bites for the contract it names (it fails if the filter re-parses the display name). **(c) declined in round 1** (an unpinned-agent comparison would codify the `(available: …)` enumeration that the FR-003/FR-004 follow-up removes) — then reconsidered and applied in round 2 as R2-3, since the comparison pins the admin/unpinned affordance *unchanged by this diff*, which is what the PR claims. |
| R1-6 | `server.go`, `profile_tool.go` | Enumeration suppression keys on `profilePinFromContext(...) != ""` only, so an unpinned restricted token on an unknown slug still receives every profile name and can initialize through a profile disjoint from its grant. Reviewer rated P1 against FR-003/FR-004. | **Declined.** Pre-existing and outside the diff (the reviewer's own note downgrades it); the diff closes only the deleted-pin branch. The selectable-profile predicate is the FR-003/FR-004 follow-up and needs a new authorization predicate, not a review-round fix. |

### Round 2 — 4 findings (1 P2, 3 P3); fixed in `b1a4864b5`

| id | sev | file | claim | disposition |
|---|---|---|---|---|
| R2-1 | P2 | `mcp_routing.go`, `mcp.go` | Prompts enabled after startup are published onto servers carrying no prompt filter: the filter was bound only under construction-time `EnablePrompts`, but `RefreshPrompts` gates on the live snapshot and runs on every `config.reloaded`; mcp-go `AddPrompts` implicitly registers the capability. Result: unfiltered `prompts/list` for every caller, with `"_meta":{"app.mcpproxy/server":{}}` on the wire. The filter-less listing hole predates the diff; the diff added the stamp to that path. | **Applied.** Reproduced with a failing test (`enable_prompts=false` at construction, both flags flipped live, `RefreshPrompts`, `prompts/list` as an `a`-only agent on all four servers → hidden prompt listed + stamp serialized). Filter now bound unconditionally on all four servers (no-op while nothing is registered; capability advertisement stays gated). `TestAggregatedPrompt_LateEnableStillFiltered` fails before, passes after; helper `createTestProxyWithRuntimeCfg` added. The handler-side authorize hook already blocked `prompts/get` on this path, so the diff never widened fetch. |
| R2-2 | P3 | `mcp_routing.go` | Stamp doc comment claimed owner and prompt are "published in ONE SetPrompts step and filtered from ONE snapshot"; mcp-go v1.0.0 `SetPrompts` clears under `promptsMu`, unlocks, then `AddPrompts` re-locks per batch, so a concurrent list can observe an empty/partial set. No cross-owner bypass follows (each prompt carries its own owner). | **Applied.** Verified (`server.go:914-919`); comment rewritten to state the per-prompt binding the guard relies on and to acknowledge the non-atomic clear/re-add. No behaviour change. |
| R2-3 | P3 | `profile_tool_test.go` | R1-5(c) marked applied but unchanged: `setProfileCtx` installs no auth context for pin `""`, so the "unpinned" comparison was administrator-shaped. | **Applied.** The unpinned call now runs with an `AuthTypeAgent` context (`ProfilePin ""`, `AllowedServers ["*"]`) and separately with no auth context. A mutant guard hiding the list from every agent fails the new assertion and passed the old fixture vacuously. |
| R2-4 | P3 (reviewer P2) | `server.go` | A deleted-pin token can still tell whether other profiles exist: zero profiles → 404 `no profiles configured` (checked before the pin check), another profile present → 404 `unknown profile '<pin>'`; empty-slug `/mcp/p` gets 404 vs 403. | **Declined.** Pre-existing (the `no profiles configured` ordering is identical on `main`); the diff only removes the name list. Already the FR-004 status/body-parity follow-up. |

### Round 3 — 2 findings (both P2, both recommended as follow-ups by the reviewer); no code change

| id | file | claim | disposition |
|---|---|---|---|
| R3-1 | `server.go` | FR-004 selectable-profile predicate absent from `profileMiddleware`: once a slug exists and passes the pin check, the `ProfileScope` is built without intersecting the profile's servers with the agent's allowed servers, so an unpinned `a`-only token initializes through a `b`-only (or empty) profile while a nonexistent slug 404s — an existence oracle. Downstream filtering still blocks `b` content. | **Declined.** Pre-existing, outside the diff: `git diff origin/main -- internal/server/server.go` has exactly two hunks (doc comment + the FR-009 404 body); the `ProfileScope` build is byte-identical on `main` and `handleSetProfile` equally lacks the intersection. Reframing of declined R1-6; listed as follow-up per the reviewer's own recommendation. |
| R3-2 | `mcp_prompt_scope_test.go` | Mandatory FR-006 fixtures missing: no `__a` server / `review` prompt fixture, no retained-old-registration-across-replacement test, no overlapping-refresh test; collision-owner change is tested at builder level only. Implementation appears correct. | **Declined** as a test-coverage gap, not a runtime defect. Verified with a scratch test (run, then deleted, never committed) through the real path — upstream `__a` serving `review` over streamable-http, published by `RefreshPrompts`, JSON-RPC `prompts/list` + `prompts/get` via `HandleMessage`: registered as `__a__review`; listed and fetchable for an unrestricted agent and an admin; withheld from an `a`-only token on list, on get (`-32602`, same shape as an absent prompt) and at the registered handler (`errPromptNotFound`). `ParseDirectToolName("__a__review")` returns `ok=false`, so `main`'s "unidentifiable owner → keep" rule would have leaked it; the canonical-owner stamp is what makes it pass. Recorded under follow-ups. |

Gates per fix round (identical invocation to the Tests section): build both editions OK; `go test -race -count=1 …/internal/server/...` ok (227 s / 226 s / 246 s); golangci-lint v2 0 issues; goldens unregenerated (`git status` clean under `internal/server/testdata` after each run); `gofmt` / `go vet` clean; pre-commit and pre-push hooks passed. Commits made by explicit path only; `.review-tmp/` never staged.

## Follow-ups / Spec 105 gaps (not in this PR)

- [ ] FR-006 / SC-005: prompts with no registration identity are still served to unscoped admin / API-key callers — an empty upstream prompt name (`a:` → registered `a__`, `mcp_routing.go` stamp path), `:x` stamping an empty owner, and any unstamped display entry (`mcp_direct_scope.go`, unreachable in production today but the filter only drops it under `enforce`). Spec names both as administrator exceptions that must be withheld from everyone. (R1-2, R1-3.)
- [ ] FR-006: add a fixture for server `__a` with prompt `review` (unparseable display name `__a__review`) — listed+fetchable for an unrestricted agent and admin, withheld from an `a`-only token. Verified by hand in review round 3 (R3-2); the committed test is still missing.
- [ ] FR-006: controlled tests for retained old registrations across a `SetPrompts` replacement and for interleaved/overlapping `RefreshPrompts` (edge case "Prompt refresh interleaving") — mcp-go v1.0.0 `SetPrompts` clears under lock then `AddPrompts` re-locks per batch, and the four routing-mode servers are updated sequentially, so empty/mixed windows exist (R2-2); plus collision-owner change exercised through authorization + dispatch, not only at builder level (both input orders at builder level and the refusal-shape parity assertion in `TestAggregatedPrompt_ScopeUsesCanonicalOwner` landed in `8466860ec`). (R3-2.)
- [ ] FR-006 with FR-013/FR-014: credential-authenticated HTTP `prompts/list` + `prompts/get` matrix across `/mcp`, `/mcp/all`, `/mcp/code`, `/mcp/call`, `/mcp/p/<slug>` with the differential sentinel fixtures — the committed prompt tests inject the auth context directly into `proxy.server.HandleMessage`, and `TestAggregatedPrompt_LateEnableStillFiltered` covers list on all four server instances but not get.
- [ ] FR-004: make the agent-facing status/body identical across "profile missing" (404), "pin mismatch" (403 body naming the pin, `server.go:2335`), "no profiles configured" (distinct 404, evaluated before the pin check at `server.go:2317` — so a deleted-pin caller can still tell an empty fleet from a non-empty one, and on empty-slug `/mcp/p` gets 404 vs 403; R2-4), and "profile exists but not selectable" (200/proceeds); only the deleted-pin case stops enumerating here.
- [ ] FR-004/FR-003: implement the selectable-profile predicate (server-set intersection with the token's allowed servers) for unpinned tokens on `/mcp/p/<slug>` and `set_profile`; today an unpinned restricted token on an unknown slug still receives the full `available` list (`server.go:2358`, `profile_tool.go:98`), `set_profile` still says `(available: ...)`, and `/mcp/p/<slug>` initializes through an existing profile whose server set is disjoint from (or empty against) the token's grant while a nonexistent slug 404s — an existence oracle (R1-6, R3-1). Add the required fixture pair: initialize through a selectable AND a non-selectable existing profile URL with an unpinned restricted token (the new deleted-pin test covers only a matching deleted slug with another profile remaining).
- [ ] FR-004: cover `/mcp/p` and `/mcp/p/` (empty slug) with tests; for an unpinned token the empty slug falls into the enumerating unknown-profile branch.
- [ ] Residual (FR-006 / FR-010): handler-side denial surfaces as mcp-go `INTERNAL_ERROR` (-32603) vs `INVALID_PARAMS` (-32602) for an unregistered name — reachable only inside the filter→handler window (scope resolved per check, not per request); message identical; no handler-controllable code in mcp-go v1.0.0 (R1-4). The reachable path is pinned to -32602 + message parity by `TestAggregatedPrompt_ScopeUsesCanonicalOwner`.
- [x] Process: re-run the opencode `gpt-6-astra` round to completion so the PR carries a real cross-review verdict — done, three rounds with verdicts (see Cross-model review).

## Notes

- Branches `claude/eager-kirch-10f6c2` (this one) and `claude/xenodochial-lumiere-5abe75` both edit `internal/server/profile_tool.go` (`handleSetProfile`); expect a merge conflict in that function with whichever lands second.
- The Spec 105 document is the acceptance contract on branch `105-agent-scope-hardening` and is not yet on `main`; code comments cite the Spec 104 FR-016g / FR-016b lineage the fix was built against, which Spec 105 FR-006 / FR-004 restate.
