### PR TITLE
fix(logs): release the per-server log sink on every Disconnect

### DIFF
--- a/internal/logs/logger.go
+++ b/internal/logs/logger.go
@@ -133,10 +133,19 @@ func SetupCommandLogger(serverCommand bool, logLevel string, logToFile bool, log
 
 // createFileCore creates a file-based logging core
 func createFileCore(config *config.LogConfig, level zapcore.Level) (zapcore.Core, error) {
-	writeSyncer, err := CreateRotatingWriteSyncer(config)
+	core, _, err := createFileCoreWithCloser(config, level)
+	return core, err
+}
+
+// createFileCoreWithCloser is createFileCore plus the sink's closer, for the
+// callers that own a logger's lifetime (per-server upstream loggers, which
+// otherwise hold one file handle per server for the life of the process).
+func createFileCoreWithCloser(config *config.LogConfig, level zapcore.Level) (zapcore.Core, io.Closer, error) {
+	sink, err := newRotatingSink(config)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+	writeSyncer := zapcore.WriteSyncer(sink)
 
 	// Choose encoder based on format preference
 	var encoder zapcore.Encoder
@@ -150,11 +159,28 @@ func createFileCore(config *config.LogConfig, level zapcore.Level) (zapcore.Core
 		encoder,
 		writeSyncer,
 		level,
-	), nil
+	), sink, nil
 }
 
 // CreateRotatingWriteSyncer creates a rotation-backed file sink for a log config.
 func CreateRotatingWriteSyncer(config *config.LogConfig) (zapcore.WriteSyncer, error) {
+	return newRotatingSink(config)
+}
+
+// rotatingSink is the lumberjack-backed file sink behind every file logger.
+// It is a WriteSyncer for zap and a Closer for whoever owns the logger's
+// lifetime: lumberjack opens the file lazily on the first Write and reopens
+// after Close, so closing an idle sink releases its handle at no cost to a
+// later write.
+type rotatingSink struct {
+	*lumberjack.Logger
+}
+
+// Sync satisfies zapcore.WriteSyncer; lumberjack writes through to the OS
+// file on every Write, so there is nothing buffered to flush.
+func (s *rotatingSink) Sync() error { return nil }
+
+func newRotatingSink(config *config.LogConfig) (*rotatingSink, error) {
 	// Get log file path with custom directory support
 	logFilePath, err := GetLogFilePathWithDir(config.LogDir, config.Filename)
 	if err != nil {
@@ -162,15 +188,13 @@ func CreateRotatingWriteSyncer(config *config.LogConfig) (zapcore.WriteSyncer, e
 	}
 
 	// Create lumberjack logger for log rotation
-	lumberjackLogger := &lumberjack.Logger{
+	return &rotatingSink{Logger: &lumberjack.Logger{
 		Filename:   logFilePath,
 		MaxSize:    config.MaxSize,
 		MaxBackups: config.MaxBackups,
 		MaxAge:     config.MaxAge,
 		Compress:   config.Compress,
-	}
-
-	return zapcore.AddSync(lumberjackLogger), nil
+	}}, nil
 }
 
 // getConsoleEncoder returns a console-friendly encoder
@@ -307,8 +331,20 @@ func sanitizeServerLogName(serverName string) string {
 	}, serverName)
 }
 
-// CreateUpstreamServerLogger creates a logger for a specific upstream server
+// CreateUpstreamServerLogger creates a logger for a specific upstream server.
+// The caller cannot release its file sink; prefer NewUpstreamServerLogger
+// wherever the logger has an owner with a teardown path.
 func CreateUpstreamServerLogger(config *config.LogConfig, serverName string) (*zap.Logger, error) {
+	logger, _, err := NewUpstreamServerLogger(config, serverName)
+	return logger, err
+}
+
+// NewUpstreamServerLogger creates a logger for a specific upstream server and
+// returns the closer of its file sink. Close it whenever the server is torn
+// down or disconnected (issue #1266: an unclosed sink held one open handle per
+// server for the life of the process, and on Windows pinned the file); a later
+// write reopens the sink, so closing it on every disconnect is safe.
+func NewUpstreamServerLogger(config *config.LogConfig, serverName string) (*zap.Logger, io.Closer, error) {
 	if config == nil {
 		config = DefaultLogConfig()
 	}
@@ -336,9 +372,9 @@ func CreateUpstreamServerLogger(config *config.LogConfig, serverName string) (*z
 	}
 
 	// Create file core for upstream server
-	fileCore, err := createFileCore(&serverConfig, level)
+	fileCore, closer, err := createFileCoreWithCloser(&serverConfig, level)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create file core for upstream server %s: %w", serverName, err)
+		return nil, nil, fmt.Errorf("failed to create file core for upstream server %s: %w", serverName, err)
 	}
 
 	// Wrap with secret sanitizer for security
