### PR TITLE
fix(test): restore the CLI output globals after every test that sets them

### DIFF
--- a/cmd/mcpproxy/output_globals_test.go
+++ b/cmd/mcpproxy/output_globals_test.go
@@ -1,0 +1,42 @@
+package main
+
+import "testing"
+
+// setOutputGlobals points the CLI's process-global output selectors at one
+// format for the duration of a test, and restores whatever was there before.
+//
+// globalOutputFormat and globalJSONOutput are package-level flag targets, so a
+// test that assigns them and never restores leaks its choice into every test
+// that runs after it. In file order that is invisible; under
+// `go test -shuffle=on` it is not. TestVersionCommandTableOutput and
+// TestOutputActivityError_TableFormat both render through
+// clioutput.ResolveFormat and assert the default table output, so a leaked
+// "json" turns them red — seed 1788937037978355714 on the advisory shuffle
+// lane added in #1230 reproduces exactly that.
+//
+// Use this instead of assigning the globals directly.
+func setOutputGlobals(t *testing.T, format string, jsonOut bool) {
+	t.Helper()
+	prevFormat, prevJSON := globalOutputFormat, globalJSONOutput
+	t.Cleanup(func() { globalOutputFormat, globalJSONOutput = prevFormat, prevJSON })
+	globalOutputFormat, globalJSONOutput = format, jsonOut
+}
+
+// TestSetOutputGlobalsRestores pins the restore half of the helper: without the
+// t.Cleanup the subtest's choice would still be installed when it returns, and
+// every later test in a shuffled run would inherit it.
+func TestSetOutputGlobalsRestores(t *testing.T) {
+	before, beforeJSON := globalOutputFormat, globalJSONOutput
+
+	t.Run("inner", func(t *testing.T) {
+		setOutputGlobals(t, "json", true)
+		if globalOutputFormat != "json" || !globalJSONOutput {
+			t.Fatalf("helper did not install the format: %q/%v", globalOutputFormat, globalJSONOutput)
+		}
+	})
+
+	if globalOutputFormat != before || globalJSONOutput != beforeJSON {
+		t.Errorf("globals leaked out of the subtest: got %q/%v, want %q/%v",
+			globalOutputFormat, globalJSONOutput, before, beforeJSON)
+	}
+}

