### PR TITLE
fix(test): register the GetServerLogs fixture client only after PhaseReady

### DIFF
--- a/internal/server/server_logs_missing_file_test.go
+++ b/internal/server/server_logs_missing_file_test.go
@@ -4,18 +4,32 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/logs"
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/runtime"
 )
 
 // newLogsTestServer builds a minimal Server whose per-server log directory is an
 // empty temp dir, and registers `serverName` with the upstream manager WITHOUT
-// connecting it (AddServerConfig), so GetServerLogs passes its existence check
-// while no log file has ever been written.
+// connecting it, so GetServerLogs passes its existence check while no log file
+// has ever been written. Callers must still invoke ensureLogsClient immediately
+// before GetServerLogs — see that helper for why registering once is not enough.
+//
+// The client is registered only once the runtime reports PhaseReady. Background
+// initialization runs LoadConfiguredServers, which snapshots the manager's
+// clients, diffs them against cfg.Servers and REMOVES the difference in
+// goroutines, and only then flips the phase. A client added before that diff is
+// on the removal list; a client added after it is not, because the diff never
+// sees it and the supervisor's periodic reconcile only ever removes names it
+// found in a config snapshot. Registering before the phase flip is what made
+// this test flake on a loaded machine: the removal landed between construction
+// and the call, and its "Disconnecting from server" line created the very log
+// file this test asserts is absent.
 func newLogsTestServer(t *testing.T, serverName string) (*Server, string) {
 	t.Helper()
 
@@ -29,14 +43,38 @@ func newLogsTestServer(t *testing.T, serverName string) (*Server, string) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = srv.Shutdown() })
 
+	require.Eventually(t, func() bool {
+		return srv.runtime.CurrentPhase() == runtime.PhaseReady
+	}, 10*time.Second, 10*time.Millisecond, "runtime never reached PhaseReady")
+
+	ensureLogsClient(t, srv, serverName)
+	return srv, logDir
+}
+
+// ensureLogsClient registers the upstream client GetServerLogs resolves, and
+// must be called IMMEDIATELY before GetServerLogs.
+//
+// This mirrors ensureFixerClient in diagnostics_fixers_test.go: a client the
+// supervisor never asked for survives only as long as nothing reconciles it
+// away, so re-registering at the call site closes the window to the few
+// microseconds before GetServerLogs. Re-registering an unchanged config keeps
+// the existing client (Manager.AddServerConfig compares first), so this never
+// disconnects or logs anything itself.
+//
+// Putting the server in cfg.Servers instead does not work (verified in
+// diagnostics_fixers_test.go): LoadConfiguredServers removes the client for a
+// DISABLED entry too, and an ENABLED entry spawns a child and a per-server log
+// writer that outlive Shutdown and then race t.TempDir()'s RemoveAll. A disabled
+// out-of-band client is the combination with no background goroutine and no
+// log writes.
+func ensureLogsClient(t *testing.T, srv *Server, serverName string) {
+	t.Helper()
 	require.NoError(t, srv.runtime.UpstreamManager().AddServerConfig(serverName, &config.ServerConfig{
 		Name:     serverName,
-		Protocol: "http",
-		URL:      "https://example.invalid/mcp",
-		Enabled:  true,
+		Protocol: "stdio",
+		Command:  "definitely-not-on-path",
+		Enabled:  false,
 	}))
-
-	return srv, logDir
 }
 
 // TestGetServerLogs_MissingFileReturnsEmptyNotError pins the UX-audit F12 fix.
@@ -55,6 +93,7 @@ func TestGetServerLogs_MissingFileReturnsEmptyNotError(t *testing.T) {
 	_, statErr := os.Stat(logFile)
 	require.True(t, os.IsNotExist(statErr), "precondition: %s must not exist", logFile)
 
+	ensureLogsClient(t, srv, serverName)
 	entries, err := srv.GetServerLogs(serverName, 10)
 	require.NoError(t, err, "an absent per-server log file is 'no entries yet', not an error")
 	require.NotNil(t, entries, "must marshal as [] rather than null")
@@ -65,8 +104,10 @@ func TestGetServerLogs_MissingFileReturnsEmptyNotError(t *testing.T) {
 // ENOENT branch is softened. A name the proxy does not know is still an error,
 // so the fix cannot mask a genuine "wrong server" mistake as an empty log.
 func TestGetServerLogs_UnknownServerStillErrors(t *testing.T) {
-	srv, _ := newLogsTestServer(t, "known")
+	const serverName = "known"
+	srv, _ := newLogsTestServer(t, serverName)
 
+	ensureLogsClient(t, srv, serverName)
 	_, err := srv.GetServerLogs("no-such-server", 10)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "server not found")


### PR DESCRIPTION
## Summary

`TestGetServerLogs_MissingFileReturnsEmptyNotError` (from #1216) flaked once on a loaded machine during the full `go test -race ./internal/server/...` run with `server not found: never-logged`, while passing 3/3 in isolation.

**Cause.** `newLogsTestServer` registered the upstream client via `UpstreamManager().AddServerConfig` at construction. Background initialization then runs `LoadConfiguredServers`, which snapshots the manager's clients, diffs them against `cfg.Servers`, and removes the difference in goroutines. A client added before that diff is on the removal list; under load the removal landed between construction and the call.

**Why the #1218 pattern alone was not enough.** Applying only `ensureFixerClient`-style re-registration at the call site fixed `server not found` but still failed 2/100 under `-race`: the removal's own `Disconnecting from server` line creates the per-server log file this test asserts is absent (`Should be empty, but was [...]`). The fixer tests never see that because they seed the log file themselves.

**Fix.** Wait for the runtime to reach `PhaseReady` before registering; the phase flips only after `LoadConfiguredServers` has taken its snapshot, so a client added afterwards is never on a removal list, and the supervisor's periodic reconcile only removes names from a config snapshot. The call-site re-registration is kept too, mirroring the fixer tests. Assertions unchanged.

## Verification

- 3s sleep between construction and the call: fails on the old fixture, passes with this change.
- `go test -race -count=5 -run 'TestGetServerLogs_' ./internal/server` — ok
- `-count=50`, twice, with 6 CPU hogs running — 200/200 pass (re-register-only variant: 2/100 fail)
- `golangci-lint run --config .github/.golangci.yml ./internal/server/...` — 0 issues

Note for #1218: `newFixerTestServer` has the same construction-time registration and could in principle lose its client to the same one-shot removal before the call-site re-register; it only survives because it re-registers immediately before invoking the fixer and writes its own log file. The `PhaseReady` wait here would harden it too if it ever flakes.
