### PR TITLE
ci: match the E2E workflow's Windows unit sweep to the 20m budget

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -97,15 +97,17 @@ jobs:
         # they run unguarded in the main-only stress-tests job below so coverage
         # is preserved.
         #
-        # Timeout is 10m to match the equivalent sweep in unit-tests.yml. It was
+        # Timeout is 20m to match the Windows sweep in unit-tests.yml. It was
         # 4m, which the windows-latest runner could not meet: internal/server
         # took 240s and died at `panic: test timed out after 4m0s` — with a
         # single test only 2s in, so cumulative slowness (Bleve index creation
         # on the Windows filesystem), never a hang. That kept this job red on
-        # main from 2026-08-13 (issue #1034). Keep the two workflows' budgets in
-        # step; the same code timing out in one and passing in the other is the
+        # main from 2026-08-13 (issue #1034). The same signature returned at
+        # 10m on 2026-09-12 (a74a7cf0f: 449s one push, 600s+ the next, a 4s
+        # test in flight), so both budgets moved to 20m. Keep them in step;
+        # the same code timing out in one and passing in the other is the
         # signature of this bug returning.
-        run: go test -v -short -race -timeout 10m -skip "Binary|MCP|E2E|TestInfoEndpoint|TestGracefulShutdownNoPanic|TestSocketInfoEndpoint" ./internal/...
+        run: go test -v -short -race -timeout 20m -skip "Binary|MCP|E2E|TestInfoEndpoint|TestGracefulShutdownNoPanic|TestSocketInfoEndpoint" ./internal/...
 
       # Binary tests are too flaky in CI due to server startup timing issues
       # All Binary tests consistently timeout waiting for server to be ready


### PR DESCRIPTION
Follow-up to #1269. On `a74a7cf0f` `Unit Tests` went green on Windows with the 20 m budget, but `E2E Tests`' own Windows `Run unit tests` step (same `internal/server` package, `-short`, no coverage) hit `panic: test timed out after 10m0s` (run 34693921568) — 449 s on the previous push, 600 s+ on this one, with a 4 s test in flight: the #1034 cumulative-slowness signature, not a hang. The step's own comment asks for the two workflows' budgets to stay in step, so this moves it to 20 m as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)