### PR TITLE
ci: add an advisory go test -shuffle=on lane so order-coupled tests fail in CI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -193,8 +193,11 @@ jobs:
   # Re-run the failing package with that exact seed to get the same order:
   #   go test -race -count=1 -shuffle=<seed> ./internal/<pkg>/
   # (add the -skip regex below if the failing test lives next to E2E tests).
-  # Note that -count=1 matters — the seed reproduces the order, not the
-  # cache, and a cached "ok" would hide the failure.
+  # -shuffle is not one of go test's cacheable flags, so the replay is never
+  # served from the result cache; -count=1 is only the idiomatic belt-and-
+  # braces bypass for when flags get trimmed while bisecting. The seed fixes
+  # the test ORDER only — not goroutine scheduling or map iteration — and the
+  # blocked-value tests also depend on the host (hostname, $HOME basename).
   test-shuffle:
     name: Unit Tests (shuffle)
     needs: [build-frontend]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -177,6 +177,83 @@ jobs:
             coverage.out
             coverage.html
 
+  # Advisory shuffle lane: the same test set as "Unit Tests" on ubuntu, run
+  # with -shuffle=on so tests that only pass because of file/declaration order
+  # fail here instead of by luck. Motivation: #1222 — two fixtures flipped the
+  # process-global registry SSRF allow-policy and never restored it, and the
+  # CWE-918 regression test passed only because its file sorted first.
+  #
+  # This job is deliberately NOT in the branch-protection required list, so a
+  # newly exposed order coupling in an unrelated package does not block a PR
+  # while the tail of such tests is being found. Promote it to required once
+  # it has a run of green results on main.
+  #
+  # Reproducing a failure: with -shuffle on, every package prints its seed as
+  # the first line of its output, e.g. `-test.shuffle 1757400000000000000`.
+  # Re-run the failing package with that exact seed to get the same order:
+  #   go test -race -count=1 -shuffle=<seed> ./internal/<pkg>/
+  # (add the -skip regex below if the failing test lives next to E2E tests).
+  # Note that -count=1 matters — the seed reproduces the order, not the
+  # cache, and a cached "ok" would hide the failure.
+  test-shuffle:
+    name: Unit Tests (shuffle)
+    needs: [build-frontend]
+    runs-on: ubuntu-latest
+
+    env:
+      GO111MODULE: "on"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
+        with:
+          go-version: "1.25"
+          cache: true
+
+      - name: Download dependencies
+        run: go mod download
+
+      # Same reason as in the "Unit Tests" job: bench/arms tscg tests hard-fail
+      # without the pinned Node shim wherever `go test ./...` runs (Spec 083).
+      - name: Set up Node.js (TSCG bench arm)
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: bench/tscg/package-lock.json
+
+      - name: Install pinned TSCG shim dependencies (FR-006)
+        run: npm ci --prefix bench/tscg
+
+      - name: Download frontend artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: frontend-dist
+          path: frontend/dist
+
+      - name: Copy frontend dist for embedding
+        run: |
+          rm -rf web/frontend
+          mkdir -p web/frontend
+          cp -r frontend/dist web/frontend/
+
+      # Same tiktoken download race as in the "Unit Tests" job; see the comment
+      # there. Warm the cache once so parallel test binaries never rename.
+      - name: Warm the tiktoken vocabulary cache
+        run: go run ./bench/cmd/warmtiktoken
+        env:
+          TIKTOKEN_CACHE_DIR: ${{ runner.temp }}/tiktoken
+
+      # Keep the flags identical to the required ubuntu lane except for
+      # -shuffle=on (and no coverage — Codecov already gets the ordered run).
+      - name: Run unit tests (shuffled)
+        run: go test -v -race -shuffle=on -skip "E2E|Binary|MCPProtocol|TestInfoEndpoint|TestGracefulShutdownNoPanic|TestSocketInfoEndpoint" ./...
+        env:
+          TIKTOKEN_CACHE_DIR: ${{ runner.temp }}/tiktoken
+
   lint:
     name: Lint
     needs: [build-frontend, verify-oas]