@@ -348,7 +384,7 @@ func CreateUpstreamServerLogger(config *config.LogConfig, serverName string) (*z
 	logger := zap.New(sanitizedCore, zap.AddCaller(), zap.AddCallerSkip(1))
 	logger = logger.With(zap.String("server", serverName))
 
-	return logger, nil
+	return logger, closer, nil
 }
 
 // CreateCLIUpstreamServerLogger creates a logger for CLI debugging that outputs to console

--- a/internal/logs/upstream_logger_close_test.go
+++ b/internal/logs/upstream_logger_close_test.go
@@ -1,0 +1,63 @@
+package logs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+)
+
+// The per-server log sink is a lumberjack writer that nothing ever closed:
+// every server a core had logged for kept an open file handle until the
+// process exited. On Windows that also pinned the file (issue #1266: CI's
+// t.TempDir() cleanup failed on server-*.log). The logger now comes with a
+// closer, and — because lumberjack reopens lazily on the next Write — closing
+// it while a server is disconnected costs nothing when it reconnects.
+func TestNewUpstreamServerLogger_CloserReleasesTheFileAndWritesReopen(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.LogConfig{LogDir: dir, Level: "info", EnableFile: true, MaxSize: 1, MaxBackups: 1, MaxAge: 1}
+
+	logger, closer, err := NewUpstreamServerLogger(cfg, "svc")
+	require.NoError(t, err)
+	require.NotNil(t, closer)
+
+	logger.Info("first line")
+	require.NoError(t, logger.Sync())
+	path := filepath.Join(dir, ServerLogFilename("svc"))
+	require.FileExists(t, path)
+
+	require.NoError(t, closer.Close())
+	require.NoError(t, closer.Close(), "closing twice must be harmless")
+
+	// Renaming an open file fails on Windows; after Close it must succeed on
+	// every platform. (On Unix this is a weaker check, but the Windows CI leg
+	// runs this test too.)
+	moved := path + ".moved"
+	require.NoError(t, os.Rename(path, moved))
+
+	// A write after Close reopens the sink at the configured path.
+	logger.Info("second line")
+	require.NoError(t, logger.Sync())
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.True(t, strings.Contains(string(data), "second line"), "post-close write must land in a reopened file: %q", data)
+
+	require.NoError(t, closer.Close())
+}
+
+// CreateUpstreamServerLogger keeps its old shape for callers that cannot own a
+// closer, and must still hand back a usable logger.
+func TestCreateUpstreamServerLogger_StillWorksWithoutACloser(t *testing.T) {
+	cfg := &config.LogConfig{LogDir: t.TempDir(), Level: "info", EnableFile: true}
+	logger, err := CreateUpstreamServerLogger(cfg, "svc")
+	require.NoError(t, err)
+	require.NotNil(t, logger)
+	logger.Info("x")
+	_ = logger.Sync()
+	_ = zap.NewNop()
+}

--- a/internal/logs/upstream_logger_close_test.go
+++ b/internal/logs/upstream_logger_close_test.go
@@ -51,13 +51,14 @@ func TestNewUpstreamServerLogger_CloserReleasesTheFileAndWritesReopen(t *testing
 }
 
 // CreateUpstreamServerLogger keeps its old shape for callers that cannot own a
-// closer, and must still hand back a usable logger.
+// closer, and must still hand back a usable logger. It deliberately never
+// writes: lumberjack opens the file on the first Write, and with no closer in
+// hand that handle would outlive the test — on Windows, failing t.TempDir()'s
+// cleanup with exactly the leak this change fixes.
 func TestCreateUpstreamServerLogger_StillWorksWithoutACloser(t *testing.T) {
 	cfg := &config.LogConfig{LogDir: t.TempDir(), Level: "info", EnableFile: true}
 	logger, err := CreateUpstreamServerLogger(cfg, "svc")
 	require.NoError(t, err)
 	require.NotNil(t, logger)
-	logger.Info("x")
-	_ = logger.Sync()
-	_ = zap.NewNop()
+	require.True(t, logger.Core().Enabled(zap.InfoLevel))
 }

