### PR TITLE
fix(mcp): stop advertising code_execution while enable_code_execution is off

### DIFF
--- a/docs/code_execution/troubleshooting.md
+++ b/docs/code_execution/troubleshooting.md
@@ -31,7 +31,7 @@ Common issues, error messages, and solutions for the `code_execution` tool.
 Error: code_execution is disabled in configuration. Set 'enable_code_execution: true' in config file.
 ```
 
-**Cause**: The `code_execution` feature is disabled by default for security. While it is disabled the tool is not listed in `tools/list`, so an MCP client will normally not see it at all; this error appears when a call reaches the proxy by name anyway (the REST API, the CLI, or a client holding a cached tool list).
+**Cause**: The `code_execution` feature is disabled by default for security. While it is disabled the tool is not listed in `tools/list`, so an MCP client will normally not see it at all; this error appears when a call reaches the handler by name anyway (the REST API or the CLI). An MCP client that calls the name from a stale tool list gets an unknown-tool error instead.
 
 **Solution**:
 1. Edit your configuration file (`~/.mcpproxy/mcp_config.json`)
@@ -56,13 +56,12 @@ Error: code_execution is disabled in configuration. Set 'enable_code_execution: 
 
 **Symptom**: LLM agent lists available tools but `code_execution` is missing.
 
-**Cause**: Feature is not enabled or server didn't restart after configuration change.
+**Cause**: Feature is not enabled — a disabled `code_execution` is deliberately absent from `tools/list` — or the client is holding a tool list from before the flag was enabled.
 
 **Solution**:
 1. Verify configuration has `"enable_code_execution": true`
-2. Restart mcpproxy server
-3. Reconnect LLM client
-4. List tools again
+2. The change is hot-reloaded and announced with `notifications/tools/list_changed`; if the client does not honor that notification, reconnect it
+3. List tools again
 
 **Verification**:
 ```bash

--- a/docs/code_execution/troubleshooting.md
+++ b/docs/code_execution/troubleshooting.md
@@ -31,12 +31,12 @@ Common issues, error messages, and solutions for the `code_execution` tool.
 Error: code_execution is disabled in configuration. Set 'enable_code_execution: true' in config file.
 ```
 
-**Cause**: The `code_execution` feature is disabled by default for security.
+**Cause**: The `code_execution` feature is disabled by default for security. While it is disabled the tool is not listed in `tools/list`, so an MCP client will normally not see it at all; this error appears when a call reaches the proxy by name anyway (the REST API, the CLI, or a client holding a cached tool list).
 
 **Solution**:
 1. Edit your configuration file (`~/.mcpproxy/mcp_config.json`)
 2. Add or update: `"enable_code_execution": true`
-3. Restart mcpproxy: `pkill mcpproxy && mcpproxy serve`
+3. The flag is hot-reloaded: the running proxy picks up the change, advertises the tool, and sends `notifications/tools/list_changed` to connected sessions. No restart is needed; clients that do not honor `list_changed` need to reconnect to see the tool.
 
 **Example Configuration**:
 ```json

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1264,7 +1264,7 @@ See [Tool Quarantine](features/tool-quarantine.md) for complete details.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `enable_code_execution` | boolean | `false` | Enable JavaScript/TypeScript code execution tool (disabled by default for security) |
+| `enable_code_execution` | boolean | `false` | Enable JavaScript/TypeScript code execution tool (disabled by default for security). While `false` the `code_execution` tool is not advertised in `tools/list`. Hot-reloaded: a flip adds/removes the tool and sends `notifications/tools/list_changed` |
 | `code_execution_timeout_ms` | integer | `120000` | Default timeout in milliseconds (1-600000, max 10 minutes) |
 | `code_execution_max_tool_calls` | integer | `0` | Maximum tool calls per execution (0 = unlimited) |
 | `code_execution_pool_size` | integer | `10` | Number of JavaScript VM instances in pool (1-100) |

--- a/docs/features/code-execution.md
+++ b/docs/features/code-execution.md
@@ -37,7 +37,7 @@ Enable code execution in your config:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `enable_code_execution` | boolean | `false` | Enable the code execution tool |
+| `enable_code_execution` | boolean | `false` | Enable the code execution tool. While `false` the tool is not listed in `tools/list`; a flip is hot-reloaded and announced with `notifications/tools/list_changed` |
 | `code_execution_timeout_ms` | integer | `120000` | Execution timeout (2 minutes) |
 | `code_execution_max_tool_calls` | integer | `0` | Max tool calls (0 = unlimited) |
 | `code_execution_pool_size` | integer | `10` | Number of VM instances to pool |

--- a/docs/features/routing-modes.md
+++ b/docs/features/routing-modes.md
@@ -165,7 +165,7 @@ Code execution mode is designed for multi-step orchestration workflows. Instead 
 - Complex conditional logic that would require many round-trips in other modes
 - Data transformation pipelines (fetch from one tool, transform, send to another)
 
-**Note:** Code execution must be enabled in config (`"enable_code_execution": true`). If disabled, the `code_execution` tool appears but returns an error message directing the user to enable it.
+**Note:** Code execution must be enabled in config (`"enable_code_execution": true`). While it is disabled, the `code_execution` tool is not listed in `tools/list` on any endpoint, so clients that pick tools from the list never attempt it. A call that still reaches the proxy by name (a cached tool list, the REST API) is refused with an error directing the user to enable it. The flag is hot-reloadable: flipping it adds or removes the tool on the live surfaces and sends `notifications/tools/list_changed` to connected sessions, no restart required.
 
 ## Choosing the Right Mode
 

--- a/docs/features/routing-modes.md
+++ b/docs/features/routing-modes.md
@@ -165,7 +165,7 @@ Code execution mode is designed for multi-step orchestration workflows. Instead 
 - Complex conditional logic that would require many round-trips in other modes
 - Data transformation pipelines (fetch from one tool, transform, send to another)
 
-**Note:** Code execution must be enabled in config (`"enable_code_execution": true`). While it is disabled, the `code_execution` tool is not listed in `tools/list` on any endpoint, so clients that pick tools from the list never attempt it. A call that still reaches the proxy by name (a cached tool list, the REST API) is refused with an error directing the user to enable it. The flag is hot-reloadable: flipping it adds or removes the tool on the live surfaces and sends `notifications/tools/list_changed` to connected sessions, no restart required.
+**Note:** Code execution must be enabled in config (`"enable_code_execution": true`). While it is disabled, the `code_execution` tool is not listed in `tools/list` on any endpoint, so clients that pick tools from the list never attempt it. An MCP `tools/call` for the name is refused as an unknown tool; a call that reaches the handler through the REST API or the CLI is refused with an error directing the user to enable it. The flag is hot-reloadable: flipping it adds or removes the tool on the live surfaces and sends `notifications/tools/list_changed` to connected sessions, no restart required.
 
 ## Choosing the Right Mode
 

