### PR TITLE
fix(windows): clean up child processes via Job Objects

### DIFF
--- a/internal/upstream/core/connection_stdio.go
+++ b/internal/upstream/core/connection_stdio.go
@@ -260,6 +260,21 @@ func (c *Client) connectStdio(ctx context.Context) error {
 		return fmt.Errorf("failed to start stdio client: %w", err)
 	}
 
+	// Extract the process group ID (Windows: assign to a Job Object) IMMEDIATELY
+	// after Start() succeeds, not after initialize() below. A restart/disconnect
+	// that interrupts an in-progress handshake (slow npx download, bulk-add
+	// contention, a timeout) previously left processGroupID at its zero value
+	// the whole time initialize() was running, so the init-failure cleanup path
+	// a few lines down (`if c.processGroupID > 0 { killProcessGroup(...) }`)
+	// silently did nothing and the spawned process (and on Windows, everything
+	// IT spawns) leaked. Setting it here means that cleanup path — and any
+	// concurrent restart that arrives before initialize() returns — has a real
+	// PID/Job Object to kill. The later extraction below is now just a no-op
+	// (its own `if c.processGroupID <= 0` guard) for the normal success path.
+	if c.processCmd != nil && c.processCmd.Process != nil {
+		c.processGroupID = extractProcessGroupID(c.processCmd, c.logger, c.config.Name)
+	}
+
 	// CRITICAL FIX: Enable stderr monitoring IMMEDIATELY after starting the process
 	// This ensures we capture startup errors (like missing API keys) even if
 	// initialization fails with timeout. Previously, stderr monitoring started

--- a/internal/upstream/core/process_windows.go
+++ b/internal/upstream/core/process_windows.go
@@ -4,9 +4,13 @@ package core
 
 import (
 	"context"
+	"os"
 	"os/exec"
+	"sync"
 
 	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/winjob"
 )
 
 // ProcessGroup represents a Windows process group for proper child process management
@@ -15,21 +19,27 @@ type ProcessGroup struct {
 	logger *zap.Logger
 }
 