--- a/cmd/mcpproxy/tools_cmd_test.go
+++ b/cmd/mcpproxy/tools_cmd_test.go
@@ -202,8 +202,7 @@ func TestOutputGlobalTools_JSONShape(t *testing.T) {
 	os.Stdout = w
 	defer func() { os.Stdout = oldStdout }()
 
-	globalOutputFormat = "json"
-	globalJSONOutput = false
+	setOutputGlobals(t, "json", false)
 	err := outputGlobalTools(tools)
 
 	w.Close()
@@ -240,8 +239,7 @@ func TestOutputGlobalTools_TableColumns(t *testing.T) {
 	os.Stdout = w
 	defer func() { os.Stdout = oldStdout }()
 
-	globalOutputFormat = "table"
-	globalJSONOutput = false
+	setOutputGlobals(t, "table", false)
 	err := outputGlobalTools(tools)
 
 	w.Close()
@@ -482,8 +480,7 @@ func TestOutputGlobalTools_HeldColumn(t *testing.T) {
 	os.Stdout = w
 	defer func() { os.Stdout = oldStdout }()
 
-	globalOutputFormat = "table"
-	globalJSONOutput = false
+	setOutputGlobals(t, "table", false)
 	err := outputGlobalTools(tools)
 
 	w.Close()

--- a/cmd/mcpproxy/upstream_cmd_test.go
+++ b/cmd/mcpproxy/upstream_cmd_test.go
@@ -46,8 +46,7 @@ func TestOutputServers_TableFormat(t *testing.T) {
 	defer func() { os.Stdout = oldStdout }()
 
 	// Use global output format (default is "table")
-	globalOutputFormat = "table"
-	globalJSONOutput = false
+	setOutputGlobals(t, "table", false)
 	err := outputServers(servers)
 
 	w.Close()
@@ -104,8 +103,7 @@ func TestOutputServers_JSONFormat(t *testing.T) {
 	defer func() { os.Stdout = oldStdout }()
 
 	// Use global output format for JSON
-	globalOutputFormat = "json"
-	globalJSONOutput = false
+	setOutputGlobals(t, "json", false)
 	err := outputServers(servers)
 
 	w.Close()
@@ -138,8 +136,7 @@ func TestOutputServers_InvalidFormat(t *testing.T) {
 	}
 
 	// Use global output format for invalid format test
-	globalOutputFormat = "invalid-format"
-	globalJSONOutput = false
+	setOutputGlobals(t, "invalid-format", false)
 	err := outputServers(servers)
 
 	if err == nil {
@@ -164,8 +161,7 @@ func TestOutputServers_Sorting(t *testing.T) {
 	defer func() { os.Stdout = oldStdout }()
 
 	// Use global output format for JSON
-	globalOutputFormat = "json"
-	globalJSONOutput = false
+	setOutputGlobals(t, "json", false)
 	err := outputServers(servers)
 
 	w.Close()
@@ -208,8 +204,7 @@ func TestOutputServers_EmptyList(t *testing.T) {
 	defer func() { os.Stdout = oldStdout }()
 
 	// Use global output format (default is "table")
-	globalOutputFormat = "table"
-	globalJSONOutput = false
+	setOutputGlobals(t, "table", false)
 	err := outputServers(servers)
 
 	w.Close()
@@ -411,8 +406,7 @@ func TestOutputServers_BooleanFields(t *testing.T) {
 			defer func() { os.Stdout = oldStdout }()
 
 			// Use global output format for table
-			globalOutputFormat = "table"
-			globalJSONOutput = false
+			setOutputGlobals(t, "table", false)
 			err := outputServers(servers)
 
 			w.Close()
@@ -459,8 +453,7 @@ func TestOutputServers_IntegerFields(t *testing.T) {
 	defer func() { os.Stdout = oldStdout }()
 
 	// Use global output format (default is "table")
-	globalOutputFormat = "table"
-	globalJSONOutput = false
+	setOutputGlobals(t, "table", false)
 	err := outputServers(servers)
 
 	w.Close()
@@ -508,8 +501,7 @@ func TestOutputServers_StatusMessages(t *testing.T) {
 	defer func() { os.Stdout = oldStdout }()
 
 	// Use global output format (default is "table")
-	globalOutputFormat = "table"
-	globalJSONOutput = false
+	setOutputGlobals(t, "table", false)
 	err := outputServers(servers)
 
 	w.Close()
@@ -1419,8 +1411,7 @@ func TestOutputError_WithRequestID(t *testing.T) {
 		defer func() { os.Stderr = oldStderr }()
 
 		// Set table format (human-readable output)
-		globalOutputFormat = "table"
-		globalJSONOutput = false
+		setOutputGlobals(t, "table", false)
 
 		// Create an APIError with request_id
 		apiErr := &cliclient.APIError{
@@ -1455,8 +1446,7 @@ func TestOutputError_WithRequestID(t *testing.T) {
 		defer func() { os.Stdout = oldStdout }()
 
 		// Set JSON format
-		globalOutputFormat = "json"
-		globalJSONOutput = true
+		setOutputGlobals(t, "json", true)
 
 		// Create an APIError with request_id
 		apiErr := &cliclient.APIError{
@@ -1498,8 +1488,7 @@ func TestOutputError_WithoutRequestID(t *testing.T) {
 		defer func() { os.Stderr = oldStderr }()
 
 		// Set table format
-		globalOutputFormat = "table"
-		globalJSONOutput = false
+		setOutputGlobals(t, "table", false)
 
 		// Create an APIError without request_id
 		apiErr := &cliclient.APIError{
@@ -1534,8 +1523,7 @@ func TestOutputError_WithoutRequestID(t *testing.T) {
 		defer func() { os.Stderr = oldStderr }()
 
 		// Set table format
-		globalOutputFormat = "table"
-		globalJSONOutput = false
+		setOutputGlobals(t, "table", false)
 
 		// Create a regular error (not APIError)
 		regularErr := os.ErrNotExist


### PR DESCRIPTION
## What the shuffle lane found

The advisory `Unit Tests (shuffle)` lane from #1230 went red on its first unrelated PR (#1232, docs only). That is the lane working as intended.

`globalOutputFormat` and `globalJSONOutput` are package-level flag targets in `cmd/mcpproxy`. **Fifteen tests assigned them and never restored**, so whichever ran last left its choice installed for the rest of the test binary. In file order that is invisible. Under `-shuffle=on` it is not: `TestVersionCommandTableOutput` and `TestOutputActivityError_TableFormat` both render through `clioutput.ResolveFormat` and assert the default table output, so an inherited `"json"` fails them.

Reproduce on `origin/main`:

```bash
go test -count=1 -shuffle=1788937037978355714 ./cmd/mcpproxy/
```

```
--- FAIL: TestVersionCommandTableOutput (0.00s)
    version_cmd_test.go:28: table output should start with "MCPProxy v0.1.0 (personal) linux/amd64", got: "{\n  \"version\": ...
--- FAIL: TestOutputActivityError_TableFormat (0.00s)
```

Same class as #1222 (registry fixtures leaking the SSRF allow-policy) and the `BlockedValues` leak fixed in #1230, different global.

## The fix

Adds `setOutputGlobals(t, format, jsonOut)` in a new `cmd/mcpproxy/output_globals_test.go`: it saves the pair and restores it from `t.Cleanup`, so a failing or panicking test still restores. All fifteen bare assignment sites route through it (3 in `tools_cmd_test.go`, 12 in `upstream_cmd_test.go`). The sites that already saved and restored by hand are left alone. No production code changes; no test's intended format changes.

`TestSetOutputGlobalsRestores` pins the restore half, so removing the `t.Cleanup` fails a test rather than only showing up as a shuffled-order surprise later.

## Verification

| Check | Result |
|---|---|
| Seed `1788937037978355714` on `origin/main` | fails both tests |
| Same seed on this branch | `ok` |
| `go test -count=1 -race -shuffle=on ./cmd/mcpproxy/` × 5 | 5 × `ok` |
| `golangci-lint` v2, `.github/.golangci.yml`, `./cmd/mcpproxy/...` | 0 issues |

## Follow-up, not touched here

`cmd/mcpproxy/activity_cmd_test.go` is already unformatted on `origin/main` (`gofmt -l` flags it before and after this change). Left alone to keep this diff to the one problem.