--- a/internal/server/code_execution_hotreload_test.go
+++ b/internal/server/code_execution_hotreload_test.go
@@ -1,8 +1,10 @@
 package server
 
 import (
+	"context"
 	"testing"
 
+	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -11,18 +13,18 @@ import (
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 )
 
-// UX audit F16: Settings advertises enable_code_execution as an
-// instantly-applied field, but the tool surfaces built their code_execution
-// entry — the live tool, or a "disabled" stub whose handler refuses every call
-// unconditionally — exactly once, at construction. Flipping the flag on
-// therefore left the stub in place on /mcp, so `code_execution` kept answering
-// "Code execution is disabled" from a brand-new MCP session until a restart,
-// even though the handler-level gate (mcp_code_execution.go) had already gone
-// live. These tests pin the rebuild seam that makes the promise true.
-
-func isDisabledCodeExecutionStub(tool mcpserver.ServerTool) bool {
-	return tool.Tool.Annotations.Title == "Code Execution (Disabled)"
-}
+// Issue #1236: with enable_code_execution=false (the default) the tool surfaces
+// used to advertise a "disabled" code_execution stub whose handler refused every
+// call. Clients that pick tools from tools/list rather than from descriptions —
+// most of them — kept calling it and burning a round trip per attempt. The
+// contract is now: disabled → NOT advertised on any surface; a runtime toggle
+// (config hot-reload) re-advertises or withdraws the tool and emits
+// notifications/tools/list_changed so caching clients refetch. These tests pin
+// both halves.
+//
+// UX audit F16 (the prior shape of this file) established that the builder
+// resolves the flag on every call and that RefreshCodeExecutionAvailability is
+// the seam config.reloaded drives; those guarantees carry over unchanged.
 
 func codeExecutionToolFrom(tools []mcpserver.ServerTool) *mcpserver.ServerTool {
 	for i := range tools {
@@ -33,107 +35,223 @@ func codeExecutionToolFrom(tools []mcpserver.ServerTool) *mcpserver.ServerTool {
 	return nil
 }
 
-// TestBuildCodeExecutionTool_FollowsCurrentConfig: the builder must resolve the
-// flag on every call, not capture it. currentConfig() falls back to p.config
-// when no runtime is attached, so mutating that snapshot models a hot reload.
+// advertisedCodeExecution returns the registered code_execution entry on a
+// server, or nil when the surface does not list it.
+func advertisedCodeExecution(s *mcpserver.MCPServer) *mcpserver.ServerTool {
+	tool, ok := s.ListTools()["code_execution"]
+	if !ok {
+		return nil
+	}
+	return tool
+}
+
+// notifyingSession is an initialized mcp-go ClientSession whose notification
+// channel is captured, so a test can observe what the server pushed to a
+// connected client. It stands in for a real Streamable HTTP session.
+type notifyingSession struct {
+	id string
+	ch chan mcp.JSONRPCNotification
+}
+
+func newNotifyingSession(id string) *notifyingSession {
+	return &notifyingSession{id: id, ch: make(chan mcp.JSONRPCNotification, 16)}
+}
+
+func (s *notifyingSession) Initialize()                                         {}
+func (s *notifyingSession) Initialized() bool                                   { return true }
+func (s *notifyingSession) NotificationChannel() chan<- mcp.JSONRPCNotification { return s.ch }
+func (s *notifyingSession) SessionID() string                                   { return s.id }
+
+// drainListChanged counts the notifications/tools/list_changed pushes queued
+// on the session and empties the channel.
+func (s *notifyingSession) drainListChanged() int {
+	n := 0
+	for {
+		select {
+		case notif := <-s.ch:
+			if notif.Method == mcp.MethodNotificationToolsListChanged {
+				n++
+			}
+		default:
+			return n
+		}
+	}
+}
+
+// newHotReloadProxy builds a proxy with all three built-in-carrying surfaces
+// registered the way production does it — the routing-mode servers through
+// initRoutingModeServers (which also seeds their content guards), the default
+// surface the way registerTools assembles it — plus one initialized session
+// per surface so list_changed pushes are observable.
+func newHotReloadProxy(t *testing.T, cfg *config.Config) (*MCPProxyServer, map[string]*notifyingSession) {
+	t.Helper()
+	p := &MCPProxyServer{
+		config: cfg,
+		logger: zap.NewNop(),
+		server: mcpserver.NewMCPServer("test", "0.0.0", mcpserver.WithToolCapabilities(true)),
+	}
+	p.initRoutingModeServers()
+	require.NotNil(t, p.callToolServer)
+	require.NotNil(t, p.codeExecServer)
+	// The default surface is assembled by registerTools; the call-tool set is
+	// a faithful stand-in (same built-ins, same code_execution gating).
+	for _, st := range p.buildCallToolModeTools() {
+		p.server.AddTool(st.Tool, st.Handler)
+	}
+
+	sessions := map[string]*notifyingSession{}
+	for name, s := range map[string]*mcpserver.MCPServer{
+		"call_tool": p.callToolServer,
+		"code_exec": p.codeExecServer,
+		"default":   p.server,
+	} {
+		sess := newNotifyingSession("sess-" + name)
+		require.NoError(t, s.RegisterSession(context.Background(), sess))
+		sess.drainListChanged() // registration-time noise, if any
+		sessions[name] = sess
+	}
+	return p, sessions
+}
+
+// TestBuildCodeExecutionTool_FollowsCurrentConfig: the builder resolves the
+// flag on every call, and a disabled flag yields NO tool — not a stub.
+// currentConfig() falls back to p.config when no runtime is attached, so
+// mutating that snapshot models a hot reload.
 func TestBuildCodeExecutionTool_FollowsCurrentConfig(t *testing.T) {
 	cfg := &config.Config{EnableCodeExecution: false}
 	p := &MCPProxyServer{config: cfg}
 
-	disabled := p.buildCodeExecutionTool()
-	require.Len(t, disabled, 1)
-	assert.True(t, isDisabledCodeExecutionStub(disabled[0]), "expected the disabled stub while the flag is off")
+	assert.Empty(t, p.buildCodeExecutionTool(),
+		"issue #1236: a disabled code_execution must not be advertised at all")
 
 	cfg.EnableCodeExecution = true
 	enabled := p.buildCodeExecutionTool()
 	require.Len(t, enabled, 1)
-	assert.False(t, isDisabledCodeExecutionStub(enabled[0]), "the live tool must appear once the flag is on")
+	assert.Equal(t, "code_execution", enabled[0].Tool.Name)
 	assert.Equal(t, codeExecutionToolDescription, enabled[0].Tool.Description)
+	assert.Equal(t, "Code Execution", enabled[0].Tool.Annotations.Title)
 
 	cfg.EnableCodeExecution = false
-	assert.True(t, isDisabledCodeExecutionStub(p.buildCodeExecutionTool()[0]),
-		"turning the flag back off must restore the stub")
+	assert.Empty(t, p.buildCodeExecutionTool(),
+		"turning the flag back off must withdraw the tool again")
 }
 
-// TestRefreshCodeExecutionAvailability_SwapsAdvertisedTool: the call-tool
-// surface (/mcp in the default retrieve_tools routing mode) and the code-exec
-// surface must both re-advertise code_execution after a config reload.
-func TestRefreshCodeExecutionAvailability_SwapsAdvertisedTool(t *testing.T) {
+// TestRoutingModeSurfaces_OmitDisabledCodeExecution: neither routing-mode
+// builder may carry code_execution while the flag is off. The retrieve_tools
+// surface is what /mcp serves in the default routing mode, so this is the
+// listing the issue reporter saw.
+func TestRoutingModeSurfaces_OmitDisabledCodeExecution(t *testing.T) {
+	p := &MCPProxyServer{config: &config.Config{EnableCodeExecution: false}, logger: zap.NewNop()}
+
+	assert.Nil(t, codeExecutionToolFrom(p.buildCallToolModeTools()),
+		"retrieve_tools mode (/mcp default) must not list a disabled code_execution")
+	assert.Nil(t, codeExecutionToolFrom(p.buildCodeExecModeTools()),
+		"code_execution mode must not list a disabled code_execution")
+
+	p.config.EnableCodeExecution = true
+	assert.NotNil(t, codeExecutionToolFrom(p.buildCallToolModeTools()))
+	assert.NotNil(t, codeExecutionToolFrom(p.buildCodeExecModeTools()))
+}
+
+// TestRefreshCodeExecutionAvailability_TogglesAdvertisedTool: a hot enable
+// adds code_execution to every surface that carries it and a hot disable
+// withdraws it again — including the default surface, which is updated in
+// place (AddTools / DeleteTools) rather than rebuilt.
+func TestRefreshCodeExecutionAvailability_TogglesAdvertisedTool(t *testing.T) {
 	cfg := &config.Config{EnableCodeExecution: false}
-	p := &MCPProxyServer{
-		config:         cfg,
-		logger:         zap.NewNop(),
-		callToolServer: mcpserver.NewMCPServer("test", "0.0.0"),
-		codeExecServer: mcpserver.NewMCPServer("test", "0.0.0"),
-		server:         mcpserver.NewMCPServer("test", "0.0.0"),
-	}
+	p, _ := newHotReloadProxy(t, cfg)
 
-	for _, st := range p.buildCallToolModeTools() {
-		p.callToolServer.AddTool(st.Tool, st.Handler)
-	}
-	for _, st := range p.buildCodeExecModeTools() {
-		p.codeExecServer.AddTool(st.Tool, st.Handler)
-	}
-
-	advertised := func(s *mcpserver.MCPServer) *mcpserver.ServerTool {
-		tool, ok := s.ListTools()["code_execution"]
-		if !ok {
-			return nil
-		}
-		return tool
-	}
-
-	require.NotNil(t, advertised(p.callToolServer))
-	assert.True(t, isDisabledCodeExecutionStub(*advertised(p.callToolServer)))
-	assert.True(t, isDisabledCodeExecutionStub(*advertised(p.codeExecServer)))
+	require.Nil(t, advertisedCodeExecution(p.callToolServer), "precondition: disabled at startup")
+	require.Nil(t, advertisedCodeExecution(p.codeExecServer))
+	require.Nil(t, advertisedCodeExecution(p.server))
 
 	// The operator flips the toggle; ApplyConfig swaps the live snapshot and
 	// emits config.reloaded, which drives this call.
 	cfg.EnableCodeExecution = true
 	p.RefreshCodeExecutionAvailability()
 
-	require.NotNil(t, advertised(p.callToolServer), "code_execution must still be advertised")
-	assert.False(t, isDisabledCodeExecutionStub(*advertised(p.callToolServer)),
-		"the call-tool surface must serve the live tool after a hot enable")
-	assert.False(t, isDisabledCodeExecutionStub(*advertised(p.codeExecServer)),
-		"the code-exec surface must serve the live tool after a hot enable")
+	for name, s := range map[string]*mcpserver.MCPServer{
+		"call_tool": p.callToolServer, "code_exec": p.codeExecServer, "default": p.server,
+	} {
+		tool := advertisedCodeExecution(s)
+		require.NotNil(t, tool, "%s surface must advertise code_execution after a hot enable", name)
+		assert.Equal(t, codeExecutionToolDescription, tool.Tool.Description,
+			"%s surface must serve the live tool, never a stub", name)
+	}
 
-	// The default/stdio surface is updated in place with AddTools, which must
-	// not disturb the tools registerTools put there.
-	require.NotNil(t, advertised(p.server))
-	assert.False(t, isDisabledCodeExecutionStub(*advertised(p.server)))
-
-	// And back off again.
+	// And back off again: the tool disappears from every surface.
 	cfg.EnableCodeExecution = false
 	p.RefreshCodeExecutionAvailability()
-	assert.True(t, isDisabledCodeExecutionStub(*advertised(p.callToolServer)),
-		"turning the flag off must restore the refusing stub")
+
+	assert.Nil(t, advertisedCodeExecution(p.callToolServer),
+		"turning the flag off must withdraw code_execution from the retrieve_tools surface")
+	assert.Nil(t, advertisedCodeExecution(p.codeExecServer),
+		"turning the flag off must withdraw code_execution from the code-exec surface")
+	assert.Nil(t, advertisedCodeExecution(p.server),
+		"turning the flag off must withdraw code_execution from the default surface")
+}
+
+// TestRefreshCodeExecutionAvailability_EmitsListChangedOnlyOnAFlip: a runtime
+// toggle must push notifications/tools/list_changed to connected sessions on
+// every affected surface (the issue's second expectation), and an unrelated
+// config reload — which also drives this refresh — must push nothing, or every
+// config edit looks to a client exactly like the tool set changing.
+func TestRefreshCodeExecutionAvailability_EmitsListChangedOnlyOnAFlip(t *testing.T) {
+	cfg := &config.Config{EnableCodeExecution: false}
+	p, sessions := newHotReloadProxy(t, cfg)
+
+	// Unrelated reload: same flag value, nothing to announce.
+	p.RefreshCodeExecutionAvailability()
+	p.RefreshCodeExecutionAvailability()
+	for name, sess := range sessions {
+		assert.Zero(t, sess.drainListChanged(),
+			"%s surface: a reload that changes nothing must not emit list_changed", name)
+	}
+
+	// Enable: exactly one list_changed per surface.
+	cfg.EnableCodeExecution = true
+	p.RefreshCodeExecutionAvailability()
+	for name, sess := range sessions {
+		assert.Equal(t, 1, sess.drainListChanged(),
+			"%s surface: a hot enable must emit exactly one list_changed", name)
+	}
+
+	// Steady state again: silence.
+	p.RefreshCodeExecutionAvailability()
+	for name, sess := range sessions {
+		assert.Zero(t, sess.drainListChanged(),
+			"%s surface: a reload after the flip must not re-announce it", name)
+	}
+
+	// Disable: exactly one list_changed per surface.
+	cfg.EnableCodeExecution = false
+	p.RefreshCodeExecutionAvailability()
+	for name, sess := range sessions {
+		assert.Equal(t, 1, sess.drainListChanged(),
+			"%s surface: a hot disable must emit exactly one list_changed", name)
+	}
 }
 
 // TestRefreshCodeExecutionAvailability_PreservesOtherTools: the default surface
-// is refreshed with AddTools rather than SetTools precisely because its tool set
-// is assembled once by registerTools; SetTools would drop everything else.
+// is refreshed in place precisely because its tool set is assembled once by
+// registerTools; a rebuild would drop everything else. Neither the add nor the
+// remove may disturb the other registrations.
 func TestRefreshCodeExecutionAvailability_PreservesOtherTools(t *testing.T) {
 	cfg := &config.Config{EnableCodeExecution: false}
-	p := &MCPProxyServer{
-		config: cfg,
-		logger: zap.NewNop(),
-		server: mcpserver.NewMCPServer("test", "0.0.0"),
-	}
+	p, _ := newHotReloadProxy(t, cfg)
 
-	callToolTools := p.buildCallToolModeTools()
-	for _, st := range callToolTools {
-		p.server.AddTool(st.Tool, st.Handler)
-	}
 	before := len(p.server.ListTools())
 	require.Greater(t, before, 1)
 
 	cfg.EnableCodeExecution = true
 	p.RefreshCodeExecutionAvailability()
+	assert.Len(t, p.server.ListTools(), before+1,
+		"a hot enable adds code_execution and nothing else")
 
+	cfg.EnableCodeExecution = false
+	p.RefreshCodeExecutionAvailability()
 	assert.Len(t, p.server.ListTools(), before,
-		"refreshing code_execution must not add or drop any other tool")
-	assert.NotNil(t, codeExecutionToolFrom(callToolTools), "sanity: the builder emits code_execution")
+		"a hot disable removes code_execution and nothing else")
 }
 
 // TestRefreshCodeExecutionAvailability_NilSafe: the refresh runs from the shared

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -216,7 +216,16 @@ type MCPProxyServer struct {
 	codeExecSurfaceFP string
 	// codeExecPublishes counts rebuilds that actually re-registered, so the
 	// guard's effect is observable rather than only visible in the log.
-	codeExecPublishes       atomic.Uint64
+	codeExecPublishes atomic.Uint64
+
+	// The call-tool surface (/mcp in the default routing mode) gets the same
+	// guard: it is rebuilt on every config.reloaded, and an unguarded SetTools
+	// tells every client the tool set changed on every unrelated edit
+	// (issue #1236).
+	callToolRefreshMu sync.Mutex
+	callToolSurfaceFP string
+	callToolPublishes atomic.Uint64
+
 	directCatalogGeneration atomic.Uint64
 
 	// directRefreshMu serializes whole rebuilds so SetTools and the matching
@@ -1132,35 +1141,14 @@ func (p *MCPProxyServer) registerTools(_ bool) {
 	)
 	p.server.AddTool(readCacheTool, p.handleReadCache)
 
-	// code_execution - JavaScript/TypeScript code execution for multi-tool orchestration (feature-flagged)
-	if p.config.EnableCodeExecution {
-		codeExecutionTool := mcp.NewTool("code_execution",
-			mcp.WithDescription(codeExecutionToolDescription),
-			mcp.WithTitleAnnotation("Code Execution"),
-			mcp.WithDestructiveHintAnnotation(true),
-			mcp.WithReadOnlyHintAnnotation(false),
-			mcp.WithOpenWorldHintAnnotation(true),
-			// Spec 097: `code` is no longer schema-required — a call may supply
-			// `script` instead. JSON Schema cannot express the exactly-one-of
-			// rule, so handleCodeExecution enforces it for every surface.
-			mcp.WithString("code",
-				mcp.Description(codeExecutionCodeDescription),
-			),
-			mcp.WithString("script",
-				mcp.Description(codeExecutionScriptDescription),
-			),
-			mcp.WithString("language",
-				mcp.Description(codeExecutionLanguageDescription),
-				mcp.Enum("javascript", "typescript"),
-			),
-			mcp.WithObject("input",
-				mcp.Description(codeExecutionInputDescription),
-			),
-			mcp.WithObject("options",
-				mcp.Description(codeExecutionOptionsDescription),
-			),
-		)
-		p.server.AddTool(codeExecutionTool, p.handleCodeExecution)
+	// code_execution - JavaScript/TypeScript code execution for multi-tool
+	// orchestration (feature-flagged). One definition for every surface:
+	// buildCodeExecutionTool returns the live tool when enable_code_execution
+	// is on and nothing at all when it is off (issue #1236 — a disabled
+	// feature is not advertised). A runtime flip is applied in place by
+	// RefreshCodeExecutionAvailability.
+	for _, st := range p.buildCodeExecutionTool() {
+		p.server.AddTool(st.Tool, st.Handler)
 	}
 
 	// Management tools (shared across routing modes)

--- a/internal/server/mcp_code_scripts_test.go
+++ b/internal/server/mcp_code_scripts_test.go
@@ -456,37 +456,28 @@ func TestCodeExecutionRegistrations_ScriptParam(t *testing.T) {
 	}
 }
 
-// TestCodeExecutionDisabledStub_AcceptsScript (T005): a script call must reach
-// the disabled handler and get the disabled explanation — so the stub takes the
-// parameter, but keeps ONLY its disabled description (no discovery prose).
-func TestCodeExecutionDisabledStub_AcceptsScript(t *testing.T) {
+// TestCodeExecutionDisabled_NotRegisteredButScriptCallStillExplained (T005,
+// issue #1236): a disabled code_execution is registered on NO surface — there
+// is no stub for a client to pick from tools/list — while a script call that
+// still reaches the handler by name (a cached listing, REST, CallToolDirect)
+// gets the disabled explanation rather than a schema rejection.
+func TestCodeExecutionDisabled_NotRegisteredButScriptCallStillExplained(t *testing.T) {
 	proxy := createTestMCPProxyServer(t)
 	proxy.config.EnableCodeExecution = false
 
-	tools := proxy.buildCodeExecutionTool()
-	require.Len(t, tools, 1)
-	stub := toolAsMap(t, tools[0].Tool)
+	require.Empty(t, proxy.buildCodeExecutionTool(),
+		"a disabled code_execution must not be advertised")
+	assert.Empty(t, codeExecutionSchemas(t, proxy),
+		"no surface may list code_execution while the feature is off")
 
-	desc, _ := stub["description"].(string)
-	assert.Contains(t, desc, "disabled")
-	assert.NotContains(t, desc, codeExecutionScriptDescription,
-		"the disabled stub keeps only its disabled description")
-	assert.False(t, strings.Contains(desc, "call_tools"),
-		"the disabled stub must not advertise the executable contract")
-
-	props := schemaProps(stub)
-	require.NotNil(t, props)
-	_, hasScript := props["script"]
-	assert.True(t, hasScript, "the stub must accept script so those calls reach the disabled handler")
-	assert.NotContains(t, requiredParams(stub), "code",
-		"the stub must not require code, or a script-only call is rejected by schema instead of explained")
-
-	result, err := tools[0].Handler(context.Background(), mcp.CallToolRequest{
+	result, err := proxy.handleCodeExecution(context.Background(), mcp.CallToolRequest{
 		Params: mcp.CallToolParams{Name: "code_execution", Arguments: map[string]interface{}{"script": "anything"}},
 	})
 	require.NoError(t, err)
 	require.True(t, result.IsError)
 	assert.Contains(t, resultText(t, result), "disabled")
+	assert.False(t, strings.Contains(resultText(t, result), "anything"),
+		"a disabled feature must not resolve the script name")
 }
 
 // TestCodeExecution_DisabledGateCoversEveryDispatch pins enable_code_execution
@@ -530,10 +521,12 @@ func TestCodeExecution_DisabledGateCoversEveryDispatch(t *testing.T) {
 		assert.NotContains(t, err.Error(), "executed")
 	})
 
-	t.Run("the wording matches the disabled stub", func(t *testing.T) {
-		stub := proxy.buildCodeExecutionTool()
-		require.Len(t, stub, 1)
-		result, err := stub[0].Handler(context.Background(), mcp.CallToolRequest{
+	t.Run("the wording matches the MCP handler", func(t *testing.T) {
+		// Issue #1236: there is no disabled stub any more — a disabled tool is
+		// not registered — so the MCP handler itself is the reference wording
+		// every dispatch path must match.
+		require.Empty(t, proxy.buildCodeExecutionTool(), "a disabled code_execution is not advertised")
+		result, err := proxy.handleCodeExecution(context.Background(), mcp.CallToolRequest{
 			Params: mcp.CallToolParams{Name: "code_execution", Arguments: map[string]interface{}{"script": "sentinel"}},
 		})
 		require.NoError(t, err)

--- a/internal/server/mcp_code_scripts_test.go
+++ b/internal/server/mcp_code_scripts_test.go
@@ -459,7 +459,8 @@ func TestCodeExecutionRegistrations_ScriptParam(t *testing.T) {
 // TestCodeExecutionDisabled_NotRegisteredButScriptCallStillExplained (T005,
 // issue #1236): a disabled code_execution is registered on NO surface — there
 // is no stub for a client to pick from tools/list — while a script call that
-// still reaches the handler by name (a cached listing, REST, CallToolDirect)
+// still reaches the handler by name (REST, CallToolDirect — an MCP tools/call
+// for the unregistered name is refused by mcp-go as an unknown tool instead)
 // gets the disabled explanation rather than a schema rejection.
 func TestCodeExecutionDisabled_NotRegisteredButScriptCallStillExplained(t *testing.T) {
 	proxy := createTestMCPProxyServer(t)

--- a/internal/server/mcp_internal_annotations_test.go
+++ b/internal/server/mcp_internal_annotations_test.go
@@ -191,11 +191,10 @@ func TestBuildCallToolModeToolsAnnotations(t *testing.T) {
 	}
 }
 
-// TestDisabledCodeExecutionAnnotations verifies the disabled stub
-// (buildCodeExecutionTool with EnableCodeExecution=false) still has explicit
-// annotation hints — preventing it from inheriting the permissive default of
-// destructive=true / openWorld=true.
-func TestDisabledCodeExecutionAnnotations(t *testing.T) {
+// TestDisabledCodeExecutionNotRegistered: with EnableCodeExecution=false the
+// builder registers nothing (issue #1236) — there is no disabled stub whose
+// annotations could drift, and no entry for a client to pick from tools/list.
+func TestDisabledCodeExecutionNotRegistered(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.EnableCodeExecution = false
 
@@ -204,9 +203,6 @@ func TestDisabledCodeExecutionAnnotations(t *testing.T) {
 		config: cfg,
 	}
 
-	serverTools := p.buildCodeExecutionTool()
-	require.Len(t, serverTools, 1)
-	tool := serverTools[0].Tool
-	assert.Equal(t, "code_execution", tool.Name)
-	assertExplicitHints(t, tool, expectedHints{readOnly: true, destructive: false, openWorld: false})
+	require.Empty(t, p.buildCodeExecutionTool(),
+		"a disabled code_execution must not be advertised on any surface")
 }

--- a/internal/server/mcp_menu_surface_test.go
+++ b/internal/server/mcp_menu_surface_test.go
@@ -117,29 +117,48 @@ func TestMenuSurface_ExactDeltaFromPreFeature(t *testing.T) {
 		"call_tool_mode":      {"describe_tool"},
 		"code_execution_mode": {},
 	}
+	// The ONLY removal is the "Code Execution (Disabled)" stub (issue #1236):
+	// the pre-feature snapshot was captured with enable_code_execution=false,
+	// when a disabled feature was still advertised as a refusing stub. A
+	// disabled tool is now not registered at all; the live tool (flag on) is
+	// unchanged. default_server never carried the stub.
+	wantRemoved := map[string][]string{
+		"default_server":      {},
+		"call_tool_mode":      {"code_execution"},
+		"code_execution_mode": {"code_execution"},
+	}
 
 	for surface, preTools := range pre {
 		surface, preTools := surface, preTools
 		t.Run(surface, func(t *testing.T) {
 			curTools := cur[surface]
 
-			// --- Name-set delta: exactly the expected additions, no removals.
-			var added []string
+			// --- Name-set delta: exactly the expected additions and removals.
+			var added, removed []string
 			for n := range curTools {
 				if _, ok := preTools[n]; !ok {
 					added = append(added, n)
 				}
 			}
+			for n := range preTools {
+				if _, ok := curTools[n]; !ok {
+					removed = append(removed, n)
+				}
+			}
 			sort.Strings(added)
+			sort.Strings(removed)
 			assert.Equal(t, wantAdded[surface], func() []string {
 				if added == nil {
 					return []string{}
 				}
 				return added
 			}(), "surface %s: only describe_tool may be added (FR-014/SC-007)", surface)
-			for n := range preTools {
-				assert.Contains(t, curTools, n, "surface %s: pre-feature tool %q must not be removed or renamed (FR-014)", surface, n)
-			}
+			assert.Equal(t, wantRemoved[surface], func() []string {
+				if removed == nil {
+					return []string{}
+				}
+				return removed
+			}(), "surface %s: only the disabled code_execution stub may be removed (issue #1236); nothing else may be removed or renamed (FR-014)", surface)
 
 			for _, name := range sortedNames(preTools) {
 				name := name
@@ -154,8 +173,6 @@ func TestMenuSurface_ExactDeltaFromPreFeature(t *testing.T) {
 					assertRetrieveToolsDelta(t, surface, preM, curM)
 				case callToolVariants[name]:
 					assertCallToolVariantDelta(t, surface, name, preM, curM)
-				case name == "code_execution":
-					assertCodeExecutionDelta(t, surface, preM, curM)
 				case name == "quarantine_security":
 					assertQuarantineSecurityDelta(t, surface, preM, curM)
 				case name == "upstream_servers":
@@ -429,55 +446,6 @@ func TestMenuSurface_AnnotationFilterParamsShared(t *testing.T) {
 		assert.Contains(t, desc, spec094WindowCaveat,
 			"surface %s: description must carry the candidate-window caveat verbatim (FR-009)", surface)
 	}
-}
-
-// Spec 097 widens the controlled delta on code_execution by exactly two
-// things: the added optional `script` parameter, and `code` losing its
-// schema-required status — JSON Schema cannot express "exactly one of", so the
-// handler owns that rule and the schema must accept a script-only call.
-// Everything else (annotations, the pre-feature parameter schemas, and — for
-// the disabled stub, which is what this surface registers — the description)
-// stays byte-identical.
-func assertCodeExecutionDelta(t *testing.T, surface string, preM, curM map[string]interface{}) {
-	t.Helper()
-
-	preProps, curProps := schemaProps(preM), schemaProps(curM)
-	require.NotNil(t, curProps, "surface %s: code_execution lost its inputSchema", surface)
-
-	var added []string
-	for p := range curProps {
-		if _, ok := preProps[p]; !ok {
-			added = append(added, p)
-		}
-	}
-	sort.Strings(added)
-	if added == nil {
-		added = []string{}
-	}
-	assert.Equal(t, []string{"script"}, added,
-		"surface %s: exact code_execution parameter delta (spec 097 FR-002)", surface)
-
-	for p, preSchema := range preProps {
-		assert.Equal(t, preSchema, curProps[p],
-			"surface %s: pre-feature code_execution parameter %q must be preserved unchanged", surface, p)
-	}
-
-	curSchema, _ := curM["inputSchema"].(map[string]interface{})
-	assert.Empty(t, curSchema["required"],
-		"surface %s: code must no longer be schema-required, or a script-only call is rejected before the handler can explain the rule", surface)
-
-	assert.Equal(t, preM["annotations"], curM["annotations"],
-		"surface %s: code_execution annotations unchanged", surface)
-
-	preDesc, _ := preM["description"].(string)
-	curDesc, _ := curM["description"].(string)
-	if strings.Contains(preDesc, "disabled") {
-		assert.Equal(t, preDesc, curDesc,
-			"surface %s: the disabled stub keeps ONLY its disabled description — no stored-script prose on a tool that cannot run", surface)
-		return
-	}
-	assert.Contains(t, curDesc, "script",
-		"surface %s: the live description must document stored scripts (spec 097 FR-008)", surface)
 }
 
 // assertCallToolVariantDelta: only the tool description and the 'args'

--- a/internal/server/mcp_routing.go
+++ b/internal/server/mcp_routing.go
@@ -795,47 +795,27 @@ func (p *MCPProxyServer) buildCallToolModeTools() []mcpserver.ServerTool {
 	return tools
 }
 
-// buildCodeExecutionTool builds the code_execution tool for routing mode servers.
-// Returns a slice (either 1 tool or 1 disabled stub) for easy appending.
+// buildCodeExecutionTool builds the code_execution tool for every surface that
+// carries it. Returns a slice (the live tool, or NOTHING) for easy appending.
+//
+// Issue #1236: a disabled feature is not advertised. This used to return a
+// "disabled" stub whose handler refused every call, on the theory that a
+// descriptive refusal beats an unknown-tool error. In practice clients select
+// tools from tools/list, not from descriptions (which harnesses routinely
+// truncate), so the stub was indistinguishable from an available tool and cost
+// a wasted round trip per session before the agent fell back. The handler-level
+// gate in mcp_code_execution.go still refuses a call that arrives by name
+// through a non-listing path (REST, CallToolDirect, a client that cached the
+// old list), so dropping the stub removes an advertisement, never a defence.
 //
 // UX audit F16: this reads the LIVE snapshot, never the construction-time
 // p.config. Settings advertises enable_code_execution as an instantly-applied
-// field; when this read was pinned to startup, flipping it on left the disabled
-// stub — whose handler refuses unconditionally — on the /mcp surface, so the
-// tool kept answering "Code execution is disabled" until a restart even though
-// the handler-level gate (mcp_code_execution.go) had already gone live. The
-// paired half of the fix is RefreshCallToolModeTools/RefreshCodeExecModeTools
-// being called on config.reloaded.
+// field, so every surface is re-derived from this builder on config.reloaded
+// (RefreshCodeExecutionAvailability) — a flip adds or withdraws the tool and
+// emits notifications/tools/list_changed without a restart.
 func (p *MCPProxyServer) buildCodeExecutionTool() []mcpserver.ServerTool {
 	if cfg := p.currentConfig(); cfg != nil && !cfg.EnableCodeExecution {
-		// Disabled stub
-		codeExecutionTool := mcp.NewTool("code_execution",
-			mcp.WithDescription("Code execution is currently disabled. Enable it by setting \"enable_code_execution\": true in your mcpproxy config."),
-			mcp.WithTitleAnnotation("Code Execution (Disabled)"),
-			mcp.WithReadOnlyHintAnnotation(true),
-			mcp.WithDestructiveHintAnnotation(false),
-			mcp.WithOpenWorldHintAnnotation(false),
-			// Spec 097: the stub mirrors the live parameter shape — optional
-			// `code`, optional `script` — so a stored-script call reaches this
-			// handler and gets the "enable it" explanation instead of a schema
-			// rejection. Its DESCRIPTIONS stay minimal and disabled-only: a
-			// disabled tool must not advertise a contract it cannot honor.
-			mcp.WithString("code",
-				mcp.Description("JavaScript source code to execute."),
-			),
-			mcp.WithString("script",
-				mcp.Description("Name of a stored script to execute."),
-			),
-		)
-		return []mcpserver.ServerTool{{
-			Tool: codeExecutionTool,
-			Handler: func(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-				// Same wording, same typed identity as the handler-level gate:
-				// which surface refused must not change what the caller is told.
-				recordCodeExecRefusal(ctx, config.ErrCodeExecutionDisabled)
-				return mcp.NewToolResultError(config.CodeExecutionDisabledMessage), nil
-			},
-		}}
+		return nil
 	}
 
 	codeExecutionTool := mcp.NewTool("code_execution",
@@ -1008,12 +988,17 @@ func (p *MCPProxyServer) initRoutingModeServers() {
 	for _, st := range codeExecTools {
 		p.codeExecServer.AddTool(st.Tool, st.Handler)
 	}
+	// Seed the content guard with what was just registered, so the first
+	// config.reloaded does not re-register (and notify every client about) an
+	// identical surface merely because the fingerprint started out empty.
+	p.codeExecSurfaceFP = toolSetFingerprint(codeExecTools)
 
 	// Register tools for call tool mode
 	callToolModeTools := p.buildCallToolModeTools()
 	for _, st := range callToolModeTools {
 		p.callToolServer.AddTool(st.Tool, st.Handler)
 	}
+	p.callToolSurfaceFP = toolSetFingerprint(callToolModeTools)
 
 	// Initial direct rebuild (D15). Done by CALLING RefreshDirectModeTools so
 	// there is exactly ONE publisher and one copy of the SetTools-then-publish
@@ -1218,7 +1203,24 @@ func (p *MCPProxyServer) RefreshCallToolModeTools() {
 	serverTools := make([]mcpserver.ServerTool, len(callToolTools))
 	copy(serverTools, callToolTools)
 
+	// Guarded on content, like the code-exec surface: this refresh runs on
+	// EVERY config.reloaded, and SetTools pushes notifications/tools/list_changed
+	// to every initialized session whether or not anything moved. Without the
+	// guard an unrelated config edit looks, to a client, exactly like the tool
+	// set changing. Issue #1236 asks for list_changed on a toggle — not on
+	// every reload.
+	fp := toolSetFingerprint(serverTools)
+	p.callToolRefreshMu.Lock()
+	defer p.callToolRefreshMu.Unlock()
+	if p.callToolSurfaceFP == fp {
+		p.logger.Debug("call tool mode tools unchanged; skipping rebuild",
+			zap.Int("tool_count", len(callToolTools)))
+		return
+	}
+
 	p.callToolServer.SetTools(serverTools...)
+	p.callToolSurfaceFP = fp
+	p.callToolPublishes.Add(1)
 
 	p.logger.Info("refreshed call tool mode tools",
 		zap.Int("tool_count", len(callToolTools)))
@@ -1226,19 +1228,32 @@ func (p *MCPProxyServer) RefreshCallToolModeTools() {
 
 // RefreshCodeExecutionAvailability re-advertises code_execution on every tool
 // surface that carries it, so an enable_code_execution flip applies without a
-// restart (UX audit F16). directServer is deliberately absent — direct mode
-// does not expose code_execution at all.
+// restart (UX audit F16, issue #1236). directServer is deliberately absent —
+// direct mode does not expose code_execution at all.
 //
-// The stdio surface (p.server) is updated with AddTools rather than SetTools:
-// its tool set is assembled once by registerTools and SetTools would drop
-// everything else. AddTools replaces the entry with the same name in place, so
-// a startup-disabled server that never registered code_execution gains it, and
-// an enabled one has it swapped for the disabled stub.
+// The routing-mode surfaces are rebuilt through their content-guarded
+// refreshers, so only a real flip re-registers and notifies. The default/stdio
+// surface (p.server) is updated IN PLACE: its tool set is assembled once by
+// registerTools and SetTools would drop everything else. A flip on adds the
+// live tool with AddTools; a flip off withdraws it with DeleteTools. Both push
+// notifications/tools/list_changed, and neither runs when the surface already
+// matches the flag — mcp-go's AddTools notifies even for an empty batch, so an
+// unguarded call would announce a change on every unrelated reload.
 func (p *MCPProxyServer) RefreshCodeExecutionAvailability() {
 	p.RefreshCallToolModeTools()
 	p.RefreshCodeExecModeTools()
-	if p.server != nil {
-		p.server.AddTools(p.buildCodeExecutionTool()...)
+	if p.server == nil {
+		return
+	}
+	live := p.buildCodeExecutionTool()
+	advertised := p.server.GetTool("code_execution") != nil
+	switch {
+	case len(live) > 0 && !advertised:
+		p.server.AddTools(live...)
+		p.logger.Info("code_execution enabled at runtime; advertised on the default surface")
+	case len(live) == 0 && advertised:
+		p.server.DeleteTools("code_execution")
+		p.logger.Info("code_execution disabled at runtime; withdrawn from the default surface")
 	}
 }
 

--- a/internal/server/mcp_routing.go
+++ b/internal/server/mcp_routing.go
@@ -805,8 +805,9 @@ func (p *MCPProxyServer) buildCallToolModeTools() []mcpserver.ServerTool {
 // truncate), so the stub was indistinguishable from an available tool and cost
 // a wasted round trip per session before the agent fell back. The handler-level
 // gate in mcp_code_execution.go still refuses a call that arrives by name
-// through a non-listing path (REST, CallToolDirect, a client that cached the
-// old list), so dropping the stub removes an advertisement, never a defence.
+// through a non-listing path (REST, CallToolDirect), and an MCP tools/call for
+// the unregistered name is refused by mcp-go as an unknown tool — so dropping
+// the stub removes an advertisement, never a defence.
 //
 // UX audit F16: this reads the LIVE snapshot, never the construction-time
 // p.config. Settings advertises enable_code_execution as an instantly-applied

--- a/internal/server/testdata/toolslist_goldens/code_execution_mode.json
+++ b/internal/server/testdata/toolslist_goldens/code_execution_mode.json
@@ -1,29 +1,4 @@
 {
-  "code_execution": {
-    "annotations": {
-      "title": "Code Execution (Disabled)",
-      "readOnlyHint": true,
-      "destructiveHint": false,
-      "idempotentHint": false,
-      "openWorldHint": false
-    },
-    "description": "Code execution is currently disabled. Enable it by setting \"enable_code_execution\": true in your mcpproxy config.",
-    "inputSchema": {
-      "properties": {
-        "code": {
-          "description": "JavaScript source code to execute.",
-          "type": "string"
-        },
-        "script": {
-          "description": "Name of a stored script to execute.",
-          "type": "string"
-        }
-      },
-      "required": [],
-      "type": "object"
-    },
-    "name": "code_execution"
-  },
   "list_registries": {
     "annotations": {
       "title": "List Registries",

--- a/internal/server/testdata/toolslist_goldens/retrieve_tools_mode.json
+++ b/internal/server/testdata/toolslist_goldens/retrieve_tools_mode.json
@@ -119,31 +119,6 @@
     },
     "name": "call_tool_write"
   },
-  "code_execution": {
-    "annotations": {
-      "title": "Code Execution (Disabled)",
-      "readOnlyHint": true,
-      "destructiveHint": false,
-      "idempotentHint": false,
-      "openWorldHint": false
-    },
-    "description": "Code execution is currently disabled. Enable it by setting \"enable_code_execution\": true in your mcpproxy config.",
-    "inputSchema": {
-      "properties": {
-        "code": {
-          "description": "JavaScript source code to execute.",
-          "type": "string"
-        },
-        "script": {
-          "description": "Name of a stored script to execute.",
-          "type": "string"
-        }
-      },
-      "required": [],
-      "type": "object"
-    },
-    "name": "code_execution"
-  },
   "describe_tool": {
     "annotations": {
       "title": "Describe Tool",

--- a/internal/server/toolslist_snapshot_test.go
+++ b/internal/server/toolslist_snapshot_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"testing"
 
@@ -196,6 +197,22 @@ var toolsListAllowedDelta = map[string][]string{
 	"code_execution_mode": {"quarantine_security", "upstream_servers"},
 }
 
+// toolsListAllowedRemovals enumerates the tool entries a shipped fix was
+// allowed to RETIRE from a surface, measured against the same frozen capture.
+// The frozen goldens were taken with enable_code_execution=false (the fixture
+// default), so they carry the "Code Execution (Disabled)" stub that used to be
+// registered in place of the real tool.
+//
+//   - code_execution — issue #1236: a disabled feature is no longer advertised.
+//     The stub is gone from both surfaces that carried it; the live tool (with
+//     the flag on) is unchanged and still pinned by the enabled-path tests.
+//     default_server never carried the stub (registerTools always gated on the
+//     flag), which is why it is absent here.
+var toolsListAllowedRemovals = map[string][]string{
+	"retrieve_tools_mode": {"code_execution"},
+	"code_execution_mode": {"code_execution"},
+}
+
 // TestToolsListSnapshot_DeltaIsEnumerated is the FR-014 gate: the goldens
 // moved, and this is the enumeration of how far.
 func TestToolsListSnapshot_DeltaIsEnumerated(t *testing.T) {
@@ -205,10 +222,18 @@ func TestToolsListSnapshot_DeltaIsEnumerated(t *testing.T) {
 			before := decodeToolsListGolden(t, filepath.Join("testdata", toolsListGoldenDir, toolsListPre099Dir, surface+".json"))
 			after := decodeToolsListGolden(t, toolsListGoldenPath(surface))
 
-			// The tool SET is unchanged: these features extend existing
-			// built-ins, they do not register or retire one.
-			assert.Equal(t, sortedToolNames(before), sortedToolNames(after),
-				"surface %s: no tool may be added or removed", surface)
+			// The tool SET moves only by the enumerated removals: these
+			// features extend existing built-ins, they do not register a new
+			// one, and the only retirement is the disabled code_execution stub
+			// (issue #1236).
+			wantNames := make([]string, 0, len(before))
+			for _, name := range sortedToolNames(before) {
+				if !slices.Contains(toolsListAllowedRemovals[surface], name) {
+					wantNames = append(wantNames, name)
+				}
+			}
+			assert.Equal(t, wantNames, sortedToolNames(after),
+				"surface %s: no tool may be added, and only the enumerated removals may be missing", surface)
 
 			changed := make([]string, 0, len(allowed))
 			for name, pre := range before {


### PR DESCRIPTION
## Problem

With `enable_code_execution: false` (the default), `tools/list` on `/mcp` still advertised `code_execution`. Only the call handler refused it. Clients select tools from the list, not from descriptions (which harnesses routinely truncate), so agents kept calling it and burning a round trip per session before falling back to another path.

Closes #1236

## Root cause

`buildCodeExecutionTool` (`internal/server/mcp_routing.go`) returned a `"Code Execution (Disabled)"` stub — a registered tool whose handler always refused — whenever the flag was off. Both routing-mode surfaces (`/mcp` in the default `retrieve_tools` mode, `/mcp/call`, `/mcp/code`) appended it unconditionally. The stub dates from PR #339, which treated a descriptive refusal as better than an unknown-tool error; in practice a disabled capability that is still advertised is indistinguishable from an available one.

A second, smaller problem: `RefreshCallToolModeTools` ran `SetTools` on **every** `config.reloaded`, so every unrelated config edit pushed `notifications/tools/list_changed` to every connected session on the default `/mcp` surface.

## Fix

- `buildCodeExecutionTool` returns nothing while the flag is off. The default surface (`registerTools` in `mcp.go`) now registers through the same builder, so there is one definition of the tool.
- `RefreshCodeExecutionAvailability` (driven by `config.reloaded`) applies a runtime flip on every surface that carries the tool:
  - routing-mode surfaces rebuild through content-guarded refreshers (`RefreshCallToolModeTools` gains the same fingerprint guard `RefreshCodeExecModeTools` already had; both guards are seeded at init so the first reload does not re-announce an unchanged set);
  - the default surface is updated in place — `AddTools` on enable, `DeleteTools` on disable — and only when its state actually differs from the flag (mcp-go's `AddTools` notifies even for an empty batch).
  - Net effect: a toggle emits exactly one `notifications/tools/list_changed` per surface; an unrelated reload emits none.
- The handler-level gate in `mcp_code_execution.go` is untouched: REST / CLI / `CallToolDirect` callers still get the "enable it" message. An MCP `tools/call` from a stale list now gets mcp-go's unknown-tool error (documented).
- Docs: `docs/features/routing-modes.md`, `docs/features/code-execution.md`, `docs/configuration.md`, `docs/code_execution/troubleshooting.md` no longer say the tool "appears but returns an error" or that a restart is needed.

### Golden tests (deliberate update)

Three frozen tool-surface gates exist. The frozen baselines (`testdata/toolslist_goldens/pre099/*.json`, `testdata/tools_list_prefeature.golden.json`) were captured with the flag off and therefore contain the stub — they are **untouched**. The current goldens `toolslist_goldens/retrieve_tools_mode.json` and `code_execution_mode.json` were regenerated via `MCPPROXY_WRITE_TOOLSLIST_GOLDENS`; the only delta is the removed `code_execution` entry (verified with `jq` diff). `default_server.json` is unchanged (that surface never carried the stub). The two enumerated-delta gates (`toolsListAllowedRemovals` in `toolslist_snapshot_test.go`, `wantRemoved` in `mcp_menu_surface_test.go`) now allow exactly that one removal per surface and still fail on any other addition, removal, or schema change. `assertCodeExecutionDelta` was deleted because it only ever compared the disabled stub; the live tool's `script` param / non-required `code` remain pinned by `TestCodeExecutionRegistrations_ScriptParam` on all three surfaces.

## Testing

Failing tests were written first (`internal/server/code_execution_hotreload_test.go`, rewritten from the F16 stub tests):
- `TestBuildCodeExecutionTool_FollowsCurrentConfig` — disabled → no tool; enabled → live tool; back off → none.
- `TestRoutingModeSurfaces_OmitDisabledCodeExecution` — neither routing-mode builder lists it while disabled.
- `TestRefreshCodeExecutionAvailability_TogglesAdvertisedTool` — hot enable adds it on all three surfaces, hot disable withdraws it.
- `TestRefreshCodeExecutionAvailability_EmitsListChangedOnlyOnAFlip` — registers an initialized session per surface and asserts exactly one `list_changed` per flip and zero on unchanged reloads (this one also caught the pre-existing per-reload churn).
- `TestRefreshCodeExecutionAvailability_PreservesOtherTools` — the in-place add/remove touches nothing else.
- Updated: `TestDisabledCodeExecutionNotRegistered`, `TestCodeExecutionDisabled_NotRegisteredButScriptCallStillExplained`, the "wording matches" subtest of `TestCodeExecution_DisabledGateCoversEveryDispatch`.

Verification run locally:
- `go build ./...` and `go build -tags server ./cmd/mcpproxy`
- `go test -race -count=1 ./internal/server/` (with the CI `-skip` regex) — ok
- `go test -race -count=1 ./internal/httpapi/ ./internal/runtime/ ./internal/config/` — ok
- `golangci-lint run --config .github/.golangci.yml ./internal/server/...` — 0 issues
- Cross-review with `opencode` (`github-copilot/gpt-6-astra`) in three file-scoped chunks: production code CLEAN, test/golden gates CLEAN, docs FINDINGS (1 — the "cached list still gets the enable hint" claim was wrong; fixed in the second commit), re-review CLEAN.

Not run here: `./scripts/test-api-e2e.sh` (CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