-// createProcessGroupCommandFunc creates a custom CommandFunc for Windows systems
-// Note: Windows process group management is different from Unix and requires different approaches
+// windowsJobs maps the "process group ID" mcpproxy uses on Windows (the
+// immediate child's PID — see extractProcessGroupID) to the Job Object that
+// PID was assigned to. killProcessGroup only receives that int, so this is
+// how it finds the Job to terminate.
+var (
+	windowsJobsMu sync.Mutex
+	windowsJobs   = map[int]*winjob.Job{}
+)
+
+// createProcessGroupCommandFunc creates a custom CommandFunc for Windows systems.
+// Job Object assignment happens later, in extractProcessGroupID, once the
+// process actually exists (a Job Object is assigned to a PID after start,
+// not configured via SysProcAttr before start).
 func createProcessGroupCommandFunc(client *Client, workingDir string, logger *zap.Logger) func(ctx context.Context, command string, env []string, args []string) (*exec.Cmd, error) {
 	return func(ctx context.Context, command string, env []string, args []string) (*exec.Cmd, error) {
 		cmd := exec.CommandContext(ctx, command, args...)
 		cmd.Env = env
 
-		// Set working directory if specified
 		if workingDir != "" {
 			cmd.Dir = workingDir
 		}
-
-		// TODO: Implement Windows-specific process group management
-		// Windows uses Job Objects instead of process groups
-		// For now, we'll use the standard command creation
 
 		logger.Debug("Process group configuration applied (Windows)",
 			zap.String("command", command),
@@ -44,38 +54,103 @@ func createProcessGroupCommandFunc(client *Client, workingDir string, logger *za
 	}
 }
 
-// killProcessGroup terminates processes on Windows systems
-// This is a simplified implementation for Windows compatibility
+// killProcessGroup terminates a process AND every descendant it has spawned
+// (e.g. cmd.exe -> node.exe -> the actual MCP server) via the Windows Job
+// Object that PID was assigned to in extractProcessGroupID. This is what
+// process_windows.go never did before: previously this function was a
+// no-op placeholder, so restarting/disconnecting a stdio server on Windows
+// left every grandchild process running forever (confirmed: 413 leaked
+// node.exe/python.exe/qmcp.exe processes accumulated from normal use in
+// under an hour on this host).
+//
+// Falls back to a plain single-process kill if no job was ever registered
+// for this PID (e.g. job-object setup itself failed) — degrades to the old
+// behaviour rather than doing nothing.
 func killProcessGroup(pgid int, logger *zap.Logger, serverName string) error {
-	// TODO: Implement proper Windows process termination
-	// For now, this is a placeholder that does nothing
-	// Windows process management would require Win32 API calls or Job Objects
+	if pgid <= 0 {
+		return nil
+	}
 
-	logger.Debug("Process group termination requested (Windows placeholder)",
+	windowsJobsMu.Lock()
+	job, ok := windowsJobs[pgid]
+	if ok {
+		delete(windowsJobs, pgid)
+	}
+	windowsJobsMu.Unlock()
+
+	if !ok || job == nil {
+		logger.Warn("No Windows Job Object tracked for this process; falling back to killing only the immediate process (any grandchildren will leak)",
+			zap.String("server", serverName),
+			zap.Int("pid", pgid))
+		proc, err := os.FindProcess(pgid)
+		if err != nil {
+			return nil // already gone
+		}
+		return proc.Kill()
+	}
+
+	logger.Info("Terminating process tree via Windows Job Object",
 		zap.String("server", serverName),
-		zap.Int("pgid", pgid))
+		zap.Int("pid", pgid))
 
+	if err := job.Close(); err != nil {
+		logger.Warn("Failed to close Windows Job Object cleanly",
+			zap.String("server", serverName),
+			zap.Int("pid", pgid),
+			zap.Error(err))
+		return err
+	}
+
+	logger.Info("Process tree terminated",
+		zap.String("server", serverName),
+		zap.Int("pid", pgid))
 	return nil
 }
 
-// extractProcessGroupID extracts the process group ID from a running command on Windows
+// extractProcessGroupID assigns the just-started process to a fresh Windows
+// Job Object configured with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, then
+// returns its PID as the "process group ID" — the identifier killProcessGroup
+// expects. Everything the process spawns AFTER this point automatically
+// joins the same job (Windows job membership is inherited), so a later
+// killProcessGroup call reaches the whole tree.
 func extractProcessGroupID(cmd *exec.Cmd, logger *zap.Logger, serverName string) int {
-	// Windows doesn't have Unix-style process groups
-	// Return the PID as a fallback identifier
 	if cmd == nil || cmd.Process == nil {
 		return 0
 	}
+	pid := cmd.Process.Pid
 
-	logger.Debug("Process group ID extracted (Windows - using PID)",
+	job, err := winjob.New()
+	if err != nil {
+		logger.Warn("Failed to create Windows Job Object; child processes spawned by this server will not be cleaned up on restart/disconnect",
+			zap.String("server", serverName),
+			zap.Int("pid", pid),
+			zap.Error(err))
+		return pid
+	}
+	if err := job.Assign(pid); err != nil {
+		logger.Warn("Failed to assign process to Windows Job Object; child processes spawned by this server will not be cleaned up on restart/disconnect",
+			zap.String("server", serverName),
+			zap.Int("pid", pid),
+			zap.Error(err))
+		_ = job.Close()
+		return pid
+	}
+
+	windowsJobsMu.Lock()
+	windowsJobs[pid] = job
+	windowsJobsMu.Unlock()
+
+	logger.Debug("Process group ID extracted and assigned to Windows Job Object",
 		zap.String("server", serverName),
-		zap.Int("pid", cmd.Process.Pid))
+		zap.Int("pid", pid))
 
-	return cmd.Process.Pid
+	return pid
 }
 
-// isProcessGroupAlive checks if processes are still running on Windows
+// isProcessGroupAlive checks if the process is still running on Windows.
 func isProcessGroupAlive(pgid int) bool {
-	// TODO: Implement Windows-specific process checking
-	// For now, return false as a safe default
-	return false
+	if pgid <= 0 {
+		return false
+	}
+	return winjob.IsProcessAlive(pgid)
 }

--- a/internal/upstream/launcher/launcher.go
+++ b/internal/upstream/launcher/launcher.go
@@ -147,6 +147,13 @@ func Spawn(ctx context.Context, spec *Spec, log *zap.Logger) (Handle, error) {
 	}
 	h.pid.Store(int64(cmd.Process.Pid))
 
+	// On Windows, wrap the just-started process in a Job Object so that
+	// terminateProcess/killProcess below (and the natural-exit path in
+	// reap) can reach grandchildren the process spawns — Process.Kill()
+	// alone only ever reaches this one PID. No-op on Unix, where the
+	// process-group attrs applied via applyProcAttrs already cover this.
+	h.job = createJob(cmd)
+
 	// Pump stdout+stderr to LogSink. Both streams write to the same
 	// sink, prefixed so they remain distinguishable. Discard mode is
 	// supported via io.Discard. We wrap LogSink in a small mutex so
@@ -195,6 +202,7 @@ type handle struct {
 	log       *zap.Logger
 	done      chan struct{}
 	stopGrace time.Duration
+	job       io.Closer // Windows Job Object wrapper; nil on Unix (see createJob)
 
 	pid    atomic.Int64 // 0 once exited
 	pumpWG sync.WaitGroup
@@ -299,6 +307,17 @@ func (h *handle) reap() {
 	// kernel propagates EOF — we don't need Wait() to reach that state.
 	h.pumpWG.Wait()
 	err := h.cmd.Wait()
+
+	// Reap any grandchildren the child spawned (Windows only — see
+	// createJob/winjob). This runs on EVERY exit path, not just Stop's
+	// SIGKILL fallback: a child that exits on its own can still leave
+	// grandchildren behind (e.g. cmd.exe returning while node.exe keeps
+	// running), and without this they leaked indefinitely (413 confirmed
+	// orphaned node.exe/python.exe processes observed from normal use on
+	// this host prior to this fix).
+	if h.job != nil {
+		_ = h.job.Close()
+	}
 
 	h.waitErrMu.Lock()
 	h.waitErr = err

--- a/internal/upstream/launcher/launcher_unix.go
+++ b/internal/upstream/launcher/launcher_unix.go
@@ -3,11 +3,20 @@
 package launcher
 
 import (
+	"io"
 	"os/exec"
 	"syscall"
 
 	"go.uber.org/zap"
 )
+
+// createJob is a no-op on Unix: applyProcAttrs' process-group setup already
+// gives terminateProcess/killProcess a way to reach grandchildren, so there
+// is nothing extra to track here. See launcher_windows.go for the platform
+// that actually needs this.
+func createJob(_ *exec.Cmd) io.Closer {
+	return nil
+}
 
 // applyProcAttrs places the child in its own process group so we can signal
 // the entire group (including grandchildren spawned via `sh -c …` or

--- a/internal/upstream/launcher/launcher_windows.go
+++ b/internal/upstream/launcher/launcher_windows.go
@@ -3,20 +3,51 @@
 package launcher
 
 import (
+	"io"
 	"os/exec"
 
 	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/winjob"
 )
 
-// applyProcAttrs is a no-op on Windows. Windows uses Job Objects rather
-// than process groups; integrating with the existing Windows process
-// management is left to a follow-up (matching the TODO already in
-// internal/upstream/core/process_windows.go).
+// applyProcAttrs is a no-op on Windows. Job Object assignment (createJob,
+// below) is what does the equivalent work here, and it has to happen AFTER
+// Start() — a Job Object is assigned to a live PID, there's no SysProcAttr
+// field to pre-configure the way Setpgid works on Unix.
 func applyProcAttrs(_ *exec.Cmd) {}
 
-// terminateProcess on Windows just signals the child directly. Without
-// Job Objects we cannot reach grandchildren; the existing stdio path has
-// the same limitation today.
+// createJob assigns the just-started process to a fresh Windows Job Object
+// (JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE) so that everything it spawns
+// afterwards — e.g. `cmd.exe /c npx ...` spawning node.exe spawning the
+// actual MCP server — dies when the returned Closer's Close is called
+// (wired into launcher.go's reap(), which runs on every exit path). Prior
+// to this, launcher_windows.go only ever reached the immediate child
+// (terminateProcess/killProcess below called cmd.Process.Kill()), so a
+// launcher-managed server on Windows leaked every grandchild it spawned —
+// the same class of leak process_windows.go had on the stdio path.
+func createJob(cmd *exec.Cmd) io.Closer {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	job, err := winjob.New()
+	if err != nil {
+		// Degrade to the old single-process behaviour rather than failing
+		// the whole launch over a diagnostics-only feature.
+		return nil
+	}
+	if err := job.Assign(cmd.Process.Pid); err != nil {
+		_ = job.Close()
+		return nil
+	}
+	return job
+}
+
+// terminateProcess signals the child directly. The Job Object (if createJob
+// succeeded) is what actually reaches grandchildren — it is closed in
+// launcher.go's reap() once the child has exited, not here, since
+// terminating the job immediately would kill descendants before giving the
+// immediate child a chance to shut down gracefully.
 func terminateProcess(cmd *exec.Cmd, _ *zap.Logger) error {
 	if cmd.Process == nil {
 		return nil
@@ -24,6 +55,9 @@ func terminateProcess(cmd *exec.Cmd, _ *zap.Logger) error {
 	return cmd.Process.Kill()
 }
 
+// killProcess is the hard-kill fallback after the grace period. Same
+// reasoning as terminateProcess: the immediate child dies here, the wider
+// tree is reaped via the Job Object in reap() once Wait() returns.
 func killProcess(cmd *exec.Cmd, _ *zap.Logger) error {
 	if cmd.Process == nil {
 		return nil

--- a/internal/winjob/winjob.go
+++ b/internal/winjob/winjob.go
@@ -1,0 +1,156 @@
+//go:build windows
+
+// Package winjob provides Windows Job Object based process-tree cleanup.
+//
+// Unix has process groups: kill(-pgid, sig) reaches every descendant a
+// spawned command has forked. Windows has no equivalent for an arbitrary
+// process tree — Process.Kill() only ever reaches the one PID mcpproxy
+// itself started (e.g. cmd.exe), never the grandchildren cmd.exe/npx/bash
+// go on to spawn (node.exe, python.exe, the real MCP server). Those
+// grandchildren were left running forever every time a stdio server was
+// restarted, reconnected, or disconnected — see
+// internal/upstream/core/process_windows.go and
+// internal/upstream/launcher/launcher_windows.go, both previously TODO
+// stubs that only killed the immediate child.
+//
+// A Job Object created with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE restores
+// the process-group-kill guarantee on Windows: once the immediate child is
+// assigned to the job, every process IT spawns afterwards automatically
+// joins the same job (job membership is inherited on process creation), so
+// terminating the job reaches the whole tree in one call — matching what
+// killProcessGroup already does on Unix via kill(-pgid, ...).
+package winjob
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// jobObjectExtendedLimitInformation / JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+// mirror the WinAPI JobObjectInfoClass / limit-flag constants. Kept local
+// (rather than relying on x/sys/windows, which does not export the
+// Set/QueryInformationJobObject calls themselves) so this file only needs
+// the raw kernel32 procedure lookups below.
+const (
+	jobObjectExtendedLimitInformation = 9
+	jobObjectLimitKillOnJobClose      = 0x00002000
+	stillActive                       = 259 // STILL_ACTIVE, per GetExitCodeProcess docs
+)
+
+var (
+	modkernel32               = windows.NewLazySystemDLL("kernel32.dll")
+	procSetInformationJobObj  = modkernel32.NewProc("SetInformationJobObject")
+)
+
+// jobobjectBasicLimitInformation mirrors JOBOBJECT_BASIC_LIMIT_INFORMATION.
+// Only LimitFlags is meaningful here; the rest exists purely so the struct
+// has the layout Win32 expects when we hand it a pointer.
+type jobobjectBasicLimitInformation struct {
+	PerProcessUserTimeLimit int64
+	PerJobUserTimeLimit     int64
+	LimitFlags              uint32
+	MinimumWorkingSetSize   uintptr
+	MaximumWorkingSetSize   uintptr
+	ActiveProcessLimit      uint32
+	Affinity                uintptr
+	PriorityClass           uint32
+	SchedulingClass         uint32
+}
+
+// jobobjectExtendedLimitInformation mirrors JOBOBJECT_EXTENDED_LIMIT_INFORMATION.
+type jobobjectExtendedLimitInformation struct {
+	BasicLimitInformation jobobjectBasicLimitInformation
+	IoInfo                [48]byte // IO_COUNTERS — unused, present for correct struct size
+	ProcessMemoryLimit    uintptr
+	JobMemoryLimit        uintptr
+	PeakProcessMemoryUsed uintptr
+	PeakJobMemoryUsed     uintptr
+}
+
+// Job wraps a Windows Job Object configured to kill every member process
+// (including any it spawns after joining) as soon as Close is called.
+type Job struct {
+	handle windows.Handle
+}
+
+// New creates a job object with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE set.
+func New() (*Job, error) {
+	handle, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("CreateJobObject: %w", err)
+	}
+
+	info := jobobjectExtendedLimitInformation{
+		BasicLimitInformation: jobobjectBasicLimitInformation{
+			LimitFlags: jobObjectLimitKillOnJobClose,
+		},
+	}
+	r1, _, callErr := procSetInformationJobObj.Call(
+		uintptr(handle),
+		uintptr(jobObjectExtendedLimitInformation),
+		uintptr(unsafe.Pointer(&info)), //nolint:gosec // required shape for the Win32 call
+		unsafe.Sizeof(info),
+	)
+	if r1 == 0 {
+		_ = windows.CloseHandle(handle)
+		return nil, fmt.Errorf("SetInformationJobObject: %w", callErr)
+	}
+
+	return &Job{handle: handle}, nil
+}
+
+// Assign adds the process with the given PID to the job. Must be called as
+// soon as possible after the process starts — everything it spawns AFTER
+// joining inherits job membership, but anything it spawns BEFORE joining
+// (a race in principle) would escape. In practice the caller starts the
+// child and assigns it within the same goroutine with no intervening work,
+// so the window is negligible — the child (a shell/npx wrapper) has not
+// yet had a chance to exec its own grandchild.
+func (j *Job) Assign(pid int) error {
+	if j == nil {
+		return fmt.Errorf("winjob: nil job")
+	}
+	proc, err := windows.OpenProcess(windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE, false, uint32(pid)) //nolint:gosec // pid is always a live PID from exec.Cmd.Process.Pid
+	if err != nil {
+		return fmt.Errorf("OpenProcess(%d): %w", pid, err)
+	}
+	defer func() { _ = windows.CloseHandle(proc) }()
+
+	if err := windows.AssignProcessToJobObject(j.handle, proc); err != nil {
+		return fmt.Errorf("AssignProcessToJobObject(%d): %w", pid, err)
+	}
+	return nil
+}
+
+// Close terminates every process still in the job and releases the handle.
+// Safe to call more than once and safe to call on a nil *Job.
+func (j *Job) Close() error {
+	if j == nil || j.handle == 0 {
+		return nil
+	}
+	// Kill first (reaches every member immediately); closing the handle
+	// after that is just resource cleanup, not what does the killing.
+	_ = windows.TerminateJobObject(j.handle, 1)
+	err := windows.CloseHandle(j.handle)
+	j.handle = 0
+	return err
+}
+
+// IsProcessAlive reports whether pid still exists and has not exited.
+// Used for the isProcessGroupAlive check that process_windows.go previously
+// hardcoded to false.
+func IsProcessAlive(pid int) bool {
+	proc, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid)) //nolint:gosec
+	if err != nil {
+		return false
+	}
+	defer func() { _ = windows.CloseHandle(proc) }()
+
+	var code uint32
+	if err := windows.GetExitCodeProcess(proc, &code); err != nil {
+		return false
+	}
+	return code == stillActive
+}


### PR DESCRIPTION
## Problem

`internal/upstream/core/process_windows.go` and `internal/upstream/launcher/launcher_windows.go` were both TODO stubs. `killProcessGroup` did nothing, and `terminateProcess`/`killProcess` only ever killed the one PID mcpproxy itself spawned (e.g. `cmd.exe`), never the grandchildren it spawns (`node.exe`, `python.exe`, the actual MCP server process).

Every stdio server restart, reconnect, or disconnect on Windows leaks its grandchild process tree permanently. Confirmed **413 orphaned `node.exe`/`python.exe`/`qmcp.exe` processes** accumulated from under an hour of normal use with ~15 configured servers on one machine.

## Fix

Wraps each spawned process in a Windows Job Object configured with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` (new `internal/winjob` package). Job membership is inherited by anything the process spawns afterwards, so closing the job reaches the whole tree in one call — the Windows equivalent of `kill(-pgid, ...)` on the existing Unix path.

Two details that mattered in testing:

1. **The job must be assigned right after `cmd.Start()` succeeds, before the MCP `initialize()` handshake** — not after a successful handshake. Assigning only on success misses every leak caused by a restart/disconnect interrupting an in-progress connect attempt, which is the dominant real-world case (a slow `npx` download, bulk server-add contention, a timeout mid-handshake). This was the actual cause of most of the 413 leaked processes observed.
2. `golang.org/x/sys/windows` (as vendored here, v0.47.0) does not export `Set/QueryInformationJobObject`, only `CreateJobObject`/`AssignProcessToJobObject`/`TerminateJobObject`. `winjob.go` binds `SetInformationJobObject` directly via `NewLazySystemDLL` rather than adding a new dependency for one call.

Same fix applied to the separate `launcher` package (HTTP/SSE launcher-managed servers with `Command` set), which had the identical gap and an explicit `// left to a follow-up (matching the TODO already in internal/upstream/core/process_windows.go)` comment pointing at this file.

## Verification

- Standalone reproduction: spawn `cmd.exe` → `ping.exe` (grandchild), assign to job, `Close()` → grandchild confirmed killed.
- 6 sequential real restarts of a stdio server (`mcpproxy upstream restart <name>`, few seconds apart) → **0 leaked processes**, where every restart leaked one before this fix.
- `go build`/`go vet` clean for `windows/amd64`.
- Existing `internal/upstream/launcher` test suite passes unmodified.

## Known remaining gap (out of scope for this PR)

Firing many restarts of the *same* server at the exact same instant (an artificial stress case constructed for testing, not normal operation — mcpproxy's own reconcile loop restarts sequentially) can still leak a few processes. That traces to a separate race on the shared `processGroupID` field across concurrent `Connect`/`Disconnect` calls on one `Client`, is not Windows-specific, and is not addressed here.