--- a/internal/upstream/core/client.go
+++ b/internal/upstream/core/client.go
@@ -49,6 +49,10 @@ type Client struct {
 
 	// Upstream server specific logger for debugging
 	upstreamLogger *zap.Logger
+	// upstreamLogCloser releases upstreamLogger's file sink. Disconnect
+	// closes it (issue #1266); the sink reopens on the next write, so a
+	// reconnecting server logs on as before. nil for console (CLI) loggers.
+	upstreamLogCloser io.Closer
 
 	// MCP client and server info
 	client     *client.Client
@@ -255,13 +259,14 @@ func NewClientWithOptions(id string, serverConfig *config.ServerConfig, logger *
 	// Create upstream server logger if provided
 	if logConfig != nil {
 		var upstreamLogger *zap.Logger
+		var upstreamLogCloser io.Closer
 		var err error
 
 		// Use CLI logger for debugging or regular logger for daemon mode
 		if cliDebugMode {
 			upstreamLogger, err = logs.CreateCLIUpstreamServerLogger(logConfig, serverConfig.Name)
 		} else {
-			upstreamLogger, err = logs.CreateUpstreamServerLogger(logConfig, serverConfig.Name)
+			upstreamLogger, upstreamLogCloser, err = logs.NewUpstreamServerLogger(logConfig, serverConfig.Name)
 		}
 
 		if err != nil {
@@ -271,6 +276,7 @@ func NewClientWithOptions(id string, serverConfig *config.ServerConfig, logger *
 				zap.Error(err))
 		} else {
 			c.upstreamLogger = upstreamLogger
+			c.upstreamLogCloser = upstreamLogCloser
 			if logConfig.Level == "trace" && cliDebugMode {
 				c.upstreamLogger.Debug("TRACE LEVEL ENABLED - All JSON-RPC frames will be logged to console",
 					zap.String("server", serverConfig.Name))

--- a/internal/upstream/core/connection_lifecycle.go
+++ b/internal/upstream/core/connection_lifecycle.go
@@ -396,7 +396,29 @@ func (c *Client) DisconnectWithContext(_ context.Context) error {
 	c.processCmd = nil
 	c.mu.Unlock()
 
+	// Step 8: release the per-server log sink (issue #1266). Every
+	// teardown path — RemoveServer, ShutdownAll, a reconnect — comes
+	// through here, and this is the last line this Disconnect writes to it.
+	// lumberjack reopens the file on the next write, so a server that
+	// reconnects logs on exactly as before; a server that is gone stops
+	// holding a file handle (and, on Windows, the file itself) for the life
+	// of the process.
+	c.closeUpstreamLog()
+
 	c.logger.Debug("Disconnect completed successfully",
 		zap.String("server", serverName))
 	return nil
+}
+
+// closeUpstreamLog syncs and closes the upstream log sink, if the logger has
+// one. Safe to call repeatedly: the sink reopens itself on the next write.
+func (c *Client) closeUpstreamLog() {
+	if c.upstreamLogger != nil {
+		_ = c.upstreamLogger.Sync()
+	}
+	if c.upstreamLogCloser != nil {
+		if err := c.upstreamLogCloser.Close(); err != nil {
+			c.logger.Debug("Failed to close upstream log sink", zap.Error(err))
+		}
+	}
 }

--- a/internal/upstream/core/upstream_log_close_test.go
+++ b/internal/upstream/core/upstream_log_close_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,9 +10,15 @@ import (
 	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
 )
 
-type recordingCloser struct{ closed int }
+// recordingCloser counts Close calls and delegates to the real sink closer, so
+// the file Disconnect's own "Disconnecting from server" line opens is released
+// before t.TempDir() cleanup (which fails on Windows if it is not).
+type recordingCloser struct {
+	real   io.Closer
+	closed int
+}
 
-func (r *recordingCloser) Close() error { r.closed++; return nil }
+func (r *recordingCloser) Close() error { r.closed++; return r.real.Close() }
 
 // Disconnect is the one path every teardown reaches (RemoveServer,
 // ShutdownAll, reconnect), so it is where the per-server log sink is
@@ -23,8 +30,9 @@ func TestDisconnect_ClosesTheUpstreamLogSink(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, c.upstreamLogCloser, "a file-backed upstream logger must come with its closer")
 
-	rec := &recordingCloser{}
+	rec := &recordingCloser{real: c.upstreamLogCloser}
 	c.upstreamLogCloser = rec
+	t.Cleanup(func() { _ = rec.real.Close() })
 
 	require.NoError(t, c.Disconnect())
 	require.Equal(t, 1, rec.closed, "Disconnect must release the per-server log sink")

--- a/internal/upstream/core/upstream_log_close_test.go
+++ b/internal/upstream/core/upstream_log_close_test.go
@@ -1,0 +1,34 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/smart-mcp-proxy/mcpproxy-go/internal/config"
+)
+
+type recordingCloser struct{ closed int }
+
+func (r *recordingCloser) Close() error { r.closed++; return nil }
+
+// Disconnect is the one path every teardown reaches (RemoveServer,
+// ShutdownAll, reconnect), so it is where the per-server log sink is
+// released — issue #1266. lumberjack reopens on the next write, so a
+// reconnecting server loses nothing.
+func TestDisconnect_ClosesTheUpstreamLogSink(t *testing.T) {
+	cfg := &config.ServerConfig{Name: "svc", Protocol: "stdio", Command: "definitely-not-on-path", Enabled: false}
+	c, err := NewClient("svc", cfg, zap.NewNop(), &config.LogConfig{LogDir: t.TempDir(), Level: "info", EnableFile: true}, nil, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, c.upstreamLogCloser, "a file-backed upstream logger must come with its closer")
+
+	rec := &recordingCloser{}
+	c.upstreamLogCloser = rec
+
+	require.NoError(t, c.Disconnect())
+	require.Equal(t, 1, rec.closed, "Disconnect must release the per-server log sink")
+
+	require.NoError(t, c.Disconnect())
+	require.Equal(t, 2, rec.closed, "every Disconnect releases it again (reopen-on-write makes this idempotent)")
+}


### PR DESCRIPTION
Closes #1266

## Problem

The per-server upstream logger's lumberjack sink was wrapped in `zapcore.AddSync` and never closed, so a core held one open file handle per server it had ever logged for, for the life of the process. On Windows an open handle also pins the file: since 2026-09-07 every `internal/server` test that spins up a `Server` failed CI's `t.TempDir()` cleanup on `server-<name>.log`, turning the `Unit Tests` and `E2E Tests` workflows red on every push to `main` (they only run their Windows leg on `main`, so PRs never saw it).

## Fix

- `internal/logs`: the file sink is a `rotatingSink` (lumberjack + `Sync`) that is also an `io.Closer`. `NewUpstreamServerLogger` returns the closer; `CreateUpstreamServerLogger` keeps its shape for callers that cannot own one.
- `core.Client` stores the closer and closes it at the end of `DisconnectWithContext` — the one path `RemoveServer`, `ShutdownAll` and a reconnect all reach. lumberjack reopens the file on the next `Write`, so a reconnecting server logs on unchanged.

## Testing

- `TestNewUpstreamServerLogger_CloserReleasesTheFileAndWritesReopen`: write → close → rename succeeds → write reopens (the rename is the real check on the Windows leg).
- `TestDisconnect_ClosesTheUpstreamLogSink`: Disconnect closes the sink, every time.
- Verified the actual leak with `lsof` from an `internal/server` fixture: after `Server.Shutdown()` no fd points into the log dir; with `closeUpstreamLog` removed the `server-*.log` handle is still open.
- `go test -race` on `internal/logs internal/upstream/... internal/runtime` and `internal/server` (CI skip regex) green; `GOOS=windows go build ./...` and `go vet` clean; golangci-lint v2 0 issues.
- opencode astra review: two test-side leaks it found are fixed in the second commit. One residual it raised is left as a follow-up: a stderr-monitor goroutine abandoned after `StopStderrMonitoring`'s 500 ms wait could log a late EOF and reopen the sink after Disconnect returns. That is pre-existing and does not affect the failing fixtures (their clients never connect); a terminal write fence for `RemoveServer`/`ShutdownAll` would close it fully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
