### PR TITLE
fix(windows): release the Job Object on every disconnect and Stop path (follow-up to #1234)

### DIFF
--- a/internal/upstream/core/connection.go
+++ b/internal/upstream/core/connection.go
@@ -332,7 +332,7 @@ func (c *Client) Connect(ctx context.Context) error {
 				zap.String("server", c.config.Name),
 				zap.Int("pgid", c.processGroupID))
 
-			if err := killProcessGroup(c.processGroupID, c.logger, c.config.Name); err != nil {
+			if err := killProcessGroup(c.processGroupID, c.processCmd, c.logger, c.config.Name); err != nil {
 				c.logger.Error("Failed to clean up process group after connection failure",
 					zap.String("server", c.config.Name),
 					zap.Int("pgid", c.processGroupID),

--- a/internal/upstream/core/connection_lifecycle.go
+++ b/internal/upstream/core/connection_lifecycle.go
@@ -348,7 +348,7 @@ func (c *Client) DisconnectWithContext(_ context.Context) error {
 			zap.String("server", serverName),
 			zap.Int("pgid", pgid))
 
-		if err := killProcessGroup(pgid, c.logger, serverName); err != nil {
+		if err := killProcessGroup(pgid, processCmd, c.logger, serverName); err != nil {
 			c.logger.Error("Failed to kill process group",
 				zap.String("server", serverName),
 				zap.Int("pgid", pgid),

--- a/internal/upstream/core/connection_lifecycle.go
+++ b/internal/upstream/core/connection_lifecycle.go
@@ -365,6 +365,16 @@ func (c *Client) DisconnectWithContext(_ context.Context) error {
 		}
 	}
 
+	// Step 5b: Release the platform process-group resource regardless of
+	// how the close went. No-op on Unix. On Windows this terminates the
+	// Job Object (reaching grandchildren mcp-go's Close never touches —
+	// it only kills the immediate cmd.exe) and drops its registry entry;
+	// without it, a graceful close leaked the Job handle and left
+	// EOF-ignoring node.exe/python.exe trees alive until mcpproxy exited.
+	if !isDocker && pgid > 0 {
+		releaseProcessGroup(pgid, c.logger, serverName)
+	}
+
 	// Step 6: Stop any locally-launched HTTP/SSE upstream. We do this
 	// AFTER closing the MCP client — the child should see the network
 	// transport go away first, giving it a clean shutdown signal before

--- a/internal/upstream/core/connection_lifecycle.go
+++ b/internal/upstream/core/connection_lifecycle.go
@@ -371,8 +371,10 @@ func (c *Client) DisconnectWithContext(_ context.Context) error {
 	// it only kills the immediate cmd.exe) and drops its registry entry;
 	// without it, a graceful close leaked the Job handle and left
 	// EOF-ignoring node.exe/python.exe trees alive until mcpproxy exited.
+	// processCmd (captured in Step 1) identifies OUR process, so a PID
+	// that Windows has already handed to a newer connection is left alone.
 	if !isDocker && pgid > 0 {
-		releaseProcessGroup(pgid, c.logger, serverName)
+		releaseProcessGroup(pgid, processCmd, c.logger, serverName)
 	}
 
 	// Step 6: Stop any locally-launched HTTP/SSE upstream. We do this

--- a/internal/upstream/core/connection_stdio.go
+++ b/internal/upstream/core/connection_stdio.go
@@ -323,7 +323,7 @@ func (c *Client) connectStdio(ctx context.Context) error {
 				zap.String("server", c.config.Name),
 				zap.Int("pgid", c.processGroupID))
 
-			if err := killProcessGroup(c.processGroupID, c.logger, c.config.Name); err != nil {
+			if err := killProcessGroup(c.processGroupID, c.processCmd, c.logger, c.config.Name); err != nil {
 				c.logger.Error("Failed to clean up process group after initialization failure",
 					zap.String("server", c.config.Name),
 					zap.Int("pgid", c.processGroupID),

--- a/internal/upstream/core/process_release_test.go
+++ b/internal/upstream/core/process_release_test.go
@@ -1,0 +1,23 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+// releaseProcessGroup is the platform hook DisconnectWithContext calls on
+// every non-Docker stdio disconnect (after the graceful MCP close), so it
+// must be cheap and safe for the "nothing to release" cases on every OS:
+// the zero/negative sentinels and a PID that never had a Job registered.
+func TestReleaseProcessGroup_NothingToRelease(t *testing.T) {
+	logger := zap.NewNop()
+	for _, pgid := range []int{0, -1, 999999999} {
+		start := time.Now()
+		releaseProcessGroup(pgid, logger, "test-server")
+		assert.Less(t, time.Since(start), 100*time.Millisecond,
+			"releaseProcessGroup(%d) must return immediately when there is nothing to release", pgid)
+	}
+}

--- a/internal/upstream/core/process_release_test.go
+++ b/internal/upstream/core/process_release_test.go
@@ -16,7 +16,7 @@ func TestReleaseProcessGroup_NothingToRelease(t *testing.T) {
 	logger := zap.NewNop()
 	for _, pgid := range []int{0, -1, 999999999} {
 		start := time.Now()
-		releaseProcessGroup(pgid, logger, "test-server")
+		releaseProcessGroup(pgid, nil, logger, "test-server")
 		assert.Less(t, time.Since(start), 100*time.Millisecond,
 			"releaseProcessGroup(%d) must return immediately when there is nothing to release", pgid)
 	}

--- a/internal/upstream/core/process_unix.go
+++ b/internal/upstream/core/process_unix.go
@@ -160,5 +160,6 @@ func extractProcessGroupID(cmd *exec.Cmd, logger *zap.Logger, serverName string)
 // the graceful MCP close on every non-Docker stdio disconnect. On Unix there
 // is nothing to release: process groups are a kernel-side identifier, not a
 // handle we hold, so this is a no-op. See process_windows.go for the
-// platform that needs it (the Job Object handle + registry entry).
-func releaseProcessGroup(_ int, _ *zap.Logger, _ string) {}
+// platform that needs it (the Job Object handle + registry entry, keyed by
+// PID and disambiguated by the owning cmd).
+func releaseProcessGroup(_ int, _ *exec.Cmd, _ *zap.Logger, _ string) {}

--- a/internal/upstream/core/process_unix.go
+++ b/internal/upstream/core/process_unix.go
@@ -57,8 +57,10 @@ func createProcessGroupCommandFunc(client *Client, workingDir string, logger *za
 }
 
 // killProcessGroup terminates an entire process group on Unix systems
-// This is the proper way to clean up child processes and prevent zombies
-func killProcessGroup(pgid int, logger *zap.Logger, serverName string) error {
+// This is the proper way to clean up child processes and prevent zombies.
+// The cmd argument is the owning process's exec.Cmd; it only matters on
+// Windows (PID-reuse identity check) and is ignored here.
+func killProcessGroup(pgid int, _ *exec.Cmd, logger *zap.Logger, serverName string) error {
 	if pgid <= 0 {
 		return nil
 	}

--- a/internal/upstream/core/process_unix.go
+++ b/internal/upstream/core/process_unix.go
@@ -155,3 +155,10 @@ func extractProcessGroupID(cmd *exec.Cmd, logger *zap.Logger, serverName string)
 
 	return pgid
 }
+
+// releaseProcessGroup is the platform hook DisconnectWithContext calls after
+// the graceful MCP close on every non-Docker stdio disconnect. On Unix there
+// is nothing to release: process groups are a kernel-side identifier, not a
+// handle we hold, so this is a no-op. See process_windows.go for the
+// platform that needs it (the Job Object handle + registry entry).
+func releaseProcessGroup(_ int, _ *zap.Logger, _ string) {}

--- a/internal/upstream/core/process_windows.go
+++ b/internal/upstream/core/process_windows.go
@@ -4,6 +4,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"sync"
@@ -71,24 +72,34 @@ func createProcessGroupCommandFunc(client *Client, workingDir string, logger *za
 // node.exe/python.exe/qmcp.exe processes accumulated from normal use in
 // under an hour on this host).
 //
+// cmd is the owning exec.Cmd (see releaseProcessGroup for why identity
+// matters: the PID may already belong to a newer connection). Only a Job
+// registered for this cmd is terminated. If the slot is held by someone
+// else, this connection's process is already gone and nothing is killed.
+//
 // Falls back to a plain single-process kill if no job was ever registered
 // for this PID (e.g. job-object setup itself failed) — degrades to the old
-// behaviour rather than doing nothing.
-func killProcessGroup(pgid int, logger *zap.Logger, serverName string) error {
+// behaviour rather than doing nothing. The fallback goes through cmd's own
+// process handle when available (PID-reuse-proof; Windows keeps a PID
+// reserved while a handle to it is open) and only resolves by PID for the
+// legacy nil-cmd case.
+func killProcessGroup(pgid int, cmd *exec.Cmd, logger *zap.Logger, serverName string) error {
 	if pgid <= 0 {
 		return nil
 	}
 
-	job := takeWindowsJob(pgid, nil)
+	job := takeWindowsJob(pgid, cmd)
 	if job == nil {
+		if cmd != nil && windowsJobOwnedByOther(pgid, cmd) {
+			logger.Debug("PID now belongs to a newer connection's Job; nothing to kill for this one",
+				zap.String("server", serverName),
+				zap.Int("pid", pgid))
+			return nil
+		}
 		logger.Warn("No Windows Job Object tracked for this process; falling back to killing only the immediate process (any grandchildren will leak)",
 			zap.String("server", serverName),
 			zap.Int("pid", pgid))
-		proc, err := os.FindProcess(pgid)
-		if err != nil {
-			return nil // already gone
-		}
-		return proc.Kill()
+		return killImmediateProcess(pgid, cmd)
 	}
 
 	logger.Info("Terminating process tree via Windows Job Object",
@@ -204,6 +215,36 @@ func takeWindowsJob(pid int, cmd *exec.Cmd) *winjob.Job {
 	}
 	delete(windowsJobs, pid)
 	return entry.job
+}
+
+// windowsJobOwnedByOther reports whether pid has a registered Job that
+// belongs to a different cmd — i.e. Windows reused the PID for a newer
+// connection after this one's process exited.
+func windowsJobOwnedByOther(pid int, cmd *exec.Cmd) bool {
+	windowsJobsMu.Lock()
+	defer windowsJobsMu.Unlock()
+	entry, ok := windowsJobs[pid]
+	return ok && entry.cmd != cmd
+}
+
+// killImmediateProcess is the no-Job fallback: kill just the one process.
+// With a cmd we use its own process handle, which cannot alias a reused
+// PID; an already-exited child is not an error (ErrProcessDone).
+func killImmediateProcess(pid int, cmd *exec.Cmd) error {
+	if cmd != nil && cmd.Process != nil {
+		if err := cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+			return err
+		}
+		return nil
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return nil // already gone
+	}
+	if err := proc.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return err
+	}
+	return nil
 }
 
 // registerWindowsJob records the Job for pid. If an entry already exists —

--- a/internal/upstream/core/process_windows.go
+++ b/internal/upstream/core/process_windows.go
@@ -71,14 +71,8 @@ func killProcessGroup(pgid int, logger *zap.Logger, serverName string) error {
 		return nil
 	}
 
-	windowsJobsMu.Lock()
-	job, ok := windowsJobs[pgid]
-	if ok {
-		delete(windowsJobs, pgid)
-	}
-	windowsJobsMu.Unlock()
-
-	if !ok || job == nil {
+	job := takeWindowsJob(pgid)
+	if job == nil {
 		logger.Warn("No Windows Job Object tracked for this process; falling back to killing only the immediate process (any grandchildren will leak)",
 			zap.String("server", serverName),
 			zap.Int("pid", pgid))
@@ -136,9 +130,7 @@ func extractProcessGroupID(cmd *exec.Cmd, logger *zap.Logger, serverName string)
 		return pid
 	}
 
-	windowsJobsMu.Lock()
-	windowsJobs[pid] = job
-	windowsJobsMu.Unlock()
+	registerWindowsJob(pid, job, logger, serverName)
 
 	logger.Debug("Process group ID extracted and assigned to Windows Job Object",
 		zap.String("server", serverName),
@@ -147,10 +139,65 @@ func extractProcessGroupID(cmd *exec.Cmd, logger *zap.Logger, serverName string)
 	return pid
 }
 
-// isProcessGroupAlive checks if the process is still running on Windows.
-func isProcessGroupAlive(pgid int) bool {
+// releaseProcessGroup is the platform hook DisconnectWithContext calls on
+// EVERY non-Docker stdio disconnect, whether or not the graceful MCP close
+// succeeded. On Unix it is a no-op. Here it terminates whatever is still
+// in the Job and drops the windowsJobs entry.
+//
+// Why it must run on the graceful path too: mcp-go's Stdio.Close() only
+// ever kills the immediate child (cmd.exe — every Windows stdio command
+// is shell-wrapped) and always returns within ~8s, under the 10s
+// mcpClientCloseTimeout, so Disconnect's force-kill step (which is where
+// killProcessGroup lives) is effectively unreachable on Windows. Without
+// this hook the grandchildren a stdin-EOF-ignoring node.exe/python.exe
+// left behind survived every restart, and the Job handle + map entry
+// leaked per disconnect until mcpproxy exited (#1234 follow-up, F1).
+func releaseProcessGroup(pgid int, logger *zap.Logger, serverName string) {
 	if pgid <= 0 {
-		return false
+		return
 	}
-	return winjob.IsProcessAlive(pgid)
+	job := takeWindowsJob(pgid)
+	if job == nil {
+		// Already killed via killProcessGroup, or job setup failed at
+		// connect time (extractProcessGroupID logged a Warn then).
+		return
+	}
+	if err := job.Close(); err != nil {
+		logger.Warn("Failed to close Windows Job Object on disconnect",
+			zap.String("server", serverName),
+			zap.Int("pid", pgid),
+			zap.Error(err))
+		return
+	}
+	logger.Debug("Released Windows Job Object; any surviving grandchildren terminated",
+		zap.String("server", serverName),
+		zap.Int("pid", pgid))
+}
+
+// takeWindowsJob removes and returns the Job registered for pid, or nil.
+// Popping under the lock gives the caller sole ownership of the Close.
+func takeWindowsJob(pid int) *winjob.Job {
+	windowsJobsMu.Lock()
+	defer windowsJobsMu.Unlock()
+	job := windowsJobs[pid]
+	delete(windowsJobs, pid)
+	return job
+}
+
+// registerWindowsJob records the Job for pid. If an entry already exists —
+// only possible when Windows reused a PID whose earlier Job was never
+// released — the old Job is closed first rather than silently dropped
+// with its handle (and any straggler still inside it) left open forever.
+func registerWindowsJob(pid int, job *winjob.Job, logger *zap.Logger, serverName string) {
+	windowsJobsMu.Lock()
+	prev := windowsJobs[pid]
+	windowsJobs[pid] = job
+	windowsJobsMu.Unlock()
+
+	if prev != nil {
+		logger.Warn("Windows Job Object already registered for reused PID; closing the stale one",
+			zap.String("server", serverName),
+			zap.Int("pid", pid))
+		_ = prev.Close()
+	}
 }

--- a/internal/upstream/core/process_windows.go
+++ b/internal/upstream/core/process_windows.go
@@ -19,13 +19,21 @@ type ProcessGroup struct {
 	logger *zap.Logger
 }
 
+// windowsJob is one registered Job Object plus the identity of the
+// exec.Cmd it was created for. The cmd pointer is what lets a delayed
+// release tell "my process" from "a newer process that reused my PID".
+type windowsJob struct {
+	job *winjob.Job
+	cmd *exec.Cmd
+}
+
 // windowsJobs maps the "process group ID" mcpproxy uses on Windows (the
 // immediate child's PID — see extractProcessGroupID) to the Job Object that
 // PID was assigned to. killProcessGroup only receives that int, so this is
 // how it finds the Job to terminate.
 var (
 	windowsJobsMu sync.Mutex
-	windowsJobs   = map[int]*winjob.Job{}
+	windowsJobs   = map[int]windowsJob{}
 )
 
 // createProcessGroupCommandFunc creates a custom CommandFunc for Windows systems.
@@ -71,7 +79,7 @@ func killProcessGroup(pgid int, logger *zap.Logger, serverName string) error {
 		return nil
 	}
 
-	job := takeWindowsJob(pgid)
+	job := takeWindowsJob(pgid, nil)
 	if job == nil {
 		logger.Warn("No Windows Job Object tracked for this process; falling back to killing only the immediate process (any grandchildren will leak)",
 			zap.String("server", serverName),
@@ -130,7 +138,7 @@ func extractProcessGroupID(cmd *exec.Cmd, logger *zap.Logger, serverName string)
 		return pid
 	}
 
-	registerWindowsJob(pid, job, logger, serverName)
+	registerWindowsJob(pid, cmd, job, logger, serverName)
 
 	logger.Debug("Process group ID extracted and assigned to Windows Job Object",
 		zap.String("server", serverName),
@@ -152,14 +160,23 @@ func extractProcessGroupID(cmd *exec.Cmd, logger *zap.Logger, serverName string)
 // this hook the grandchildren a stdin-EOF-ignoring node.exe/python.exe
 // left behind survived every restart, and the Job handle + map entry
 // leaked per disconnect until mcpproxy exited (#1234 follow-up, F1).
-func releaseProcessGroup(pgid int, logger *zap.Logger, serverName string) {
+//
+// cmd identifies the connection's own process: by the time this runs the
+// graceful close may already have reaped cmd.exe, and Windows reuses PIDs
+// eagerly, so a concurrently connecting server can have registered a NEW
+// Job under the same PID. Only the entry registered for this exact cmd is
+// released; if the slot now belongs to someone else, ours was already
+// closed by registerWindowsJob when it took the slot over. A nil cmd
+// disables the identity check (not used by production callers).
+func releaseProcessGroup(pgid int, cmd *exec.Cmd, logger *zap.Logger, serverName string) {
 	if pgid <= 0 {
 		return
 	}
-	job := takeWindowsJob(pgid)
+	job := takeWindowsJob(pgid, cmd)
 	if job == nil {
-		// Already killed via killProcessGroup, or job setup failed at
-		// connect time (extractProcessGroupID logged a Warn then).
+		// Already killed via killProcessGroup, job setup failed at connect
+		// time (extractProcessGroupID logged a Warn then), or the PID slot
+		// was taken over by a newer process (see above).
 		return
 	}
 	if err := job.Close(); err != nil {
@@ -175,29 +192,36 @@ func releaseProcessGroup(pgid int, logger *zap.Logger, serverName string) {
 }
 
 // takeWindowsJob removes and returns the Job registered for pid, or nil.
-// Popping under the lock gives the caller sole ownership of the Close.
-func takeWindowsJob(pid int) *winjob.Job {
+// When cmd is non-nil the entry is only taken if it was registered for
+// that same cmd. Popping under the lock gives the caller sole ownership
+// of the Close.
+func takeWindowsJob(pid int, cmd *exec.Cmd) *winjob.Job {
 	windowsJobsMu.Lock()
 	defer windowsJobsMu.Unlock()
-	job := windowsJobs[pid]
+	entry, ok := windowsJobs[pid]
+	if !ok || (cmd != nil && entry.cmd != cmd) {
+		return nil
+	}
 	delete(windowsJobs, pid)
-	return job
+	return entry.job
 }
 
 // registerWindowsJob records the Job for pid. If an entry already exists —
-// only possible when Windows reused a PID whose earlier Job was never
-// released — the old Job is closed first rather than silently dropped
-// with its handle (and any straggler still inside it) left open forever.
-func registerWindowsJob(pid int, job *winjob.Job, logger *zap.Logger, serverName string) {
+// Windows reused a PID whose earlier Job has not been released yet — the
+// old Job is closed first rather than silently dropped with its handle
+// (and any straggler still inside it) left open forever. The previous
+// owner's later releaseProcessGroup then finds the slot belongs to a
+// different cmd and does nothing.
+func registerWindowsJob(pid int, cmd *exec.Cmd, job *winjob.Job, logger *zap.Logger, serverName string) {
 	windowsJobsMu.Lock()
-	prev := windowsJobs[pid]
-	windowsJobs[pid] = job
+	prev, hadPrev := windowsJobs[pid]
+	windowsJobs[pid] = windowsJob{job: job, cmd: cmd}
 	windowsJobsMu.Unlock()
 
-	if prev != nil {
+	if hadPrev {
 		logger.Warn("Windows Job Object already registered for reused PID; closing the stale one",
 			zap.String("server", serverName),
 			zap.Int("pid", pid))
-		_ = prev.Close()
+		_ = prev.job.Close()
 	}
 }

--- a/internal/upstream/core/process_windows_test.go
+++ b/internal/upstream/core/process_windows_test.go
@@ -1,0 +1,89 @@
+//go:build windows
+
+package core
+
+import (
+	"io"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// startPingTree mirrors internal/winjob's helper: cmd.exe -> ping.exe, where
+// ping.exe inherits the stdout pipe so EOF == "the whole tree is gone".
+func startPingTree(t *testing.T) (*exec.Cmd, <-chan struct{}) {
+	t.Helper()
+	cmd := exec.Command("cmd.exe", "/c", "ping -n 30 127.0.0.1")
+	stdout, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() { _ = cmd.Process.Kill(); _ = cmd.Wait() })
+
+	eof := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, stdout)
+		close(eof)
+	}()
+	return cmd, eof
+}
+
+func hasWindowsJob(pid int) bool {
+	windowsJobsMu.Lock()
+	defer windowsJobsMu.Unlock()
+	_, ok := windowsJobs[pid]
+	return ok
+}
+
+// TestReleaseProcessGroup_KillsTreeAndForgetsJob covers the normal
+// Disconnect path (F1 of the #1234 review): mcp-go's Close() only ever
+// reaches the immediate child, so releaseProcessGroup must both terminate
+// the surviving grandchildren AND drop the windowsJobs entry, or the Job
+// handle and the tree live until mcpproxy exits.
+func TestReleaseProcessGroup_KillsTreeAndForgetsJob(t *testing.T) {
+	logger := zap.NewNop()
+	cmd, eof := startPingTree(t)
+
+	pgid := extractProcessGroupID(cmd, logger, "test-server")
+	require.Equal(t, cmd.Process.Pid, pgid)
+	require.True(t, hasWindowsJob(pgid), "extractProcessGroupID must register the Job")
+
+	// Simulate what mcp-go's Stdio.Close() does on Windows: kill cmd.exe only.
+	require.NoError(t, cmd.Process.Kill())
+	select {
+	case <-eof:
+		t.Fatal("grandchild did not inherit the pipe; test cannot prove anything")
+	case <-time.After(1500 * time.Millisecond):
+	}
+
+	releaseProcessGroup(pgid, logger, "test-server")
+
+	assert.False(t, hasWindowsJob(pgid), "releaseProcessGroup must drop the windowsJobs entry")
+	select {
+	case <-eof:
+	case <-time.After(5 * time.Second):
+		t.Fatal("grandchild survived releaseProcessGroup")
+	}
+}
+
+// TestKillProcessGroup_ForgetsJob: the pre-existing force-kill path must
+// leave no entry behind either, so a later releaseProcessGroup is a no-op.
+func TestKillProcessGroup_ForgetsJob(t *testing.T) {
+	logger := zap.NewNop()
+	cmd, eof := startPingTree(t)
+
+	pgid := extractProcessGroupID(cmd, logger, "test-server")
+	require.True(t, hasWindowsJob(pgid))
+
+	require.NoError(t, killProcessGroup(pgid, logger, "test-server"))
+	assert.False(t, hasWindowsJob(pgid))
+	select {
+	case <-eof:
+	case <-time.After(5 * time.Second):
+		t.Fatal("tree survived killProcessGroup")
+	}
+	releaseProcessGroup(pgid, logger, "test-server") // must be a harmless no-op
+}

--- a/internal/upstream/core/process_windows_test.go
+++ b/internal/upstream/core/process_windows_test.go
@@ -3,32 +3,67 @@
 package core
 
 import (
+	"bufio"
 	"io"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/winjob"
 )
 
-// startPingTree mirrors internal/winjob's helper: cmd.exe -> ping.exe, where
+// pingTree mirrors internal/winjob's test helper: a cmd.exe -> ping.exe
+// tree where cmd.exe blocks on `set /p` until release() writes a line to
+// stdin (so the Job is attached BEFORE the grandchild exists), and where
 // ping.exe inherits the stdout pipe so EOF == "the whole tree is gone".
-func startPingTree(t *testing.T) (*exec.Cmd, <-chan struct{}) {
+type pingTree struct {
+	cmd     *exec.Cmd
+	stdin   io.WriteCloser
+	pinging <-chan struct{}
+	eof     <-chan struct{}
+}
+
+func startPingTree(t *testing.T) *pingTree {
 	t.Helper()
-	cmd := exec.Command("cmd.exe", "/c", "ping -n 30 127.0.0.1")
+	cmd := exec.Command("cmd.exe", "/c", "set /p x=& ping -n 30 127.0.0.1")
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
 	stdout, err := cmd.StdoutPipe()
 	require.NoError(t, err)
 	require.NoError(t, cmd.Start())
 	t.Cleanup(func() { _ = cmd.Process.Kill(); _ = cmd.Wait() })
 
+	pinging := make(chan struct{})
 	eof := make(chan struct{})
 	go func() {
-		_, _ = io.Copy(io.Discard, stdout)
-		close(eof)
+		defer close(eof)
+		seen := false
+		sc := bufio.NewScanner(stdout)
+		for sc.Scan() {
+			// Any ping output line names the target; locale-neutral.
+			if !seen && strings.Contains(sc.Text(), "127.0.0.1") {
+				seen = true
+				close(pinging)
+			}
+		}
 	}()
-	return cmd, eof
+	return &pingTree{cmd: cmd, stdin: stdin, pinging: pinging, eof: eof}
+}
+
+func (p *pingTree) release(t *testing.T) {
+	t.Helper()
+	_, err := io.WriteString(p.stdin, "\r\n")
+	require.NoError(t, err)
+	select {
+	case <-p.pinging:
+	case <-time.After(10 * time.Second):
+		t.Fatal("ping.exe never produced output; grandchild not running")
+	}
 }
 
 func hasWindowsJob(pid int) bool {
@@ -45,25 +80,26 @@ func hasWindowsJob(pid int) bool {
 // handle and the tree live until mcpproxy exits.
 func TestReleaseProcessGroup_KillsTreeAndForgetsJob(t *testing.T) {
 	logger := zap.NewNop()
-	cmd, eof := startPingTree(t)
+	tree := startPingTree(t)
 
-	pgid := extractProcessGroupID(cmd, logger, "test-server")
-	require.Equal(t, cmd.Process.Pid, pgid)
+	pgid := extractProcessGroupID(tree.cmd, logger, "test-server")
+	require.Equal(t, tree.cmd.Process.Pid, pgid)
 	require.True(t, hasWindowsJob(pgid), "extractProcessGroupID must register the Job")
+	tree.release(t)
 
 	// Simulate what mcp-go's Stdio.Close() does on Windows: kill cmd.exe only.
-	require.NoError(t, cmd.Process.Kill())
+	require.NoError(t, tree.cmd.Process.Kill())
 	select {
-	case <-eof:
+	case <-tree.eof:
 		t.Fatal("grandchild did not inherit the pipe; test cannot prove anything")
 	case <-time.After(1500 * time.Millisecond):
 	}
 
-	releaseProcessGroup(pgid, logger, "test-server")
+	releaseProcessGroup(pgid, tree.cmd, logger, "test-server")
 
 	assert.False(t, hasWindowsJob(pgid), "releaseProcessGroup must drop the windowsJobs entry")
 	select {
-	case <-eof:
+	case <-tree.eof:
 	case <-time.After(5 * time.Second):
 		t.Fatal("grandchild survived releaseProcessGroup")
 	}
@@ -73,17 +109,52 @@ func TestReleaseProcessGroup_KillsTreeAndForgetsJob(t *testing.T) {
 // leave no entry behind either, so a later releaseProcessGroup is a no-op.
 func TestKillProcessGroup_ForgetsJob(t *testing.T) {
 	logger := zap.NewNop()
-	cmd, eof := startPingTree(t)
+	tree := startPingTree(t)
 
-	pgid := extractProcessGroupID(cmd, logger, "test-server")
+	pgid := extractProcessGroupID(tree.cmd, logger, "test-server")
 	require.True(t, hasWindowsJob(pgid))
+	tree.release(t)
 
 	require.NoError(t, killProcessGroup(pgid, logger, "test-server"))
 	assert.False(t, hasWindowsJob(pgid))
 	select {
-	case <-eof:
+	case <-tree.eof:
 	case <-time.After(5 * time.Second):
 		t.Fatal("tree survived killProcessGroup")
 	}
-	releaseProcessGroup(pgid, logger, "test-server") // must be a harmless no-op
+	releaseProcessGroup(pgid, tree.cmd, logger, "test-server") // must be a harmless no-op
+}
+
+// TestReleaseProcessGroup_PIDReuseLeavesNewOwnerAlone: Disconnect captures
+// pgid+cmd, then mcp-go's Close() reaps cmd.exe, and only THEN does
+// releaseProcessGroup run. In that window Windows can hand the PID to a
+// concurrently connecting server. The old owner's release must not close
+// the new owner's Job; the takeover itself must close the old one.
+func TestReleaseProcessGroup_PIDReuseLeavesNewOwnerAlone(t *testing.T) {
+	logger := zap.NewNop()
+	const pid = 1 << 30 // never a real PID; the map does not care
+	oldCmd, newCmd := exec.Command("cmd.exe"), exec.Command("cmd.exe")
+
+	oldJob, err := winjob.New()
+	require.NoError(t, err)
+	newJob, err := winjob.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = oldJob.Close(); _ = newJob.Close() })
+
+	registerWindowsJob(pid, oldCmd, oldJob, logger, "old-server")
+	registerWindowsJob(pid, newCmd, newJob, logger, "new-server") // PID reuse
+
+	// The takeover closed the old Job: Assign on a closed Job fails
+	// without touching Win32 (a live Job with a bogus PID would fail
+	// differently, inside OpenProcess).
+	err = oldJob.Assign(pid)
+	require.ErrorContains(t, err, "already closed")
+
+	// The old owner's delayed release must leave the new owner's entry alone.
+	releaseProcessGroup(pid, oldCmd, logger, "old-server")
+	require.True(t, hasWindowsJob(pid), "old owner's release must not evict the new owner's Job")
+
+	// The new owner's own release works as usual.
+	releaseProcessGroup(pid, newCmd, logger, "new-server")
+	assert.False(t, hasWindowsJob(pid))
 }

--- a/internal/upstream/core/process_windows_test.go
+++ b/internal/upstream/core/process_windows_test.go
@@ -125,49 +125,73 @@ func TestKillProcessGroup_ForgetsJob(t *testing.T) {
 	releaseProcessGroup(pgid, tree.cmd, logger, "test-server") // must be a harmless no-op
 }
 
-// TestReleaseProcessGroup_PIDReuseLeavesNewOwnerAlone: Disconnect captures
-// pgid+cmd, then mcp-go's Close() reaps cmd.exe, and only THEN does
-// releaseProcessGroup run. In that window Windows can hand the PID to a
-// concurrently connecting server. The old owner's release must not close
-// the new owner's Job; the takeover itself must close the old one.
-func TestReleaseProcessGroup_PIDReuseLeavesNewOwnerAlone(t *testing.T) {
+// TestPIDReuse_OldOwnerCannotKillNewOwner: Disconnect captures pgid+cmd,
+// then mcp-go's Close() reaps cmd.exe, and only THEN do
+// releaseProcessGroup / killProcessGroup run. In that window Windows can
+// hand the PID to a concurrently connecting server. Neither the old
+// owner's release nor its force-kill may touch the new owner's Job OR its
+// process; the takeover itself must close the old Job.
+//
+// The new owner is a LIVE, test-owned `ping.exe` (no grandchild, so its
+// stdout pipe reaching EOF means exactly "ping.exe died"). That is what
+// makes a forbidden PID-based fallback kill observable: an unstarted
+// oldCmd has no process handle, so a fallback could only reach the live
+// process by PID — and would close the pipe.
+func TestPIDReuse_OldOwnerCannotKillNewOwner(t *testing.T) {
 	logger := zap.NewNop()
-	const pid = 1 << 30 // never a real PID; the map does not care
-	oldCmd, newCmd := exec.Command("cmd.exe"), exec.Command("cmd.exe")
 
+	newProc := exec.Command("ping", "-n", "30", "127.0.0.1")
+	stdout, err := newProc.StdoutPipe()
+	require.NoError(t, err)
+	require.NoError(t, newProc.Start())
+	t.Cleanup(func() { _ = newProc.Process.Kill(); _ = newProc.Wait() })
+	pid := newProc.Process.Pid
+
+	eof := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, stdout)
+		close(eof)
+	}()
+	assertAlive := func(what string) {
+		t.Helper()
+		select {
+		case <-eof:
+			t.Fatalf("%s killed the new owner's live process", what)
+		case <-time.After(1500 * time.Millisecond):
+		}
+	}
+
+	// The old owner registered first, for a process that has since exited
+	// and whose PID Windows handed to newProc.
+	oldCmd := exec.Command("cmd.exe") // never started: no handle, only the (reused) PID
 	oldJob, err := winjob.New()
 	require.NoError(t, err)
-	newJob, err := winjob.New()
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = oldJob.Close(); _ = newJob.Close() })
-
+	t.Cleanup(func() { _ = oldJob.Close() })
 	registerWindowsJob(pid, oldCmd, oldJob, logger, "old-server")
-	registerWindowsJob(pid, newCmd, newJob, logger, "new-server") // PID reuse
 
-	// The takeover closed the old Job: Assign on a closed Job fails
-	// without touching Win32 (a live Job with a bogus PID would fail
-	// differently, inside OpenProcess).
-	err = oldJob.Assign(pid)
-	require.ErrorContains(t, err, "already closed")
+	// The new owner connects: the takeover closes the stale Job. Assign on
+	// a closed Job fails before touching Win32, with a distinct message.
+	require.Equal(t, pid, extractProcessGroupID(newProc, logger, "new-server"))
+	require.ErrorContains(t, oldJob.Assign(pid), "already closed", "takeover must close the stale Job")
+	require.True(t, hasWindowsJob(pid))
 
-	// The old owner's delayed release must leave the new owner's entry alone.
+	// Old owner's delayed release (Disconnect Step 5b): must be a no-op.
 	releaseProcessGroup(pid, oldCmd, logger, "old-server")
 	require.True(t, hasWindowsJob(pid), "old owner's release must not evict the new owner's Job")
+	assertAlive("releaseProcessGroup(old owner)")
 
-	// Same for the force-kill path (Disconnect Step 5 after a Close timeout):
-	// it must neither take the new owner's Job nor fall back to a PID kill.
-	// oldCmd was never started, so a fallback would hit cmd.Process == nil
-	// and os.FindProcess(1<<30); returning nil without touching the map is
-	// the only correct outcome.
+	// Old owner's force-kill (Disconnect Step 5 after a Close timeout):
+	// must neither take the Job nor fall back to a PID kill.
 	require.NoError(t, killProcessGroup(pid, oldCmd, logger, "old-server"))
 	require.True(t, hasWindowsJob(pid), "old owner's force-kill must not evict the new owner's Job")
-	// newJob must still be open: Assign on a bogus PID fails inside
-	// OpenProcess, whereas a closed Job fails earlier with "already closed".
-	err = newJob.Assign(pid)
-	require.Error(t, err)
-	require.NotContains(t, err.Error(), "already closed", "new owner's Job must not have been closed")
+	assertAlive("killProcessGroup(old owner)")
 
-	// The new owner's own release works as usual.
-	releaseProcessGroup(pid, newCmd, logger, "new-server")
+	// The new owner's own release works as usual and does kill it.
+	releaseProcessGroup(pid, newProc, logger, "new-server")
 	assert.False(t, hasWindowsJob(pid))
+	select {
+	case <-eof:
+	case <-time.After(5 * time.Second):
+		t.Fatal("new owner's release did not terminate its process")
+	}
 }

--- a/internal/upstream/core/process_windows_test.go
+++ b/internal/upstream/core/process_windows_test.go
@@ -115,7 +115,7 @@ func TestKillProcessGroup_ForgetsJob(t *testing.T) {
 	require.True(t, hasWindowsJob(pgid))
 	tree.release(t)
 
-	require.NoError(t, killProcessGroup(pgid, logger, "test-server"))
+	require.NoError(t, killProcessGroup(pgid, tree.cmd, logger, "test-server"))
 	assert.False(t, hasWindowsJob(pgid))
 	select {
 	case <-tree.eof:
@@ -153,6 +153,19 @@ func TestReleaseProcessGroup_PIDReuseLeavesNewOwnerAlone(t *testing.T) {
 	// The old owner's delayed release must leave the new owner's entry alone.
 	releaseProcessGroup(pid, oldCmd, logger, "old-server")
 	require.True(t, hasWindowsJob(pid), "old owner's release must not evict the new owner's Job")
+
+	// Same for the force-kill path (Disconnect Step 5 after a Close timeout):
+	// it must neither take the new owner's Job nor fall back to a PID kill.
+	// oldCmd was never started, so a fallback would hit cmd.Process == nil
+	// and os.FindProcess(1<<30); returning nil without touching the map is
+	// the only correct outcome.
+	require.NoError(t, killProcessGroup(pid, oldCmd, logger, "old-server"))
+	require.True(t, hasWindowsJob(pid), "old owner's force-kill must not evict the new owner's Job")
+	// newJob must still be open: Assign on a bogus PID fails inside
+	// OpenProcess, whereas a closed Job fails earlier with "already closed".
+	err = newJob.Assign(pid)
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "already closed", "new owner's Job must not have been closed")
 
 	// The new owner's own release works as usual.
 	releaseProcessGroup(pid, newCmd, logger, "new-server")

--- a/internal/upstream/core/shutdown_test.go
+++ b/internal/upstream/core/shutdown_test.go
@@ -34,7 +34,7 @@ func TestKillProcessGroup_AlreadyDead(t *testing.T) {
 	nonExistentPGID := 999999999
 
 	start := time.Now()
-	err := killProcessGroup(nonExistentPGID, logger, "test-server")
+	err := killProcessGroup(nonExistentPGID, nil, logger, "test-server")
 	elapsed := time.Since(start)
 
 	// Should return without error (process already dead is not an error)
@@ -50,7 +50,7 @@ func TestKillProcessGroup_InvalidPGID(t *testing.T) {
 
 	// Zero PGID should return immediately
 	start := time.Now()
-	err := killProcessGroup(0, logger, "test-server")
+	err := killProcessGroup(0, nil, logger, "test-server")
 	elapsed := time.Since(start)
 
 	assert.NoError(t, err)
@@ -59,7 +59,7 @@ func TestKillProcessGroup_InvalidPGID(t *testing.T) {
 
 	// Negative PGID should return immediately
 	start = time.Now()
-	err = killProcessGroup(-1, logger, "test-server")
+	err = killProcessGroup(-1, nil, logger, "test-server")
 	elapsed = time.Since(start)
 
 	assert.NoError(t, err)

--- a/internal/upstream/launcher/launcher.go
+++ b/internal/upstream/launcher/launcher.go
@@ -264,8 +264,9 @@ func (h *handle) stopLocked(ctx context.Context) error {
 		zap.Int("pid", h.Pid()),
 		zap.Duration("grace", h.stopGrace))
 
-	// SIGTERM the process group (Unix) / process (Windows fallback).
-	if err := terminateProcess(h.cmd, h.log); err != nil {
+	// SIGTERM the process group (Unix) / terminate the Job Object tree
+	// (Windows) — see the platform files for h.terminate.
+	if err := h.terminate(); err != nil {
 		h.log.Warn("terminate failed (will fall through to wait/kill)",
 			zap.Error(err))
 	}
@@ -284,7 +285,7 @@ func (h *handle) stopLocked(ctx context.Context) error {
 	h.log.Warn("child did not exit within grace period; sending SIGKILL",
 		zap.Int("pid", h.Pid()),
 		zap.Duration("grace", h.stopGrace))
-	if err := killProcess(h.cmd, h.log); err != nil {
+	if err := h.kill(); err != nil {
 		h.log.Error("kill failed", zap.Error(err))
 		// Fall through — we still wait for done.
 	}
@@ -308,13 +309,11 @@ func (h *handle) reap() {
 	h.pumpWG.Wait()
 	err := h.cmd.Wait()
 
-	// Reap any grandchildren the child spawned (Windows only — see
-	// createJob/winjob). This runs on EVERY exit path, not just Stop's
-	// SIGKILL fallback: a child that exits on its own can still leave
-	// grandchildren behind (e.g. cmd.exe returning while node.exe keeps
-	// running), and without this they leaked indefinitely (413 confirmed
-	// orphaned node.exe/python.exe processes observed from normal use on
-	// this host prior to this fix).
+	// Release the Job Object (Windows only — see createJob/winjob). By the
+	// time we get here every pipe holder has exited, so on the Stop path
+	// this is a no-op (h.terminate/h.kill already closed the job — that is
+	// what made the pumps reach EOF); it only does real work when the
+	// whole tree exited on its own. Close is idempotent and goroutine-safe.
 	if h.job != nil {
 		_ = h.job.Close()
 	}

--- a/internal/upstream/launcher/launcher_unix.go
+++ b/internal/upstream/launcher/launcher_unix.go
@@ -56,3 +56,9 @@ func killProcess(cmd *exec.Cmd, log *zap.Logger) error {
 	}
 	return syscall.Kill(-pgid, syscall.SIGKILL)
 }
+
+// terminate and kill are the two escalation steps stopLocked drives. On
+// Unix they are the process-group signals above; the Job Object argument
+// the Windows build needs does not exist here.
+func (h *handle) terminate() error { return terminateProcess(h.cmd, h.log) }
+func (h *handle) kill() error      { return killProcess(h.cmd, h.log) }

--- a/internal/upstream/launcher/launcher_windows.go
+++ b/internal/upstream/launcher/launcher_windows.go
@@ -20,9 +20,8 @@ func applyProcAttrs(_ *exec.Cmd) {}
 // createJob assigns the just-started process to a fresh Windows Job Object
 // (JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE) so that everything it spawns
 // afterwards — e.g. `cmd.exe /c npx ...` spawning node.exe spawning the
-// actual MCP server — dies when the returned Closer's Close is called
-// (wired into launcher.go's reap(), which runs on every exit path). Prior
-// to this, launcher_windows.go only ever reached the immediate child
+// actual MCP server — dies when the returned Closer's Close is called.
+// Prior to this, launcher_windows.go only ever reached the immediate child
 // (terminateProcess/killProcess below called cmd.Process.Kill()), so a
 // launcher-managed server on Windows leaked every grandchild it spawned —
 // the same class of leak process_windows.go had on the stdio path.
@@ -43,11 +42,35 @@ func createJob(cmd *exec.Cmd) io.Closer {
 	return job
 }
 
-// terminateProcess signals the child directly. The Job Object (if createJob
-// succeeded) is what actually reaches grandchildren — it is closed in
-// launcher.go's reap() once the child has exited, not here, since
-// terminating the job immediately would kill descendants before giving the
-// immediate child a chance to shut down gracefully.
+// terminate is stopLocked's first escalation step. On Windows there is no
+// graceful phase to protect: Process.Kill() is TerminateProcess, so the
+// immediate child gets no chance to shut down cleanly either way. What
+// matters is reaching the WHOLE tree right here, not in reap(): the
+// grandchildren inherit the child's stdout/stderr pipe handles, so if only
+// cmd.exe dies the log pumps never see EOF, reap() never runs, Done()
+// never closes and Stop() blocks until the caller's ctx expires — the Job
+// would only ever have been closed once the tree was already gone (#1234
+// follow-up, F2). Closing the job kills every member, the pipes close, the
+// pumps drain, and reap() proceeds.
+func (h *handle) terminate() error {
+	if h.job != nil {
+		return h.job.Close()
+	}
+	return terminateProcess(h.cmd, h.log)
+}
+
+// kill is the hard-kill step after the grace period. With a Job the tree is
+// already gone (terminate closed it); this only matters when createJob
+// failed and we are back to the single-process fallback.
+func (h *handle) kill() error {
+	if h.job != nil {
+		_ = h.job.Close()
+	}
+	return killProcess(h.cmd, h.log)
+}
+
+// terminateProcess kills the immediate child only. Used when no Job Object
+// could be created (see createJob) — grandchildren will leak in that case.
 func terminateProcess(cmd *exec.Cmd, _ *zap.Logger) error {
 	if cmd.Process == nil {
 		return nil
@@ -55,9 +78,7 @@ func terminateProcess(cmd *exec.Cmd, _ *zap.Logger) error {
 	return cmd.Process.Kill()
 }
 
-// killProcess is the hard-kill fallback after the grace period. Same
-// reasoning as terminateProcess: the immediate child dies here, the wider
-// tree is reaped via the Job Object in reap() once Wait() returns.
+// killProcess is the single-process fallback for the hard-kill step.
 func killProcess(cmd *exec.Cmd, _ *zap.Logger) error {
 	if cmd.Process == nil {
 		return nil

--- a/internal/upstream/launcher/launcher_windows.go
+++ b/internal/upstream/launcher/launcher_windows.go
@@ -60,11 +60,13 @@ func (h *handle) terminate() error {
 }
 
 // kill is the hard-kill step after the grace period. With a Job the tree is
-// already gone (terminate closed it); this only matters when createJob
-// failed and we are back to the single-process fallback.
+// already gone (terminate closed it, and Close is idempotent), so this is a
+// no-op there — falling through to Process.Kill() on the dead-but-unreaped
+// child would only yield a misleading "kill failed" error. It does real
+// work only when createJob failed and we are on the single-process fallback.
 func (h *handle) kill() error {
 	if h.job != nil {
-		_ = h.job.Close()
+		return h.job.Close()
 	}
 	return killProcess(h.cmd, h.log)
 }

--- a/internal/upstream/launcher/launcher_windows_test.go
+++ b/internal/upstream/launcher/launcher_windows_test.go
@@ -4,6 +4,7 @@ package launcher
 
 import (
 	"context"
+	"io"
 	"os/exec"
 	"testing"
 	"time"
@@ -20,13 +21,21 @@ import (
 // used to block until the caller's ctx expired. Stop must instead
 // terminate the whole Job so the pipes close and the child is reaped.
 func TestSpawn_Stop_KillsGrandchildHoldingPipe(t *testing.T) {
-	// ping.exe prints "Reply from 127.0.0.1" once per second; the launcher
-	// banner echoes argv un-expanded, so it cannot false-positive on this.
+	// cmd.exe blocks on `set /p` (one line from stdin) until we release it
+	// below, so Spawn's createJob has attached the Job BEFORE ping.exe is
+	// spawned — otherwise the grandchild could legitimately escape the job.
+	cmd := exec.Command("cmd.exe", "/c", "set /p x=& ping -n 30 127.0.0.1")
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
+
+	// A reply line looks like "Reply from 127.0.0.1: bytes=32 ..."; the
+	// "127.0.0.1:" form is locale-neutral and cannot match the launcher's
+	// startup banner, which echoes argv as "... 127.0.0.1]".
 	sinkCh := make(chan struct{}, 1)
-	sink := newRegexDetector(`Reply from 127\.0\.0\.1`, sinkCh)
+	sink := newRegexDetector(`127\.0\.0\.1:`, sinkCh)
 
 	h, err := Spawn(context.Background(), &Spec{
-		Cmd:       exec.Command("cmd.exe", "/c", "ping -n 30 127.0.0.1"),
+		Cmd:       cmd,
 		LogSink:   sink,
 		Name:      "test-ping-tree",
 		StopGrace: 2 * time.Second,
@@ -34,11 +43,11 @@ func TestSpawn_Stop_KillsGrandchildHoldingPipe(t *testing.T) {
 	require.NoError(t, err)
 	require.Greater(t, h.Pid(), 0)
 
-	// Let cmd.exe actually spawn ping.exe before we stop it, otherwise the
-	// test could pass by killing cmd.exe before the grandchild exists.
+	_, err = io.WriteString(stdin, "\r\n")
+	require.NoError(t, err)
 	select {
 	case <-sinkCh:
-	case <-time.After(5 * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatal("ping.exe never produced output; grandchild not running")
 	}
 

--- a/internal/upstream/launcher/launcher_windows_test.go
+++ b/internal/upstream/launcher/launcher_windows_test.go
@@ -1,0 +1,58 @@
+//go:build windows
+
+package launcher
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// TestSpawn_Stop_KillsGrandchildHoldingPipe reproduces F2 of the #1234
+// review: `cmd.exe /c ping ...` leaves ping.exe holding the inherited
+// stdout/stderr pipes. Process.Kill() on cmd.exe alone never makes the log
+// pumps reach EOF, so reap() never runs, Done() never closes and Stop()
+// used to block until the caller's ctx expired. Stop must instead
+// terminate the whole Job so the pipes close and the child is reaped.
+func TestSpawn_Stop_KillsGrandchildHoldingPipe(t *testing.T) {
+	// ping.exe prints "Reply from 127.0.0.1" once per second; the launcher
+	// banner echoes argv un-expanded, so it cannot false-positive on this.
+	sinkCh := make(chan struct{}, 1)
+	sink := newRegexDetector(`Reply from 127\.0\.0\.1`, sinkCh)
+
+	h, err := Spawn(context.Background(), &Spec{
+		Cmd:       exec.Command("cmd.exe", "/c", "ping -n 30 127.0.0.1"),
+		LogSink:   sink,
+		Name:      "test-ping-tree",
+		StopGrace: 2 * time.Second,
+	}, zap.NewNop())
+	require.NoError(t, err)
+	require.Greater(t, h.Pid(), 0)
+
+	// Let cmd.exe actually spawn ping.exe before we stop it, otherwise the
+	// test could pass by killing cmd.exe before the grandchild exists.
+	select {
+	case <-sinkCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ping.exe never produced output; grandchild not running")
+	}
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	start := time.Now()
+	err = h.Stop(stopCtx)
+	assert.NoError(t, err, "Stop must not time out while a grandchild holds the pipes")
+	assert.Less(t, time.Since(start), 8*time.Second, "Stop should not need the full ctx")
+
+	select {
+	case <-h.Done():
+	case <-time.After(time.Second):
+		t.Fatal("Done() not closed after Stop returned")
+	}
+	assert.Equal(t, 0, h.Pid())
+}

--- a/internal/winjob/winjob.go
+++ b/internal/winjob/winjob.go
@@ -23,55 +23,20 @@ package winjob
 
 import (
 	"fmt"
+	"sync"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
 
-// jobObjectExtendedLimitInformation / JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
-// mirror the WinAPI JobObjectInfoClass / limit-flag constants. Kept local
-// (rather than relying on x/sys/windows, which does not export the
-// Set/QueryInformationJobObject calls themselves) so this file only needs
-// the raw kernel32 procedure lookups below.
-const (
-	jobObjectExtendedLimitInformation = 9
-	jobObjectLimitKillOnJobClose      = 0x00002000
-	stillActive                       = 259 // STILL_ACTIVE, per GetExitCodeProcess docs
-)
-
-var (
-	modkernel32               = windows.NewLazySystemDLL("kernel32.dll")
-	procSetInformationJobObj  = modkernel32.NewProc("SetInformationJobObject")
-)
-
-// jobobjectBasicLimitInformation mirrors JOBOBJECT_BASIC_LIMIT_INFORMATION.
-// Only LimitFlags is meaningful here; the rest exists purely so the struct
-// has the layout Win32 expects when we hand it a pointer.
-type jobobjectBasicLimitInformation struct {
-	PerProcessUserTimeLimit int64
-	PerJobUserTimeLimit     int64
-	LimitFlags              uint32
-	MinimumWorkingSetSize   uintptr
-	MaximumWorkingSetSize   uintptr
-	ActiveProcessLimit      uint32
-	Affinity                uintptr
-	PriorityClass           uint32
-	SchedulingClass         uint32
-}
-
-// jobobjectExtendedLimitInformation mirrors JOBOBJECT_EXTENDED_LIMIT_INFORMATION.
-type jobobjectExtendedLimitInformation struct {
-	BasicLimitInformation jobobjectBasicLimitInformation
-	IoInfo                [48]byte // IO_COUNTERS — unused, present for correct struct size
-	ProcessMemoryLimit    uintptr
-	JobMemoryLimit        uintptr
-	PeakProcessMemoryUsed uintptr
-	PeakJobMemoryUsed     uintptr
-}
-
 // Job wraps a Windows Job Object configured to kill every member process
 // (including any it spawns after joining) as soon as Close is called.
+//
+// Close may be reached from more than one goroutine at once — the
+// launcher's Stop path and its reaper both close the job — so the handle
+// is guarded by a mutex and Close is idempotent.
 type Job struct {
+	mu     sync.Mutex
 	handle windows.Handle
 }
 
@@ -82,20 +47,19 @@ func New() (*Job, error) {
 		return nil, fmt.Errorf("CreateJobObject: %w", err)
 	}
 
-	info := jobobjectExtendedLimitInformation{
-		BasicLimitInformation: jobobjectBasicLimitInformation{
-			LimitFlags: jobObjectLimitKillOnJobClose,
-		},
-	}
-	r1, _, callErr := procSetInformationJobObj.Call(
-		uintptr(handle),
-		uintptr(jobObjectExtendedLimitInformation),
+	// x/sys/windows exports the struct, the info class and the limit flag,
+	// so the layout (including the arch-specific trailing pad on 386/arm)
+	// is the library's problem, not ours.
+	var info windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+	info.BasicLimitInformation.LimitFlags = windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+	if _, err := windows.SetInformationJobObject(
+		handle,
+		windows.JobObjectExtendedLimitInformation,
 		uintptr(unsafe.Pointer(&info)), //nolint:gosec // required shape for the Win32 call
-		unsafe.Sizeof(info),
-	)
-	if r1 == 0 {
+		uint32(unsafe.Sizeof(info)),
+	); err != nil {
 		_ = windows.CloseHandle(handle)
-		return nil, fmt.Errorf("SetInformationJobObject: %w", callErr)
+		return nil, fmt.Errorf("SetInformationJobObject: %w", err)
 	}
 
 	return &Job{handle: handle}, nil
@@ -112,6 +76,12 @@ func (j *Job) Assign(pid int) error {
 	if j == nil {
 		return fmt.Errorf("winjob: nil job")
 	}
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.handle == 0 {
+		return fmt.Errorf("winjob: job already closed")
+	}
+
 	proc, err := windows.OpenProcess(windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE, false, uint32(pid)) //nolint:gosec // pid is always a live PID from exec.Cmd.Process.Pid
 	if err != nil {
 		return fmt.Errorf("OpenProcess(%d): %w", pid, err)
@@ -125,9 +95,14 @@ func (j *Job) Assign(pid int) error {
 }
 
 // Close terminates every process still in the job and releases the handle.
-// Safe to call more than once and safe to call on a nil *Job.
+// Safe to call more than once, concurrently, and on a nil *Job.
 func (j *Job) Close() error {
-	if j == nil || j.handle == 0 {
+	if j == nil {
+		return nil
+	}
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.handle == 0 {
 		return nil
 	}
 	// Kill first (reaches every member immediately); closing the handle
@@ -136,21 +111,4 @@ func (j *Job) Close() error {
 	err := windows.CloseHandle(j.handle)
 	j.handle = 0
 	return err
-}
-
-// IsProcessAlive reports whether pid still exists and has not exited.
-// Used for the isProcessGroupAlive check that process_windows.go previously
-// hardcoded to false.
-func IsProcessAlive(pid int) bool {
-	proc, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid)) //nolint:gosec
-	if err != nil {
-		return false
-	}
-	defer func() { _ = windows.CloseHandle(proc) }()
-
-	var code uint32
-	if err := windows.GetExitCodeProcess(proc, &code); err != nil {
-		return false
-	}
-	return code == stillActive
 }

--- a/internal/winjob/winjob_test.go
+++ b/internal/winjob/winjob_test.go
@@ -3,34 +3,72 @@
 package winjob
 
 import (
+	"bufio"
 	"io"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
-// startPingTree starts `cmd.exe /c ping -n 30 127.0.0.1` with a stdout pipe.
-// ping.exe (the grandchild) inherits the pipe's write end from cmd.exe, so
-// the read side only reaches EOF once EVERY holder — cmd.exe AND ping.exe —
-// has exited. That makes "did the grandchild die?" observable without PID
-// discovery: kill cmd.exe alone and the pipe stays open; kill the job and
-// it closes.
-func startPingTree(t *testing.T) (*exec.Cmd, <-chan struct{}) {
+// pingTree is a deterministic cmd.exe -> ping.exe process tree.
+//
+//   - The shell first runs `set /p x=`, which blocks reading one line from
+//     stdin, so the caller can assign cmd.exe to a Job BEFORE ping.exe
+//     exists (release() writes that line). Without the gate, ping.exe could
+//     be spawned before Assign and legitimately escape the job.
+//   - ping.exe inherits the stdout pipe's write end from cmd.exe, so the
+//     read side only reaches EOF once EVERY holder has exited. That makes
+//     "did the grandchild die?" observable without PID discovery: kill
+//     cmd.exe alone and the pipe stays open; kill the job and it closes.
+//   - pinging is closed once ping.exe has written a line naming the target
+//     address (locale-neutral, unlike "Pinging"/"Reply from"), i.e. once
+//     the grandchild provably exists and holds the pipe.
+type pingTree struct {
+	cmd     *exec.Cmd
+	stdin   io.WriteCloser
+	pinging <-chan struct{}
+	eof     <-chan struct{}
+}
+
+func startPingTree(t *testing.T) *pingTree {
 	t.Helper()
-	cmd := exec.Command("cmd.exe", "/c", "ping -n 30 127.0.0.1")
+	cmd := exec.Command("cmd.exe", "/c", "set /p x=& ping -n 30 127.0.0.1")
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
 	stdout, err := cmd.StdoutPipe()
 	require.NoError(t, err)
 	require.NoError(t, cmd.Start())
 	t.Cleanup(func() { _ = cmd.Process.Kill(); _ = cmd.Wait() })
 
+	pinging := make(chan struct{})
 	eof := make(chan struct{})
 	go func() {
-		_, _ = io.Copy(io.Discard, stdout)
-		close(eof)
+		defer close(eof)
+		seen := false
+		sc := bufio.NewScanner(stdout)
+		for sc.Scan() {
+			if !seen && strings.Contains(sc.Text(), "127.0.0.1") {
+				seen = true
+				close(pinging)
+			}
+		}
 	}()
-	return cmd, eof
+	return &pingTree{cmd: cmd, stdin: stdin, pinging: pinging, eof: eof}
+}
+
+// release lets cmd.exe past `set /p` and waits until ping.exe is running.
+func (p *pingTree) release(t *testing.T) {
+	t.Helper()
+	_, err := io.WriteString(p.stdin, "\r\n")
+	require.NoError(t, err)
+	select {
+	case <-p.pinging:
+	case <-time.After(10 * time.Second):
+		t.Fatal("ping.exe never produced output; grandchild not running")
+	}
 }
 
 func TestJob_CloseKillsGrandchildren(t *testing.T) {
@@ -38,14 +76,15 @@ func TestJob_CloseKillsGrandchildren(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = job.Close() })
 
-	cmd, eof := startPingTree(t)
-	require.NoError(t, job.Assign(cmd.Process.Pid))
+	tree := startPingTree(t)
+	require.NoError(t, job.Assign(tree.cmd.Process.Pid))
+	tree.release(t)
 
 	// Kill only the immediate child. The grandchild (ping.exe) must still
 	// hold the pipe open — otherwise the assertion below is vacuous.
-	require.NoError(t, cmd.Process.Kill())
+	require.NoError(t, tree.cmd.Process.Kill())
 	select {
-	case <-eof:
+	case <-tree.eof:
 		t.Fatal("stdout hit EOF after killing cmd.exe alone; the grandchild did not inherit the pipe, test cannot prove anything")
 	case <-time.After(1500 * time.Millisecond):
 	}
@@ -53,7 +92,7 @@ func TestJob_CloseKillsGrandchildren(t *testing.T) {
 	// Closing the job terminates every remaining member, including ping.exe.
 	require.NoError(t, job.Close())
 	select {
-	case <-eof:
+	case <-tree.eof:
 	case <-time.After(5 * time.Second):
 		t.Fatal("grandchild survived Job.Close(): stdout pipe never reached EOF")
 	}

--- a/internal/winjob/winjob_test.go
+++ b/internal/winjob/winjob_test.go
@@ -1,0 +1,71 @@
+//go:build windows
+
+package winjob
+
+import (
+	"io"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// startPingTree starts `cmd.exe /c ping -n 30 127.0.0.1` with a stdout pipe.
+// ping.exe (the grandchild) inherits the pipe's write end from cmd.exe, so
+// the read side only reaches EOF once EVERY holder — cmd.exe AND ping.exe —
+// has exited. That makes "did the grandchild die?" observable without PID
+// discovery: kill cmd.exe alone and the pipe stays open; kill the job and
+// it closes.
+func startPingTree(t *testing.T) (*exec.Cmd, <-chan struct{}) {
+	t.Helper()
+	cmd := exec.Command("cmd.exe", "/c", "ping -n 30 127.0.0.1")
+	stdout, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() { _ = cmd.Process.Kill(); _ = cmd.Wait() })
+
+	eof := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, stdout)
+		close(eof)
+	}()
+	return cmd, eof
+}
+
+func TestJob_CloseKillsGrandchildren(t *testing.T) {
+	job, err := New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = job.Close() })
+
+	cmd, eof := startPingTree(t)
+	require.NoError(t, job.Assign(cmd.Process.Pid))
+
+	// Kill only the immediate child. The grandchild (ping.exe) must still
+	// hold the pipe open — otherwise the assertion below is vacuous.
+	require.NoError(t, cmd.Process.Kill())
+	select {
+	case <-eof:
+		t.Fatal("stdout hit EOF after killing cmd.exe alone; the grandchild did not inherit the pipe, test cannot prove anything")
+	case <-time.After(1500 * time.Millisecond):
+	}
+
+	// Closing the job terminates every remaining member, including ping.exe.
+	require.NoError(t, job.Close())
+	select {
+	case <-eof:
+	case <-time.After(5 * time.Second):
+		t.Fatal("grandchild survived Job.Close(): stdout pipe never reached EOF")
+	}
+}
+
+func TestJob_CloseIsIdempotentAndNilSafe(t *testing.T) {
+	var nilJob *Job
+	require.NoError(t, nilJob.Close())
+
+	job, err := New()
+	require.NoError(t, err)
+	require.NoError(t, job.Close())
+	require.NoError(t, job.Close(), "second Close must be a no-op")
+	require.Error(t, job.Assign(1), "Assign after Close must fail, not touch a stale handle")
+}


### PR DESCRIPTION
Follow-up to @LocoLoboZ's #1234 (Windows Job Objects for child-process cleanup). This branch is based on `pr-1234`, so until #1234 lands the diff here also shows its commit; once #1234 is merged first (as planned) only the five follow-up commits remain. No separate issue exists for this — it closes the gaps found in the cross-model review of #1234. Related: #1234.

## Problem

#1234 wraps every stdio/launcher child in a Job Object with `KILL_ON_JOB_CLOSE`, but the Job was only ever closed on connect/init failure and at mcpproxy exit. The two normal paths never reached it:

1. **core Disconnect (F1).** mcp-go's `Stdio.Close()` kills only the immediate `cmd.exe` and always returns within ~8s, under the 10s `mcpClientCloseTimeout`, so the "graceful close failed" force-kill step (the only caller of `killProcessGroup`) was effectively unreachable on Windows. Grandchildren that ignore stdin EOF (`node.exe`, `python.exe`) survived every restart, and the Job handle + `windowsJobs` entry leaked per disconnect until mcpproxy exited. PID reuse then silently overwrote the stale entry, orphaning its handle.
2. **launcher Stop (F2).** `reap()` waits for the stdout/stderr pumps before closing the Job, but a grandchild holding the inherited pipe handles never lets the pumps reach EOF once `cmd.exe` alone is killed. `Stop()` hung until the caller's 10s ctx expired and the Job was never closed. The comment justifying the deferral ("give the child a chance to shut down gracefully") did not hold: `Process.Kill()` is already `TerminateProcess` on Windows.
3. **winjob (F3/F5).** Hand-rolled `JOBOBJECT_EXTENDED_LIMIT_INFORMATION` + `kernel32` LazyDLL although `x/sys/windows` v0.47.0 exports everything needed; the hand-rolled layout is 4 bytes short on 386/arm; not gofmt-clean; `IsProcessAlive`/`isProcessGroupAlive` were dead code.

## Root cause

The Job's lifetime was tied to code paths that only run when something has already gone wrong (timeouts, failures) or when the whole tree has already exited, never to the ordinary disconnect/stop sequence.

## Fix

- **`releaseProcessGroup(pgid, cmd, …)`** platform hook: Unix no-op; Windows pops the registry entry and closes the Job. `DisconnectWithContext` calls it (new Step 5b) for every non-Docker stdio disconnect regardless of how the graceful close went.
- **Ownership by `*exec.Cmd`, not PID alone.** Disconnect captures `pgid`+`processCmd` before `Close()` reaps the child, and Windows reuses PIDs eagerly, so a concurrently connecting server can register a new Job under the same PID in that window. Registry entries record the owning cmd; `releaseProcessGroup` and `killProcessGroup` only take a matching entry, do nothing when the slot belongs to a newer connection, and `registerWindowsJob` closes any stale entry it displaces. The no-Job fallback is handle-based (`cmd.Process.Kill`, `ErrProcessDone` benign) instead of `os.FindProcess(pid)`.
- **Launcher:** `stopLocked`'s two escalation steps go through `h.terminate()`/`h.kill()` handle methods. Unix = the same process-group signals as before. Windows = close the Job (kills the tree, pipes close, pumps drain, `reap()` proceeds); `Process.Kill` only on the no-Job fallback. `reap()`'s pumps-before-`Wait` ordering is unchanged; its `job.Close()` is now an idempotent no-op on the Stop path and only does real work on natural whole-tree exit. Natural exit of `cmd.exe` with a surviving grandchild is deliberately left matching Unix (detected at Stop, not eagerly).
- **winjob:** `windows.SetInformationJobObject` / `JOBOBJECT_EXTENDED_LIMIT_INFORMATION` / `JobObjectExtendedLimitInformation` / `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`; hand-rolled structs, consts and LazyDLL removed (-35 lines, fixes the 386/arm layout and gofmt). `Job.Close`/`Assign` are mutex-guarded and `Close` idempotent, since Stop and the reaper can now both close the same Job. Dead `IsProcessAlive`/`isProcessGroupAlive` removed (note: `syscall.STILL_ACTIVE` does not exist in Go 1.25, contrary to the review note).

Unix/macOS behaviour is unchanged: `process_unix.go` gains an ignored `cmd` parameter and a no-op; `launcher_unix.go` gains two one-line delegating methods.

## Testing

Windows-tagged tests (run on `main`'s `windows-latest` job; cannot run on the macOS dev host):

- `internal/winjob/winjob_test.go` — `cmd.exe /c set /p x=& ping -n 30 127.0.0.1`: the shell blocks on stdin so `Assign` provably precedes the grandchild; `ping.exe` inherits the stdout pipe so EOF is the proof it died. Kill `cmd.exe` alone → no EOF (guards against a vacuous pass); `Job.Close()` → EOF. Plus nil-safety/idempotency.
- `internal/upstream/core/process_windows_test.go` — `releaseProcessGroup` kills the tree and drops the entry; `killProcessGroup` drops the entry; PID-reuse regression with a live test-owned `ping.exe` as the new owner: the old owner's release and force-kill must leave both its Job and its process untouched (a PID-based fallback would close the pipe and fail the test), and the takeover must close the stale Job.
- `internal/upstream/launcher/launcher_windows_test.go` — `Stop()` with a grandchild holding the pipes returns nil promptly instead of timing out.
- `internal/upstream/core/process_release_test.go` (all platforms) — `releaseProcessGroup` is immediate for 0/-1/unregistered.

Local (macOS): `go build ./...`; `GOOS=windows GOARCH=amd64|arm64|386 go build`; `GOOS=windows go vet ./internal/winjob/ ./internal/upstream/...`; `go test -race ./internal/upstream/... -count=1`; `go test -tags server ./internal/serveredition/...`; golangci-lint v2 with `.github/.golangci.yml` → 0 issues on darwin; under `GOOS=windows` only the three `unused` hits already present on `main` (`processGracefulTimeout`, `processTerminationPollInterval`, `ProcessGroup.logger`). Cross-model review (opencode / gpt-6-astra, three file-scoped chunks): CLEAN after 3 fix→re-review rounds (findings fixed: test spawn race, PID-reuse identity on release and force-kill, launcher `kill()` log noise, vacuous PID-reuse test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
