### PR TITLE
ci: give the Windows unit-test leg a 20m package timeout

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -137,10 +137,15 @@ jobs:
         env:
           TIKTOKEN_CACHE_DIR: ${{ runner.temp }}/tiktoken
 
+      # internal/server alone takes 450-600s on windows-latest under -race with
+      # atomic coverage (the E2E workflow's -short, coverage-free run of the
+      # same package takes ~450s), so the default 10m package timeout is one
+      # slow runner away from "panic: test timed out" — which is how the leg
+      # failed on the first green-again push after #1266.
       - name: Run unit tests (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh
-        run: go test -v -race -timeout 10m '-coverprofile=coverage.out' -covermode=atomic '-skip=E2E|Binary|MCPProtocol|TestInfoEndpoint|TestGracefulShutdownNoPanic|TestSocketInfoEndpoint' ./...
+        run: go test -v -race -timeout 20m '-coverprofile=coverage.out' -covermode=atomic '-skip=E2E|Binary|MCPProtocol|TestInfoEndpoint|TestGracefulShutdownNoPanic|TestSocketInfoEndpoint' ./...
         env:
           TIKTOKEN_CACHE_DIR: ${{ runner.temp }}/tiktoken
 


### PR DESCRIPTION
Follow-up to #1268 / #1266. The first push-to-main run after the handle-leak fix no longer fails on TempDir cleanup, but `Unit Tests (windows-latest, 1.25)` hit `panic: test timed out after 10m0s` in `internal/server` (run 34692065096): under `-race` + atomic coverage that package takes 450–600 s on that runner class, so the default 10 m was one slow runner away from red. The E2E workflow's `-short`, coverage-free run of the same package took 449 s and passed on the same commit.

Raises the Windows leg's `-timeout` to 20 m; the Unix legs are unchanged.

Not touched: a recovered nil-pointer panic in `handleAddFromRegistry` during `TestMutatingServerRoutes_AdminAllowed/registry-add-server` (the test's stub controller returns a nil config with a nil error; chi's Recoverer turns it into a 500 and the test still passes). Pre-existing on every platform and every earlier run; worth its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)