--- a/internal/telemetry/anonymity_test.go
+++ b/internal/telemetry/anonymity_test.go
@@ -195,6 +195,17 @@ func TestScanForPII_RawMachineIDBlocked(t *testing.T) {
 // one malformed field into an otherwise-clean payload and expects the
 // v7_field_invalid rule to fire with the field name as the pattern.
 func TestScanForPII_V7FieldViolations(t *testing.T) {
+	// Isolate from the process-global BlockedValues. Any earlier test that
+	// calls Service.Start reaches PopulateBlockedValues, which appends the real
+	// hostname and home-dir basename and is never undone (sync.Once). Under
+	// -shuffle that leaks into this test: a basename such as "user" trips rule
+	// 2 ("blocked_value") on the "terminated by user" payload before rule 7
+	// gets to report v7_field_invalid. Same save-and-restore as the other
+	// ScanForPII tests in this file.
+	prev := BlockedValues
+	BlockedValues = nil
+	defer func() { BlockedValues = prev }()
+
 	cases := map[string]struct {
 		payload string
 		field   string


### PR DESCRIPTION
## Motivation

#1222 (@loloDawit) fixed two `internal/server` fixtures that flipped the process-global registry SSRF allow-policy and never restored it. `TestBuildRegistrySourceEntry_RejectsSSRFLiteralIP` — the CWE-918 regression test — only passed because its file sorted ahead of both fixtures. The PR closed with:

> `-shuffle=on` in a CI lane. It would prevent this class from recurring, but it may surface unrelated order dependencies elsewhere in the tree, which should not be resolved as part of this fix. Happy to open it separately.

This is that lane. Nothing under `.github/workflows/` ran with `-shuffle` before, so no CI job could ever see an order other than file/declaration order.

## What the lane runs

A new job **`Unit Tests (shuffle)`** in `unit-tests.yml`, ubuntu-latest only:

```
go test -v -race -shuffle=on -skip "E2E|Binary|MCPProtocol|TestInfoEndpoint|TestGracefulShutdownNoPanic|TestSocketInfoEndpoint" ./...
```

That is the required ubuntu lane's invocation with one flag added (`-shuffle=on`) and one dropped (`-coverprofile` — Codecov already gets the ordered run). It reuses the same provisioning the required job needs for `go test ./...`: Go 1.25 with module cache, the pinned TSCG Node shim (`npm ci --prefix bench/tscg`, Spec 083 FR-006 hard-fails without it), the `frontend-dist` artifact copied into `web/frontend/` for the embed, and the `warmtiktoken` pre-step that removes the tiktoken download rename race. The required `Unit Tests` job is unchanged.

## Why advisory first

The job is deliberately **not** in the branch-protection required list (`Unit Tests (ubuntu-latest, 1.25)`, `Lint`, `Build (ubuntu-latest)`, … — `gh api .../branches/main/protection/required_status_checks`), so a newly exposed order coupling in an unrelated package cannot block a PR while the tail of such tests is being found. It has **no** `continue-on-error`: a failure shows as a red check on the PR so it gets looked at, it just cannot block the merge.

Each CI run draws a fresh seed, so exposure accumulates across runs rather than re-testing one order forever.

**Proposal:** promote it to required after 10 consecutive green runs on `main`.

## Reproducing a failure from the log

With `-shuffle` on, every test binary prints its seed as the first line of the package's output:

```
-test.shuffle 1788926312892506000
--- FAIL: TestScanForPII_V7FieldViolations (0.00s)
```

Re-run the failing package with that exact seed:

```
go test -race -count=1 -shuffle=1788926312892506000 ./internal/telemetry/
```

`-count=1` matters — the seed reproduces the order, not the cache, and a cached `ok` would hide the failure. Add the `-skip` regex from the workflow if the failing test lives next to E2E tests. The workflow carries this recipe as a comment above the job.

## Local run

```
go test -race -shuffle=on -count=1 -skip 'E2E|Binary|MCPProtocol|TestInfoEndpoint|TestGracefulShutdownNoPanic|TestSocketInfoEndpoint' ./internal/...
```

on this branch's base (`a742ef75d`): **64 packages ok, 1 FAIL** — `internal/telemetry`, seed `1788926312892506000`:

```
--- FAIL: TestScanForPII_V7FieldViolations/previous_shutdown_outside_enum (0.00s)
    anonymity_test.go:265: expected rule=v7_field_invalid, got "blocked_value"
    anonymity_test.go:268: expected pattern="previous_shutdown", got "user"
```

Same class as #1222, different global. `Service.Start` calls `PopulateBlockedValues()`, a `sync.Once` that appends the real hostname and home-dir basename to the package-global `BlockedValues` and is never undone. Five test files call `Start`. Every other `ScanForPII` test in `anonymity_test.go` snapshots `BlockedValues` and restores it; `TestScanForPII_V7FieldViolations` was the one that did not, so when a `Start` test runs first, a home basename such as `user` trips rule 2 (`blocked_value`) on the `"terminated by user"` payload before rule 7 can report `v7_field_invalid`.

Fixed here because it is trivially the #1222 shape — three lines of save/nil/restore, identical to the neighbouring tests in the same file. Verified: the reproducing seed fails on the base commit and passes with the fix; ordered run and seeds 1, 2, 3 all pass; `golangci-lint` v2 with `.github/.golangci.yml` reports 0 issues on the package.

Note this one is environment-dependent: it bites only when the runner's home basename or hostname is a substring of a test payload, so CI (`/home/runner`) may never have hit it, and a laptop with a different login may not either. The seed reproduces it on a machine where `basename $HOME` is `user`.

Ordered run: `TestGetServerLogs_MissingFileReturnsEmptyNotError`, which #1222 flagged as a pre-existing `-count=2` failure, was fixed in #1228 and did not fail here.

## Follow-ups

- Watch the first CI runs: they cover `./...` (bench, cmd, …), while the local run covered `./internal/...` only, so the first few seeds may surface more.
- After 10 consecutive green runs on `main`, add `Unit Tests (shuffle)` to the required checks.
- If a failure repeats, fix it in the #1222 / this-PR shape (fixtures restore what they flip; readers of a process global snapshot it) rather than by pinning a seed.

## Testing

- [x] `actionlint .github/workflows/unit-tests.yml` — clean
- [x] Local shuffled run over `./internal/...` — one order coupling found, fixed here, re-verified against the reproducing seed
- [x] `golangci-lint` v2 (`.github/.golangci.yml`) on the changed package — 0 issues
